### PR TITLE
Request and response logging in the backend

### DIFF
--- a/src/test/backend/apihandler_test.go
+++ b/src/test/backend/apihandler_test.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	restful "github.com/emicklei/go-restful"
+)
+
+func TestGetRemoteAddr(t *testing.T) {
+	cases := []struct {
+		request  *restful.Request
+		expected string
+	}{
+		{
+			&restful.Request{
+				Request: &http.Request{
+					RemoteAddr: "192.168.1.1:8080",
+				},
+			},
+			"192.168.1.1",
+		},
+		{
+			&restful.Request{
+				Request: &http.Request{
+					RemoteAddr: "192.168.1.2",
+				},
+			},
+			"192.168.1.2",
+		},
+	}
+	for _, c := range cases {
+		actual := GetRemoteAddr(c.request)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetRemoteAddr(%#v) == %#v, expected %#v", c.request, actual, c.expected)
+		}
+	}
+}
+
+func TestFormatRequestLog(t *testing.T) {
+	cases := []struct {
+		request    *restful.Request
+		remoteAddr string
+		expected   string
+	}{
+		{
+			&restful.Request{
+				Request: &http.Request{
+					RemoteAddr: "192.168.1.1:8080",
+					Proto:      "HTTP 1.1",
+					Method:     "GET",
+				},
+			},
+			"192.168.1.1",
+			fmt.Sprintf(RequestLogString, "HTTP 1.1", "GET", "", "192.168.1.1", "[]"),
+		},
+	}
+	for _, c := range cases {
+		actual := FormatRequestLog(c.request, c.remoteAddr)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetRemoteAddr(%#v, %#v) == %#v, expected %#v", c.request, c.remoteAddr,
+				actual, c.expected)
+		}
+	}
+}
+
+func TestFormatResponseLog(t *testing.T) {
+	cases := []struct {
+		response   *restful.Response
+		remoteAddr string
+		expected   string
+	}{
+		{
+			&restful.Response{},
+			"192.168.1.1",
+			fmt.Sprintf(ResponseLogString, "192.168.1.1", http.StatusOK),
+		},
+	}
+	for _, c := range cases {
+		actual := FormatResponseLog(c.response, c.remoteAddr)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetRemoteAddr(%#v, %#v) == %#v, expected %#v", c.response, c.remoteAddr,
+				actual, c.expected)
+		}
+	}
+}

--- a/src/test/backend/replicasetlist_test.go
+++ b/src/test/backend/replicasetlist_test.go
@@ -134,7 +134,7 @@ func TestGetReplicaSetList(t *testing.T) {
 				},
 			},
 			[]api.Pod{
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -143,7 +143,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodFailed,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -152,7 +152,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodFailed,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -161,7 +161,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodPending,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-2",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -170,7 +170,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodPending,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -179,7 +179,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodRunning,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},
@@ -188,7 +188,7 @@ func TestGetReplicaSetList(t *testing.T) {
 						Phase: api.PodSucceeded,
 					},
 				},
-				api.Pod{
+				{
 					ObjectMeta: api.ObjectMeta{
 						Namespace: "namespace-1",
 						Labels:    map[string]string{"app": "my-name-1"},


### PR DESCRIPTION
Added request and response logging in the backend for all registered webservices. Related to #228 issue.