### PR TITLE
Run test, build and lint checks on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ cache:
 # Use Node.js as primary language because Gulp is the build system used in the project.
 language: node_js
 before_script:
+  # Prepare environment for the Chrome browser.
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
   # Install frontend dependencies to be able to build the project.
   - ./node_modules/.bin/bower install
 
@@ -35,4 +40,4 @@ before_script:
   # Download godep tool and make add it to PATH environment variable.
   - go get github.com/tools/godep
   - export PATH=$PATH:$GOPATH/bin
-script: ./node_modules/.bin/gulp build
+script: ./node_modules/.bin/gulp check

--- a/build/build.js
+++ b/build/build.js
@@ -33,7 +33,19 @@ import conf from './conf';
 /**
  * Builds production package and places it in the dist directory.
  */
-gulp.task('build', ['backend:prod', 'build-frontend'], function () {
+gulp.task('build', ['backend:prod', 'build-frontend']);
+
+
+/**
+ * Builds production version of the frontend application.
+ *
+ * Following steps are done here:
+ *  1. Vendor CSS and JS files are concatenated and minified.
+ *  2. index.html is minified.
+ *  3. CSS and JS assets are suffixed with version hash.
+ *  4. Everything is saved in the dist directory.
+ */
+gulp.task('build-frontend', ['assets', 'index:prod'], function () {
   let htmlFilter = gulpFilter('*.html', {restore: true});
   let vendorCssFilter = gulpFilter('**/vendor.css', {restore: true});
   let vendorJsFilter = gulpFilter('**/vendor.js', {restore: true});
@@ -67,18 +79,6 @@ gulp.task('build', ['backend:prod', 'build-frontend'], function () {
     .pipe(htmlFilter.restore)
     .pipe(gulp.dest(conf.paths.dist));
 });
-
-
-/**
- * Builds production version of the frontend application.
- *
- * Following steps are done here:
- *  1. Vendor CSS and JS files are concatenated and minified.
- *  2. index.html is minified.
- *  3. CSS and JS assets are suffixed with version hash.
- *  4. Everything is saved in the dist directory.
- */
-gulp.task('build-frontend', ['assets', 'index:prod']);
 
 
 /**

--- a/build/check.js
+++ b/build/check.js
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Gulp tasks for checking and validating the code or a commit.
+ */
+import gulp from 'gulp';
+import gulpEslint from 'gulp-eslint';
+import path from 'path';
+
+import conf from './conf';
+
+
+/**
+ * Checks whether codebase is in a state that is ready for submission. This means that code
+ * follows the style guide, it is buildable and all tests pass.
+ *
+ * This task should be used prior to publishing a change.
+ */
+gulp.task('check', ['lint', 'build', 'test', 'integration-test:prod']);
+
+
+/**
+ * Lints all projects code files. This includes frontend source code, as well as, build scripts.
+ */
+gulp.task('lint', function() {
+  // TODO(bryk): Also lint Go files here.
+  return gulp.src([path.join(conf.paths.src, '**/*.js'), path.join(conf.paths.build, '**/*.js')])
+    // Attach lint output to the eslint property of the file.
+    .pipe(gulpEslint())
+    // Output the lint results to the console.
+    .pipe(gulpEslint.format())
+    // Exit with an error code (1) on a lint error.
+    .pipe(gulpEslint.failOnError());
+});

--- a/build/conf.js
+++ b/build/conf.js
@@ -39,11 +39,11 @@ export default {
     /**
      * Name of the main backend package that is used in go build command.
      */
-    packageName: './src/app/backend',
+    packageName: 'app/backend',
     /**
      * Name of the test backend package that is used in go test command.
      */
-    testPackageName: './src/test/backend',
+    testPackageName: 'test/backend',
   },
 
   /**

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -18,18 +18,22 @@
 import child from 'child_process';
 import lodash from 'lodash';
 
+import conf from './conf';
+
 
 /**
  * Spawns Go process wrapped with the Godep command.
  *
  * @param {!Array<string>} args
  * @param {function(?Error=)} doneFn
- * @param {!Object<string, string>=} opt_env Optional environment variables to be concatenated with
- *     default ones.
  */
-export default function spawnGoProcess(args, doneFn, opt_env) {
+export default function spawnGoProcess(args, doneFn) {
+  // Add base directory to the gopath so that local imports work.
+  let sourceGopath = `${process.env.GOPATH}:${conf.paths.base}`;
+  let env = lodash.merge(process.env, {GOPATH: sourceGopath});
+
   let goTask = child.spawn('godep', ['go'].concat(args), {
-    env: lodash.merge(process.env, opt_env || {}),
+    env: env,
   });
 
   // Call Gulp callback on task exit. This has to be done to make Gulp dependency management

--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -62,6 +62,15 @@ export default function(config) {
 
     browsers: ['Chrome'],
 
+    customLaunchers: {
+      // Custom launcher for Travis CI. It is required because Travis environment cannot use
+      // sandbox.
+      chromeTravis: {
+        base: 'Chrome',
+        flags: ['--no-sandbox'],
+      },
+    },
+
     reporters: ['progress'],
 
     preprocessors: {}, // This field is filled with values later.
@@ -92,6 +101,11 @@ export default function(config) {
       moduleName: conf.frontend.moduleName,
     },
   };
+
+  // Use custom browser configuration when running on Travis CI.
+  if (process.env.TRAVIS) {
+    configuration.browsers = ['chromeTravis'];
+  }
 
   // Convert all JS code written ES6 with modules to ES5 bundles that browsers can digest.
   configuration.preprocessors[path.join(conf.paths.frontendTest, '**/*.js')] = ['browserify'];

--- a/build/protractor.conf.js
+++ b/build/protractor.conf.js
@@ -29,11 +29,15 @@ var path = require('path');
  * Schema can be found here: https://github.com/angular/protractor/blob/master/docs/referenceConf.js
  */
 exports.config = {
+  baseUrl: 'http://localhost:3000',
+
   capabilities: {
-    'browserName': 'chrome',
+    // Firefox is used instead of Chrome, because that's what Travis supports best.
+    // The browser that is used in the integration tests should not affect the results, anyway.
+    'browserName': 'firefox',
   },
 
-  baseUrl: 'http://localhost:3000',
+  framework: 'jasmine',
 
   specs: [path.join(conf.paths.integrationTest, '**/*.js')],
 };

--- a/build/script.js
+++ b/build/script.js
@@ -18,7 +18,6 @@
 import gulp from 'gulp';
 import gulpAngularTemplatecache from 'gulp-angular-templatecache';
 import gulpClosureCompiler from 'gulp-closure-compiler';
-import gulpEslint from 'gulp-eslint';
 import gulpMinifyHtml from 'gulp-minify-html';
 import path from 'path';
 import webpackStream from 'webpack-stream';
@@ -133,18 +132,4 @@ gulp.task('angular-templates', function () {
  */
 gulp.task('create-serve-folders', function () {
   return gulp.src('').pipe(gulp.dest(conf.paths.serve));
-});
-
-
-/**
- * Lints all projects code files. This includes frontend source code, as well as, build scripts.
- */
-gulp.task('lint', function () {
-  return gulp.src([path.join(conf.paths.src, '**/*.js'), path.join(conf.paths.build, '**/*.js')])
-    // Attach lint output to the eslint property of the file.
-    .pipe(gulpEslint())
-    // Output the lint results to the console.
-    .pipe(gulpEslint.format())
-    // Exit with an error code (1) on a lint error.
-    .pipe(gulpEslint.failOnError());
 });

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,6 +18,7 @@
  *
  * Learn more at: http://gulpjs.com
  */
+import './build/check';
 import './build/backend';
 import './build/build';
 import './build/deploy';

--- a/src/test/backend/apiserverclient_test.go
+++ b/src/test/backend/apiserverclient_test.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	backend "github.com/dashboard/src/app/backend"
+	backend "app/backend"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"testing"
 )


### PR DESCRIPTION
This change makes it possible to run tests, integration tests and lint
on Travis CI. It also prepares a special Gulp task to perform the same
activities locally. This is handy when, e.g., sending a pull requrest.