### PR TITLE
Fix unit tests and prevent protractor from hanging

### DIFF
--- a/build/serve.js
+++ b/build/serve.js
@@ -25,6 +25,12 @@ import conf from './conf';
 
 
 /**
+ * Browser sync instance that serves the application.
+ */
+export const browserSyncInstance = browserSync.create();
+
+
+/**
  * Currently running backend process object. Null if the backend is not running.
  *
  * @type {?child.ChildProcess}
@@ -39,11 +45,11 @@ let runningBackendProcess = null;
  */
 function browserSyncInit(baseDir) {
   // Enable custom support for Angular apps, e.g., history management.
-  browserSync.use(browserSyncSpa({
+  browserSyncInstance.use(browserSyncSpa({
     selector: '[ng-app]',
   }));
 
-  browserSync.instance = browserSync.init({
+  browserSyncInstance.init({
     // TODO(bryk): Add proxy to the backend here.
     startPath: '/',
     server: {
@@ -57,14 +63,27 @@ function browserSyncInit(baseDir) {
 /**
  * Serves the application in development mode.
  */
-gulp.task('serve', ['spawn-backend', 'watch'], function () {
+function serveDevelopmentMode() {
   browserSyncInit([
     conf.paths.serve,
     conf.paths.frontendSrc, // For angular templates to work.
     conf.paths.app, // For assets to work.
     conf.paths.base, // For bower dependencies to work.
   ]);
-});
+}
+
+
+/**
+ * Serves the application in development mode. Watches for changes in the source files to rebuild
+ * development artifacts.
+ */
+gulp.task('serve:watch', ['watch'], serveDevelopmentMode);
+
+
+/**
+ * Serves the application in development mode.
+ */
+gulp.task('serve', ['index'], serveDevelopmentMode);
 
 
 /**
@@ -136,3 +155,4 @@ gulp.task('watch', ['index'], function () {
   gulp.watch(path.join(conf.paths.frontendSrc, '**/*.js'), ['scripts']);
   gulp.watch(path.join(conf.paths.backendSrc, '**/*.go'), ['spawn-backend']);
 });
+

--- a/build/style.js
+++ b/build/style.js
@@ -15,7 +15,6 @@
 /**
  * @fileoverview Gulp tasks for processing stylesheets.
  */
-import browserSync from 'browser-sync';
 import gulp from 'gulp';
 import gulpAutoprefixer from 'gulp-autoprefixer';
 import gulpMinifyCss from 'gulp-minify-css';
@@ -24,6 +23,7 @@ import gulpSass from 'gulp-sass';
 import path from 'path';
 import gulpConcat from 'gulp-concat';
 
+import {browserSyncInstance} from './serve';
 import conf from './conf';
 
 
@@ -42,7 +42,7 @@ gulp.task('styles', function () {
     .pipe(gulpSourcemaps.write("."))
     .pipe(gulp.dest(conf.paths.serve))
     // If BrowserSync is running, inform it that styles have changed.
-    .pipe(browserSync.stream());
+    .pipe(browserSyncInstance.stream());
 });
 
 

--- a/build/test.js
+++ b/build/test.js
@@ -15,12 +15,12 @@
 /**
  * @fileoverview Gulp tasks for unit and integration tests.
  */
-import browserSync from 'browser-sync';
 import gulp from 'gulp';
 import gulpProtractor from 'gulp-protractor';
 import karma from 'karma';
 import path from 'path';
 
+import {browserSyncInstance} from './serve';
 import conf from './conf';
 
 
@@ -51,11 +51,17 @@ function runProtractorTests(doneFn) {
       configFile: conf.paths.protractorConf,
     }))
     .on('error', function (err) {
+      // Close browser sync server to prevent the process from hanging.
+      browserSyncInstance.exit();
+      // Kill backend server, if running.
+      gulp.start('kill-backend');
       doneFn(err);
     })
     .on('end', function () {
-      // Close browser sync server.
-      browserSync.exit();
+      // Close browser sync server to prevent the process from hanging.
+      browserSyncInstance.exit();
+      // Kill backend server, if running.
+      gulp.start('kill-backend');
       doneFn();
     });
 }

--- a/src/test/frontend/.eslintrc
+++ b/src/test/frontend/.eslintrc
@@ -2,8 +2,8 @@
   "env": {
     "jasmine": true,
   },
+  // Define missing global Angular testing environment variables.
   "globals": {
-    // Define missing global Angular variables.
     "inject": true,
     "module": true,
   },


### PR DESCRIPTION
Once unit and integration tests are hooked to travis, such errors should
not happen again.