### PR TITLE
gulp check for go minimum version is added

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "q": "~1.4.1",
     "request": "~2.67.0",
     "run-sequence": "~1.1.5",
+    "semver": "~2.0.0",
     "vinyl-source-stream": "1.1.0",
     "webpack-stream": "~2.3.0",
     "wiredep": "~3.0.0-beta",


### PR DESCRIPTION
gulp check fails if go version is older than `1.5.0`