### PR TITLE
Backend api for replica set pods (pod contains containers)

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -48,6 +48,10 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 		replicaSetWs.GET("/{namespace}/{replicaSet}").
 			To(apiHandler.handleGetReplicaSetDetail).
 			Writes(ReplicaSetDetail{}))
+	replicaSetWs.Route(
+		replicaSetWs.GET("/pods/{namespace}/{replicaSet}").
+			To(apiHandler.handleGetReplicaSetPods).
+			Writes(ReplicaSetPods{}))
 	wsContainer.Add(replicaSetWs)
 
 	namespacesWs := new(restful.WebService)
@@ -125,6 +129,21 @@ func (apiHandler *ApiHandler) handleGetReplicaSetDetail(
 	namespace := request.PathParameter("namespace")
 	replicaSet := request.PathParameter("replicaSet")
 	result, err := GetReplicaSetDetail(apiHandler.client, namespace, replicaSet)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get Replica Set Pods API call.
+func (apiHandler *ApiHandler) handleGetReplicaSetPods(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	replicaSet := request.PathParameter("replicaSet")
+	result, err := GetReplicaSetPods(apiHandler.client, namespace, replicaSet)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/replicasetcommon.go
+++ b/src/app/backend/replicasetcommon.go
@@ -1,0 +1,59 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+type ReplicaSetWithPods struct {
+	ReplicaSet *api.ReplicationController
+	Pods       *api.PodList
+}
+
+// Returns structure containing ReplicaSet and Pods for the given replica set.
+func getRawReplicaSetWithPods(client *client.Client, namespace string, name string) (
+	*ReplicaSetWithPods, error) {
+	replicaSet, err := client.ReplicationControllers(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := labels.SelectorFromSet(replicaSet.Spec.Selector)
+	pods, err := client.Pods(namespace).List(labelSelector, fields.Everything())
+
+	if err != nil {
+		return nil, err
+	}
+
+	replicaSetAndPods := &ReplicaSetWithPods{
+		ReplicaSet: replicaSet,
+		Pods:       pods,
+	}
+	return replicaSetAndPods, nil
+}
+
+// Retrieves Pod list that belongs to a Replica Set.
+func getRawReplicaSetPods(client *client.Client, namespace string, name string) (
+	*api.PodList, error) {
+	replicaSetAndPods, err := getRawReplicaSetWithPods(client, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	return replicaSetAndPods.Pods, nil
+}

--- a/src/app/backend/replicasetpods.go
+++ b/src/app/backend/replicasetpods.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	types "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// Information about a Container that belongs to a Pod.
+type PodContainer struct {
+	// Name of a Container.
+	Name string `json:"name"`
+
+	// Container state.
+	State types.ContainerState `json:"state,omitempty"`
+
+	// Number of restarts.
+	RestartCount int `json:"restartCount"`
+}
+
+// List of pods that belongs to a Replica Set.
+type ReplicaSetPods struct {
+	// List of pods that belongs to a Replica Set.
+	Pods []ReplicaSetPodWithContainers `json:"pods"`
+}
+
+// Detailed information about a Pod that belongs to a Replica Set.
+type ReplicaSetPodWithContainers struct {
+	// Name of the Pod.
+	Name string `json:"name"`
+
+	// Time the Pod has started. Empty if not started.
+	StartTime *unversioned.Time `json:"startTime"`
+
+	// List of Containers that belongs to particular Pod.
+	PodContainers []PodContainer `json:"podContainers"`
+}
+
+// Returns list of pods with containers for the given replica set in the given namespace.
+func GetReplicaSetPods(client *client.Client, namespace string, name string) (
+	*ReplicaSetPods, error) {
+	pods, err := getRawReplicaSetPods(client, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return getReplicaSetPods(pods.Items), nil
+}
+
+// Creates and return structure containing pods with containers for given replica set.
+func getReplicaSetPods(pods []api.Pod) *ReplicaSetPods {
+	replicaSetPods := &ReplicaSetPods{}
+
+	for _, pod := range pods {
+		replicaSetPodWithContainers := ReplicaSetPodWithContainers{
+			Name:      pod.Name,
+			StartTime: pod.Status.StartTime,
+		}
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			podContainer := PodContainer{
+				Name:         containerStatus.Name,
+				RestartCount: containerStatus.RestartCount,
+				State:        containerStatus.State,
+			}
+			replicaSetPodWithContainers.PodContainers =
+				append(replicaSetPodWithContainers.PodContainers, podContainer)
+		}
+		replicaSetPods.Pods = append(replicaSetPods.Pods, replicaSetPodWithContainers)
+	}
+
+	return replicaSetPods
+}

--- a/src/test/backend/replicasetpods_test.go
+++ b/src/test/backend/replicasetpods_test.go
@@ -1,0 +1,94 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"reflect"
+	"testing"
+)
+
+func TestGetReplicaSetPods(t *testing.T) {
+
+	cases := []struct {
+		pods     []api.Pod
+		expected *ReplicaSetPods
+	}{
+		{nil, &ReplicaSetPods{}},
+		{[]api.Pod{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name: "pod-1",
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-1",
+							RestartCount: 0,
+						},
+						{
+							Name:         "container-2",
+							RestartCount: 2,
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name: "pod-2",
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-3",
+							RestartCount: 10,
+						},
+					},
+				},
+			},
+		}, &ReplicaSetPods{Pods: []ReplicaSetPodWithContainers{
+			{
+				Name: "pod-1",
+				PodContainers: []PodContainer{
+					{
+						Name:         "container-1",
+						RestartCount: 0,
+					},
+					{
+						Name:         "container-2",
+						RestartCount: 2,
+					},
+				},
+			},
+			{
+				Name: "pod-2",
+				PodContainers: []PodContainer{
+					{
+						Name:         "container-3",
+						RestartCount: 10,
+					},
+				},
+			},
+		}},
+		},
+	}
+	for _, c := range cases {
+		actual := getReplicaSetPods(c.pods)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getReplicaSetPods(%#v) == %#v, expected %#v",
+				c.pods, actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
Backend API to retrieve pods with containers for replica set. Needed for this view:
![logmenu](https://cloud.githubusercontent.com/assets/13030040/11585341/3dfed0cc-9a63-11e5-8f21-62095666b593.png)
