### PR TITLE
Connect replica set list and detail views

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -40,6 +40,11 @@ gulp.task('scripts', function() {
       loaders: [{test: /\.js$/, exclude: /node_modules/, loaders: ['babel-loader']}],
     },
     output: {filename: 'app-dev.js'},
+    resolve: {
+      // Set the module resolve root, so that webpack knows how to process non-relative imports.
+      // Should be kept in sync with respective Closure Compiler option.
+      root: conf.paths.frontendSrc,
+    },
     quiet: true,
   };
 

--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -27,7 +27,7 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 	wsContainer := restful.NewContainer()
 
 	deployWs := new(restful.WebService)
-	deployWs.Path("/api/deploy").
+	deployWs.Path("/api/appdeployments").
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 	deployWs.Route(
@@ -38,7 +38,7 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 	wsContainer.Add(deployWs)
 
 	replicaSetListWs := new(restful.WebService)
-	replicaSetListWs.Path("/api/replicaset").
+	replicaSetListWs.Path("/api/replicasets").
 		Produces(restful.MIME_JSON)
 	replicaSetListWs.Route(
 		replicaSetListWs.GET("").
@@ -47,7 +47,7 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 	wsContainer.Add(replicaSetListWs)
 
 	namespaceListWs := new(restful.WebService)
-	namespaceListWs.Path("/api/namespace").
+	namespaceListWs.Path("/api/namespaces").
 		Produces(restful.MIME_JSON)
 	namespaceListWs.Route(
 		namespaceListWs.GET("").

--- a/src/app/frontend/deploy/deploy_controller.js
+++ b/src/app/frontend/deploy/deploy_controller.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as zerostate} from 'zerostate/zerostate_state';
+import {stateName as replicasetliststate} from 'replicasetlist/replicasetlist_state';
+
 
 /**
  * Controller for the deploy view.
@@ -93,7 +96,7 @@ export default class DeployController {
     };
 
     /** @type {!angular.Resource<!backendApi.AppDeployment>} */
-    let resource = this.resource_('/api/deploy');
+    let resource = this.resource_('/api/appdeployments');
 
     this.isDeployInProgress_ = true;
     resource.save(
@@ -101,7 +104,7 @@ export default class DeployController {
         (savedConfig) => {
           this.isDeployInProgress_ = false;
           this.log_.info('Successfully deployed application: ', savedConfig);
-          this.state_.go('replicasetlist');
+          this.state_.go(replicasetliststate);
         },
         (err) => {
           this.isDeployInProgress_ = false;
@@ -123,7 +126,7 @@ export default class DeployController {
    * @export
    */
   cancel() {
-    this.state_.go('zero');
+    this.state_.go(zerostate);
   }
 
   /**

--- a/src/app/frontend/deploy/deploy_state.js
+++ b/src/app/frontend/deploy/deploy_state.js
@@ -15,6 +15,10 @@
 import DeployController from './deploy_controller';
 
 
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'deploy';
+
+
 /**
  * Configures states for the deploy view.
  *
@@ -22,7 +26,7 @@ import DeployController from './deploy_controller';
  * @ngInject
  */
 export default function stateConfig($stateProvider) {
-  $stateProvider.state('deploy', {
+  $stateProvider.state(stateName, {
     controller: DeployController,
     controllerAs: 'ctrl',
     url: '/deploy',
@@ -40,7 +44,7 @@ export default function stateConfig($stateProvider) {
    */
   function resolveNamespaces($resource) {
     /** @type {!angular.Resource<!backendApi.NamespaceList>} */
-    let resource = $resource('/api/namespace');
+    let resource = $resource('/api/namespaces');
 
     return resource.get().$promise;
   }

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -15,5 +15,6 @@ limitations under the License.
 -->
 
 <div layout="row" layout-margin layout-align="center center">
-  TODO(bryk): Page content goes here.
+  Displaying details for replica set {{ctrl.stateParams.replicaSet}} in namespace
+  {{ctrl.stateParams.namespace}}.
 </div>

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -20,10 +20,13 @@
  */
 export default class ReplicaSetDetailController {
   /**
-   * @param {!angular.$log} $log
+   * @param {!./replicasetdetail_state.StateParams} $stateParams
    * @ngInject
    */
-  constructor($log) {
-    $log.info('TODO(bryk): this controller should do something');
+  constructor($stateParams) {
+    /**
+     * @export {!./replicasetdetail_state.StateParams}
+     */
+    this.stateParams = $stateParams;
   }
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail_state.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_state.js
@@ -15,6 +15,31 @@
 import ReplicaSetDetailController from './replicasetdetail_controller';
 
 
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'replicasetdetail';
+
+
+/**
+ * Parameters for this state.
+ *
+ * All properties are @exported and in sync with URL param names.
+ * @final
+ */
+export class StateParams {
+  /**
+   * @param {string} namespace
+   * @param {string} replicaSet
+   */
+  constructor(namespace, replicaSet) {
+    /** @export {string} Namespace of this Replica Set. */
+    this.namespace = namespace;
+
+    /** @export {string} Name of this Replica Set. */
+    this.replicaSet = replicaSet;
+  }
+}
+
+
 /**
  * Configures states for the service view.
  *
@@ -22,10 +47,10 @@ import ReplicaSetDetailController from './replicasetdetail_controller';
  * @ngInject
  */
 export default function stateConfig($stateProvider) {
-  $stateProvider.state('replicasetdetail', {
+  $stateProvider.state(stateName, {
     controller: ReplicaSetDetailController,
     controllerAs: 'ctrl',
-    url: '/replicasetdetail',
+    url: '/replicasets/:namespace/:replicaSet',
     templateUrl: 'replicasetdetail/replicasetdetail.html',
   });
 }

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -17,9 +17,11 @@ limitations under the License.
 <div layout="row" layout-wrap layout-margin layout-align="center center">
   <md-card ng-repeat="replicaSet in ctrl.replicaSets">
     <md-card-content class="kd-replicaset-card">
-      <div layout="row" layout-align="space-between start">
+      <div layout="row" layout-align="space-between center">
         <div flex layout="column">
-          <div flex>{{replicaSet.name}}</div>
+          <a ng-href="{{ctrl.getReplicaSetDetailHref(replicaSet)}}" flex>
+            {{replicaSet.name}}
+          </a>
           <div flex class="md-caption">
             <span ng-repeat="(label, value) in replicaSet.labels"
                 class="kd-replicaset-card-label">
@@ -27,7 +29,7 @@ limitations under the License.
             </span>
           </div>
         </div>
-        <md-button flex="initial" class="md-icon-button kd-replicaset-card-menu">
+        <md-button flex="none" class="md-icon-button">
           <md-icon md-font-library="material-icons">more_vert</md-icon>
         </md-button>
       </div>

--- a/src/app/frontend/replicasetlist/replicasetlist.scss
+++ b/src/app/frontend/replicasetlist/replicasetlist.scss
@@ -21,11 +21,6 @@
   text-decoration: none;
 }
 
-.kd-replicaset-card-logs {
-  color: inherit;
-  text-decoration: none;
-}
-
 .kd-replicaset-card-logs:after {
   content: '\25BC';
 }

--- a/src/app/frontend/replicasetlist/replicasetlist_controller.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_controller.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {StateParams} from 'replicasetdetail/replicasetdetail_state';
+import {stateName} from 'replicasetdetail/replicasetdetail_state';
+
 
 /**
  * Controller for the replica set list view.
@@ -22,11 +25,15 @@ export default class ReplicaSetListController {
   /**
    * @param {!angular.$log} $log
    * @param {!angular.$resource} $resource
+   * @param {!ui.router.$state} $state
    * @ngInject
    */
-  constructor($log, $resource) {
+  constructor($log, $resource, $state) {
     /** @export {!Array<backendApi.ReplicaSet>} */
     this.replicaSets = [];
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
 
     this.initialize_($log, $resource);
   }
@@ -38,7 +45,7 @@ export default class ReplicaSetListController {
    */
   initialize_($log, $resource) {
     /** @type {!angular.Resource<!backendApi.ReplicaSetList>} */
-    let resource = $resource('/api/replicaset');
+    let resource = $resource('/api/replicasets');
 
     resource.get((replicaSetList) => {
       $log.info('Successfully fetched Replica Set list: ', replicaSetList);
@@ -46,5 +53,15 @@ export default class ReplicaSetListController {
     }, (err) => {
       $log.error('Error fetching Replica Set list: ', err);
     });
+  }
+
+  /**
+   * @param {!backendApi.ReplicaSet} replicaSet
+   * @return {string}
+   * @export
+   */
+  getReplicaSetDetailHref(replicaSet) {
+    // TODO(bryk): Set proper namespace here.
+    return this.state_.href(stateName, new StateParams('default', replicaSet.name));
   }
 }

--- a/src/app/frontend/replicasetlist/replicasetlist_state.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_state.js
@@ -15,6 +15,10 @@
 import ReplicaSetListController from './replicasetlist_controller';
 
 
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'replicasets';
+
+
 /**
  * Configures states for the service view.
  *
@@ -22,10 +26,10 @@ import ReplicaSetListController from './replicasetlist_controller';
  * @ngInject
  */
 export default function stateConfig($stateProvider) {
-  $stateProvider.state('replicasetlist', {
+  $stateProvider.state(stateName, {
     controller: ReplicaSetListController,
     controllerAs: 'ctrl',
-    url: '/replicasetlist',
+    url: '/replicasets',
     templateUrl: 'replicasetlist/replicasetlist.html',
   });
 }

--- a/src/app/frontend/zerostate/zerostate_state.js
+++ b/src/app/frontend/zerostate/zerostate_state.js
@@ -15,6 +15,10 @@
 import ZeroStateController from './zerostate_controller';
 
 
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'zero';
+
+
 /**
  * Configures states for the zero state view.
  *
@@ -22,7 +26,7 @@ import ZeroStateController from './zerostate_controller';
  * @ngInject
  */
 export default function stateConfig($stateProvider) {
-  $stateProvider.state('zero', {
+  $stateProvider.state(stateName, {
     controller: ZeroStateController,
     controllerAs: 'ctrl',
     url: '/',


### PR DESCRIPTION
This change connects replica set list and detail views and applies
RESTful conventions to the API.

Now API and app URLs follow RESTful API conventions. This change is also
an example of how views hould be connected. See state params and state
name exports.