### PR TITLE
Resolved circural dependencies issue (#153)

### DIFF
--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './deploy_state';
+import stateConfig from './deploy_stateconfig';
 import deployFromSettingsDirective from './deployfromsettings_directive';
 import deployLabelDirective from './deploylabel_directive';
 import deployFromFileDirective from './deployfromfile_directive';

--- a/src/app/frontend/deploy/deploy_state.js
+++ b/src/app/frontend/deploy/deploy_state.js
@@ -12,37 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeployController from './deploy_controller';
-
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'deploy';
-
-/**
- * Configures states for the deploy view.
- *
- * @param {!ui.router.$stateProvider} $stateProvider
- * @ngInject
- */
-export default function stateConfig($stateProvider) {
-  $stateProvider.state(stateName, {
-    controller: DeployController,
-    controllerAs: 'ctrl',
-    url: '/deploy',
-    resolve: {
-      'namespaces': resolveNamespaces,
-    },
-    templateUrl: 'deploy/deploy.html',
-  });
-}
-
-/**
- * @param {!angular.$resource} $resource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveNamespaces($resource) {
-  /** @type {!angular.Resource<!backendApi.NamespaceList>} */
-  let resource = $resource('/api/namespaces');
-
-  return resource.get().$promise;
-}

--- a/src/app/frontend/deploy/deploy_stateconfig.js
+++ b/src/app/frontend/deploy/deploy_stateconfig.js
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import DeployController from './deploy_controller';
+import {stateName} from './deploy_state';
+
+/**
+ * Configures states for the deploy view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    controller: DeployController,
+    controllerAs: 'ctrl',
+    url: '/deploy',
+    resolve: {
+      'namespaces': resolveNamespaces,
+    },
+    templateUrl: 'deploy/deploy.html',
+  });
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolveNamespaces($resource) {
+  /** @type {!angular.Resource<!backendApi.NamespaceList>} */
+  let resource = $resource('/api/namespaces');
+
+  return resource.get().$promise;
+}

--- a/src/app/frontend/logs/logs_module.js
+++ b/src/app/frontend/logs/logs_module.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './logs_state';
+import stateConfig from './logs_stateconfig';
 import {LogColorInversionService} from './logs_service';
 
 /**

--- a/src/app/frontend/logs/logs_state.js
+++ b/src/app/frontend/logs/logs_state.js
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {LogsController} from './logs_controller';
-import LogsToolbarController from './logstoolbar/logstoolbar_controller';
-import {toolbarViewName} from '../chrome/chrome_state';
-
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'logs';
 
@@ -45,60 +41,4 @@ export class StateParams {
     /** @export {string} Name of this pod container. */
     this.container = container;
   }
-}
-
-/**
- * Configures states for the logs view.
- *
- * @param {!ui.router.$stateProvider} $stateProvider
- * @ngInject
- */
-export default function stateConfig($stateProvider) {
-  let views = {
-    '': {
-      templateUrl: 'logs/logs.html',
-      controller: LogsController,
-      controllerAs: 'ctrl',
-    },
-    [toolbarViewName]: {
-      templateUrl: 'logs/logstoolbar/logstoolbar.html',
-      controller: LogsToolbarController,
-      controllerAs: 'ctrl',
-    },
-  };
-
-  $stateProvider.state(stateName, {
-    url: '/logs/:namespace/:replicaSet/:podId/:container',
-    resolve: {
-      'replicaSetPods': resolveReplicaSetPods,
-      'podLogs': resolvePodLogs,
-    },
-    views: views,
-  });
-}
-
-/**
- * @param {!StateParams} $stateParams
- * @param {!angular.$resource} $resource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveReplicaSetPods($stateParams, $resource) {
-  /** @type {!angular.Resource<!backendApi.ReplicaSetPods>} */
-  let resource = $resource('/api/replicasets/pods/:namespace/:replicaSet', $stateParams);
-
-  return resource.get().$promise;
-}
-
-/**
- * @param {!StateParams} $stateParams
- * @param {!angular.$resource} $resource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolvePodLogs($stateParams, $resource) {
-  /** @type {!angular.Resource<!backendApi.Logs>} */
-  let resource = $resource('/api/logs/:namespace/:podId/:container', $stateParams);
-
-  return resource.get().$promise;
 }

--- a/src/app/frontend/logs/logs_stateconfig.js
+++ b/src/app/frontend/logs/logs_stateconfig.js
@@ -1,0 +1,74 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {LogsController} from './logs_controller';
+import {stateName} from './logs_state';
+import LogsToolbarController from './logstoolbar/logstoolbar_controller';
+import {toolbarViewName} from '../chrome/chrome_state';
+
+/**
+ * Configures states for the logs view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  let views = {
+    '': {
+      templateUrl: 'logs/logs.html',
+      controller: LogsController,
+      controllerAs: 'ctrl',
+    },
+    [toolbarViewName]: {
+      templateUrl: 'logs/logstoolbar/logstoolbar.html',
+      controller: LogsToolbarController,
+      controllerAs: 'ctrl',
+    },
+  };
+
+  $stateProvider.state(stateName, {
+    url: '/logs/:namespace/:replicaSet/:podId/:container',
+    resolve: {
+      'replicaSetPods': resolveReplicaSetPods,
+      'podLogs': resolvePodLogs,
+    },
+    views: views,
+  });
+}
+
+/**
+ * @param {!./logs_state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolveReplicaSetPods($stateParams, $resource) {
+  /** @type {!angular.Resource<!backendApi.ReplicaSetPods>} */
+  let resource = $resource('/api/replicasets/pods/:namespace/:replicaSet', $stateParams);
+
+  return resource.get().$promise;
+}
+
+/**
+ * @param {!./logs_state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolvePodLogs($stateParams, $resource) {
+  /** @type {!angular.Resource<!backendApi.Logs>} */
+  let resource = $resource('/api/logs/:namespace/:podId/:container', $stateParams);
+
+  return resource.get().$promise;
+}

--- a/src/app/frontend/logs/logstoolbar/logstoolbar_controller.js
+++ b/src/app/frontend/logs/logstoolbar/logstoolbar_controller.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {StateParams, stateName as logs} from './../logs_state';
+
 /**
  * Controller for the logs view.
  * @final
@@ -19,17 +21,17 @@
 export default class LogsToolbarController {
   /**
    * @param {!ui.router.$state} $state
+   * @param {!StateParams} $stateParams
    * @param {!backendApi.ReplicaSetPods} replicaSetPods
    * @param {!../logs_service.LogColorInversionService} logsColorInversionService
    * @ngInject
    */
-  constructor($state, replicaSetPods, logsColorInversionService) {
+  constructor($state, $stateParams, replicaSetPods, logsColorInversionService) {
     /** @private {!ui.router.$state} */
     this.state_ = $state;
 
-    // TODO(zreigz): should be StateParam but can not be import from logstoolbar_state. Issue 153.
-    /** @private {!Object.<string, string, string, string>|null} */
-    this.params = this.state_.params;
+    /** @private {!StateParams} */
+    this.params = $stateParams;
 
     /**
      * Service to notify logs controller if any changes on toolbar.
@@ -86,13 +88,8 @@ export default class LogsToolbarController {
    * @export
    */
   onPodChange(podId) {
-    // TODO(zreigz): state name and StateParam can not be import from logstoolbar_state. Issue 153.
-    return this.state_.transitionTo("logs", {
-      namespace: this.namespace,
-      replicaSet: this.replicaSetName,
-      podId: podId,
-      container: this.container.name,
-    });
+    return this.state_.transitionTo(
+        logs, new StateParams(this.namespace, this.replicaSetName, podId, this.container.name));
   }
 
   /**
@@ -102,13 +99,8 @@ export default class LogsToolbarController {
    * @export
    */
   onContainerChange(container) {
-    // TODO(zreigz): state name and StateParam can not be import from logstoolbar_state. Issue 153.
-    return this.state_.transitionTo("logs", {
-      namespace: this.namespace,
-      replicaSet: this.replicaSetName,
-      podId: this.pod.name,
-      container: container,
-    });
+    return this.state_.transitionTo(
+        logs, new StateParams(this.namespace, this.replicaSetName, this.pod.name, container));
   }
 
   /**

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -15,6 +15,7 @@
 import showDeleteReplicaSetDialog from 'replicasetdetail/deletereplicaset_dialog';
 import showUpdateReplicasDialog from 'replicasetdetail/updatereplicas_dialog';
 import {UPWARDS, DOWNWARDS} from 'replicasetdetail/sortedheader_controller';
+import {stateName as replicasets} from 'replicasetlist/replicasetlist_state';
 
 // Filter type and source values for events.
 const EVENT_ALL = 'All';
@@ -226,8 +227,7 @@ export default class ReplicaSetDetailController {
    */
   onReplicaSetDeleteSuccess_() {
     this.log_.info('Replica set successfully deleted.');
-    // State name can not be imported. Related issue: #153
-    this.state_.go('replicasets');
+    this.state_.go(replicasets);
   }
 
   /**

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import serviceEndpointDirective from './serviceendpoint_directive';
-import stateConfig from './replicasetdetail_state';
+import stateConfig from './replicasetdetail_stateconfig';
 import sortedHeaderDirective from './sortedheader_directive';
 
 /**

--- a/src/app/frontend/replicasetdetail/replicasetdetail_state.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_state.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ReplicaSetDetailController from './replicasetdetail_controller';
-
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'replicasetdetail';
 
@@ -35,67 +33,4 @@ export class StateParams {
     /** @export {string} Name of this Replica Set. */
     this.replicaSet = replicaSet;
   }
-}
-
-/**
- * Configures states for the service view.
- *
- * @param {!ui.router.$stateProvider} $stateProvider
- * @ngInject
- */
-export default function stateConfig($stateProvider) {
-  $stateProvider.state(stateName, {
-    controller: ReplicaSetDetailController,
-    controllerAs: 'ctrl',
-    url: '/replicasets/:namespace/:replicaSet',
-    templateUrl: 'replicasetdetail/replicasetdetail.html',
-    resolve: {
-      'replicaSetSpecPodsResource': getReplicaSetSpecPodsResource,
-      'replicaSetDetailResource': getReplicaSetDetailsResource,
-      'replicaSetDetail': resolveReplicaSetDetails,
-      'replicaSetEvents': resolveReplicaSetEvents,
-    },
-  });
-}
-
-/**
- * @param {!StateParams} $stateParams
- * @param {!angular.$resource} $resource
- * @return {!angular.Resource<!backendApi.ReplicaSetDetail>}
- * @ngInject
- */
-function getReplicaSetDetailsResource($stateParams, $resource) {
-  return $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
-}
-
-/**
- * @param {!StateParams} $stateParams
- * @param {!angular.$resource} $resource
- * @return {!angular.Resource<!backendApi.ReplicaSetSpec>}
- * @ngInject
- */
-function getReplicaSetSpecPodsResource($stateParams, $resource) {
-  return $resource('/api/replicasets/:namespace/:replicaSet/update/pods', $stateParams);
-}
-
-/**
- * @param {!angular.Resource<!backendApi.ReplicaSetDetail>} replicaSetDetailResource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveReplicaSetDetails(replicaSetDetailResource) {
-  return replicaSetDetailResource.get().$promise;
-}
-
-/**
- * @param {!StateParams} $stateParams
- * @param {!angular.$resource} $resource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveReplicaSetEvents($stateParams, $resource) {
-  /** @type {!angular.Resource<!backendApi.Events>} */
-  let resource = $resource('/api/events/:namespace/:replicaSet', $stateParams);
-
-  return resource.get().$promise;
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ReplicaSetDetailController from './replicasetdetail_controller';
+import {stateName} from './replicasetdetail_state';
+
+/**
+ * Configures states for the service view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    controller: ReplicaSetDetailController,
+    controllerAs: 'ctrl',
+    url: '/replicasets/:namespace/:replicaSet',
+    templateUrl: 'replicasetdetail/replicasetdetail.html',
+    resolve: {
+      'replicaSetSpecPodsResource': getReplicaSetSpecPodsResource,
+      'replicaSetDetailResource': getReplicaSetDetailsResource,
+      'replicaSetDetail': resolveReplicaSetDetails,
+      'replicaSetEvents': resolveReplicaSetEvents,
+    },
+  });
+}
+
+/**
+ * @param {!./replicasetdetail_state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource<!backendApi.ReplicaSetDetail>}
+ * @ngInject
+ */
+function getReplicaSetDetailsResource($stateParams, $resource) {
+  return $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
+}
+
+/**
+ * @param {!./replicasetdetail_state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource<!backendApi.ReplicaSetSpec>}
+ * @ngInject
+ */
+function getReplicaSetSpecPodsResource($stateParams, $resource) {
+  return $resource('/api/replicasets/:namespace/:replicaSet/update/pods', $stateParams);
+}
+
+/**
+ * @param {!angular.Resource<!backendApi.ReplicaSetDetail>} replicaSetDetailResource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolveReplicaSetDetails(replicaSetDetailResource) {
+  return replicaSetDetailResource.get().$promise;
+}
+
+/**
+ * @param {!./replicasetdetail_state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolveReplicaSetEvents($stateParams, $resource) {
+  /** @type {!angular.Resource<!backendApi.Events>} */
+  let resource = $resource('/api/events/:namespace/:replicaSet', $stateParams);
+
+  return resource.get().$promise;
+}

--- a/src/app/frontend/replicasetlist/replicasetlist_controller.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_controller.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as deploy} from 'deploy/deploy_state';
+
 /**
  * Controller for the replica set list view.
  *
@@ -32,8 +34,7 @@ export default class ReplicaSetListController {
   }
 
   /**
-   * TODO(floreks): Should be changed to state variable. Related issue #153.
    * @export
    */
-  redirectToDeployPage() { this.state_.go('deploy'); }
+  redirectToDeployPage() { this.state_.go(deploy); }
 }

--- a/src/app/frontend/replicasetlist/replicasetlist_module.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_module.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicasetlist_state';
+import stateConfig from './replicasetlist_stateconfig';
 import logsMenuDirective from './logsmenu_directive';
 import middleEllipsisFilter from 'common/filters/middleellipsis_filter';
 import replicaSetCardDirective from './replicasetcard_directive';

--- a/src/app/frontend/replicasetlist/replicasetlist_state.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_state.js
@@ -12,58 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {stateName as zerostate} from 'zerostate/zerostate_state';
-import ReplicaSetListController from './replicasetlist_controller';
-
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'replicasets';
 
 /** Absolute URL of the state. */
 export const stateUrl = '/replicasets';
-
-/**
- * Configures states for the service view.
- *
- * @param {!ui.router.$stateProvider} $stateProvider
- * @ngInject
- */
-export default function stateConfig($stateProvider) {
-  $stateProvider.state(stateName, {
-    controller: ReplicaSetListController,
-    controllerAs: 'ctrl',
-    url: stateUrl,
-    resolve: {
-      'replicaSets': resolveReplicaSets,
-    },
-    templateUrl: 'replicasetlist/replicasetlist.html',
-    onEnter: redirectIfNeeded,
-  });
-}
-
-/**
- * Avoids entering replica set list page when there are no replica sets.
- * Used f.e. when last replica set gets deleted.
- * Transition to: zerostate
- * @param {!ui.router.$state} $state
- * @param {!angular.$timeout} $timeout
- * @param {!backendApi.ReplicaSetList} replicaSets
- * @ngInject
- */
-function redirectIfNeeded($state, $timeout, replicaSets) {
-  if (replicaSets.replicaSets.length === 0) {
-    // allow original state change to finish before redirecting to new state to avoid error
-    $timeout(() => { $state.go(zerostate); });
-  }
-}
-
-/**
- * @param {!angular.$resource} $resource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveReplicaSets($resource) {
-  /** @type {!angular.Resource<!backendApi.ReplicaSetList>} */
-  let resource = $resource('/api/replicasets');
-
-  return resource.get().$promise;
-}

--- a/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
@@ -1,0 +1,65 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as zerostate} from 'zerostate/zerostate_state';
+import {stateName as replicasets} from './replicasetlist_state';
+import {stateUrl as replicasetsUrl} from './replicasetlist_state';
+import ReplicaSetListController from './replicasetlist_controller';
+
+/**
+ * Configures states for the service view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(replicasets, {
+    controller: ReplicaSetListController,
+    controllerAs: 'ctrl',
+    url: replicasetsUrl,
+    resolve: {
+      'replicaSets': resolveReplicaSets,
+    },
+    templateUrl: 'replicasetlist/replicasetlist.html',
+    onEnter: redirectIfNeeded,
+  });
+}
+
+/**
+ * Avoids entering replica set list page when there are no replica sets.
+ * Used f.e. when last replica set gets deleted.
+ * Transition to: zerostate
+ * @param {!ui.router.$state} $state
+ * @param {!angular.$timeout} $timeout
+ * @param {!backendApi.ReplicaSetList} replicaSets
+ * @ngInject
+ */
+function redirectIfNeeded($state, $timeout, replicaSets) {
+  if (replicaSets.replicaSets.length === 0) {
+    // allow original state change to finish before redirecting to new state to avoid error
+    $timeout(() => { $state.go(zerostate); });
+  }
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolveReplicaSets($resource) {
+  /** @type {!angular.Resource<!backendApi.ReplicaSetList>} */
+  let resource = $resource('/api/replicasets');
+
+  return resource.get().$promise;
+}

--- a/src/app/frontend/zerostate/zerostate_state.js
+++ b/src/app/frontend/zerostate/zerostate_state.js
@@ -12,22 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ZeroStateController from './zerostate_controller';
-
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'zero';
-
-/**
- * Configures states for the zero state view.
- *
- * @param {!ui.router.$stateProvider} $stateProvider
- * @ngInject
- */
-export default function stateConfig($stateProvider) {
-  $stateProvider.state(stateName, {
-    controller: ZeroStateController,
-    controllerAs: 'ctrl',
-    url: '/zerostate',
-    templateUrl: 'zerostate/zerostate.html',
-  });
-}

--- a/src/app/frontend/zerostate/zerostate_stateconfig.js
+++ b/src/app/frontend/zerostate/zerostate_stateconfig.js
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './zerostate_stateconfig';
+import ZeroStateController from './zerostate_controller';
+import {stateName} from './zerostate_state';
 
 /**
- * Angular module for the zero state view.
+ * Configures states for the zero state view.
  *
- * The view is active on the first launch of the application and is used for onboarding new users.
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
  */
-export default angular.module(
-                          'kubernetesDashboard.zerostate',
-                          [
-                            'ui.router',
-                          ])
-    .config(stateConfig);
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    controller: ZeroStateController,
+    controllerAs: 'ctrl',
+    url: '/zerostate',
+    templateUrl: 'zerostate/zerostate.html',
+  });
+}

--- a/src/test/frontend/logs/logstoolbar/logstoolbar_controller_test.js
+++ b/src/test/frontend/logs/logstoolbar/logstoolbar_controller_test.js
@@ -65,8 +65,9 @@ describe('Logs toolbar controller', () => {
 
     angular.mock.inject(($controller, $state) => {
       state = $state;
-      state.params = stateParams;
-      ctrl = $controller(LogsToolbarController, {replicaSetPods: replicaSetPods}, $state);
+      ctrl = $controller(
+          LogsToolbarController, {replicaSetPods: replicaSetPods, $stateParams: stateParams},
+          $state);
     });
   });
 


### PR DESCRIPTION
I've been thinking about some good way to resolve this issue (#153).

## Proposals
1. Introduce new module with module constant `states` that can be injected on demand.
2. Introduce new file with const object `states` not related to modules that can be imported on demand.

I've chosen second option as it seems to be cleaner and simpler. There is no need to define additional dependencies between modules and we don't have to inject constant to the function where we want it to be used.

## Architecture

I've externalized all state names to separate `states.js` file in order to get rid of circual dependencies between modules. Currently all modules can import on demand defined object and use its state properties.

## Usage

Usage is pretty straighforward. Just import `states` object and use predefined states f.e. `state.STATE_DEPLOY`.

## Things to improve

* Filename - As it is not related to any module I've chosen simple `states.js`. We can think about better name here
* Filepath - It's part of the global configuration, so I've decided to put it directly under `frontend` folder. Does it need new folder?


Questions? Comments? Any other ideas?

@bryk @zreigz @maciaszczykm @cheld 