### PR TITLE
Add command and command args to the deploy form

### DIFF
--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -36,9 +36,11 @@ backendApi.PortMapping;
 /**
  * @typedef {{
  *   containerImage: string,
+ *   containerCommand: ?string,
+ *   containerCommandArgs: ?string,
  *   isExternal: boolean,
  *   name: string,
- *   description: string,
+ *   description: ?string,
  *   portMappings: !Array<!backendApi.PortMapping>,
  *   replicas: number,
  *   namespace: string,

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -114,3 +114,22 @@ limitations under the License.
     <a href="">Learn more</a>
   </kd-user-help>
 </kd-help-section>
+
+<kd-help-section>
+  <div>
+    <md-input-container class="md-block">
+      <label>Run command (optional)</label>
+      <input ng-model="ctrl.containerCommand">
+    </md-input-container>
+
+    <md-input-container class="md-block">
+      <label>Run command arguments (optional)</label>
+      <input ng-model="ctrl.containerCommandArgs">
+    </md-input-container>
+  </div>
+  <kd-user-help>
+    By default, your containers run the selected image's default entrypoint command. You can use the
+    command options to override the default. 
+    <a href="">Learn more</a>
+  </kd-user-help>
+</kd-help-section>

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -45,6 +45,12 @@ export default class DeployFromSettingsController {
     /** @export {string} */
     this.containerImage = '';
 
+    /** @export {string} */
+    this.containerCommand = '';
+
+    /** @export {string} */
+    this.containerCommandArgs = '';
+
     /** @export {number} */
     this.replicas = 1;
 
@@ -112,9 +118,11 @@ export default class DeployFromSettingsController {
     /** @type {!backendApi.AppDeploymentSpec} */
     let appDeploymentSpec = {
       containerImage: this.containerImage,
+      containerCommand: this.containerCommand ? this.containerCommand : null,
+      containerCommandArgs: this.containerCommandArgs ? this.containerCommandArgs : null,
       isExternal: this.isExternal,
       name: this.name,
-      description: this.description,
+      description: this.description ? this.description : null,
       portMappings: this.portMappings.filter(this.isPortMappingEmpty_),
       replicas: this.replicas,
       namespace: this.namespace,

--- a/src/test/backend/deploy_test.go
+++ b/src/test/backend/deploy_test.go
@@ -1,0 +1,99 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"reflect"
+	"testing"
+)
+
+func TestDeployApp(t *testing.T) {
+	namespace := "foo-namespace"
+	spec := &AppDeploymentSpec{
+		Namespace: namespace,
+		Name:      "foo-name",
+	}
+	expectedRc := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name:        "foo-name",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Spec: api.ReplicationControllerSpec{
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Name:        "foo-name",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{{
+						Name: "foo-name",
+					}},
+				},
+			},
+			Selector: map[string]string{},
+		},
+	}
+
+	testClient := testclient.NewSimpleFake()
+
+	DeployApp(spec, testClient)
+
+	createAction := testClient.Actions()[0].(testclient.CreateActionImpl)
+	if len(testClient.Actions()) != 1 {
+		t.Errorf("Expected one create action but got %#v", len(testClient.Actions()))
+	}
+
+	if createAction.Namespace != namespace {
+		t.Errorf("Expected namespace to be %#v but go %#v", namespace, createAction.Namespace)
+	}
+
+	rc := createAction.GetObject().(*api.ReplicationController)
+	if !reflect.DeepEqual(rc, expectedRc) {
+		t.Errorf("Expected replication controller \n%#v\n to be created but got \n%#v\n",
+			expectedRc, rc)
+	}
+}
+
+func TestDeployAppContainerCommands(t *testing.T) {
+	command := "foo-command"
+	commandArgs := "foo-command-args"
+	spec := &AppDeploymentSpec{
+		Namespace:            "foo-namespace",
+		Name:                 "foo-name",
+		ContainerCommand:     &command,
+		ContainerCommandArgs: &commandArgs,
+	}
+	testClient := testclient.NewSimpleFake()
+
+	DeployApp(spec, testClient)
+
+	createAction := testClient.Actions()[0].(testclient.CreateActionImpl)
+
+	rc := createAction.GetObject().(*api.ReplicationController)
+	container := rc.Spec.Template.Spec.Containers[0]
+	if container.Command[0] != command {
+		t.Errorf("Expected command to be %#v but got %#v",
+			command, container.Command)
+	}
+
+	if container.Args[0] != commandArgs {
+		t.Errorf("Expected command args to be %#v but got %#v",
+			commandArgs, container.Args)
+	}
+}


### PR DESCRIPTION
The UI is as specified in the mocks, except for the names of the fields.
I decided to go with what is in the API.

Everything is extensively tested. I also added some tests for previously
untested cases.