### PR TITLE
Spawn backend application process on serve task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@ node_modules/
 bower_components/
 
 ## Build and test artifacts
-coverage/
+.go_workspace/
 .sass-cache/
 .tmp/
+coverage/
 dist/
 
 ## IDE specific files

--- a/build/backend.js
+++ b/build/backend.js
@@ -45,7 +45,7 @@ const goBackendDependencies = [
  */
 function spawnGoProcess(args, doneFn, opt_env) {
   let goTask = child.spawn('go', args, {
-    env: lodash.merge(process.env, {GOPATH: conf.paths.backendTmp}, opt_env || {}),
+    env: lodash.merge(process.env, {GOPATH: conf.paths.goWorkspace}, opt_env || {}),
   });
 
   // Call Gulp callback on task exit. This has to be done to make Gulp dependency management
@@ -75,7 +75,7 @@ function spawnGoProcess(args, doneFn, opt_env) {
 gulp.task('backend', ['backend-dependencies'], function(doneFn) {
   spawnGoProcess([
     'build',
-    '-o', path.join(conf.paths.serve, 'dashboard'),
+    '-o', path.join(conf.paths.serve, conf.backend.binaryName),
     path.join(conf.paths.backendSrc, 'dashboard.go'),
   ], doneFn);
 });
@@ -89,7 +89,8 @@ gulp.task('backend', ['backend-dependencies'], function(doneFn) {
  * dependencies inside it and is targeted for Linux.
  */
 gulp.task('backend:prod', ['backend-dependencies'], function(doneFn) {
-  let outputBinaryPath = path.join(conf.paths.dist, 'dashboard');
+  let outputBinaryPath = path.join(conf.paths.dist, conf.backend.binaryName);
+
   // Delete output binary first. This is required because prod build does not override it.
   del(outputBinaryPath)
       .then(function() {

--- a/build/build.js
+++ b/build/build.js
@@ -32,14 +32,8 @@ import conf from './conf';
 
 /**
  * Builds production package and places it in the dist directory.
- *
- * Following steps are done here:
- *  1. Vendor CSS and JS files are concatenated and minified.
- *  2. index.html is minified.
- *  3. CSS and JS assets are suffixed with version hash.
- *  4. Everything is saved in the dist directory.
  */
-gulp.task('build', ['assets', 'backend:prod', 'index:prod'], function () {
+gulp.task('build', ['backend:prod', 'build-frontend'], function () {
   let htmlFilter = gulpFilter('*.html', {restore: true});
   let vendorCssFilter = gulpFilter('**/vendor.css', {restore: true});
   let vendorJsFilter = gulpFilter('**/vendor.js', {restore: true});
@@ -76,6 +70,18 @@ gulp.task('build', ['assets', 'backend:prod', 'index:prod'], function () {
 
 
 /**
+ * Builds production version of the frontend application.
+ *
+ * Following steps are done here:
+ *  1. Vendor CSS and JS files are concatenated and minified.
+ *  2. index.html is minified.
+ *  3. CSS and JS assets are suffixed with version hash.
+ *  4. Everything is saved in the dist directory.
+ */
+gulp.task('build-frontend', ['assets', 'index:prod']);
+
+
+/**
  * Copies assets to the dist directory.
  */
 gulp.task('assets', function () {
@@ -88,5 +94,5 @@ gulp.task('assets', function () {
  * Cleans all build artifacts.
  */
 gulp.task('clean', function () {
-  return del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')]);
+  return del([conf.paths.dist, conf.paths.goWorkspace, conf.paths.tmp]);
 });

--- a/build/conf.js
+++ b/build/conf.js
@@ -29,6 +29,16 @@ const basePath = path.join(__dirname, '../');
  */
 export default {
   /**
+   * Backend application constants.
+   */
+  backend: {
+    /**
+     * The name of the backend binary.
+     */
+    binaryName: 'dashboard',
+  },
+
+  /**
    * Deployment constants configuration.
    */
   deploy: {
@@ -64,6 +74,7 @@ export default {
     externs: path.join(basePath, 'src/app/externs'),
     frontendSrc: path.join(basePath, 'src/app/frontend'),
     frontendTest: path.join(basePath, 'src/test/frontend'),
+    goWorkspace: path.join(basePath, '.go_workspace'),
     integrationTest: path.join(basePath, 'src/test/integration'),
     karmaConf: path.join(basePath, 'build/karma.conf.js'),
     nodeModules: path.join(basePath, 'node_modules'),


### PR DESCRIPTION
This setup autoreloads backend process on source change and ensures that
there is only one process running.

Follow up would be to wire this setup with browser sync to proxy API
calls to the backend.