### PR TITLE
Add license and repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "//": "Specification of this file can be found at: https://docs.npmjs.com/files/package.json",
   "name": "kubernetes-dashboard",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kubernetes/dashboard.git"
+  },
+  "license": "Apache-2.0",
   "devDependencies": {
     "babel": "~6.1.18",
     "babel-core": "~6.2.1",


### PR DESCRIPTION
This is to have valid package definition and clear warnings.