### PR TITLE
Create namespace dialog bugfix (production)

### DIFF
--- a/src/app/frontend/deploy/createnamespace_controller.js
+++ b/src/app/frontend/deploy/createnamespace_controller.js
@@ -48,17 +48,22 @@ export default class NamespaceDialogController {
   /**
    * Returns true if new namespace name hasn't been filled by the user, i.e, is empty.
    * @return {boolean}
+   * @export
    */
   isDisabled() {
     return !this.namespace || /^\s*$/.test(!this.namespace) ||
            this.namespaces.indexOf(this.namespace) >= 0;
   }
 
-  /** Cancels the new namespace form. */
+  /**
+   * Cancels the new namespace form.
+   * @export
+   */
   cancel() { this.mdDialog_.cancel(); }
 
   /**
    * Creates new namespace based on the state of the controller.
+   * @export
    */
   createNamespace() {
     /** @type {!backendApi.NamespaceSpec} */

--- a/src/app/frontend/deploy/createnamespace_dialog.js
+++ b/src/app/frontend/deploy/createnamespace_dialog.js
@@ -28,7 +28,7 @@ export default function showNamespaceDialog(mdDialog, event, namespaces) {
     controllerAs: 'ctrl',
     clickOutsideToClose: true,
     targetEvent: event,
-    templateUrl: '/deploy/createnamespace.html',
+    templateUrl: 'deploy/createnamespace.html',
     locals: {
       namespaces: namespaces,
     },

--- a/src/app/frontend/deploy/deploy_controller.js
+++ b/src/app/frontend/deploy/deploy_controller.js
@@ -80,7 +80,6 @@ export default class DeployController {
 
   /**
    * Notifies the child scopes to call their deploy methods.
-   *
    * @export
    */
   deployBySelection() {
@@ -90,8 +89,8 @@ export default class DeployController {
 
   /**
    * Displays new namespace creation dialog.
-   *
    * @param {!angular.Scope.Event} event
+   * @export
    */
   handleNamespaceDialog(event) {
     showNamespaceDialog(this.mdDialog_, event, this.namespaces)


### PR DESCRIPTION
###  This is not meant to be merged immediately.
There is currently a bug when running 'gulp serve:prod' - the namespace creation dialog in the deploy view does not respond (the dialog window does not open). Now looking at it, this was because of the following two issues:

* Some of the referenced functions were actually not @exported, and hence their names were minified => they couldn't be found after compilation in production. I've added the respective @export annotations.
* After fixing the first issue, another problem appeared: apparently the $mdDialog.show() method has problems resolving the template url '/deploy/createnamespace.html' when the app is run in production mode.

Pasting the template directly as shown here works, and this is a quick-fix workaround. Nevertheless, could anyone propose a better method of handling this?

