### PR TITLE
[WIP] Add Dockerfile to build kubernetes-dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+WD=$(shell pwd)
+
+build-docker:
+	cp build/Dockerfile .
+	docker build -t dashboard-builder .
+	docker run --name dashboard-builder -t dashboard-builder gulp build
+	docker cp dashboard-builder:/src/dist $(WD)/dist
+	docker rm dashboard-builder
+	rm -f $(WD)/Dockerfile
+
+image-docker:
+	cp src/app/deploy/Dockerfile $(WD)/dist/
+	docker build --rm=true --tag kubernetes/dashboard $(WD)/dist/
+
+clean-docker:
+	docker rmi dashboard-builder
+	rm -rf $(WD)/dist

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,17 @@
+#
+FROM debian:sid
+
+RUN apt-get update -y && apt-get install -y nodejs golang nodejs-legacy npm libzmq3-dev git-core wget openjdk-7-jre
+
+WORKDIR /src
+
+RUN npm install bower gulp -g
+
+RUN wget https://github.com/tools/godep/releases/download/v34/godep_linux_amd64 -O /usr/local/bin/godep
+RUN chmod +x /usr/local/bin/godep
+
+ADD . /src
+
+RUN npm install
+
+RUN bower install --allow-root


### PR DESCRIPTION
Hello !

I'm trying to build Kubernetes dashboard using a dockerfile.

I have a couple of questions:
* Are you interested by a such patch ?
* If yes, in which folder I have to put it ?
* When I try to build I got this error:

```
docker build -t k9sdashoard .
...
...
Step 9 : RUN gulp build
 ---> Running in 5793c494e9a0
[20:24:04] Requiring external module babel-core/register
[20:24:10] Using gulpfile /src/gulpfile.babel.js
[20:24:10] Starting 'package-backend-source'...
[20:24:10] Starting 'assets'...
[20:24:10] Starting 'angular-templates'...
[20:24:10] Starting 'styles:prod'...
[20:24:11] Finished 'assets' after 197 ms
[20:24:11] Finished 'styles:prod' after 248 ms
[20:24:11] Finished 'package-backend-source' after 297 ms
[20:24:11] Starting 'backend:prod'...
[20:24:11] Finished 'angular-templates' after 356 ms
[20:24:11] Starting 'scripts:prod'...

stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^
Error: spawn java ENOENT
    at exports._errnoException (util.js:874:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:178:32)
    at onErrorNT (internal/child_process.js:344:16)
    at doNTCallback2 (node.js:441:9)
    at process._tickCallback (node.js:355:17)
The command '/bin/sh -c gulp build' returned a non-zero code: 1

```

Thanks for your help