### PR TITLE
Implemented existing namespaces handling in deploy form

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -46,6 +46,15 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 			Writes(ReplicaSetList{}))
 	wsContainer.Add(replicaSetListWs)
 
+	namespaceListWs := new(restful.WebService)
+	namespaceListWs.Path("/api/namespace").
+		Produces(restful.MIME_JSON)
+	namespaceListWs.Route(
+		namespaceListWs.GET("").
+			To(apiHandler.handleGetNamespaceList).
+			Writes(NamespacesList{}))
+	wsContainer.Add(namespaceListWs)
+
 	return wsContainer
 }
 
@@ -73,6 +82,19 @@ func (apiHandler *ApiHandler) handleGetReplicaSetList(
 	request *restful.Request, response *restful.Response) {
 
 	result, err := GetReplicaSetList(apiHandler.client)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get namespace list API call.
+func (apiHandler *ApiHandler) handleGetNamespaceList(
+	request *restful.Request, response *restful.Response) {
+
+	result, err := GetNamespaceList(apiHandler.client)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/deploy.go
+++ b/src/app/backend/deploy.go
@@ -37,6 +37,9 @@ type AppDeployment struct {
 
 	// Whether the created service is external.
 	IsExternal bool `json:"isExternal"`
+
+	// Target namespace of the application.
+	Namespace string `json:"namespace"`
 }
 
 // Port mapping for an application deployment.
@@ -79,7 +82,7 @@ func DeployApp(deployment *AppDeployment, client *client.Client) error {
 		},
 	}
 
-	_, err := client.ReplicationControllers(api.NamespaceDefault).Create(replicaSet)
+	_, err := client.ReplicationControllers(deployment.Namespace).Create(replicaSet)
 
 	if err != nil {
 		// TODO(bryk): Roll back created resources in case of error.
@@ -116,7 +119,7 @@ func DeployApp(deployment *AppDeployment, client *client.Client) error {
 			service.Spec.Ports = append(service.Spec.Ports, servicePort)
 		}
 
-		_, err = client.Services(api.NamespaceDefault).Create(service)
+		_, err = client.Services(deployment.Namespace).Create(service)
 
 		// TODO(bryk): Roll back created resources in case of error.
 

--- a/src/app/backend/namespacelist.go
+++ b/src/app/backend/namespacelist.go
@@ -1,0 +1,44 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// List of Namespaces in the cluster.
+type NamespacesList struct {
+	// Unordered list of Namespaces.
+	Namespaces []string `json:"namespaces"`
+}
+
+// Returns a list of all namespaces in the cluster.
+func GetNamespaceList(client *client.Client) (*NamespacesList, error) {
+	list, err := client.Namespaces().List(labels.Everything(), fields.Everything())
+
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceList := &NamespacesList{}
+
+	for _, element := range list.Items {
+		namespaceList.Namespaces = append(namespaceList.Namespaces, element.ObjectMeta.Name)
+	}
+
+	return namespaceList, nil
+}

--- a/src/app/externs/angularresource.js
+++ b/src/app/externs/angularresource.js
@@ -21,6 +21,14 @@
 
 
 /**
+ * @typedef {{
+ *   $promise: !angular.$q.Promise
+ * }}
+ */
+angular.ResourceClass;
+
+
+/**
  * @typedef {function(string):!angular.Resource}
  */
 angular.$resource;
@@ -38,6 +46,7 @@ angular.Resource = function() {};
  * @param {!T} data
  * @param {function(!T)=} opt_callback
  * @param {function(!angular.$http.Response)=} opt_errback
+ * @returns {!angular.ResourceClass}
  */
 angular.Resource.prototype.save = function(data, opt_callback, opt_errback) {};
 
@@ -45,5 +54,15 @@ angular.Resource.prototype.save = function(data, opt_callback, opt_errback) {};
 /**
  * @param {function(!T)=} opt_callback
  * @param {function(!angular.$http.Response)=} opt_errback
+ * @returns {!angular.ResourceClass}
  */
 angular.Resource.prototype.get = function(opt_callback, opt_errback) {};
+
+
+/**
+ * @param {function(!T)=} opt_callback
+ * @param {function(!angular.$http.Response)=} opt_errback
+ * @returns {!angular.ResourceClass}
+ */
+angular.Resource.prototype.query = function(opt_callback, opt_errback) {};
+

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -42,7 +42,8 @@ backendApi.PortMapping;
  *   isExternal: boolean,
  *   name: string,
  *   portMappings: !Array<!backendApi.PortMapping>,
- *   replicas: number
+ *   replicas: number,
+ *   namespace: string
  * }}
  */
 backendApi.AppDeployment;
@@ -70,3 +71,10 @@ backendApi.ReplicaSetList;
  * }}
  */
 backendApi.ReplicaSet;
+
+/**
+ * @typedef {{
+ *   namespaces: !Array<string>
+ * }}
+ */
+backendApi.NamespaceList;

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -56,6 +56,14 @@ limitations under the License.
           </md-select>
         </md-input-container>
       </div>
+      <md-input-container class="md-block">
+        <label>Namespace</label>
+        <md-select ng-model="ctrl.namespace" required>
+          <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
+            {{namespace}}
+          </md-option>
+        </md-select>
+      </md-input-container>
       <md-switch ng-model="ctrl.isExternal" class="md-primary">
         Expose service externally
       </md-switch>

--- a/src/app/frontend/deploy/deploy_controller.js
+++ b/src/app/frontend/deploy/deploy_controller.js
@@ -23,9 +23,10 @@ export default class DeployController {
    * @param {!angular.$resource} $resource
    * @param {!angular.$log} $log
    * @param {!ui.router.$state} $state
+   * @param {!backendApi.NamespaceList} namespaces
    * @ngInject
    */
-  constructor($resource, $log, $state) {
+  constructor($resource, $log, $state, namespaces) {
     /** @export {string} */
     this.name = '';
 
@@ -45,11 +46,23 @@ export default class DeployController {
     /** @export {!Array<!backendApi.PortMapping>} */
     this.portMappings = [this.newEmptyPortMapping_(this.protocols[0])];
 
+    /**
+     * List of available namespaces.
+     * @export {!Array<string>}
+     */
+    this.namespaces = namespaces.namespaces;
+
+    /**
+     * Currently chosen namespace.
+     * @export {(string|undefined)}
+     */
+    this.namespace = this.namespaces.length > 0 ? this.namespaces[0] : undefined;
+
     /** @export {boolean} */
     this.isExternal = false;
 
-    /** @private {!angular.Resource<!backendApi.AppDeployment>} */
-    this.resource_ = $resource('/api/deploy');
+    /** @private {!angular.$resource} */
+    this.resource_ = $resource;
 
     /** @private {!angular.$log} */
     this.log_ = $log;
@@ -76,10 +89,14 @@ export default class DeployController {
       name: this.name,
       portMappings: this.portMappings.filter(this.isPortMappingEmpty_),
       replicas: this.replicas,
+      namespace: this.namespace,
     };
 
+    /** @type {!angular.Resource<!backendApi.AppDeployment>} */
+    let resource = this.resource_('/api/deploy');
+
     this.isDeployInProgress_ = true;
-    this.resource_.save(
+    resource.save(
         deployAppConfig,
         (savedConfig) => {
           this.isDeployInProgress_ = false;

--- a/src/app/frontend/deploy/deploy_state.js
+++ b/src/app/frontend/deploy/deploy_state.js
@@ -26,6 +26,22 @@ export default function stateConfig($stateProvider) {
     controller: DeployController,
     controllerAs: 'ctrl',
     url: '/deploy',
+    resolve: {
+      namespaces: resolveNamespaces,
+    },
     templateUrl: 'deploy/deploy.html',
   });
+
+  /**
+   * Resolves namespaces for the deploy view.
+   *
+   * @param {!angular.$resource} $resource
+   * @ngInject
+   */
+  function resolveNamespaces($resource) {
+    /** @type {!angular.Resource<!backendApi.NamespaceList>} */
+    let resource = $resource('/api/namespace');
+
+    return resource.get().$promise;
+  }
 }


### PR DESCRIPTION
Connected to #73 issue. Added:
- backend API to retrieve available namespaces
- frontend namespace field in deploy form
- backend handling of chosen namespace, it will be assigned to created services and replication controllers

New namespace creation from deploy form is still missing.
