### PR TITLE
Implemented section directive to support user help tips.

### DIFF
--- a/src/app/frontend/deploy/createnamespace.html
+++ b/src/app/frontend/deploy/createnamespace.html
@@ -18,7 +18,7 @@ limitations under the License.
   <md-content layout-padding>
     <h4 class="md-title" >Create a new namespace</h4>
     <p>The new namespace will be added to the cluster.</p>
-    <!-- TODO(maciaszczykm): Missing detailed cluster info and learn more link. -->
+    <!-- TODO(maciaszczykm): Missing detailed cluster info. -->
     <form id="namespaceForm" ng-submit="ctrl.createNamespace()">
       <md-input-container class="md-block">
         <label>Namespace name</label>

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -18,33 +18,40 @@ limitations under the License.
   <md-whiteframe class="kd-deploy-whiteframe md-whiteframe-5dp" flex flex-gt-md>
     <h3 class="md-headline">Deploy a Containerized App</h3>
     <form name="ctrl.deployForm" ng-submit="ctrl.deployBySelection()">
-      <md-input-container class="md-block">
-        <label>App name</label>
-        <input ng-model="ctrl.name" required>
-      </md-input-container>
-      <md-radio-group ng-model="ctrl.selection">
-        <md-radio-button value="Settings" class="md-primary">
-          Specify app details below
-        </md-radio-button>
-        <md-radio-button value="File" class="md-primary">
-          Upload a YAML or JSON file
-        </md-radio-button>
-      </md-radio-group>
+
+      <kd-help-section>
+        <md-input-container class="md-block" ng-model-options="{ updateOn: 'blur' }">
+          <label>App name</label>
+          <input ng-model="ctrl.name" required>
+        </md-input-container>
+        <kd-user-help>
+          An 'app' label with this value will be added to the Replica Set and Service that get deployed.
+        </kd-user-help>
+      </kd-help-section>
+
+      <kd-help-section>
+        <md-radio-group ng-model="ctrl.selection">
+          <md-radio-button value="Settings" class="md-primary">
+            Specify app details below
+          </md-radio-button>
+          <md-radio-button value="File" class="md-primary">
+            Upload a YAML or JSON file
+          </md-radio-button>
+        </md-radio-group>
+      </kd-help-section>
+
       <div ng-switch="ctrl.selection">
-        <deploy-from-settings ng-switch-when="Settings"
-                              name="ctrl.name"
-                              namespaces="ctrl.namespaces"
-                              detail="ctrl.detail">
+        <deploy-from-settings ng-switch-when="Settings" name="ctrl.name" namespaces="ctrl.namespaces" detail="ctrl.detail">
         </deploy-from-settings>
-        <deploy-from-file ng-switch-when="File"
-                          name="ctrl.name"
-                          detail="ctrl.detail">
+        <deploy-from-file ng-switch-when="File" name="ctrl.name" detail="ctrl.detail">
         </deploy-from-file>
       </div>
+
       <md-button class="md-raised md-primary" type="submit" ng-disabled="ctrl.isDeployDisabled()">
         Deploy
       </md-button>
       <md-button class="md-raised" ng-click="ctrl.cancel()">Cancel</md-button>
+
     </form>
   </md-whiteframe>
 </div>

--- a/src/app/frontend/deploy/deploy.scss
+++ b/src/app/frontend/deploy/deploy.scss
@@ -17,4 +17,5 @@
   margin: 1em;
   // TODO(bryk): Find a better, application wide constant for the min width.
   min-width: 600px;
+  max-width: 960px;
 }

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -18,6 +18,7 @@ import deployLabelDirective from './deploylabel_directive';
 import deployFromFileDirective from './deployfromfile_directive';
 import fileReaderDirective from './filereader_directive';
 import uploadDirective from './upload_directive';
+import helpSectionModule from './helpsection/helpsection_module';
 
 /**
  * Angular module for the deploy view.
@@ -30,6 +31,7 @@ export default angular.module(
                             'ngMaterial',
                             'ngResource',
                             'ui.router',
+                            helpSectionModule.name,
                           ])
     .config(stateConfig)
     .directive('deployFromSettings', deployFromSettingsDirective)

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -14,59 +14,103 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-input-container class="md-block">
-  <label>Container image</label>
-  <input ng-model="ctrl.containerImage" required>
-</md-input-container>
-<md-input-container class="md-block">
-  <label>Number of pods</label>
-  <input ng-model="ctrl.replicas" type="number" required min="1">
-</md-input-container>
-<div layout="row" ng-repeat="portMapping in ctrl.portMappings">
-  <md-input-container flex>
-    <label>Port</label>
-    <input ng-model="portMapping.port" type="number" min="0">
+<kd-help-section>
+  <md-input-container class="md-block">
+    <label>Container image</label>
+    <input ng-model="ctrl.containerImage" required>
   </md-input-container>
-  <md-input-container flex>
-    <label>Target port</label>
-    <input ng-model="portMapping.targetPort" type="number" min="0">
+  <kd-user-help>
+    Enter the URL of a public image on any registry, or a private image hosted on Docker Hub or Google Container Registry.
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>
+
+<kd-help-section>
+  <md-input-container class="md-block">
+    <label>Number of pods</label>
+    <input ng-model="ctrl.replicas" type="number" required min="1">
   </md-input-container>
-  <md-input-container flex="none">
-    <label>Protocol</label>
-    <md-select ng-model="portMapping.protocol" required>
-      <md-option ng-repeat="protocol in ctrl.protocols" ng-value="protocol">
-        {{protocol}}
+  <kd-user-help>
+    A Replica Set will be created to maintain the desired number of pods across your cluster.
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>
+
+<kd-help-section>
+  <div layout="row" ng-repeat="portMapping in ctrl.portMappings">
+    <md-input-container flex>
+      <label>Port</label>
+      <input ng-model="portMapping.port" type="number" min="0">
+    </md-input-container>
+    <md-input-container flex>
+      <label>Target port</label>
+      <input ng-model="portMapping.targetPort" type="number" min="0">
+    </md-input-container>
+    <md-input-container flex="none">
+      <label>Protocol</label>
+      <md-select ng-model="portMapping.protocol" required>
+        <md-option ng-repeat="protocol in ctrl.protocols" ng-value="protocol">
+          {{protocol}}
+        </md-option>
+      </md-select>
+    </md-input-container>
+  </div>
+  <kd-user-help>
+    Ports are optional. If specified, a Service will be created mapping the Port (incoming) to a target Port seen by the container.
+    <span ng-if="ctrl.name">The internal DNS name for this Service will be: <b>{{ctrl.name}}</b>.</span>
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>
+
+<kd-help-section>
+  <md-switch ng-model="ctrl.isExternal" class="md-primary">
+    Expose service externally
+  </md-switch>
+</kd-help-section>
+
+<kd-help-section>
+  <md-input-container>
+    <label>Description (optional)</label>
+    <textarea ng-model="ctrl.description"></textarea>
+  </md-input-container>
+  <kd-user-help>
+    The description will be added as an annotation to the Replica Set and displayed in the application's details.
+  </kd-user-help>
+</kd-help-section>
+
+<kd-help-section>
+  <div>
+    <div>Labels (optional)</div>
+    <div layout="column">
+      <div layout="row">
+        <p flex>Key</p>
+        <p flex>Value</p>
+      </div>
+      <div ng-repeat="label in ctrl.labels">
+        <kd-label layout="row" flex label="label" labels="ctrl.labels"></kd-label>
+      </div>
+    </div>
+  </div>
+  <kd-user-help>
+    The specified labels will be applied to the created Replica Set, Service (if any) and Pods. Common labels include release, environment, tier, partition and track.
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>
+
+<kd-help-section>
+  <md-input-container class="md-block">
+    <label>Namespace</label>
+    <md-select ng-model="ctrl.namespace" required>
+      <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
+        {{namespace}}
+      </md-option>
+      <md-option ng-click="ctrl.handleNamespaceDialog($event)">
+        Create a new namespace...
       </md-option>
     </md-select>
   </md-input-container>
-</div>
-<md-switch ng-model="ctrl.isExternal" class="md-primary">
-  Expose service externally
-</md-switch>
-<md-input-container>
-  <label>Description (optional)</label>
-  <textarea ng-model="ctrl.description"></textarea>
-</md-input-container>
-<div>
-  <div>Labels (optional)</div>
-  <div layout="column">
-    <div layout="row">
-      <p flex>Key</p>
-      <p flex>Value</p>
-    </div>
-    <div ng-repeat="label in ctrl.labels">
-      <kd-label layout="row" flex label="label" labels="ctrl.labels"></kd-label>
-    </div>
-  </div>
-</div>
-<md-input-container class="md-block">
-  <label>Namespace</label>
-  <md-select ng-model="ctrl.namespace" required>
-    <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
-      {{namespace}}
-    </md-option>
-    <md-option ng-click="ctrl.handleNamespaceDialog($event)">
-      Create a new namespace...
-    </md-option>
-  </md-select>
-</md-input-container>
+  <kd-user-help>
+    Namespaces let you partition resources into logically named groups.
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>

--- a/src/app/frontend/deploy/helpsection/helpsection.html
+++ b/src/app/frontend/deploy/helpsection/helpsection.html
@@ -1,0 +1,17 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ng-transclude class="kd-help-section" layout="row" layout-xs="column" layout-sm="column"> </ng-transclude>

--- a/src/app/frontend/deploy/helpsection/helpsection.scss
+++ b/src/app/frontend/deploy/helpsection/helpsection.scss
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(floreks): Find appropriate place for global color definitions.
-$primary: #326DE6;
-$delicate: #AAAAAA;
-$muted: #888888;
-$hoverPrimary: #1254DF;
+// This rule is meant to align items only in the current layout (kd-help-section).
+.kd-help-section > * {
+  flex: 1;
+  padding-right: 50px;
+  margin-bottom: 20px;
+}

--- a/src/app/frontend/deploy/helpsection/helpsection_directive.js
+++ b/src/app/frontend/deploy/helpsection/helpsection_directive.js
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(floreks): Find appropriate place for global color definitions.
-$primary: #326DE6;
-$delicate: #AAAAAA;
-$muted: #888888;
-$hoverPrimary: #1254DF;
+/**
+ * Returns a directive definition object for sections with help.
+ * @return {!angular.Directive} the directive definition
+ */
+export default function() {
+  return {
+    scope: {},
+    templateUrl: 'deploy/helpsection/helpsection.html',
+    transclude: true,
+  };
+}

--- a/src/app/frontend/deploy/helpsection/helpsection_module.js
+++ b/src/app/frontend/deploy/helpsection/helpsection_module.js
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(floreks): Find appropriate place for global color definitions.
-$primary: #326DE6;
-$delicate: #AAAAAA;
-$muted: #888888;
-$hoverPrimary: #1254DF;
+import helpSectionDirective from './helpsection_directive';
+import userHelpDirective from './userhelp_directive';
+
+/**
+ * Angular module for a reusable section with user help and a preset layout.
+ *
+ */
+export default angular.module('kubernetesDashboard.helpsection', [])
+    .directive('kdHelpSection', helpSectionDirective)
+    .directive('kdUserHelp', userHelpDirective);

--- a/src/app/frontend/deploy/helpsection/userhelp.html
+++ b/src/app/frontend/deploy/helpsection/userhelp.html
@@ -1,0 +1,17 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div ng-transclude class="kd-user-help" layout-align="start center"> </div>

--- a/src/app/frontend/deploy/helpsection/userhelp.scss
+++ b/src/app/frontend/deploy/helpsection/userhelp.scss
@@ -11,9 +11,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+@import "../../../assets/styles/color_variables";
 
-// TODO(floreks): Find appropriate place for global color definitions.
-$primary: #326DE6;
-$delicate: #AAAAAA;
-$muted: #888888;
-$hoverPrimary: #1254DF;
+.kd-user-help * {
+  color: $muted;
+}
+
+.kd-user-help a {
+  color: $primary;
+  opacity: 1;
+  text-decoration: none;
+}
+
+.kd-user-help b {
+  color: black;
+}
+
+.kd-user-help a:hover {
+  color: $hoverPrimary;
+}

--- a/src/app/frontend/deploy/helpsection/userhelp_directive.js
+++ b/src/app/frontend/deploy/helpsection/userhelp_directive.js
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(floreks): Find appropriate place for global color definitions.
-$primary: #326DE6;
-$delicate: #AAAAAA;
-$muted: #888888;
-$hoverPrimary: #1254DF;
+/**
+ * Returns a reusable directive which adds user help.
+ * @return {!angular.Directive} the directive definition
+ */
+export default function() {
+  return {
+    scope: {},
+    templateUrl: 'deploy/helpsection/userhelp.html',
+    transclude: true,
+  };
+}

--- a/src/app/frontend/deploy/upload.html
+++ b/src/app/frontend/deploy/upload.html
@@ -14,20 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div layout="row" layout-align="space-between start">
-  <div flex>
-    <md-input-container class="md-block">
-      <label>YAML or JSON file</label>
-      <!--TODO: Browse file on focus doesn't work in Firefox. It is to be investigated.-->
-      <input ng-model="ctrl.file.name" ng-focus="ctrl.browseFile()" ng-readonly="true"/>
+<kd-help-section>
+  <div layout="row" layout-align="space-between start">
+    <div flex>
+      <md-input-container class="md-block">
+        <label>YAML or JSON file</label>
+        <!--TODO: Browse file on focus doesn't work in Firefox. It is to be investigated.-->
+        <input ng-model="ctrl.file.name" ng-focus="ctrl.browseFile()" ng-readonly="true" />
       </md-input-container>
-  </div>
+    </div>
     <md-button type="button" class="md-raised kd-upload-button" ng-click="ctrl.browseFile()">
       <label class="kd-upload-label">
         <md-icon>
           <i class="material-icons">more_horiz</i>
         </md-icon>
-        </label>
+      </label>
     </md-button>
     <input type="file" style="display:none" kd-file-reader ng-model="ctrl.file">
-</div>
+  </div>
+  <kd-user-help>
+    Select a YAML or JSON file, specifying the resources to deploy.
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -57,13 +57,13 @@ $replicasetdetails-warning: orange;
 .kd-replicasetdetail-sidebar-line {
   padding-bottom: 6px;
   font-size: 11px;
-  color: $line
+  color: $delicate;
 }
 
 .kd-replicasetdetail-sidebar-subline {
   padding-bottom: 8px;
   font-size: 13px;
-  color: $subline
+  color: $muted;
 }
 
 .kd-replicasetdetail-sidebar-icon {
@@ -81,7 +81,7 @@ $replicasetdetails-warning: orange;
 }
 
 .kd-replicasetdetail-sidebar-service-icon {
-  color: $subline;
+  color: $muted;
   padding: 0 3px 0 3px;
   vertical-align: top;
   font-size: 14px;


### PR DESCRIPTION
This is my idea of how we could add the "Help tips" and the links to the help pages to the existing dashboard elements (the ones on the right in this example design):

![04_deploy form upload](https://cloud.githubusercontent.com/assets/8666527/11744570/b897b64c-a011-11e5-81eb-41237ff8c6ef.png)


In essence, I created a small reusable wrapper element that allows for the insertion of help tips and which has a predefined reusable layout.

@bryk PTAL