### PR TITLE
Do not serve files from working directory on dev servers

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -77,7 +77,7 @@ gulp.task('build-frontend', ['assets', 'index:prod'], function () {
       quotes: true,
     }))
     .pipe(htmlFilter.restore)
-    .pipe(gulp.dest(conf.paths.dist));
+    .pipe(gulp.dest(conf.paths.distPublic));
 });
 
 
@@ -86,7 +86,7 @@ gulp.task('build-frontend', ['assets', 'index:prod'], function () {
  */
 gulp.task('assets', function () {
   return gulp.src(path.join(conf.paths.assets, '/**/*'), {base: conf.paths.app})
-    .pipe(gulp.dest(conf.paths.dist));
+    .pipe(gulp.dest(conf.paths.distPublic));
 });
 
 

--- a/build/conf.js
+++ b/build/conf.js
@@ -80,6 +80,7 @@ export default {
     build: path.join(basePath, 'build'),
     deploySrc: path.join(basePath, 'src/app/deploy'),
     dist: path.join(basePath, 'dist'),
+    distPublic: path.join(basePath, 'dist/public'),
     externs: path.join(basePath, 'src/app/externs'),
     frontendSrc: path.join(basePath, 'src/app/frontend'),
     frontendTest: path.join(basePath, 'src/test/frontend'),

--- a/build/index.js
+++ b/build/index.js
@@ -43,7 +43,7 @@ function createIndexFile(indexPath) {
 
   let wiredepOptions = {
     // Make wiredep dependencies begin with "bower_components/" not "../../...".
-    ignorePath: path.relative(conf.paths.frontendSrc, conf.paths.base) + '/',
+    ignorePath: path.relative(conf.paths.frontendSrc, conf.paths.base),
   };
 
   return gulp.src(path.join(conf.paths.frontendSrc, 'index.html'))

--- a/build/serve.js
+++ b/build/serve.js
@@ -39,24 +39,36 @@ let runningBackendProcess = null;
 
 
 /**
- * Initializes BrowserSync tool. Files are server from baseDir directory list.
+ * Initializes BrowserSync tool. Files are server from baseDir directory list. When
+ * includeBowerComponents is true, requests for paths starting with '/bower_components' are
+ * routed to bower components directory.
  *
  * @param {!Array<string>|string} baseDir
+ * @param {boolean} includeBowerComponents
  */
-function browserSyncInit(baseDir) {
+function browserSyncInit(baseDir, includeBowerComponents) {
   // Enable custom support for Angular apps, e.g., history management.
   browserSyncInstance.use(browserSyncSpa({
     selector: '[ng-app]',
   }));
 
-  browserSyncInstance.init({
+  let config = {
+    browser: [], // Needed so that the browser does not auto-launch.
+    directory: false, // Disable directory listings.
     // TODO(bryk): Add proxy to the backend here.
     startPath: '/',
     server: {
       baseDir: baseDir,
     },
-    browser: [], // Needed so that the browser does not auto-launch.
-  });
+  };
+
+  if (includeBowerComponents) {
+    config.server.routes = {
+      '/bower_components': conf.paths.bowerComponents,
+    };
+  }
+
+  browserSyncInstance.init(config);
 }
 
 
@@ -68,8 +80,7 @@ function serveDevelopmentMode() {
     conf.paths.serve,
     conf.paths.frontendSrc, // For angular templates to work.
     conf.paths.app, // For assets to work.
-    conf.paths.base, // For bower dependencies to work.
-  ]);
+  ], true);
 }
 
 
@@ -90,7 +101,7 @@ gulp.task('serve', ['index'], serveDevelopmentMode);
  * Serves the application in production mode.
  */
 gulp.task('serve:prod', ['build-frontend'], function () {
-  browserSyncInit(conf.paths.dist);
+  browserSyncInit(conf.paths.distPublic, false);
 });
 
 
@@ -155,4 +166,3 @@ gulp.task('watch', ['index'], function () {
   gulp.watch(path.join(conf.paths.frontendSrc, '**/*.js'), ['scripts']);
   gulp.watch(path.join(conf.paths.backendSrc, '**/*.go'), ['spawn-backend']);
 });
-

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -51,9 +51,9 @@ func main() {
 	// Display Apiserver version. This is just for tests.
 	println("Server API version: " + serverAPIVersion.GoString())
 
-	// Run a HTTP server that serves static files from current directory and handles API calls.
+	// Run a HTTP server that serves static public files from './public' and handles API calls.
 	// TODO(bryk): Disable directory listing.
-	http.Handle("/", http.FileServer(http.Dir("./")))
+	http.Handle("/", http.FileServer(http.Dir("./public")))
 	http.Handle("/api/", createApiHandler())
 	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
 }


### PR DESCRIPTION
After this change local development servers do not serve from the repository root. The reason is that the root contains .git folder which may include confidential information.