### PR TITLE
Relative time filter

### DIFF
--- a/src/app/frontend/common/filters/filters_module.js
+++ b/src/app/frontend/common/filters/filters_module.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import middleEllipsisFilter from './middleellipsis_filter';
+import relativeTimeFilter from './relativetime_filter';
 
 /**
  * Module containing common filters for the application.
@@ -22,4 +23,5 @@ export default angular.module(
                           [
                             'ngMaterial',
                           ])
-    .filter('middleEllipsis', middleEllipsisFilter);
+    .filter('middleEllipsis', middleEllipsisFilter)
+    .filter('relativeTime', relativeTimeFilter);

--- a/src/app/frontend/common/filters/relativetime_filter.js
+++ b/src/app/frontend/common/filters/relativetime_filter.js
@@ -1,0 +1,111 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Unit name constants (singular and plural form), that will be used by the filter.
+ * @enum {!Array<string>}
+ */
+const Units = {
+  SECOND: ['a second', 'seconds'],
+  MINUTE: ['a minute', 'minutes'],
+  HOUR: ['an hour', 'hours'],
+  DAY: ['a day', 'days'],
+  MONTH: ['a month', 'months'],
+  YEAR: ['a year', 'years'],
+};
+
+/**
+ * Unit conversion constants.
+ * @enum {number}
+ */
+const UnitConversions = {
+  MILLISECONDS_PER_SECOND: 1000,
+  SECONDS_PER_MINUTE: 60,
+  MINUTES_PER_HOUR: 60,
+  HOURS_PER_DAY: 24,
+  DAYS_PER_MONTH: 30,
+  DAYS_PER_YEAR: 365,
+  MONTHS_PER_YEAR: 12,
+};
+
+/**
+ * Time constants.
+ * @enum {string}
+ */
+const TimeConstants = {
+  NOT_YET: `didn't happen yet`,
+  NOW: `just now`,
+};
+
+/**
+ * Returns filter function to display relative time since given date.
+ * @return {Function}
+ */
+export default function relativeTimeFilter() {
+  /**
+   * Filter function to display relative time since given date.
+   * @param {string} value Filtered value.
+   * @return {string}
+   */
+  let filterFunction = function(value) {
+    // Current and given times in miliseconds.
+    let currentTime = (new Date()).getTime();  // TODO(maciaszczykm): Use server time.
+    let givenTime = (new Date(value)).getTime();
+
+    // Time differences between current time and given time in specific units.
+    let diffInMilliseconds = currentTime - givenTime;
+    let diffInSeconds = Math.floor(diffInMilliseconds / UnitConversions.MILLISECONDS_PER_SECOND);
+    let diffInMinutes = Math.floor(diffInSeconds / UnitConversions.SECONDS_PER_MINUTE);
+    let diffInHours = Math.floor(diffInMinutes / UnitConversions.MINUTES_PER_HOUR);
+    let diffInDays = Math.floor(diffInHours / UnitConversions.HOURS_PER_DAY);
+    let diffInMonths = Math.floor(diffInDays / UnitConversions.DAYS_PER_MONTH);
+    let diffInYears = Math.floor(diffInDays / UnitConversions.DAYS_PER_YEAR);
+
+    // Returns relative time value. Only biggest unit will be taken into consideration, so if time
+    // difference is 2 days and 15 hours, only '2 days' string will be returned.
+    if (diffInMilliseconds < 0) {
+      return TimeConstants.NOT_YET;
+    } else if (diffInSeconds < 1) {
+      return TimeConstants.NOW;
+    } else if (diffInMinutes < 1) {
+      return formatOutputTimeString_(diffInSeconds, Units.SECOND);
+    } else if (diffInHours < 1) {
+      return formatOutputTimeString_(diffInMinutes, Units.MINUTE);
+    } else if (diffInDays < 1) {
+      return formatOutputTimeString_(diffInHours, Units.HOUR);
+    } else if (diffInMonths < 1) {
+      return formatOutputTimeString_(diffInDays, Units.DAY);
+    } else if (diffInYears < 1) {
+      return formatOutputTimeString_(diffInMonths, Units.MONTH);
+    } else {
+      return formatOutputTimeString_(diffInYears, Units.YEAR);
+    }
+  };
+  return filterFunction;
+}
+
+/**
+ * Formats relative time string. Sample results look following: 'a year', '2 days' or '14 hours'.
+ * @param {number} timeValue Time value in specified unit.
+ * @param {!Array<string>} timeUnit Specified unit.
+ * @return {string} Formatted time string.
+ * @private
+ */
+function formatOutputTimeString_(timeValue, timeUnit) {
+  if (timeValue > 1) {
+    return `${timeValue} ${timeUnit[1]}`;
+  } else {
+    return timeUnit[0];
+  }
+}

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -165,7 +165,8 @@ limitations under the License.
               {{pod.restartCount}}<!-- TODO(maciaszczykm): Add info about last restart date. -->
             </td>
             <td class="kd-replicasetdetail-table-cell">
-              {{pod.startTime | date:'short'}}<!-- TODO(maciaszczykm): Format data. -->
+              {{pod.startTime | relativeTime}}
+              <md-tooltip>{{pod.startTime | date : 'yyyy-MM-dd HH:mm:ss'}}</md-tooltip>
             </td>
             <td class="kd-replicasetdetail-table-cell">
               0.4 CPU<!-- TODO(maciaszczykm): Fill with data and plot. -->

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import filtersModule from 'common/filters/filters_module';
 import serviceEndpointDirective from './serviceendpoint_directive';
 import stateConfig from './replicasetdetail_stateconfig';
 import sortedHeaderDirective from './sortedheader_directive';
@@ -27,6 +28,7 @@ export default angular.module(
                             'ngMaterial',
                             'ngResource',
                             'ui.router',
+                            filtersModule.name,
                           ])
     .config(stateConfig)
     .directive('kdServiceEndpoint', serviceEndpointDirective)

--- a/src/app/frontend/replicasetlist/replicasetcard.html
+++ b/src/app/frontend/replicasetlist/replicasetcard.html
@@ -67,8 +67,13 @@ limitations under the License.
         </div>
 
         <div flex="40" layout="column" class="kd-replicaset-card-section">
-          <span flex="initial" class="kd-replicaset-card-section-title">Creation time</span>
-          <span flex>{{::(ctrl.replicaSet.creationTime | date:'short')}}</span>
+          <span flex="initial" class="kd-replicaset-card-section-title">Age</span>
+          <span flex>
+            {{::ctrl.replicaSet.creationTime | relativeTime}}
+            <md-tooltip>
+              {{::ctrl.replicaSet.creationTime | date : 'yyyy-MM-dd HH:mm:ss'}}
+            </md-tooltip>
+          </span>
         </div>
 
         <div flex="60" layout="column" class="kd-replicaset-card-section">

--- a/src/test/frontend/common/filters/relativetime_filter_test.js
+++ b/src/test/frontend/common/filters/relativetime_filter_test.js
@@ -1,0 +1,230 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import replicasetlistModule from 'replicasetlist/replicasetlist_module';
+
+describe('Relative time filter', () => {
+
+  let currentTime = new Date(
+      2015,  // year
+      11,    // month
+      29,    // day
+      23,    // hour
+      59,    // minute
+      59     // second
+      );
+
+  beforeEach(function() {
+    jasmine.clock().mockDate(currentTime);
+    angular.mock.module(replicasetlistModule.name);
+  });
+
+  it(`should return 'didn't happen yet' string if given time is (a year ahead) in the future`,
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setYear(givenTime.getFullYear() + 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual(`didn't happen yet`);
+     }));
+
+  it("should return 'just now' string if given time is the same as current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('just now');
+     }));
+
+  it("should return 'a second' string if given time is a second before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setSeconds(givenTime.getSeconds() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('a second');
+     }));
+
+  it("should return '15 seconds' string if given time is 15 seconds before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setSeconds(givenTime.getSeconds() - 15);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('15 seconds');
+     }));
+
+  it("should return 'a minute' string if given time is a minute before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setMinutes(givenTime.getMinutes() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('a minute');
+     }));
+
+  it("should return '30 minutes' string if given time is 30 minutes before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setMinutes(givenTime.getMinutes() - 30);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('30 minutes');
+     }));
+
+  it("should return 'an hour' string if given time is an hour before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setHours(givenTime.getHours() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('an hour');
+     }));
+
+  it("should return '3 hours' string if given time is 3 hours before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setHours(givenTime.getHours() - 3);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('3 hours');
+     }));
+
+  it("should return 'a day' string if given time is a day before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setDate(givenTime.getDate() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('a day');
+     }));
+
+  it("should return '8 days' string if given time is 8 days before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setDate(givenTime.getDate() - 8);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('8 days');
+     }));
+
+  it("should return 'a month' string if given time is a month before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setMonth(givenTime.getMonth() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('a month');
+     }));
+
+  it("should return '11 months' string if given time is 11 months before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setMonth(givenTime.getMonth() - 11);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('11 months');
+     }));
+
+  it("should return 'a year' string if given time is a year before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setYear(givenTime.getFullYear() - 1);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('a year');
+     }));
+
+  it("should return '134 years' string if given time is 134 years before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setYear(givenTime.getFullYear() - 134);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('134 years');
+     }));
+
+  it("should return '11 months' string if given time is 11 months, 7 days, 5 hours and 3 minutes" +
+         " before current time",
+     angular.mock.inject(function(relativeTimeFilter) {
+       // given
+       let givenTime = new Date(currentTime);
+       givenTime.setMonth(givenTime.getMonth() - 11);
+       givenTime.setDate(givenTime.getDate() - 7);
+       givenTime.setHours(givenTime.getHours() - 5);
+       givenTime.setMinutes(givenTime.getMinutes() - 3);
+
+       // when
+       let relativeTime = relativeTimeFilter(givenTime);
+
+       // then
+       expect(relativeTime).toEqual('11 months');
+     }));
+});


### PR DESCRIPTION
Connected to issue #191.

I've implemented relative time filter which can be used in multiple views. At this point I've added it to replica set details and replica set list. Filter transforms date to relative date string, which can be seen on mocks. Added tests covering all important date units.

There is still one thing to do, but to keep this pull request small I think it will be better to move it to another pull request. The issue is, that at the moment filter uses client side current time and it's invalid in many cases. Date should be taken from server in all cases, that I know. **Please let me know if you have any suggestions how we should solve it**.

@floreks @bryk Can you review?