### PR TITLE
Replica set detail view update

### DIFF
--- a/src/app/backend/replicasetdetail.go
+++ b/src/app/backend/replicasetdetail.go
@@ -65,6 +65,9 @@ type ReplicaSetPod struct {
 
 	// Name of the Node this Pod runs on.
 	NodeName string `json:"nodeName"`
+
+	// Count of containers restarts.
+	RestartCount int `json:"restartCount"`
 }
 
 // Detailed information about a Service connected to Replica Set.
@@ -130,10 +133,11 @@ func GetReplicaSetDetail(client *client.Client, namespace string, name string) (
 
 	for _, pod := range pods.Items {
 		podDetail := ReplicaSetPod{
-			Name:      pod.Name,
-			StartTime: pod.Status.StartTime,
-			PodIP:     pod.Status.PodIP,
-			NodeName:  pod.Spec.NodeName,
+			Name:         pod.Name,
+			StartTime:    pod.Status.StartTime,
+			PodIP:        pod.Status.PodIP,
+			NodeName:     pod.Spec.NodeName,
+			RestartCount: getRestartCount(pod),
 		}
 		replicaSetDetail.Pods = append(replicaSetDetail.Pods, podDetail)
 	}
@@ -197,4 +201,13 @@ func getServiceDetail(service api.Service) ServiceDetail {
 	}
 
 	return serviceDetail
+}
+
+// Gets restart count of given pod (total number of its containers restarts).
+func getRestartCount(pod api.Pod) int {
+	restartCount := 0
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		restartCount += containerStatus.RestartCount
+	}
+	return restartCount
 }

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -122,7 +122,8 @@ backendApi.ReplicaSetSpec;
  *   name: string,
  *   startTime: ?string,
  *   podIP: string,
- *   nodeName: string
+ *   nodeName: string,
+ *   restartCount: number
  * }}
  */
 backendApi.ReplicaSetPod;

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -72,7 +72,7 @@ limitations under the License.
                  ng-repeat="service in ctrl.replicaSetDetail.services">
               <div ng-show="service.internalEndpoint">
                 {{service.internalEndpoint}}
-                <i class="material-icons kd-replicasetdetail-sidebar-service-icon">
+                <i class="material-icons kd-replicasetdetail-help-icon">
                   help
                 </i>
               </div>
@@ -80,10 +80,10 @@ limitations under the License.
             </div>
             <span class="kd-replicasetdetail-sidebar-line">External endpoint</span>
             <div class="kd-replicasetdetail-sidebar-subline"
-                ng-repeat="service in ctrl.replicaSetDetail.services">
+                 ng-repeat="service in ctrl.replicaSetDetail.services">
               <div ng-show="service.externalEndpoints">
                 {{service.externalEndpoints}}
-                <i class="material-icons kd-replicasetdetail-sidebar-service-icon">open_in_new</i>
+                <i class="material-icons kd-replicasetdetail-help-icon">open_in_new</i>
               </div>
               <span class="kd-replicasetdetail-sidebar-subline" ng-hide="service.externalEndpoints">
                 none
@@ -97,31 +97,97 @@ limitations under the License.
   <md-tabs flex md-border-bottom md-dynamic-height>
     <md-tab label="Pods">
       <md-content>
-        <table class="kd-replicasetdetail-table" cellspacing="0" cellpadding="15">
+        <table class="kd-replicasetdetail-table" cellspacing="0">
           <thead>
           <tr>
-            <th class="kd-replicasetdetail-table-cell">
-              Pod<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="name">
+                Pod
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              Start time<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="restartCount"
+                                tooltip="Restarts count and last restart time of the pod">
+                Restarts
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              <i class="material-icons kd-replicasetdetail-table-icon">arrow_downward</i>
-              IP
-              <i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="startTime" tooltip="Age of the pod">
+                Age
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              Node<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="cpu" tooltip="CPU used by the pod">
+                CPU
+              </kd-sorted-header>
             </th>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="memory" tooltip="Memory used by the pod">
+                Memory
+              </kd-sorted-header>
+            </th>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="podIP" tooltip="IP adress of the pod">
+                IP
+              </kd-sorted-header>
+            </th>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
+                                currently-selected-order="ctrl.podsOrder"
+                                column-name="nodeName"
+                                tooltip="Name of the node, that the pod is running on">
+                Node
+              </kd-sorted-header>
+            </th>
+            <th class="kd-replicasetdetail-table-header">
+              Logs
+              <i class="material-icons kd-replicasetdetail-help-icon">
+                help
+                <md-tooltip>Display logs from the pod</md-tooltip>
+              </i>
+            </th>
+            <th class="kd-replicasetdetail-table-header"/>
           </tr>
           </thead>
           <tbody>
-          <tr ng-repeat="pod in ctrl.replicaSetDetail.pods">
+          <tr ng-repeat="pod in ctrl.replicaSetDetail.pods | orderBy:ctrl.sortPodsBy:ctrl.podsOrder">
             <td class="kd-replicasetdetail-table-cell">{{pod.name}}</td>
-            <td class="kd-replicasetdetail-table-cell">{{pod.startTime | date:'short'}}</td>
+            <td class="kd-replicasetdetail-table-cell">
+              {{pod.restartCount}}<!-- TODO(maciaszczykm): Add info about last restart date. -->
+            </td>
+            <td class="kd-replicasetdetail-table-cell">
+              {{pod.startTime | date:'short'}}<!-- TODO(maciaszczykm): Format data. -->
+            </td>
+            <td class="kd-replicasetdetail-table-cell">
+              0.4 CPU<!-- TODO(maciaszczykm): Fill with data and plot. -->
+            </td>
+            <td class="kd-replicasetdetail-table-cell">
+              12 MB<!-- TODO(maciaszczykm): Fill with data and plot. -->
+            </td>
             <td class="kd-replicasetdetail-table-cell">{{pod.podIP}}</td>
             <td class="kd-replicasetdetail-table-cell">{{pod.nodeName}}</td>
+            <td class="kd-replicasetdetail-table-cell">
+              Logs <i class="material-icons kd-replicasetdetail-logs-icon">arrow_drop_down</i>
+              <!-- TODO(maciaszczykm): Handle it. -->
+            </td>
+            <td class="kd-replicasetdetail-table-cell">
+              <md-button class="md-icon-button">
+                <md-icon md-font-library="material-icons">more_vert</md-icon>
+                <!-- TODO(maciaszczykm): Handle it. -->
+              </md-button>
+            </td>
           </tr>
           </tbody>
         </table>
@@ -152,29 +218,56 @@ limitations under the License.
         <table class="kd-replicasetdetail-table" cellspacing="0" cellpadding="15">
           <thead>
           <tr>
-            <th class="kd-replicasetdetail-table-cell">
-              Message<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="message" tooltip="Event message">
+                Message
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              Source<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="['sourceComponent','sourceHost']"
+                                tooltip="Source of the event, details of component and host">
+                Source
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              Sub-object<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="object" tooltip="Sub-object of the event">
+                Sub-object
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              Count<i class="material-icons kd-replicasetdetail-table-icon">help</i></th>
-            <th class="kd-replicasetdetail-table-cell">
-              First seen<i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="count"
+                                tooltip="Number of times, that the event occured">
+                Count
+              </kd-sorted-header>
             </th>
-            <th class="kd-replicasetdetail-table-cell">
-              <i class="material-icons kd-replicasetdetail-table-icon">arrow_downward</i>
-              Last seen
-              <i class="material-icons kd-replicasetdetail-table-icon">help</i>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="firstSeen"
+                                tooltip="When the event was seen for the first time">
+                First seen
+              </kd-sorted-header>
+            </th>
+            <th class="kd-replicasetdetail-table-header">
+              <kd-sorted-header currently-selected-column="ctrl.sortEventsBy"
+                                currently-selected-order="ctrl.eventsOrder"
+                                column-name="lastSeen"
+                                tooltip="When the event was seen for the last time">
+                Last seen
+              </kd-sorted-header>
             </th>
           </tr>
           </thead>
           <tbody>
-          <tr ng-repeat="event in ctrl.events">
+          <tr ng-repeat="event in ctrl.events | orderBy:ctrl.sortEventsBy:ctrl.eventsOrder">
             <td class="kd-replicasetdetail-table-cell kd-replicasetdetail-table-message">
               <i ng-if="ctrl.isEventWarning(event)"
                  class="material-icons kd-replicasetdetail-warning-icon">warning</i>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -80,13 +80,6 @@ $replicasetdetails-warning: orange;
   font-size: 24px;
 }
 
-.kd-replicasetdetail-sidebar-service-icon {
-  color: $muted;
-  padding: 0 3px 0 3px;
-  vertical-align: top;
-  font-size: 14px;
-}
-
 .kd-replicasetdetail-sidebar-button {
   padding-left: 0;
   margin: 0;
@@ -114,12 +107,26 @@ $replicasetdetails-warning: orange;
   padding-right: 25px;
 }
 
+.kd-replicasetdetail-table-header {
+  text-align: left;
+  font-size: 14px;
+  font-weight: 500;
+  color: $replicasetdetails-table-cell;
+  border-bottom: 1px solid $replicasetdetails-border;
+  padding: 15px 10px 15px 15px;
+}
+
+.kd-replicasetdetail-pointer {
+  cursor: pointer;
+}
 
 .kd-replicasetdetail-table-cell {
   text-align: left;
   color: $replicasetdetails-table-cell;
   font-size: 13px;
   border-bottom: 1px solid $replicasetdetails-border;
+  height: 40px;
+  padding: 5px 5px 5px 15px;
 }
 
 .kd-replicasetdetail-table-message {
@@ -133,4 +140,12 @@ $replicasetdetails-warning: orange;
   font-size: 14px;
   padding: 0 3px 0 3px;
   vertical-align: top;
+}
+
+.kd-replicasetdetail-help-icon {
+  font-size: 14px;
+  padding: 0 3px 0 3px;
+  vertical-align: middle;
+  cursor: help;
+  color: $muted;
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -14,6 +14,7 @@
 
 import showDeleteReplicaSetDialog from 'replicasetdetail/deletereplicaset_dialog';
 import showUpdateReplicasDialog from 'replicasetdetail/updatereplicas_dialog';
+import {UPWARDS, DOWNWARDS} from 'replicasetdetail/sortedheader_controller';
 
 // Filter type and source values for events.
 const EVENT_ALL = 'All';
@@ -79,6 +80,30 @@ export default class ReplicaSetDetailController {
 
     /** @private {!angular.$log} */
     this.log_ = $log;
+
+    /**
+     * Name of column, that will be used for pods sorting.
+     * @export {string}
+     */
+    this.sortPodsBy = 'name';
+
+    /**
+     * Pods sorting order.
+     * @export {boolean}
+     */
+    this.podsOrder = UPWARDS;
+
+    /**
+     * Name of column, that will be used for events sorting.
+     * @export {string}
+     */
+    this.sortEventsBy = 'lastSeen';
+
+    /**
+     * Events sorting order.
+     * @export {boolean}
+     */
+    this.eventsOrder = DOWNWARDS;
   }
 
   /**

--- a/src/app/frontend/replicasetdetail/sortedheader.html
+++ b/src/app/frontend/replicasetdetail/sortedheader.html
@@ -1,0 +1,32 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<a class="kd-sortedheader-pointer" ng-click="sortCtrl.changeSorting()">
+  <md-icon md-font-library="material-icons" ng-show="sortCtrl.isArrowDown()"
+           class="kd-sortedheader-sort-icon">
+    arrow_downward
+  </md-icon>
+  <md-icon md-font-library="material-icons" ng-show="sortCtrl.isArrowUp()"
+           class="kd-sortedheader-sort-icon">
+    arrow_upward
+  </md-icon>
+  <ng-transclude></ng-transclude>
+</a>
+<md-icon ng-show="sortCtrl.isTooltipAvailable()" md-font-library="material-icons"
+         class="kd-sortedheader-help-icon">
+  help
+  <md-tooltip>{{sortCtrl.tooltip}}</md-tooltip>
+</md-icon>

--- a/src/app/frontend/replicasetdetail/sortedheader.scss
+++ b/src/app/frontend/replicasetdetail/sortedheader.scss
@@ -12,20 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicasetdetail_state';
-import sortedHeaderDirective from './sortedheader_directive';
+@import "../../assets/styles/color_variables";
 
-/**
- * Angular module for the Replica Set details view.
- *
- * The view shows detailed view of a Replica Sets.
- */
-export default angular.module(
-                          'kubernetesDashboard.replicaSetDetail',
-                          [
-                            'ngMaterial',
-                            'ngResource',
-                            'ui.router',
-                          ])
-    .config(stateConfig)
-    .directive('kdSortedHeader', sortedHeaderDirective);
+$sortedheader-font-size: 14px;
+
+.kd-sortedheader-pointer {
+  cursor: pointer;
+}
+
+.kd-sortedheader-help-icon {
+  font-size: $sortedheader-font-size;
+  padding: 0 3px 0 3px;
+  vertical-align: text-top;
+  cursor: help;
+  color: $muted;
+  height: $sortedheader-font-size;
+  width: $sortedheader-font-size;
+}
+
+.kd-sortedheader-sort-icon {
+  font-size: $sortedheader-font-size;
+  padding: 0 3px 0 3px;
+  vertical-align: text-top;
+  height: $sortedheader-font-size;
+  width: $sortedheader-font-size;
+}

--- a/src/app/frontend/replicasetdetail/sortedheader_controller.js
+++ b/src/app/frontend/replicasetdetail/sortedheader_controller.js
@@ -1,0 +1,101 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Sorting order variable. Represents ascending order.
+ * @type {boolean}
+ */
+export const UPWARDS = false;
+
+/**
+ * Sorting order variable. Represents descending order.
+ * @type {boolean}
+ */
+export const DOWNWARDS = true;
+
+/**
+ * Controller for the sorted header directive.
+ * @final
+ */
+export default class SortedHeaderController {
+  constructor() {
+    /**
+     * Tooltip message for current header column. Initialized from the scope (read-only).
+     * @export {string}
+     */
+    this.tooltip;
+
+    /**
+     * Name of current header column. Initialized from the scope (read-only).
+     * @export {string}
+     */
+    this.columnName;
+
+    /**
+     * Name of column currently used for sorting. Initialized from the scope (two-way binding).
+     * @export {string}
+     */
+    this.currentlySelectedColumn;
+
+    /**
+     * If true then sorting will be reversed. Initialized from the scope (two-way binding).
+     * @export {boolean}
+     */
+    this.currentlySelectedOrder;
+  }
+
+  /**
+   * Applies sorting on current column of the table. If sorting on specific column was already
+   * applied only order will be switched.
+   * @export
+   */
+  changeSorting() {
+    this.currentlySelectedOrder =
+        (this.currentlySelectedColumn === this.columnName) ? !this.currentlySelectedOrder : false;
+    this.currentlySelectedColumn = this.columnName;
+  }
+
+  /**
+   * Returns true if upwards arrow should be displayed in the header.
+   * @return {boolean}
+   * @export
+   */
+  isArrowUp() { return this.isSortedBy_(this.columnName, UPWARDS); }
+
+  /**
+   * Returns true if downwards arrow should be displayed in the header.
+   * @return {boolean}
+   * @export
+   */
+  isArrowDown() { return this.isSortedBy_(this.columnName, DOWNWARDS); }
+
+  /**
+   * Used to determine which arrow should be displayed in header. Returns true if sorting on
+   * specific column and in specific order of the table is currently applied.
+   * @param {string} sortColumn
+   * @param {boolean} sortOrder
+   * @return {boolean}
+   * @private
+   */
+  isSortedBy_(sortColumn, sortOrder) {
+    return this.currentlySelectedColumn === sortColumn && this.currentlySelectedOrder === sortOrder;
+  }
+
+  /**
+   * Checks if header tooltip is available.
+   * @return {boolean}
+   * @export
+   */
+  isTooltipAvailable() { return this.tooltip !== undefined && this.tooltip.length > 0; }
+}

--- a/src/app/frontend/replicasetdetail/sortedheader_directive.js
+++ b/src/app/frontend/replicasetdetail/sortedheader_directive.js
@@ -12,20 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicasetdetail_state';
-import sortedHeaderDirective from './sortedheader_directive';
+import SortedHeaderController from 'replicasetdetail/sortedheader_controller';
 
 /**
- * Angular module for the Replica Set details view.
- *
- * The view shows detailed view of a Replica Sets.
+ * Returns directive definition object for the sorted header directive.
+ * @return {!angular.Directive}
  */
-export default angular.module(
-                          'kubernetesDashboard.replicaSetDetail',
-                          [
-                            'ngMaterial',
-                            'ngResource',
-                            'ui.router',
-                          ])
-    .config(stateConfig)
-    .directive('kdSortedHeader', sortedHeaderDirective);
+export default function sortedHeaderDirective() {
+  return {
+    controller: SortedHeaderController,
+    controllerAs: 'sortCtrl',
+    templateUrl: 'replicasetdetail/sortedheader.html',
+    scope: {},
+    bindToController: {
+      'columnName': '@',
+      'tooltip': '@',
+      'currentlySelectedColumn': '=',
+      'currentlySelectedOrder': '=',
+    },
+    transclude: true,
+  };
+}

--- a/src/test/backend/replicasetdetail_test.go
+++ b/src/test/backend/replicasetdetail_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"reflect"
 	"testing"
 )
 
@@ -65,5 +66,52 @@ func TestUpdateReplicasCount(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestGetRestartCount(t *testing.T) {
+	cases := []struct {
+		pod      api.Pod
+		expected int
+	}{
+		{
+			api.Pod{}, 0,
+		},
+		{
+			api.Pod{
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-1",
+							RestartCount: 1,
+						},
+					},
+				},
+			},
+			1,
+		},
+		{
+			api.Pod{
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-1",
+							RestartCount: 3,
+						},
+						{
+							Name:         "container-2",
+							RestartCount: 2,
+						},
+					},
+				},
+			},
+			5,
+		},
+	}
+	for _, c := range cases {
+		actual := getRestartCount(c.pod)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("AppendEvents(%#v) == %#v, expected %#v", c.pod, actual, c.expected)
+		}
 	}
 }

--- a/src/test/frontend/replicasetdetail/sortedheader_controller_test.js
+++ b/src/test/frontend/replicasetdetail/sortedheader_controller_test.js
@@ -1,0 +1,58 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SortedHeaderController from 'replicasetdetail/sortedheader_controller';
+import {UPWARDS, DOWNWARDS} from 'replicasetdetail/sortedheader_controller';
+
+describe('Sorted header controller', () => {
+  /**
+   * Sorted header controller.
+   * @type {!SortedHeaderController}
+   */
+  let ctrl;
+
+  beforeEach(() => { ctrl = new SortedHeaderController(); });
+
+  it('should switch sorting direction after clicking same column twice', () => {
+    // given "selected-column" is sorted upwards
+    ctrl.currentlySelectedOrder = UPWARDS;
+    ctrl.currentlySelectedColumn = "selected-column";
+    ctrl.columnName = "selected-column";
+
+    // when user clicks "selected-column" once more
+    ctrl.changeSorting();
+
+    // then it should be sorted downwards
+    expect(ctrl.currentlySelectedColumn).toEqual(ctrl.columnName);
+    expect(ctrl.currentlySelectedOrder).toEqual(DOWNWARDS);
+    expect(ctrl.isArrowUp()).toEqual(false);
+    expect(ctrl.isArrowDown()).toEqual(true);
+  });
+
+  it('should switch sorting column after clicking second column', () => {
+    // given "first-column", however sorting is on "second-column"
+    ctrl.columnName = "first-column";
+    ctrl.currentlySelectedOrder = UPWARDS;
+    ctrl.currentlySelectedColumn = "second-column";
+
+    // when user clicks "first-column"
+    ctrl.changeSorting();
+
+    // then it should be sorted by "first-column" upwards
+    expect(ctrl.currentlySelectedColumn).toEqual(ctrl.columnName);
+    expect(ctrl.currentlySelectedOrder).toEqual(UPWARDS);
+    expect(ctrl.isArrowUp()).toEqual(true);
+    expect(ctrl.isArrowDown()).toEqual(false);
+  });
+});


### PR DESCRIPTION
Connected to #156 and #104 issues. Updated replica set detail view:

- added restarts column to pods table
- implemented pods table and events sort (with `sorted-header` directive)
- updated styling of pods and events table
- added tooltips for pods and events table
- added backend and frontend tests