### PR TITLE
Introduce Heapster to local Kubernetes cluster

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -46,6 +46,10 @@ export default {
     * Address for the Kubernetes API server.
     */
     apiServerHost: 'localhost:8080',
+    /**
+     * Address for the Heapster API server.
+     */
+    heapsterServerHost: 'localhost:8082',
   },
 
   /**

--- a/build/hyperkube.sh
+++ b/build/hyperkube.sh
@@ -20,6 +20,8 @@
 K8S_VERSION="1.1.2"
 # Port of the apiserver to serve on.
 PORT=8080
+# Port of the heapster to serve on.
+HEAPSTER_PORT=8082
 
 docker run --net=host -d gcr.io/google_containers/etcd:2.0.12 \
    /usr/local/bin/etcd --addr=127.0.0.1:4001 --bind-addr=0.0.0.0:4001 --data-dir=/var/etcd/data
@@ -43,3 +45,7 @@ docker run \
 
 docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
     /hyperkube proxy --master=http://127.0.0.1:${PORT} --v=2
+
+# Runs Heapster in standalone mode
+docker run --net=host -d kubernetes/heapster -port ${HEAPSTER_PORT}\
+    --source=kubernetes:http://127.0.0.1:${PORT}?inClusterConfig=false&auth=""


### PR DESCRIPTION
This commit introduces Heapster to local Kubernetes cluster. Heapster listens on port 8082:
http://localhost:8082/api/v1/model/

To check if it is up and running:
http://localhost:8082/api/v1/model/stats
```
{
  "uptime": 99,
  "stats": {
   "cpu-limit": {
    "minute": {
     "average": 8000,
     "percentile": 8000,
     "max": 8000
    },
    "hour": {
   ...........


}
```
 