### PR TITLE
Proxy API calls to backend when running dev server

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -44,6 +44,10 @@ export default {
      * Name of the test backend package that is used in go test command.
      */
     testPackageName: 'test/backend',
+    /**
+     * Port number of the development server started by Gulp.
+     */
+    devServerPort: 8080,
   },
 
   /**

--- a/build/script.js
+++ b/build/script.js
@@ -32,7 +32,7 @@ import conf from './conf';
  *
  * Only dependencies of root application module are included in the bundle.
  */
-gulp.task('scripts', ['create-serve-folders'], function() {
+gulp.task('scripts', function() {
   let webpackOptions = {
     devtool: 'inline-source-map',
     module: {
@@ -124,12 +124,4 @@ gulp.task('angular-templates', function () {
       module: conf.frontend.rootModuleName,
     }))
     .pipe(gulp.dest(conf.paths.partials));
-});
-
-
-/**
- * Creates {conf.paths.serve} folder.
- */
-gulp.task('create-serve-folders', function () {
-  return gulp.src('').pipe(gulp.dest(conf.paths.serve));
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "karma-sourcemap-loader": "~0.3.6",
     "lodash": "~3.10.1",
     "uglify-save-license": "~0.4.1",
+    "proxy-middleware": "~0.15.0",
     "webpack-stream": "~2.1.1",
     "wiredep": "~2.2.2",
     "wrench": "~1.5.8"


### PR DESCRIPTION
With this change one can run the backend and browser sync at the same
time. All API calls are proxied to the backend.