### PR TITLE
Added common label formatting (as chips) and unified across the project.

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -49,7 +49,7 @@ function getFileList() {
  */
 module.exports = function(config) {
   let configuration = {
-    basePath: conf.paths.base,
+    basePath: '.',
 
     files: getFileList(),
 
@@ -109,7 +109,8 @@ module.exports = function(config) {
     // karma-ng-html2js-preprocessor plugin config.
     ngHtml2JsPreprocessor: {
       stripPrefix: `${conf.paths.frontendSrc}/`,
-      moduleName: conf.frontend.moduleName,
+      // Load all template related stuff under ng module as it's loaded with every module.
+      moduleName: 'ng',
     },
   };
 

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import middleEllipsisFilter from './middleellipsis_filter';
-import relativeTimeFilter from './relativetime_filter';
+import labelsDirective from './labels/labels_directive';
 
 /**
- * Module containing common filters for the application.
+ * Module containing common components for the application.
  */
 export default angular.module(
-                          'kubernetesDashboard.common.filters',
+                          'kubernetesDashboard.common.components',
                           [
                             'ngMaterial',
                           ])
-    .filter('middleEllipsis', middleEllipsisFilter)
-    .filter('relativeTime', relativeTimeFilter);
+    .directive('kdLabels', labelsDirective);

--- a/src/app/frontend/common/components/labels/labels.html
+++ b/src/app/frontend/common/components/labels/labels.html
@@ -1,0 +1,21 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<md-content>
+  <div class="kd-labels" ng-repeat="(key, value) in ::labelsCtrl.labels">
+    {{key}}={{value}}
+  </div>
+</md-content>

--- a/src/app/frontend/common/components/labels/labels.scss
+++ b/src/app/frontend/common/components/labels/labels.scss
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import middleEllipsisFilter from './middleellipsis_filter';
-import relativeTimeFilter from './relativetime_filter';
+@import '../../../variables';
 
-/**
- * Module containing common filters for the application.
- */
-export default angular.module(
-                          'kubernetesDashboard.common.filters',
-                          [
-                            'ngMaterial',
-                          ])
-    .filter('middleEllipsis', middleEllipsisFilter)
-    .filter('relativeTime', relativeTimeFilter);
+$label-height: $caption-font-size-base + 6;
+$label-margin: 0 $baseline-grid $baseline-grid 0;
+
+// Style taken(mostly) from angular material md-chip style.
+.kd-labels {
+  background-color: $body;
+  border-radius: $label-height / 2;
+  display: inline-block;
+  font-size: $caption-font-size-base;
+  line-height: $label-height;
+  margin: $label-margin;
+  padding: 0 $baseline-grid;
+  vertical-align: middle;
+}

--- a/src/app/frontend/common/components/labels/labels_controller.js
+++ b/src/app/frontend/common/components/labels/labels_controller.js
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import middleEllipsisFilter from './middleellipsis_filter';
-import relativeTimeFilter from './relativetime_filter';
-
 /**
- * Module containing common filters for the application.
+ * @final
  */
-export default angular.module(
-                          'kubernetesDashboard.common.filters',
-                          [
-                            'ngMaterial',
-                          ])
-    .filter('middleEllipsis', middleEllipsisFilter)
-    .filter('relativeTime', relativeTimeFilter);
+export default class LabelsController {
+  /**
+   * Constructs labels controller.
+   * @ngInject
+   */
+  constructor() {
+    /** @export {Object<string, string>} Initialized from the scope. */
+    this.labels;
+  }
+}

--- a/src/app/frontend/common/components/labels/labels_directive.js
+++ b/src/app/frontend/common/components/labels/labels_directive.js
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import middleEllipsisFilter from './middleellipsis_filter';
-import relativeTimeFilter from './relativetime_filter';
+import LabelsController from './labels_controller';
 
 /**
- * Module containing common filters for the application.
+ * Returns directive definition for label.
+ *
+ * @return {!angular.Directive}
  */
-export default angular.module(
-                          'kubernetesDashboard.common.filters',
-                          [
-                            'ngMaterial',
-                          ])
-    .filter('middleEllipsis', middleEllipsisFilter)
-    .filter('relativeTime', relativeTimeFilter);
+export default function labelsDirective() {
+  return {
+    controller: LabelsController,
+    controllerAs: 'labelsCtrl',
+    templateUrl: 'common/components/labels/labels.html',
+    scope: {},
+    bindToController: {
+      'labels': '=',
+    },
+  };
+}

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -42,4 +42,4 @@ export default angular.module(
     .directive('kdUniqueName', uniqueNameDirective)
     .directive('kdFileReader', fileReaderDirective)
     .directive('kdUpload', uploadDirective)
-    .directive('kdLabel', deployLabelDirective);
+    .directive('kdDeployLabel', deployLabelDirective);

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -110,7 +110,7 @@ limitations under the License.
           <p flex>Value</p>
         </div>
         <div ng-repeat="label in ctrl.labels">
-          <kd-label layout="row" flex label="label" labels="ctrl.labels"></kd-label>
+          <kd-deploy-label layout="row" flex label="label" labels="ctrl.labels"></kd-deploy-label>
         </div>
       </div>
     </div>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -48,12 +48,12 @@ limitations under the License.
           </span>
           <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
           <span class="kd-replicasetdetail-sidebar-subline">
-            {{ctrl.formatLabelString(ctrl.replicaSetDetail.labelSelector)}}
+            <kd-labels labels="::ctrl.replicaSetDetail.labelSelector"></kd-labels>
           </span>
           <span class="kd-replicasetdetail-sidebar-title">Replica Sets</span>
           <span class="kd-replicasetdetail-sidebar-line">Labels</span>
           <span class="kd-replicasetdetail-sidebar-subline">
-            {{ctrl.formatLabelString(ctrl.replicaSetDetail.labels)}}
+            <kd-labels labels="::ctrl.replicaSetDetail.labels"></kd-labels>
           </span>
           <span class="kd-replicasetdetail-sidebar-line">Images</span>
           <span class="kd-replicasetdetail-sidebar-subline"
@@ -65,7 +65,7 @@ limitations under the License.
             <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
             <span class="kd-replicasetdetail-sidebar-subline"
                   ng-repeat="service in ::ctrl.replicaSetDetail.services">
-              {{::ctrl.formatLabelString(service.selector)}}
+              <kd-labels labels="::service.selector"></kd-labels>
             </span>
             <span class="kd-replicasetdetail-sidebar-line">Internal endpoint</span>
             <div class="kd-replicasetdetail-sidebar-subline"

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -18,6 +18,7 @@ $replicasetdetails-sidebar-bg: #fafafa;
 $replicasetdetails-border: #ddd;
 $replicasetdetails-table-message: #000;
 $replicasetdetails-table-cell: #777;
+$replicasetdetails-sidebar-width: 315px;
 
 .kd-replicasetdetail-app-name {
   color: $foreground-2;
@@ -26,7 +27,8 @@ $replicasetdetails-table-cell: #777;
 
 .kd-replicasetdetail-sidebar {
   background-color: $replicasetdetails-sidebar-bg;
-  min-width: 315px;
+  max-width: $replicasetdetails-sidebar-width;
+  min-width: $replicasetdetails-sidebar-width;
 }
 
 .kd-replicasetdetail-table {
@@ -76,7 +78,6 @@ $replicasetdetails-table-cell: #777;
 .kd-replicasetdetail-sidebar-subline {
   color: $muted;
   font-size: $caption-font-size-base;
-  padding-bottom: 8px;
 }
 
 .kd-replicasetdetail-sidebar-icon {

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -115,19 +115,6 @@ export default class ReplicaSetDetailController {
   }
 
   /**
-   * TODO(floreks): Reuse this in replicasetlist controller.
-   * Formats labels object to readable string.
-   * @param {!Object} object
-   * @return {string}
-   * @export
-   */
-  formatLabelString(object) {
-    let result = '';
-    angular.forEach(object, function(value, key) { result += `,${key}=${value}`; });
-    return result.substring(1);
-  }
-
-  /**
    * Returns true if event is a warning.
    * @param {!backendApi.Event} event
    * @return {boolean}

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import componentsModule from './../common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
 import serviceEndpointDirective from './serviceendpoint_directive';
 import stateConfig from './replicasetdetail_stateconfig';
@@ -30,6 +31,7 @@ export default angular.module(
                             'ngResource',
                             'ui.router',
                             filtersModule.name,
+                            componentsModule.name,
                           ])
     .config(stateConfig)
     .directive('kdServiceEndpoint', serviceEndpointDirective)

--- a/src/app/frontend/replicasetlist/replicasetcard.html
+++ b/src/app/frontend/replicasetlist/replicasetcard.html
@@ -28,10 +28,7 @@ limitations under the License.
         <kd-replica-set-card-menu replica-set="::ctrl.replicaSet"></kd-replica-set-card-menu>
       </div>
       <div flex class="md-caption">
-        <span ng-repeat="(label, value) in ::ctrl.replicaSet.labels"
-            class="kd-replicaset-card-label">
-          {{::label}}:{{::value}}
-        </span>
+        <kd-labels labels="::ctrl.replicaSet.labels"></kd-labels>
       </div>
     </div>
     <div class="md-caption">

--- a/src/app/frontend/replicasetlist/replicasetlist_module.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_module.js
@@ -15,6 +15,7 @@
 import stateConfig from './replicasetlist_stateconfig';
 import logsMenuDirective from './logsmenu_directive';
 import filtersModule from 'common/filters/filters_module';
+import componentsModule from 'common/components/components_module';
 import replicaSetCardDirective from './replicasetcard_directive';
 import replicaSetCardMenuDirective from './replicasetcardmenu_directive';
 import replicaSetDetailModule from 'replicasetdetail/replicasetdetail_module';
@@ -33,6 +34,7 @@ export default angular.module(
                             'ui.router',
                             replicaSetDetailModule.name,
                             filtersModule.name,
+                            componentsModule.name,
                           ])
     .config(stateConfig)
     .directive('logsMenu', logsMenuDirective)

--- a/src/test/frontend/common/components/labels/labels_controller_test.js
+++ b/src/test/frontend/common/components/labels/labels_controller_test.js
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import componentsModule from 'common/components/components_module';
+
+describe('Labels directive', () => {
+  /** @type {!angular.Scope} */
+  let scope;
+  /** @type {function(!angular.Scope):!angular.JQLite} */
+  let compileFn;
+
+  beforeEach(() => {
+    angular.mock.module(componentsModule.name);
+
+    angular.mock.inject(($rootScope, $compile) => {
+      scope = $rootScope.$new();
+      compileFn = $compile('<kd-labels labels="labels"></kd-labels>');
+    });
+  });
+
+  it('should render 3 labels', () => {
+    // given
+    scope.labels = {
+      app: 'app',
+      version: 'version',
+      testLabel: 'test',
+    };
+
+    // when
+    let element = compileFn(scope);
+    scope.$digest();
+
+    // then
+    let labels = element.find('div');
+    expect(labels.length).toEqual(3);
+    angular.forEach(
+        (key, value, index) => { expect(labels.eq(index).text()).toBe(`${key}=${value}`); });
+  });
+});


### PR DESCRIPTION
This is how it looks:

![zrzut ekranu z 2016-01-05 17-29-05](https://cloud.githubusercontent.com/assets/2285385/12120630/def33b80-b3d1-11e5-86b0-8cbaefb29934.png)

![zrzut ekranu z 2016-01-05 17-29-11](https://cloud.githubusercontent.com/assets/2285385/12120634/e096c5ba-b3d1-11e5-940d-387882d3a3ca.png)

I've changed default chips styling to fit application style. I think that similar look can be applied to deploy page labels if needed. Only 1 key/value input row would be left and all added labels would be displayed below as list of chips.

@bryk @maciaszczykm what do you think?