### PR TITLE
Rename Kubernetes Console to Kubernetes Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# Kubernetes Console
-Kubernetes Console is a general purpose, web-based UI for Kubernetes clusters. It allows to manage applications running in the cluster, troubleshoot them, as well as, manage the cluster itself.
+# Kubernetes Dashboard
+Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters. It allows to
+manage applications running in the cluster, troubleshoot them, as well as, manage the cluster
+itself.
 
-The console is currently under active development and is not ready for production use (yet!).
+The dashboard is currently under active development and is not ready for production use (yet!).
 
-# Contribute:
+# Contribute
 
-Wish to contribute !! Great start [here](https://github.com/kubernetes/console/blob/master/CONTRIBUTING.md).
+Wish to contribute !! Great start [here](CONTRIBUTING.md).
 
-# License:
+# License
 
-The work done has been licensed under Apache License 2.0.The license file can be found [here](https://github.com/kubernetes/console/blob/master/LICENSE). You can find out more about license,at
+The work done has been licensed under Apache License 2.0. The license file can be found
+[here](LICENSE). You can find out more about the license at:
 
 http://www.apache.org/licenses/LICENSE-2.0

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "//": "Specification of this file can be found at:",
   "//": "https://github.com/bower/spec/blob/master/json.md",
 
-  "name": "kubernetes-console",
+  "name": "kubernetes-dashboard",
   "version": "0.0.1",
   "dependencies": {
     "angular": "~1.4.2",

--- a/build/backend.js
+++ b/build/backend.js
@@ -69,27 +69,27 @@ function spawnGoProcess(args, doneFn, opt_env) {
 
 
 /**
- * Compiles backend application in development mode and places 'console' binary in the serve
+ * Compiles backend application in development mode and places the binary in the serve
  * directory.
  */
 gulp.task('backend', ['backend-dependencies'], function(doneFn) {
   spawnGoProcess([
     'build',
-    '-o', path.join(conf.paths.serve, 'console'),
-    path.join(conf.paths.backendSrc, 'console.go'),
+    '-o', path.join(conf.paths.serve, 'dashboard'),
+    path.join(conf.paths.backendSrc, 'dashboard.go'),
   ], doneFn);
 });
 
 
 /**
- * Compiles backend application in production mode and places 'console' binary in the dist
+ * Compiles backend application in production mode and places the binary in the dist
  * directory.
  *
  * The production binary difference from development binary is only that it contains all
  * dependencies inside it and is targeted for Linux.
  */
 gulp.task('backend:prod', ['backend-dependencies'], function(doneFn) {
-  let outputBinaryPath = path.join(conf.paths.dist, 'console');
+  let outputBinaryPath = path.join(conf.paths.dist, 'dashboard');
   // Delete output binary first. This is required because prod build does not override it.
   del(outputBinaryPath)
       .then(function() {
@@ -98,7 +98,7 @@ gulp.task('backend:prod', ['backend-dependencies'], function(doneFn) {
           '-a',
           '-installsuffix', 'cgo',
           '-o', outputBinaryPath,
-          path.join(conf.paths.backendSrc, 'console.go'),
+          path.join(conf.paths.backendSrc, 'dashboard.go'),
         ], doneFn, {
           // Disable cgo package. Required to run on scratch docker image.
           CGO_ENABLED: '0',

--- a/build/conf.js
+++ b/build/conf.js
@@ -35,7 +35,7 @@ export default {
     /**
      * The name of the Docker image with the application.
      */ 
-    imageName: 'kubernetes/console',
+    imageName: 'kubernetes/dashboard',
   },
 
   /**
@@ -45,7 +45,7 @@ export default {
     /**
      * The name of the root Angular module, i.e., the module that bootstraps the application.
      */
-    rootModuleName: 'kubernetesConsole',
+    rootModuleName: 'kubernetesDashboard',
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "//": "Specification of this file can be found at: https://docs.npmjs.com/files/package.json",
   "//": "When a dependency is not needed it should be removed from the list.",
 
-  "name": "kubernetes-console",
+  "name": "kubernetes-dashboard",
   "version": "0.0.1",
   "devDependencies": {
     "babel": "~5.8.23",

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -15,26 +15,26 @@
 package main
 
 import (
-  "flag"
-  "fmt"
-  "net/http"
+	"flag"
+	"fmt"
+	"net/http"
 
-  "github.com/golang/glog"
-  "github.com/spf13/pflag"
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 )
 
 var (
-  argPort = pflag.Int("port", 8080, "The port to listen to for incomming HTTP requests")
+	argPort = pflag.Int("port", 8080, "The port to listen to for incomming HTTP requests")
 )
 
 func main() {
-  pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-  pflag.Parse()
-  glog.Info("Starting HTTP server on port ", *argPort)
-  defer glog.Flush();
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	glog.Info("Starting HTTP server on port ", *argPort)
+	defer glog.Flush()
 
-  // Run a HTTP server that serves static files from current directory.
-  // TODO(bryk): Disable directory listing.
-  http.Handle("/", http.FileServer(http.Dir("./")))
-  glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
+	// Run a HTTP server that serves static files from current directory.
+	// TODO(bryk): Disable directory listing.
+	http.Handle("/", http.FileServer(http.Dir("./")))
+	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
 }

--- a/src/app/deploy/Dockerfile
+++ b/src/app/deploy/Dockerfile
@@ -27,4 +27,4 @@ ADD . /
 # The port that the application listens on.
 # TODO(bryk): Parametrize this argument so that other build tools are aware of the exposed port.
 EXPOSE 8080
-ENTRYPOINT ["/console"]
+ENTRYPOINT ["/dashboard"]

--- a/src/app/frontend/chrome/chrome.module.js
+++ b/src/app/frontend/chrome/chrome.module.js
@@ -19,7 +19,7 @@ import chromeDirective from './chrome.directive';
  * Angular module containing navigation chrome for the application.
  */
 export default angular.module(
-    'kubernetesConsole.chrome',
+    'kubernetesDashboard.chrome',
     [
       'ngMaterial',
     ])

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -1,18 +1,18 @@
 <!doctype html>
-<html ng-app="kubernetesConsole" ng-strict-di>
+<html ng-app="kubernetesDashboard" ng-strict-di>
   <head>
     <meta charset="utf-8">
-    <title>Kubernetes Console</title>
+    <title>Kubernetes Dashboard</title>
     <meta name="viewport" content="width=device-width">
 
-    <!-- build:css console/vendor.css -->
+    <!-- build:css static/vendor.css -->
     <!-- bower:css -->
     <!-- Bower CSS dependencies are populated here (dev build) and compiled
          into vendor.css (prod build). -->
     <!-- endbower -->
     <!-- endbuild -->
 
-    <!-- build:css console/app.css -->
+    <!-- build:css static/app.css -->
     <!-- inject:css -->
     <!-- Application css files are populated here (dev build) and compiled
          into app.css (prod build). -->
@@ -29,14 +29,14 @@
     <chrome>
       <div ui-view> <!-- Application content is inserted here. --> </div>
     </chrome>
-    <!-- build:js console/vendor.js -->
+    <!-- build:js static/vendor.js -->
     <!-- bower:js -->
     <!-- Bower JS dependencies are populated here (dev build) and compiled
          into vendor.js (prod build). -->
     <!-- endbower -->
     <!-- endbuild -->
 
-    <!-- build:js console/app.js -->
+    <!-- build:js static/app.js -->
     <!-- inject:js -->
     <!-- Application JS files are populated here. -->
     <!-- endinject -->

--- a/src/app/frontend/index.module.js
+++ b/src/app/frontend/index.module.js
@@ -21,7 +21,7 @@ import mainModule from './main/main.module';
 import routeConfig from './index.route';
 
 export default angular.module(
-    'kubernetesConsole',
+    'kubernetesDashboard',
     [
       'ngAnimate',
       'ngAria',

--- a/src/app/frontend/main/main.module.js
+++ b/src/app/frontend/main/main.module.js
@@ -15,5 +15,5 @@
 import stateConfig from './main.state';
 
 
-export default angular.module('kubernetesConsole.main', [])
+export default angular.module('kubernetesDashboard.main', [])
     .config(stateConfig);


### PR DESCRIPTION
This commit changes all occurrences of word "console" to "dashboard".

The rename was required due to collision with an other project.