### PR TITLE
Replica set list: handle endpoints and descirption

### DIFF
--- a/build/backend.js
+++ b/build/backend.js
@@ -26,7 +26,7 @@ import goCommand from './gocommand';
  * Compiles backend application in development mode and places the binary in the serve
  * directory.
  */
-gulp.task('backend', function(doneFn) {
+gulp.task('backend', ['package-backend-source'], function(doneFn) {
   goCommand(
       [
         'build',
@@ -46,7 +46,7 @@ gulp.task('backend', function(doneFn) {
  * The production binary difference from development binary is only that it contains all
  * dependencies inside it and is targeted for Linux.
  */
-gulp.task('backend:prod', function(doneFn) {
+gulp.task('backend:prod', ['package-backend-source'], function(doneFn) {
   let outputBinaryPath = path.join(conf.paths.dist, conf.backend.binaryName);
 
   // Delete output binary first. This is required because prod build does not override it.
@@ -71,4 +71,17 @@ gulp.task('backend:prod', function(doneFn) {
                 });
           },
           function(error) { doneFn(error); });
+});
+
+/**
+ * Moves all backend source files (app and tests) to a temporary package directory where it can be
+ * applied go commands.
+ *
+ * This is required to consolidate test and app files into single directories and to make packaging
+ * work.
+ */
+gulp.task('package-backend-source', function() {
+  return gulp
+      .src([path.join(conf.paths.backendSrc, '**/*'), path.join(conf.paths.backendTest, '**/*')])
+      .pipe(gulp.dest(conf.paths.backendTmpSrc));
 });

--- a/build/conf.js
+++ b/build/conf.js
@@ -37,11 +37,7 @@ export default {
     /**
      * Name of the main backend package that is used in go build command.
      */
-    packageName: 'app/backend',
-    /**
-     * Name of the test backend package that is used in go test command.
-     */
-    testPackageName: 'test/backend',
+    packageName: 'github.com/kubernetes/dashboard',
     /**
      * Port number of the backend server. Only used during development.
      */
@@ -86,6 +82,7 @@ export default {
     backendSrc: path.join(basePath, 'src/app/backend'),
     backendTest: path.join(basePath, 'src/test/backend'),
     backendTmp: path.join(basePath, '.tmp/backend'),
+    backendTmpSrc: path.join(basePath, '.tmp/backend/src/github.com/kubernetes/dashboard'),
     bowerComponents: path.join(basePath, 'bower_components'),
     build: path.join(basePath, 'build'),
     deploySrc: path.join(basePath, 'src/app/deploy'),

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -21,7 +21,8 @@ import lodash from 'lodash';
 import conf from './conf';
 
 /**
- * Spawns Go process wrapped with the Godep command.
+ * Spawns Go process wrapped with the Godep command. Backend source files must me packaged with
+ * 'package-backend-source' task before running this command.
  *
  * @param {!Array<string>} args
  * @param {function(?Error=)} doneFn
@@ -33,7 +34,7 @@ export default function spawnGoProcess(args, doneFn) {
     return;
   }
 
-  let sourceGopath = `${process.env.GOPATH}:${conf.paths.base}`;
+  let sourceGopath = `${process.env.GOPATH}:${conf.paths.backendTmp}`;
   let env = lodash.merge(process.env, {GOPATH: sourceGopath});
 
   let goTask = child.spawn('godep', ['go'].concat(args), {

--- a/build/test.js
+++ b/build/test.js
@@ -28,7 +28,7 @@ import goCommand from './gocommand';
  * @param {boolean} singleRun
  * @param {function(?Error=)} doneFn
  */
-function runUnitTests(singleRun, doneFn) {
+function runFrontendUnitTests(singleRun, doneFn) {
   let localConfig = {
     configFile: conf.paths.karmaConf,
     singleRun: singleRun,
@@ -39,18 +39,6 @@ function runUnitTests(singleRun, doneFn) {
     doneFn(failCount ? new Error(`Failed ${failCount} tests.`) : undefined);
   });
   server.start();
-}
-
-/**
- * @param {function(?Error=)} doneFn
- */
-function runBackendTests(doneFn) {
-  goCommand(
-      [
-        'test',
-        conf.backend.testPackageName,
-      ],
-      doneFn);
 }
 
 /**
@@ -86,12 +74,19 @@ gulp.task('test', ['frontend-test', 'backend-test']);
 /**
  * Runs once all unit tests of the frontend application.
  */
-gulp.task('frontend-test', function(doneFn) { runUnitTests(true, doneFn); });
+gulp.task('frontend-test', function(doneFn) { runFrontendUnitTests(true, doneFn); });
 
 /**
  * Runs once all unit tests of the backend application.
  */
-gulp.task('backend-test', runBackendTests);
+gulp.task('backend-test', ['package-backend-source'], function(doneFn) {
+  goCommand(
+      [
+        'test',
+        conf.backend.packageName,
+      ],
+      doneFn);
+});
 
 /**
  * Runs all unit tests of the application. Watches for changes in the source files to rerun
@@ -103,7 +98,7 @@ gulp.task('test:watch', ['frontend-test:watch', 'backend-test:watch']);
  * Runs frontend backend application tests. Watches for changes in the source files to rerun
  * the tests.
  */
-gulp.task('frontend-test:watch', function(doneFn) { runUnitTests(false, doneFn); });
+gulp.task('frontend-test:watch', function(doneFn) { runFrontendUnitTests(false, doneFn); });
 
 /**
  * Runs backend application tests. Watches for changes in the source files to rerun

--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -62,7 +62,7 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 	namespacesWs.Route(
 		namespacesWs.GET("").
 			To(apiHandler.handleGetNamespaces).
-			Writes(NamespacesList{}))
+			Writes(NamespaceList{}))
 	wsContainer.Add(namespacesWs)
 
 	logsWs := new(restful.WebService)

--- a/src/app/backend/namespaces.go
+++ b/src/app/backend/namespaces.go
@@ -28,7 +28,7 @@ type NamespaceSpec struct {
 }
 
 // List of Namespaces in the cluster.
-type NamespacesList struct {
+type NamespaceList struct {
 	// Unordered list of Namespaces.
 	Namespaces []string `json:"namespaces"`
 }
@@ -47,14 +47,14 @@ func CreateNamespace(spec *NamespaceSpec, client *client.Client) error {
 }
 
 // Returns a list of all namespaces in the cluster.
-func GetNamespaceList(client *client.Client) (*NamespacesList, error) {
+func GetNamespaceList(client *client.Client) (*NamespaceList, error) {
 	list, err := client.Namespaces().List(labels.Everything(), fields.Everything())
 
 	if err != nil {
 		return nil, err
 	}
 
-	namespaceList := &NamespacesList{}
+	namespaceList := &NamespaceList{}
 
 	for _, element := range list.Items {
 		namespaceList.Namespaces = append(namespaceList.Namespaces, element.ObjectMeta.Name)

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -38,6 +38,7 @@ backendApi.PortMapping;
  *   containerImage: string,
  *   isExternal: boolean,
  *   name: string,
+ *   description: string,
  *   portMappings: !Array<!backendApi.PortMapping>,
  *   replicas: number,
  *   namespace: string

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -18,7 +18,7 @@ limitations under the License.
   <md-whiteframe class="kd-deploy-whiteframe md-whiteframe-5dp" flex flex-gt-md>
     <h3 class="md-headline">Deploy a Containerized App</h3>
     <form ng-submit="ctrl.deploy()">
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>App name</label>
         <input ng-model="ctrl.name" required>
       </md-input-container>
@@ -30,24 +30,24 @@ limitations under the License.
           Upload a YAML or JSON file
         </md-radio-button>
       </md-radio-group>
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>Container image</label>
         <input ng-model="ctrl.containerImage" required>
       </md-input-container>
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>Number of pods</label>
         <input ng-model="ctrl.replicas" type="number" required min="1">
       </md-input-container>
       <div layout="row" ng-repeat="portMapping in ctrl.portMappings">
-        <md-input-container class="md-block">
+        <md-input-container flex>
           <label>Port</label>
           <input ng-model="portMapping.port" type="number" min="0">
         </md-input-container>
-        <md-input-container class="md-block">
+        <md-input-container flex>
           <label>Target port</label>
           <input ng-model="portMapping.targetPort" type="number" min="0">
         </md-input-container>
-        <md-input-container class="md-block">
+        <md-input-container flex="none">
           <label>Protocol</label>
           <md-select ng-model="portMapping.protocol" required>
             <md-option ng-repeat="protocol in ctrl.protocols" ng-value="protocol">
@@ -56,7 +56,7 @@ limitations under the License.
           </md-select>
         </md-input-container>
       </div>
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>Namespace</label>
         <md-select ng-model="ctrl.namespace" required>
           <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
@@ -70,6 +70,10 @@ limitations under the License.
       <md-switch ng-model="ctrl.isExternal" class="md-primary">
         Expose service externally
       </md-switch>
+      <md-input-container>
+        <label>Description (optional)</label>
+        <textarea ng-model="ctrl.description"></textarea>
+      </md-input-container>
       <md-button class="md-raised md-primary" type="submit" ng-disabled="ctrl.isDeployDisabled()">
         Deploy
       </md-button>

--- a/src/app/frontend/deploy/deploy_controller.js
+++ b/src/app/frontend/deploy/deploy_controller.js
@@ -40,6 +40,9 @@ export default class DeployController {
     /** @export {number} */
     this.replicas = 1;
 
+    /** @export {string} */
+    this.description = '';
+
     /**
      * List of supported protocols.
      * TODO(bryk): Do not hardcode the here, move to backend.
@@ -94,6 +97,7 @@ export default class DeployController {
       containerImage: this.containerImage,
       isExternal: this.isExternal,
       name: this.name,
+      description: this.description,
       portMappings: this.portMappings.filter(this.isPortMappingEmpty_),
       replicas: this.replicas,
       namespace: this.namespace,

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -15,17 +15,17 @@ limitations under the License.
 -->
 
 <div layout="row" layout-wrap layout-margin layout-align="center center">
-  <md-card ng-repeat="replicaSet in ctrl.replicaSets">
+  <md-card ng-repeat="replicaSet in ::ctrl.replicaSets">
     <md-card-content class="kd-replicaset-card">
       <div layout="row" layout-align="space-between center">
         <div flex layout="column">
-          <a ng-href="{{ctrl.getReplicaSetDetailHref(replicaSet)}}" flex>
-            {{replicaSet.name}}
+          <a ng-href="{{::ctrl.getReplicaSetDetailHref(replicaSet)}}" flex>
+            {{::replicaSet.name}}
           </a>
           <div flex class="md-caption">
-            <span ng-repeat="(label, value) in replicaSet.labels"
+            <span ng-repeat="(label, value) in ::replicaSet.labels"
                 class="kd-replicaset-card-label">
-              {{label}}:{{value}}
+              {{::label}}:{{::value}}
             </span>
           </div>
         </div>
@@ -36,50 +36,56 @@ limitations under the License.
       <div class="md-caption">
         <div layout="row">
           <span flex="60">
-            {{replicaSet.podsRunning}} pods running, {{replicaSet.podsPending}} pending
+            {{::replicaSet.podsRunning}} pods running, {{::replicaSet.podsPending}} pending
           </span>
           <a flex="40" href="#" class="kd-replicaset-card-logs">Logs</a>
         </div>
         <hr class="kd-replicaset-card-divider"></hr>
         <div layout="row" layout-wrap>
-          <div ng-if="replicaSet.description" flex="100" layout="column"
+          <div ng-if="::replicaSet.description" flex="100" layout="column"
               class="kd-replicaset-card-section">
             <span flex>Description</span>
             <div flex>
-              {{replicaSet.description}}
+              {{::replicaSet.description}}
             </div>
           </div>
 
           <div flex="60" layout="column" class="kd-replicaset-card-section">
             <span flex>Image</span>
             <div flex>
-              <div ng-repeat="image in replicaSet.containerImages"
+              <div ng-repeat="image in ::replicaSet.containerImages track by $index"
                   class="kd-replicaset-card-section-image">
-                {{image}}
+                {{::image}}
               </div>
             </div>
           </div>
 
           <div flex="40" layout="column" class="kd-replicaset-card-section">
             <span flex="initial">Creation time</span>
-            <span flex>{{replicaSet.creationTime}}</span>
+            <span flex>{{::replicaSet.creationTime}}</span>
           </div>
 
           <div flex="60" layout="column" class="kd-replicaset-card-section">
             <span flex="initial">Internal Endpoint</span>
             <div flex>
-              <span ng-repeat="endpoint in replicaSet.internalEndpoints">
-                {{endpoint}}
-              </span>
+              <div ng-repeat="endpoint in ::replicaSet.internalEndpoints track by $index">
+                {{::endpoint}}
+              </div>
+              <div ng-if="::!replicaSet.internalEndpoints.length">
+                none
+              </div>
             </div>
           </div>
 
           <div flex="40" layout="column" class="kd-replicaset-card-section">
             <span flex="initial">External Endpoint</span>
             <div flex>
-              <span ng-repeat="endpoint in replicaSet.externalEndpoints">
-                {{endpoint}}
-              </span>
+              <div ng-repeat="endpoint in ::replicaSet.externalEndpoints track by $index">
+                <a ng-href="http://{{::endpoint}}" target="_blank">{{::endpoint}}</a>
+              </div>
+              <div ng-if="::!replicaSet.externalEndpoints.length">
+                none
+              </div>
             </div>
           </div>
         </div>

--- a/src/test/backend/apiserverclient_test.go
+++ b/src/test/backend/apiserverclient_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	backend "app/backend"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"testing"
 )
@@ -34,14 +33,14 @@ func (FakeClientFactory) NewInCluster() (*client.Client, error) {
 }
 
 func TestCreateApiserverClient_inCluster(t *testing.T) {
-	client, _ := backend.CreateApiserverClient("", new(FakeClientFactory))
+	client, _ := CreateApiserverClient("", new(FakeClientFactory))
 	if client != fakeInClusterClient {
 		t.Fatal("Expected in cluster client to be created")
 	}
 }
 
 func TestCreateApiserverClient_remote(t *testing.T) {
-	client, _ := backend.CreateApiserverClient("http://foo:bar", new(FakeClientFactory))
+	client, _ := CreateApiserverClient("http://foo:bar", new(FakeClientFactory))
 	if client != fakeRemoteClient {
 		t.Fatal("Expected remote client to be created")
 	}

--- a/src/test/backend/replicasetlist_test.go
+++ b/src/test/backend/replicasetlist_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	// TODO(bryk): Write tests here.
+	isServiceMatchingReplicaSet(nil, nil)
+}


### PR DESCRIPTION
This change handles replica set description end-to-end: saving in on the
deploy form and then displaying. It also handles replica set endpoints.


I also attempted to write tests for the go code, but this change grew
too much, because I had to change golang packaging setup. This was required to access private functions inside go tests and have proper package names. I'll do the tests later.