### PR TITLE
Update gulp-sass dependency so that it compiles on OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-replace": "~0.5.4",
     "gulp-rev": "~6.0.1",
     "gulp-rev-replace": "~0.4.2",
-    "gulp-sass": "~0.7.1",
+    "gulp-sass": "~2.1.0",
     "gulp-size": "~2.0.0",
     "gulp-sourcemaps": "~1.5.2",
     "gulp-uglify": "~1.3.0",


### PR DESCRIPTION
There was an issue with the package that prevented it from compilation on OSX, see: https://github.com/sass/node-sass/issues/1086