### PR TITLE
Fixed a typo that prevented the proper configuration of kubectl

### DIFF
--- a/build/cluster.js
+++ b/build/cluster.js
@@ -244,7 +244,7 @@ gulp.task(
     function(doneFn) {
       executeKubectlCommand(
           `config set-cluster local --server=http://${conf.backend.apiServerHost}` +
-              `--insecure-skip-tls-verify=true`,
+              ' --insecure-skip-tls-verify=true',
           doneFn);
     });
 


### PR DESCRIPTION
Minor fix. Now the kubectl utility should be configured properly.