### PR TITLE
Added functionality to edit number of replicas in replica set

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -50,6 +50,10 @@ func CreateHttpApiHandler(client *client.Client) http.Handler {
 			To(apiHandler.handleGetReplicaSetDetail).
 			Writes(ReplicaSetDetail{}))
 	replicaSetWs.Route(
+		replicaSetWs.POST("/{namespace}/{replicaSet}/update/pods").
+			To(apiHandler.handleUpdateReplicasCount).
+			Reads(ReplicaSetSpec{}))
+	replicaSetWs.Route(
 		replicaSetWs.DELETE("/{namespace}/{replicaSet}").
 			To(apiHandler.handleDeleteReplicaSet))
 	replicaSetWs.Route(
@@ -139,6 +143,28 @@ func (apiHandler *ApiHandler) handleGetReplicaSetDetail(
 	}
 
 	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles update of Replica Set pods update API call.
+func (apiHandler *ApiHandler) handleUpdateReplicasCount(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	replicaSetName := request.PathParameter("replicaSet")
+	replicaSetSpec := new(ReplicaSetSpec)
+
+	if err := request.ReadEntity(replicaSetSpec); err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	if err := UpdateReplicasCount(apiHandler.client, namespace, replicaSetName,
+		replicaSetSpec); err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeader(http.StatusAccepted)
 }
 
 // Handles delete Replica Set API call.

--- a/src/app/backend/replicasetdetail.go
+++ b/src/app/backend/replicasetdetail.go
@@ -83,6 +83,12 @@ type ServiceDetail struct {
 	Selector map[string]string `json:"selector"`
 }
 
+// Information needed to update replica set
+type ReplicaSetSpec struct {
+	// Replicas (pods) number in replicas set
+	Replicas int `json:"replicas"`
+}
+
 // Returns detailed information about the given replica set in the given namespace.
 func GetReplicaSetDetail(client *client.Client, namespace string, name string) (
 	*ReplicaSetDetail, error) {
@@ -152,6 +158,24 @@ func DeleteReplicaSetWithPods(client *client.Client, namespace string, name stri
 		if err := client.Pods(namespace).Delete(pod.Name, &api.DeleteOptions{}); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// Updates number of replicas in Replica Set based on Replica Set Spec
+func UpdateReplicasCount(client client.Interface, namespace string, name string,
+	replicaSetSpec *ReplicaSetSpec) error {
+	replicaSet, err := client.ReplicationControllers(namespace).Get(name)
+	if err != nil {
+		return err
+	}
+
+	replicaSet.Spec.Replicas = replicaSetSpec.Replicas
+
+	_, err = client.ReplicationControllers(namespace).Update(replicaSet)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -112,6 +112,13 @@ backendApi.ReplicaSetDetail;
 
 /**
  * @typedef {{
+ *   replicas: number
+ * }}
+ */
+backendApi.ReplicaSetSpec;
+
+/**
+ * @typedef {{
  *   name: string,
  *   startTime: ?string,
  *   podIP: string,

--- a/src/app/frontend/replicasetdetail/deletereplicaset_dialog.js
+++ b/src/app/frontend/replicasetdetail/deletereplicaset_dialog.js
@@ -22,8 +22,8 @@ export default function showDeleteReplicaSetDialog(mdDialog, deleteReplicaSetFn)
               mdDialog.confirm()
                   .title('Delete Replica Set')
                   .textContent(
-                      'All related pods will be deleted. Are you sure you want to' +
-                      ' delete this replica set? ')
+                      'All related pods will be deleted. Are you sure you want to delete this' +
+                      ' replica set? ')
                   .ok('Ok')
                   .cancel('Cancel'))
       .then(deleteReplicaSetFn);

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -38,11 +38,13 @@ limitations under the License.
           </md-button>
         </div>
         <div flex layout="column" class="kd-replicasetdetail-sidebar-info">
-          <span class="kd-replicasetdetail-sidebar-title">
-            {{ctrl.replicaSetDetail.pods.length}} pods
-            <i class="material-icons kd-replicasetdetail-sidebar-icon">
-              mode_edit
-            </i>
+          <span>
+            {{ctrl.replicaSetDetail.podsDesired}} pods
+            <md-button class="kd-replicasetdetail-sidebar-editpods-button">
+              <md-icon class="material-icons md-primary" ng-click="ctrl.handleUpdateReplicasDialog()">
+                mode_edit
+              </md-icon>
+            </md-button>
           </span>
           <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
           <span class="kd-replicasetdetail-sidebar-subline">

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -93,6 +93,14 @@ $replicasetdetails-warning: orange;
   font-size: 0.85em;
 }
 
+.kd-replicasetdetail-sidebar-editpods-button {
+  margin: 0;
+  min-width: 25px;
+  > md-icon {
+    outline: none;
+  }
+}
+
 .kd-replicasetdetail-options {
   margin: 15px;
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import showDeleteReplicaSetDialog from 'replicasetdetail/deletereplicaset_dialog';
+import showUpdateReplicasDialog from 'replicasetdetail/updatereplicas_dialog';
 
 // Filter type and source values for events.
 const EVENT_ALL = 'All';
@@ -34,11 +35,12 @@ export default class ReplicaSetDetailController {
    * @param {!backendApi.ReplicaSetDetail} replicaSetDetail
    * @param {!backendApi.Events} replicaSetEvents
    * @param {!angular.Resource<!backendApi.ReplicaSetDetail>} replicaSetDetailResource
+   * @param {!angular.Resource<!backendApi.ReplicaSetSpec>} replicaSetSpecPodsResource
    * @ngInject
    */
   constructor(
       $mdDialog, $state, $resource, $log, replicaSetDetail, replicaSetEvents,
-      replicaSetDetailResource) {
+      replicaSetDetailResource, replicaSetSpecPodsResource) {
     /** @export {!backendApi.ReplicaSetDetail} */
     this.replicaSetDetail = replicaSetDetail;
 
@@ -47,6 +49,9 @@ export default class ReplicaSetDetailController {
 
     /** @private {!angular.Resource<!backendApi.ReplicaSetDetail>} */
     this.replicaSetDetailResource_ = replicaSetDetailResource;
+
+    /** @private {!angular.Resource<!backendApi.ReplicaSetSpec>} */
+    this.replicaSetSpecPodsResource_ = replicaSetSpecPodsResource;
 
     /** @export !Array<!backendApi.Event> */
     this.events = replicaSetEvents.events;
@@ -143,6 +148,15 @@ export default class ReplicaSetDetailController {
   }
 
   /**
+   * Handles update of replicas count in replica set dialog.
+   * @export
+   */
+  handleUpdateReplicasDialog() {
+    showUpdateReplicasDialog(
+        this.mdDialog_, this.replicaSetDetail, this.updateReplicas_.bind(this));
+  }
+
+  /**
    * Handles replica set delete dialog.
    * @export
    */
@@ -154,6 +168,23 @@ export default class ReplicaSetDetailController {
    * Callbacks used after clicking dialog confirmation button in order to delete replica set
    * or log unsuccessful operation error.
    */
+
+  /**
+   * Updates replicas count in replica set
+   * @param {number} replicasCount
+   * @param {function(!backendApi.ReplicaSetSpec)=} opt_callback
+   * @param {function(!angular.$http.Response)=} opt_errback
+   * @private
+   */
+  updateReplicas_(replicasCount, opt_callback, opt_errback) {
+    /** @type {!backendApi.ReplicaSetSpec} */
+    let replicaSetSpec = {
+      replicas: replicasCount,
+    };
+
+    this.replicaSetSpecPodsResource_.save(replicaSetSpec, opt_callback, opt_errback);
+    // TODO(floreks): Think about refreshing data on this page after update.
+  }
 
   /**
    * Deletes replica set based on current replica set namespace and name.

--- a/src/app/frontend/replicasetdetail/replicasetdetail_state.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_state.js
@@ -50,6 +50,7 @@ export default function stateConfig($stateProvider) {
     url: '/replicasets/:namespace/:replicaSet',
     templateUrl: 'replicasetdetail/replicasetdetail.html',
     resolve: {
+      'replicaSetSpecPodsResource': getReplicaSetSpecPodsResource,
       'replicaSetDetailResource': getReplicaSetDetailsResource,
       'replicaSetDetail': resolveReplicaSetDetails,
       'replicaSetEvents': resolveReplicaSetEvents,
@@ -58,7 +59,6 @@ export default function stateConfig($stateProvider) {
 }
 
 /**
- *
  * @param {!StateParams} $stateParams
  * @param {!angular.$resource} $resource
  * @return {!angular.Resource<!backendApi.ReplicaSetDetail>}
@@ -66,6 +66,16 @@ export default function stateConfig($stateProvider) {
  */
 function getReplicaSetDetailsResource($stateParams, $resource) {
   return $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
+}
+
+/**
+ * @param {!StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource<!backendApi.ReplicaSetSpec>}
+ * @ngInject
+ */
+function getReplicaSetSpecPodsResource($stateParams, $resource) {
+  return $resource('/api/replicasets/:namespace/:replicaSet/update/pods', $stateParams);
 }
 
 /**

--- a/src/app/frontend/replicasetdetail/updatereplicas.html
+++ b/src/app/frontend/replicasetdetail/updatereplicas.html
@@ -1,0 +1,38 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<md-dialog aria-label="Create a new namespace" layout="column" layout-padding>
+  <md-content layout-padding>
+    <h4 class="md-title" >Set desired number of pods</h4>
+    <p>Replica set {{ctrl.replicaSetDetail.name}} will be updated to reflect the desired count.
+      <br/>
+      <span class="kd-updatereplicas-pod-status">
+        Current status: {{ctrl.replicaSetDetail.podsRunning}}
+        running, {{ctrl.replicaSetDetail.podsDesired}} desired
+      </span>
+    </p>
+    <form ng-submit="ctrl.updateReplicasCount()">
+      <md-input-container class="md-block">
+        <label>Number of pods</label>
+        <input type="number" min="1" ng-model="ctrl.replicas" required>
+      </md-input-container>
+      <md-dialog-actions layout="row">
+        <md-button class="md-primary" ng-click="ctrl.cancel()">Cancel</md-button>
+        <md-button class="md-primary" type="submit">OK</md-button>
+      </md-dialog-actions>
+    </form>
+  </md-content>
+</md-dialog>

--- a/src/app/frontend/replicasetdetail/updatereplicas.scss
+++ b/src/app/frontend/replicasetdetail/updatereplicas.scss
@@ -12,15 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import PageObject from './zerostate_po';
-
-describe('Zero state view', () => {
-  let page;
-
-  beforeEach(() => {
-    browser.get('#/zerostate');
-    page = new PageObject();
-  });
-
-  it('should do something', () => { expect(page.deployButton.getText()).toContain('DEPLOY'); });
-});
+.kd-updatereplicas-pod-status {
+  font-size: 14px;
+}

--- a/src/app/frontend/replicasetdetail/updatereplicas_controller.js
+++ b/src/app/frontend/replicasetdetail/updatereplicas_controller.js
@@ -1,0 +1,81 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Controller for the update replica set dialog.
+ *
+ * @final
+ */
+export default class UpdateReplicasDialogController {
+  /**
+   * @param {!md.$dialog} $mdDialog
+   * @param {!angular.$log} $log
+   * @param {!backendApi.ReplicaSetDetail} replicaSetDetail
+   * @param {!function(number, function(!backendApi.ReplicaSetSpec),
+   * function(!angular.$http.Response)=)} updateReplicasFn
+   * @ngInject
+   */
+  constructor($mdDialog, $log, replicaSetDetail, updateReplicasFn) {
+    /** @export {number} */
+    this.replicas;
+
+    /** @export {!backendApi.ReplicaSetDetail} */
+    this.replicaSetDetail = replicaSetDetail;
+
+    /** @private {!md.$dialog} */
+    this.mdDialog_ = $mdDialog;
+
+    /** @private {!function(number, function(!backendApi.ReplicaSetSpec),
+     * function(!angular.$http.Response)=)} */
+    this.updateReplicasFn_ = updateReplicasFn;
+
+    /** @private {!angular.$log} */
+    this.log_ = $log;
+  }
+
+  /**
+   * Executes callback function to update replicas count in replica set.
+   * @export
+   */
+  updateReplicasCount() {
+    this.updateReplicasFn_(
+        this.replicas, this.onUpdateReplicasSuccess_.bind(this),
+        this.onUpdateReplicasError_.bind(this));
+  }
+
+  /**
+   *  Cancels the update replica set dialog.
+   *  @export
+   */
+  cancel() { this.mdDialog_.cancel(); }
+
+  /**
+   * @param {!backendApi.ReplicaSetSpec} updatedSpec
+   * @private
+   */
+  onUpdateReplicasSuccess_(updatedSpec) {
+    this.log_.info('Successfully updated replica set.');
+    this.log_.info(updatedSpec);
+    this.mdDialog_.hide();
+  }
+
+  /**
+   * @param {!angular.$http.Response} err
+   * @private
+   */
+  onUpdateReplicasError_(err) {
+    this.log_.error(err);
+    this.mdDialog_.hide();
+  }
+}

--- a/src/app/frontend/replicasetdetail/updatereplicas_dialog.js
+++ b/src/app/frontend/replicasetdetail/updatereplicas_dialog.js
@@ -1,0 +1,36 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UpdateReplicasDialogController from 'replicasetdetail/updatereplicas_controller';
+
+/**
+ * Opens update replicas dialog.
+ * @param {!md.$dialog} mdDialog
+ * @param {!backendApi.ReplicaSetDetail} replicaSetDetail
+ * @param {!function(number, function(!backendApi.ReplicaSetSpec)=,
+ * function(!angular.$http.Response)=)} updateReplicasFn
+ * @return {!angular.$q.Promise}
+ */
+export default function showUpdateReplicasDialog(mdDialog, replicaSetDetail, updateReplicasFn) {
+  return mdDialog.show({
+    controller: UpdateReplicasDialogController,
+    controllerAs: 'ctrl',
+    clickOutsideToClose: true,
+    templateUrl: 'replicasetdetail/updatereplicas.html',
+    locals: {
+      'updateReplicasFn': updateReplicasFn,
+      'replicaSetDetail': replicaSetDetail,
+    },
+  });
+}

--- a/src/test/backend/replicasetdetail_test.go
+++ b/src/test/backend/replicasetdetail_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"testing"
+)
+
+func TestUpdateReplicasCount(t *testing.T) {
+	cases := []struct {
+		namespace, replicaSetName string
+		replicaSetSpec            *ReplicaSetSpec
+		expected                  int
+		expectedActions           []string
+	}{
+		{
+			"default-ns", "replicaSet-1",
+			&ReplicaSetSpec{Replicas: 5},
+			5,
+			[]string{"get", "update"},
+		},
+	}
+
+	for _, c := range cases {
+		replicationCtrl := &api.ReplicationController{}
+		fakeClient := testclient.NewSimpleFake(replicationCtrl)
+
+		UpdateReplicasCount(fakeClient, c.namespace, c.replicaSetName, c.replicaSetSpec)
+
+		actual := fakeClient.Actions()[1].(testclient.UpdateAction).GetObject().(*api.ReplicationController)
+		if actual.Spec.Replicas != c.expected {
+			t.Errorf("UpdateReplicasCount(client, %+v, %+v, %+v). Got %+v, expected %+v",
+				c.namespace, c.replicaSetName, c.replicaSetSpec, actual.Spec.Replicas, c.expected)
+		}
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetResource() != "replicationcontrollers" {
+				t.Errorf("Unexpected action: %+v, expected %s-replicationController",
+					actions[i], verb)
+			}
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s-replicationController",
+					actions[i], verb)
+			}
+		}
+
+	}
+}

--- a/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
+++ b/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
@@ -22,11 +22,15 @@ describe('Replica Set Detail controller', () => {
    */
   let ctrl;
 
+  /** @type {!md.$dialog} */
+  let mdDialog;
+
   beforeEach(() => {
     angular.mock.module(replicaSetDetailModule.name);
 
     angular.mock.inject(($resource, $log, $state, $mdDialog) => {
-      ctrl = new ReplicaSetDetailController($mdDialog, $state, $resource, $log, [], [], []);
+      mdDialog = $mdDialog;
+      ctrl = new ReplicaSetDetailController(mdDialog, $state, $resource, $log, [], [], []);
     });
   });
 
@@ -74,5 +78,19 @@ describe('Replica Set Detail controller', () => {
 
     // then
     expect(result.length).toEqual(1);
+  });
+
+  it('should show edit replicas dialog', () => {
+    // given
+    ctrl.replicaSetDetail = {
+      pods: [],
+    };
+    spyOn(mdDialog, 'show');
+
+    // when
+    ctrl.handleUpdateReplicasDialog();
+
+    // then
+    expect(mdDialog.show).toHaveBeenCalled();
   });
 });

--- a/src/test/frontend/replicasetdetail/updatereplicas_controller_test.js
+++ b/src/test/frontend/replicasetdetail/updatereplicas_controller_test.js
@@ -1,0 +1,85 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UpdateReplicasDialogController from 'replicasetdetail/updatereplicas_controller';
+import replicaSetDetailModule from 'replicasetdetail/replicasetdetail_module';
+
+describe('Replica Set Detail controller', () => {
+  /**
+   * Replica Set Detail controller.
+   * @type {!ReplicaSetDetailController}
+   */
+  let ctrl;
+
+  /** @type {!md.$dialog} */
+  let mdDialog;
+
+  /** @type {!angular.$log} */
+  let log;
+
+  /**
+   * First parameter behavior is changed to indicate successful/failed update.
+   * @param {!boolean} isError
+   * @param {!function(!backendApi.ReplicaSetSpec)} onSuccess
+   * @param {!function(!angular.$http.Response)} onError
+   */
+  let mockUpdateReplicasFn = function(isError, onSuccess, onError) {
+    if (isError) {
+      onError();
+    } else {
+      onSuccess();
+    }
+  };
+
+  beforeEach(() => {
+    angular.mock.module(replicaSetDetailModule.name);
+
+    angular.mock.inject(($resource, $log, $state, $mdDialog) => {
+      mdDialog = $mdDialog;
+      log = $log;
+
+      ctrl = new UpdateReplicasDialogController(mdDialog, log, {}, mockUpdateReplicasFn);
+    });
+  });
+
+  it('should log success after edit replicas and hide the dialog', () => {
+    // given
+    spyOn(log, 'info');
+    spyOn(mdDialog, 'hide');
+    // Indicates if there was error during update
+    ctrl.replicas = false;
+
+    // when
+    ctrl.updateReplicasCount();
+
+    // then
+    expect(log.info).toHaveBeenCalledWith('Successfully updated replica set.');
+    expect(mdDialog.hide).toHaveBeenCalled();
+  });
+
+  it('should log error after edit replicas and hide the dialog', () => {
+    // given
+    spyOn(log, 'error');
+    spyOn(mdDialog, 'hide');
+    // Indicates if there was error during update
+    ctrl.replicas = true;
+
+    // when
+    ctrl.updateReplicasCount();
+
+    // then
+    expect(log.error).toHaveBeenCalled();
+    expect(mdDialog.hide).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Related issue: #104 
Next button on events page.

![zrzut ekranu z 2015-12-14 11-31-55](https://cloud.githubusercontent.com/assets/2285385/11778704/648d9dc2-a256-11e5-921c-92ab4b4fdad8.png)

Refreshing number of pods in the UI after update is not implemented. This has to be discussed as process of creating/deleting pods is not immediate.