### PR TITLE
Initial validators for create namespace dialog

### DIFF
--- a/src/app/frontend/deploy/createnamespace.html
+++ b/src/app/frontend/deploy/createnamespace.html
@@ -19,10 +19,21 @@ limitations under the License.
     <h4 class="md-title" >Create a new namespace</h4>
     <p>The new namespace will be added to the cluster.</p>
     <!-- TODO(maciaszczykm): Missing detailed cluster info and learn more link. -->
-    <form id="namespaceForm" ng-submit="ctrl.createNamespace()">
+    <form name="namespaceForm" ng-submit="ctrl.createNamespace()" novalidate>
       <md-input-container class="md-block">
         <label>Namespace name</label>
-        <input ng-model="ctrl.namespace" required>
+        <input name="namespace" ng-model="ctrl.namespace"
+               md-maxlength="{{ctrl.namespaceMaxLength}}"
+               ng-pattern="ctrl.namespacePattern"
+               reject="ctrl.namespaces"
+               required>
+        <div ng-messages="namespaceForm.namespace.$error">
+          <!-- TODO(cheld): better error message -->
+          <div ng-message="pattern">Name must be alphanumeric</div>
+          <div ng-message="md-maxlength">Name is too long</div>
+          <div ng-message="reject">Namespace already exists</div>
+          <div ng-message="required" ng-if="namespaceForm.namespace.$touched">Name is required</div>
+        </div>
       </md-input-container>
       <div class="md-actions" layout="row">
         <md-button ng-disabled="ctrl.isDisabled()" class="md-primary" type="submit">OK</md-button>

--- a/src/app/frontend/deploy/createnamespace_controller.js
+++ b/src/app/frontend/deploy/createnamespace_controller.js
@@ -43,9 +43,16 @@ export default class NamespaceDialogController {
 
     /** @export {string} */
     this.namespace = '';
+
+    //TODO(cheld) move to some central place or html?
+    this.namespaceMaxLength = 63;
+
+    this.namespacePattern = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$";
+
   }
 
   /**
+   * TODO(cheld) clean up
    * Returns true if new namespace name hasn't been filled by the user, i.e, is empty.
    * @return {boolean}
    */

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -15,6 +15,7 @@
 import stateConfig from './deploy_state';
 import deployFromSettingsDirective from './deployfromsettings_directive';
 import deployLabelDirective from './deploylabel_directive';
+import rejectDirective from './reject_directive';
 
 /**
  * Angular module for the deploy view.
@@ -30,4 +31,5 @@ export default angular.module(
                           ])
     .config(stateConfig)
     .directive('deployFromSettings', deployFromSettingsDirective)
-    .directive('kdLabel', deployLabelDirective);
+    .directive('kdLabel', deployLabelDirective)
+    .directive('reject',rejectDirective);

--- a/src/app/frontend/deploy/reject_directive.js
+++ b/src/app/frontend/deploy/reject_directive.js
@@ -1,0 +1,19 @@
+
+//TODO(cheld) could be reused? Implement in different way? Does make sense? We need proper server error handling anyay...
+export default function() {
+    return {
+        scope:{
+          reject: '=',
+        },
+        restrict: "A",
+        require: "ngModel",
+        link: function(scope, element, attributes, ngModel) {
+            ngModel.$validators.reject = function(modelValue) {
+                if(scope.reject.indexOf(modelValue) >= 0){
+                  return false;
+                }
+                return true;
+            };
+        },
+    };
+}


### PR DESCRIPTION
DO NOT MERGE. I created this pull request just for discussion.

I think so far, in dashboard there is almost no validation. In this dialog I tried to validate everything.

Please note:
- I removed html5 validations with 'novalidate'
- There is some flickering when the validation error is shown. Seems to be a broken transition.
- I created a uniqueness check as a reusable directive. We have another uniqueness check implemented differently. Not sure which version is better.
- Where should be store validation patterns. I don't have a clear opinion on this.
- We still need proper server error handling. e.g. a duplicate namespace could be created concurrently (not realistic, but QA will test it). 
