### PR TITLE
Implement global page for internal errors

### DIFF
--- a/src/app/frontend/_variables.scss
+++ b/src/app/frontend/_variables.scss
@@ -19,6 +19,7 @@
   @return $multiplier * $font-size;
 }
 
+$display-4-font-size-base: rem(11.2) !default;
 $headline-font-size-base:  rem(2.4) !default;
 $subhead-font-size-base:   rem(1.6) !default;
 $body-font-size-base:      rem(1.4) !default;

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -27,7 +27,7 @@ limitations under the License.
     </div>
   </md-toolbar>
   <div class="kd-app-content-wrapper" ng-switch="ctrl.showLoadingSpinner">
-    <div ng-switch-when="true" class="kd-chrome-loading-container">
+    <div ng-switch-when="true" class="kd-center-fixed">
       <md-progress-circular md-mode="indeterminate" md-diameter="96">
       </md-progress-circular>
     </div>

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -14,42 +14,7 @@
 
 @import '../variables';
 
-.kd-toolbar-logo {
-  height: 42px;
-  margin-right: 1em;
-  width: 42px;
-}
-
-.kd-toolbar {
-  box-shadow: $whiteframe-shadow-1dp;
-}
-
-body {
-  background-color: $body;
-  height: 100%;
-}
-
-a {
-  text-decoration: inherit;
-}
-
-.kd-toolbar-tools,
-.kd-app-content-wrapper {
-  margin: 0 auto;
-}
-
-.kd-app-content {
-  position: relative;
-}
-
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
+.kd-error-view-icon {
+  color: $foreground-2;
+  font-size: $display-4-font-size-base;
 }

--- a/src/app/frontend/error/error_module.js
+++ b/src/app/frontend/error/error_module.js
@@ -1,0 +1,45 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName, StateParams} from './internalerror_state';
+import stateConfig from './internalerror_stateconfig';
+
+/**
+ * Angular module for error views.
+ */
+export default angular.module(
+                          'kubernetesDashboard.error',
+                          [
+                            'ui.router',
+                          ])
+    .config(stateConfig)
+    .run(errorConfig);
+
+/**
+ * Configures event catchers for the error views.
+ *
+ * @param {!angular.Scope} $rootScope
+ * @param {!ui.router.$state} $state
+ * @ngInject
+ */
+function errorConfig($rootScope, $state) {
+  let deregistrationHandler = $rootScope.$on(
+      '$stateChangeError', (event, toState, toParams, fromState, fromParams, error) => {
+        // Prevent default behavior of coming back to previous state.
+        event.preventDefault();
+        $state.go(stateName, new StateParams(error));
+      });
+
+  $rootScope.$on('$destroy', deregistrationHandler);
+}

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -1,0 +1,35 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div class="kd-center-fixed">
+  <div layout="column"  layout-align="center center">
+    <i flex class="material-icons kd-error-view-icon">error_outline</i>
+    <div flex>
+      <h2 class="md-headline">
+        <span ng-if="::ctrl.error.statusText">
+          {{ctrl.error.statusText}}
+        </span>
+        <span ng-if="::!ctrl.error.statusText">
+          Unknown Server Error
+        </span>
+        <span ng-if="::ctrl.showStatus()">
+         ({{ctrl.error.status}})
+        </span>
+      </h2>
+      <pre ng-if="::ctrl.error.data">{{ctrl.error.data}}</pre>
+    </div>
+  </div>
+</div>

--- a/src/app/frontend/error/internalerror_controller.js
+++ b/src/app/frontend/error/internalerror_controller.js
@@ -12,44 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../variables';
+/**
+ * @final
+ */
+export class InternalErrorController {
+  /**
+   * @param {!./internalerror_state.StateParams} $stateParams
+   * @ngInject
+   */
+  constructor($stateParams) {
+    /** @export {!angular.$http.Response} */
+    this.error = $stateParams.error;
+  }
 
-.kd-toolbar-logo {
-  height: 42px;
-  margin-right: 1em;
-  width: 42px;
-}
-
-.kd-toolbar {
-  box-shadow: $whiteframe-shadow-1dp;
-}
-
-body {
-  background-color: $body;
-  height: 100%;
-}
-
-a {
-  text-decoration: inherit;
-}
-
-.kd-toolbar-tools,
-.kd-app-content-wrapper {
-  margin: 0 auto;
-}
-
-.kd-app-content {
-  position: relative;
-}
-
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
+  /**
+   * @export
+   * @return {boolean}
+   */
+  showStatus() { return angular.isNumber(this.error.status) && this.error.status > 0; }
 }

--- a/src/app/frontend/error/internalerror_state.js
+++ b/src/app/frontend/error/internalerror_state.js
@@ -12,44 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../variables';
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'internalerror';
 
-.kd-toolbar-logo {
-  height: 42px;
-  margin-right: 1em;
-  width: 42px;
-}
-
-.kd-toolbar {
-  box-shadow: $whiteframe-shadow-1dp;
-}
-
-body {
-  background-color: $body;
-  height: 100%;
-}
-
-a {
-  text-decoration: inherit;
-}
-
-.kd-toolbar-tools,
-.kd-app-content-wrapper {
-  margin: 0 auto;
-}
-
-.kd-app-content {
-  position: relative;
-}
-
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
+/**
+ * Parameters for this state.
+ */
+export class StateParams {
+  /**
+   * @param {!angular.$http.Response} error
+   */
+  constructor(error) {
+    /** @type {!angular.$http.Response} */
+    this.error = error;
+  }
 }

--- a/src/app/frontend/error/internalerror_stateconfig.js
+++ b/src/app/frontend/error/internalerror_stateconfig.js
@@ -12,44 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../variables';
+import {stateName, StateParams} from './internalerror_state';
+import {InternalErrorController} from './internalerror_controller';
 
-.kd-toolbar-logo {
-  height: 42px;
-  margin-right: 1em;
-  width: 42px;
-}
-
-.kd-toolbar {
-  box-shadow: $whiteframe-shadow-1dp;
-}
-
-body {
-  background-color: $body;
-  height: 100%;
-}
-
-a {
-  text-decoration: inherit;
-}
-
-.kd-toolbar-tools,
-.kd-app-content-wrapper {
-  margin: 0 auto;
-}
-
-.kd-app-content {
-  position: relative;
-}
-
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
+/**
+ * Configures states for the internal error view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    controller: InternalErrorController,
+    controllerAs: 'ctrl',
+    params: new StateParams(/** @type {!angular.$http.Response} */ ({})),
+    templateUrl: 'error/internalerror.html',
+  });
 }

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -18,9 +18,10 @@
  */
 import chromeModule from './chrome/chrome_module';
 import deployModule from './deploy/deploy_module';
+import errorModule from './error/error_module';
 import indexConfig from './index_config';
-import logsModule from './logs/logs_module';
 import routeConfig from './index_route';
+import logsModule from './logs/logs_module';
 import replicaSetDetailModule from './replicasetdetail/replicasetdetail_module';
 import replicaSetListModule from './replicasetlist/replicasetlist_module';
 
@@ -36,6 +37,7 @@ export default angular.module(
                             'ui.router',
                             chromeModule.name,
                             deployModule.name,
+                            errorModule.name,
                             logsModule.name,
                             replicaSetDetailModule.name,
                             replicaSetListModule.name,

--- a/src/test/frontend/error/error_module_test.js
+++ b/src/test/frontend/error/error_module_test.js
@@ -12,44 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../variables';
+import errorModule from 'error/error_module';
 
-.kd-toolbar-logo {
-  height: 42px;
-  margin-right: 1em;
-  width: 42px;
-}
+describe('Error module', () => {
+  beforeEach(angular.mock.module(errorModule.name));
 
-.kd-toolbar {
-  box-shadow: $whiteframe-shadow-1dp;
-}
+  it('should register route error handlers', angular.mock.inject(($rootScope, $state) => {
+    // given
+    let error = {error: 'bar'};
+    expect($state.current.name).toBe('');
 
-body {
-  background-color: $body;
-  height: 100%;
-}
+    // when
+    $rootScope.$broadcast('$stateChangeError', null, null, null, null, error);
+    $rootScope.$apply();
 
-a {
-  text-decoration: inherit;
-}
-
-.kd-toolbar-tools,
-.kd-app-content-wrapper {
-  margin: 0 auto;
-}
-
-.kd-app-content {
-  position: relative;
-}
-
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-}
+    // then
+    expect($state.current.name).toBe('internalerror');
+  }));
+});

--- a/src/test/frontend/error/internalerror_controller_test.js
+++ b/src/test/frontend/error/internalerror_controller_test.js
@@ -1,0 +1,51 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import errorModule from 'error/error_module';
+import {InternalErrorController} from 'error/internalerror_controller';
+import {StateParams} from 'error/internalerror_state';
+
+describe('Internal error controller', () => {
+  /** @type {!InternalErrorController} */
+  let ctrl;
+  /** @type {!StateParams} */
+  let stateParams;
+
+  beforeEach(() => {
+    angular.mock.module(errorModule.name);
+
+    angular.mock.inject(($controller) => {
+      stateParams = new StateParams({status: undefined});
+      ctrl = $controller(InternalErrorController, {$stateParams: stateParams});
+    });
+  });
+
+  it('should hide status when no error', () => { expect(ctrl.showStatus()).toBe(false); });
+
+  it('should hide status when there is unknown error', () => {
+    // given
+    stateParams.error.status = -1;
+
+    // then
+    expect(ctrl.showStatus()).toBe(false);
+  });
+
+  it('should show status when there known error', () => {
+    // given
+    stateParams.error.status = 404;
+
+    // then
+    expect(ctrl.showStatus()).toBe(true);
+  });
+});


### PR DESCRIPTION
To test this make, e.g., details API call always return errors.
Or got to: http://localhost:9090/#/replicasets/foo/bar