### PR TITLE
Prevent 'Invalid Version' when Go patch number is missing

### DIFF
--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -98,10 +98,15 @@ function checkGoVersion() {
           deferred.reject(new Error('Go version not found.'));
           return;
         }
-        if (semver.lt(match[0], minGoVersion)) {
+        let currentGoVersion = match[0];
+        // semver requires a patch number, so we'll append '.0' if it isn't present.
+        if (currentGoVersion.split('.').length === 2) {
+          currentGoVersion = `${currentGoVersion}.0`;
+        }
+        if (semver.lt(currentGoVersion, minGoVersion)) {
           deferred.reject(
               new Error(
-                  `The current go version "${match[0]}" is older than ` +
+                  `The current go version "${currentGoVersion}" is older than ` +
                   `the minimum required version "${minGoVersion}". ` +
                   `Please upgrade your go version!`));
           return;


### PR DESCRIPTION
When I first ran `gulp serve`, semver threw `TypeError: Invalid Version: 1.5` (see output below). This was due to semver expecting a patch number (e.g. `1.5.0`), while `go version` was returning `go version go1.5 darwin/amd64`.

If the user's Go version is missing a patch number, we can append a patch number of 0 to prevent this error. AFAICT, semver doesn't provide logic for performing this check and transformation, unfortunately, but that would've been preferable.

```bash
$ gulp serve
[21:12:29] Requiring external module babel-core/register
[21:12:37] Using gulpfile ~/Projects/dashboard/gulpfile.babel.js
[21:12:37] Starting 'package-backend-source'...
[21:12:37] Starting 'kill-backend'...
[21:12:37] Finished 'kill-backend' after 95 μs
[21:12:37] Starting 'scripts'...
[21:12:37] Starting 'styles'...
[21:12:38] Finished 'scripts' after 1.61 s
[21:12:38] Finished 'styles' after 1.35 s
[21:12:38] Starting 'index'...
[21:12:38] Finished 'package-backend-source' after 1.68 s
[21:12:38] Starting 'backend'...
[21:12:38] Finished 'index' after 61 ms
[21:12:38] Starting 'watch'...
[21:12:38] Finished 'watch' after 44 ms
/Users/tom/Projects/dashboard/node_modules/semver/semver.js:256
    throw new TypeError('Invalid Version: ' + version);
          ^
TypeError: Invalid Version: 1.5
    at new SemVer (/Users/tom/Projects/dashboard/node_modules/semver/semver.js:256:11)
    at compare (/Users/tom/Projects/dashboard/node_modules/semver/semver.js:409:10)
    at Function.lt (/Users/tom/Projects/dashboard/node_modules/semver/semver.js:443:10)
    at gocommand.js:101:20
    at ChildProcess.exithandler (child_process.js:742:7)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1015:16)
    at Process.ChildProcess._handle.onexit (child_process.js:1087:5)
```