### PR TITLE
Fix stdio:inherit option for building go code

### DIFF
--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -34,7 +34,8 @@ export default function spawnGoProcess(args, doneFn) {
 
   let goTask = child.spawn('godep', ['go'].concat(args), {
     env: env,
-  }, {stdio: 'inherit'});
+    stdio: 'inherit',
+  });
 
   // Call Gulp callback on task exit. This has to be done to make Gulp dependency management
   // work.

--- a/build/serve.js
+++ b/build/serve.js
@@ -120,7 +120,8 @@ gulp.task('serve:prod', ['build-frontend'], function () {
 gulp.task('spawn-backend', ['backend', 'kill-backend'], function () {
   runningBackendProcess = child.spawn(
       path.join(conf.paths.serve, conf.backend.binaryName),
-      [`--port=${conf.backend.devServerPort}`], {stdio: 'inherit'});
+      [`--port=${conf.backend.devServerPort}`],
+      {stdio: 'inherit'});
 
   runningBackendProcess.on('exit', function() {
     // Mark that there is no backend process running anymore.


### PR DESCRIPTION
Previously it was in the wrong parameter.