### PR TITLE
simplified gulp scripts

### DIFF
--- a/build/deploy.js
+++ b/build/deploy.js
@@ -47,7 +47,7 @@ function spawnDockerProcess(args, doneFn) {
  *
  * In order to run the image on a Kubernates cluster, it has to be deployed to a registry.
  */
-gulp.task('docker-image', ['docker-file'], function(doneFn) {
+gulp.task('docker-image', ['build', 'docker-file'], function(doneFn) {
   spawnDockerProcess([
     'build',
     // Remove intermediate containers after a successful build.

--- a/build/serve.js
+++ b/build/serve.js
@@ -97,13 +97,13 @@ function serveDevelopmentMode() {
  * Serves the application in development mode. Watches for changes in the source files to rebuild
  * development artifacts.
  */
-gulp.task('serve:watch', ['spawn-backend', 'watch'], serveDevelopmentMode);
+gulp.task('serve', ['spawn-backend', 'watch'], serveDevelopmentMode);
 
 
 /**
  * Serves the application in development mode.
  */
-gulp.task('serve', ['spawn-backend', 'index'], serveDevelopmentMode);
+gulp.task('serve:nowatch', ['spawn-backend', 'index'], serveDevelopmentMode);
 
 
 /**

--- a/build/test.js
+++ b/build/test.js
@@ -130,7 +130,7 @@ gulp.task('backend-test:watch', ['backend-test'], function() {
 /**
  * Runs application integration tests. Uses development version of the application.
  */
-gulp.task('integration-test', ['serve', 'webdriver-update'], runProtractorTests);
+gulp.task('integration-test', ['serve:nowatch', 'webdriver-update'], runProtractorTests);
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "scripts": {
+    "postinstall": "./node_modules/.bin/bower install"
   }
 }


### PR DESCRIPTION
I made three small changes. These are intended to make working with the scripts more convenient.

1. 'bower install' called implicitly from 'npm install'. (Copied from Angular-Seed project.)

2. added dependency from docker-image to build. This is needed to avoid empty docker image after 'gulp clean'

3. Renamed serve tasks: 'serve:watch' -> 'serve' and 'serve' -> 'serve:nowatch'. Reason: for development serving with watch is default choice. The name for this task should be short and obvious.