### PR TITLE
Added go environment prerequisite checks, godep is now installed via npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bower_components/
 coverage/
 dist/
 kubernetes/
+.tools/
 
 ## IDE specific files
 # IntelliJ

--- a/build/conf.js
+++ b/build/conf.js
@@ -91,6 +91,7 @@ export default {
     externs: path.join(basePath, 'src/app/externs'),
     frontendSrc: path.join(basePath, 'src/app/frontend'),
     frontendTest: path.join(basePath, 'src/test/frontend'),
+    goTools: path.join(basePath, '.tools/go'),
     goWorkspace: path.join(basePath, '.go_workspace'),
     integrationTest: path.join(basePath, 'src/test/integration'),
     karmaConf: path.join(basePath, 'build/karma.conf.js'),

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -17,38 +17,109 @@
  */
 import child from 'child_process';
 import lodash from 'lodash';
+import q from 'q';
 
 import conf from './conf';
 
+// Add base directory to the gopath so that local imports work.
+const sourceGopath = `${conf.paths.backendTmp}`;
+// Add the project's required go tools to the PATH.
+const devPath = `${process.env.PATH}:${conf.paths.goTools}/bin`;
+
 /**
- * Spawns Go process wrapped with the Godep command. Backend source files must me packaged with
- * 'package-backend-source' task before running this command.
+ * The environment needed for the execution of any go command.
+ */
+const env = lodash.merge(process.env, {GOPATH: sourceGopath, PATH: devPath});
+
+/**
+ * Spawns a Go process wrapped with the Godep command after making sure all GO prerequisites are
+ * present. Backend source files must be packaged with 'package-backend-source' task before running
+ * this command.
  *
- * @param {!Array<string>} args
- * @param {function(?Error=)} doneFn
+ * @param {!Array<string>} args - Arguments of the go command.
+ * @param {function(?Error=)} doneFn - Callback.
  */
 export default function spawnGoProcess(args, doneFn) {
-  // Add base directory to the gopath so that local imports work.
-  if (!process.env.GOPATH) {
-    doneFn(new Error('GOPATH is not set. Go process will not be spawned.'));
-    return;
-  }
+  checkPrerequisites().then(() => spawnProcess(args)).then(doneFn).fail((error) => doneFn(error));
+}
 
-  let sourceGopath = `${process.env.GOPATH}:${conf.paths.backendTmp}`;
-  let env = lodash.merge(process.env, {GOPATH: sourceGopath});
+/**
+ * Checks if all prerequisites for a go-command execution are present.
+ * @return {Q.Promise} A promise object.
+ */
+function checkPrerequisites() {
+  return checkGo().then(checkGodep);
+}
 
+/**
+ * Checks if go is on the PATH prior to a go command execution, promises an error otherwise.
+ * @return {Q.Promise} A promise object.
+ */
+function checkGo() {
+  let deferred = q.defer();
+  child.exec(
+      'which go',
+      {
+        env: env,
+      },
+      function(error, stdout, stderror) {
+        if (error || stderror || !stdout) {
+          deferred.reject(
+              new Error(
+                  'Go is not on the path. Please pass the PATH variable when you run ' +
+                  'the gulp task with "PATH=$PATH" or install go if you have not yet.'));
+          return;
+        }
+        deferred.resolve();
+      });
+  return deferred.promise;
+}
+
+/**
+ * Checks if godep is on the PATH prior to a go command execution, promises an error otherwise.
+ * @return {Q.Promise} A promise object.
+ */
+function checkGodep() {
+  let deferred = q.defer();
+  child.exec(
+      'which godep',
+      {
+        env: env,
+      },
+      function(error, stdout, stderror) {
+        if (error || stderror || !stdout) {
+          deferred.reject(
+              new Error(
+                  'Godep is not on the path. ' +
+                  'Please run "npm install" in the base directory of the project.'));
+          return;
+        }
+        deferred.resolve();
+      });
+  return deferred.promise;
+}
+
+/**
+ * Spawns Go process wrapped with the Godep command.
+ * Promises an error if the go command process fails.
+ *
+ * @param {!Array<string>} args - Arguments of the go command.
+ * @return {Q.Promise} A promise object.
+ */
+function spawnProcess(args) {
+  let deferred = q.defer();
   let goTask = child.spawn('godep', ['go'].concat(args), {
     env: env,
     stdio: 'inherit',
   });
-
   // Call Gulp callback on task exit. This has to be done to make Gulp dependency management
   // work.
   goTask.on('exit', function(code) {
-    if (code === 0) {
-      doneFn();
-    } else {
-      doneFn(new Error(`Go command error, code: ${code}`));
+    if (code !== 0) {
+      deferred.reject(Error(`Go command error, code: ${code}`));
+      return;
     }
+    deferred.resolve();
   });
+  return deferred.promise;
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "uglify-save-license": "~0.4.1",
     "path-exists": "~2.1.0",
     "proxy-middleware": "~0.15.0",
+    "q": "~1.4.1",
     "request": "~2.65.0",
     "run-sequence": "~1.1.5",
     "vinyl-source-stream": "1.1.0",
@@ -68,6 +69,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower install"
+    "postinstall": "./node_modules/.bin/bower install",
+    "postinstall": "export GOPATH=`pwd`/.tools/go && go get github.com/tools/godep"
   }
 }


### PR DESCRIPTION
Added additional checks of the prerequisites to executing the go command in dashboard. This includes:

* check if go is on the PATH (if not, probably the user ran with sudo and didn't pass his path with PATH=$PATH)
* check if godep is on the PATH
* from now on, running npm install also installs godep as a local project dependency (under /tools/go)

@bryk PTAL