### PR TITLE
Added functionality to delete replica set from events page

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -49,6 +49,9 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 			To(apiHandler.handleGetReplicaSetDetail).
 			Writes(ReplicaSetDetail{}))
 	replicaSetWs.Route(
+		replicaSetWs.DELETE("/{namespace}/{replicaSet}").
+			To(apiHandler.handleDeleteReplicaSet))
+	replicaSetWs.Route(
 		replicaSetWs.GET("/pods/{namespace}/{replicaSet}").
 			To(apiHandler.handleGetReplicaSetPods).
 			Writes(ReplicaSetPods{}))
@@ -135,6 +138,21 @@ func (apiHandler *ApiHandler) handleGetReplicaSetDetail(
 	}
 
 	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles delete Replica Set API call.
+func (apiHandler *ApiHandler) handleDeleteReplicaSet(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	replicaSet := request.PathParameter("replicaSet")
+
+	if err := DeleteReplicaSetWithPods(apiHandler.client, namespace, replicaSet); err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeader(http.StatusOK)
 }
 
 // Handles get Replica Set Pods API call.

--- a/src/app/backend/replicasetlist.go
+++ b/src/app/backend/replicasetlist.go
@@ -97,7 +97,7 @@ func GetReplicaSetList(client *client.Client) (*ReplicaSetList, error) {
 func getReplicaSetList(
 	replicaSets []api.ReplicationController, services []api.Service) *ReplicaSetList {
 
-	replicaSetList := &ReplicaSetList{}
+	replicaSetList := &ReplicaSetList{ReplicaSets: make([]ReplicaSet, 0)}
 
 	for _, replicaSet := range replicaSets {
 		var containerImages []string

--- a/src/app/externs/angularresource.js
+++ b/src/app/externs/angularresource.js
@@ -58,3 +58,10 @@ angular.Resource.prototype.get = function(opt_callback, opt_errback) {};
  * @return {!angular.ResourceClass}
  */
 angular.Resource.prototype.query = function(opt_callback, opt_errback) {};
+
+/**
+ * @param {function(!T)=} opt_callback
+ * @param {function(!angular.$http.Response)=} opt_errback
+ * @return {!angular.ResourceClass}
+ */
+angular.Resource.prototype.delete = function(opt_callback, opt_errback) {};

--- a/src/app/frontend/deploy/deploy_state.js
+++ b/src/app/frontend/deploy/deploy_state.js
@@ -29,7 +29,7 @@ export default function stateConfig($stateProvider) {
     controllerAs: 'ctrl',
     url: '/deploy',
     resolve: {
-      namespaces: resolveNamespaces,
+      'namespaces': resolveNamespaces,
     },
     templateUrl: 'deploy/deploy.html',
   });
@@ -40,7 +40,7 @@ export default function stateConfig($stateProvider) {
  * @return {!angular.$q.Promise}
  * @ngInject
  */
-export function resolveNamespaces($resource) {
+function resolveNamespaces($resource) {
   /** @type {!angular.Resource<!backendApi.NamespaceList>} */
   let resource = $resource('/api/namespaces');
 

--- a/src/app/frontend/replicasetdetail/deletereplicaset_dialog.js
+++ b/src/app/frontend/replicasetdetail/deletereplicaset_dialog.js
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicasetdetail_state';
-
 /**
- * Angular module for the Replica Set details view.
- *
- * The view shows detailed view of a Replica Sets.
+ * Opens replica set delete dialog.
+ * @param {!md.$dialog} mdDialog
+ * @param {!function()} deleteReplicaSetFn - callback
  */
-export default angular.module(
-                          'kubernetesDashboard.replicaSetDetail',
-                          [
-                            'ngMaterial',
-                            'ngResource',
-                            'ui.router',
-                          ])
-    .config(stateConfig);
+export default function showDeleteReplicaSetDialog(mdDialog, deleteReplicaSetFn) {
+  mdDialog.show(
+              mdDialog.confirm()
+                  .title('Delete Replica Set')
+                  .textContent(
+                      'All related pods will be deleted. Are you sure you want to' +
+                      ' delete this replica set? ')
+                  .ok('Ok')
+                  .cancel('Cancel'))
+      .then(deleteReplicaSetFn);
+}

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -26,15 +26,16 @@ limitations under the License.
     </div>
     <div flex-offset="5" flex layout-align="start start" layout-padding layout="row">
       <div flex layout="column">
-        <div layout="row" class="kd-replicasetdetail-sidebar-buttons">
-          <span flex="55">
-            <i class="material-icons kd-replicasetdetail-sidebar-icon">refresh</i>
+        <div layout="row" flex>
+          <md-button class="md-primary kd-replicasetdetail-sidebar-button">
+            <md-icon class="material-icons">refresh</md-icon>
             ROLLING UPDATE
-          </span>
-          <span flex-offset="5" flex>
-            <i class="material-icons kd-replicasetdetail-sidebar-icon">delete</i>
+          </md-button>
+          <md-button class="md-primary kd-replicasetdetail-sidebar-button"
+                     ng-click="ctrl.handleDeleteReplicaSetDialog()">
+            <md-icon class="material-icons">delete</md-icon>
             DELETE
-          </span>
+          </md-button>
         </div>
         <div flex layout="column" class="kd-replicasetdetail-sidebar-info">
           <span class="kd-replicasetdetail-sidebar-title">
@@ -57,35 +58,35 @@ limitations under the License.
                 ng-repeat="image in ctrl.replicaSetDetail.containerImages">
             {{image}}
           </span>
-          <span class="kd-replicasetdetail-sidebar-title">Service</span>
-          <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
-          <span class="kd-replicasetdetail-sidebar-subline"
+          <div ng-show="ctrl.replicaSetDetail.services" layout="column">
+            <span class="kd-replicasetdetail-sidebar-title">Service</span>
+            <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
+            <span class="kd-replicasetdetail-sidebar-subline"
+                  ng-repeat="service in ctrl.replicaSetDetail.services">
+              {{ctrl.formatLabelString(service.selector)}}
+            </span>
+            <span class="kd-replicasetdetail-sidebar-line">Internal endpoint</span>
+            <div class="kd-replicasetdetail-sidebar-subline"
+                 ng-repeat="service in ctrl.replicaSetDetail.services">
+              <div ng-show="service.internalEndpoint">
+                {{service.internalEndpoint}}
+                <i class="material-icons kd-replicasetdetail-sidebar-service-icon">
+                  help
+                </i>
+              </div>
+              <span ng-hide="service.internalEndpoint">none</span>
+            </div>
+            <span class="kd-replicasetdetail-sidebar-line">External endpoint</span>
+            <div class="kd-replicasetdetail-sidebar-subline"
                 ng-repeat="service in ctrl.replicaSetDetail.services">
-            {{ctrl.formatLabelString(service.selector)}}
-          </span>
-          <span class="kd-replicasetdetail-sidebar-line">Internal endpoint</span>
-          <div class="kd-replicasetdetail-sidebar-subline"
-               ng-repeat="service in ctrl.replicaSetDetail.services">
-            <span ng-show="service.internalEndpoint">
-              {{service.internalEndpoint}}
-            </span>
-            <i ng-show="service.internalEndpoint"
-               class="material-icons kd-replicasetdetail-sidebar-service-icon">
-              help
-            </i>
-            <span ng-hide="service.internalEndpoint">none</span>
-          </div>
-          <span class="kd-replicasetdetail-sidebar-line">External endpoint</span>
-          <div class="kd-replicasetdetail-sidebar-subline"
-               ng-repeat="service in ctrl.replicaSetDetail.services">
-            <span ng-show="service.externalEndpoints">
-              {{service.externalEndpoints}}
-            </span>
-            <i ng-show="service.externalEndpoints"
-               class="material-icons kd-replicasetdetail-sidebar-service-icon">open_in_new</i>
-            <span class="kd-replicasetdetail-sidebar-subline" ng-hide="service.externalEndpoints">
-              none
-            </span>
+              <div ng-show="service.externalEndpoints">
+                {{service.externalEndpoints}}
+                <i class="material-icons kd-replicasetdetail-sidebar-service-icon">open_in_new</i>
+              </div>
+              <span class="kd-replicasetdetail-sidebar-subline" ng-hide="service.externalEndpoints">
+                none
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -87,8 +87,9 @@ $replicasetdetails-warning: orange;
   font-size: 14px;
 }
 
-.kd-replicasetdetail-sidebar-buttons {
-  color: $primary;
+.kd-replicasetdetail-sidebar-button {
+  padding-left: 0;
+  margin: 0;
   font-size: 0.85em;
 }
 

--- a/src/app/frontend/replicasetdetail/replicasetdetail_state.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_state.js
@@ -50,23 +50,31 @@ export default function stateConfig($stateProvider) {
     url: '/replicasets/:namespace/:replicaSet',
     templateUrl: 'replicasetdetail/replicasetdetail.html',
     resolve: {
-      replicaSetDetail: resolveReplicaSetDetails,
-      replicaSetEvents: resolveReplicaSetEvents,
+      'replicaSetDetailResource': getReplicaSetDetailsResource,
+      'replicaSetDetail': resolveReplicaSetDetails,
+      'replicaSetEvents': resolveReplicaSetEvents,
     },
   });
 }
 
 /**
+ *
  * @param {!StateParams} $stateParams
  * @param {!angular.$resource} $resource
+ * @return {!angular.Resource<!backendApi.ReplicaSetDetail>}
+ * @ngInject
+ */
+function getReplicaSetDetailsResource($stateParams, $resource) {
+  return $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
+}
+
+/**
+ * @param {!angular.Resource<!backendApi.ReplicaSetDetail>} replicaSetDetailResource
  * @return {!angular.$q.Promise}
  * @ngInject
  */
-export function resolveReplicaSetDetails($stateParams, $resource) {
-  /** @type {!angular.Resource<!backendApi.ReplicaSetDetail>} */
-  let resource = $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
-
-  return resource.get().$promise;
+function resolveReplicaSetDetails(replicaSetDetailResource) {
+  return replicaSetDetailResource.get().$promise;
 }
 
 /**
@@ -75,7 +83,7 @@ export function resolveReplicaSetDetails($stateParams, $resource) {
  * @return {!angular.$q.Promise}
  * @ngInject
  */
-export function resolveReplicaSetEvents($stateParams, $resource) {
+function resolveReplicaSetEvents($stateParams, $resource) {
   /** @type {!angular.Resource<!backendApi.Events>} */
   let resource = $resource('/api/events/:namespace/:replicaSet', $stateParams);
 

--- a/src/test/backend/replicasetlist_test.go
+++ b/src/test/backend/replicasetlist_test.go
@@ -149,7 +149,7 @@ func TestGetReplicaSetList(t *testing.T) {
 		services    []api.Service
 		expected    *ReplicaSetList
 	}{
-		{nil, nil, &ReplicaSetList{}},
+		{nil, nil, &ReplicaSetList{ReplicaSets: []ReplicaSet{}}},
 		{
 			[]api.ReplicationController{
 				{

--- a/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
+++ b/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import ReplicaSetDetailController from 'replicasetdetail/replicasetdetail_controller';
+import replicaSetDetailModule from 'replicasetdetail/replicasetdetail_module';
 
 describe('Replica Set Detail controller', () => {
   /**
@@ -21,7 +22,13 @@ describe('Replica Set Detail controller', () => {
    */
   let ctrl;
 
-  beforeEach(() => { ctrl = new ReplicaSetDetailController([], []); });
+  beforeEach(() => {
+    angular.mock.module(replicaSetDetailModule.name);
+
+    angular.mock.inject(($resource, $log, $state, $mdDialog) => {
+      ctrl = new ReplicaSetDetailController($mdDialog, $state, $resource, $log, [], [], []);
+    });
+  });
 
   it('should not filter any events if all option is selected', () => {
     // given


### PR DESCRIPTION
Related to issue #104.
- [x] Delete button on replica set detail page will open a dialog and ask user if he wants to delete current replica set.
- [x] Added check on replica set list page to prevent it from showing when there are not replica sets. 
- [x] Added check to hide `Service` block on events page sidebar when there are no service related to replica set.

![zrzut ekranu z 2015-12-11 09-44-00](https://cloud.githubusercontent.com/assets/2285385/11739431/c204b8a4-9feb-11e5-93a6-b8745baf0316.png)

![zrzut ekranu z 2015-12-11 09-44-10](https://cloud.githubusercontent.com/assets/2285385/11739436/c5c033b0-9feb-11e5-8d3a-55e3dd1f4d76.png)

