### PR TITLE
Considerations for i18n in dashboard - Overview & angular-translate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "angular-messages": "~1.4.8",
     "angular-ui-router": "~0.2.15",
     "angular-resource": "~1.4.8",
-    "angular-sanitize": "~1.4.8"
+    "angular-sanitize": "~1.4.8",
+    "angular-translate": "~2.8.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.8",

--- a/docs/design/i18n-angular-translate.md
+++ b/docs/design/i18n-angular-translate.md
@@ -1,0 +1,19 @@
+# Using angular-translate
+Angular JS is currently an external project supporting AngularJS 1.X and is entirely based on the Angular functionality. It relies heavily on the data-bindings and no build step is required (in contrast to the Closure Templates). A fully dynamic framework (all translations are available at runtime without reload), which also makes it a bit more demanding performance-wise.
+
+To use it:
+* in some structure (e.g. a JSON file) define a key-value object, containing all the translated messages.
+* Bind this object's to the `$translateProvider` that comes with the framework.
+* Use `{{ <message_key> | translate }}` in the angular templates.
+
+## Pros of angular-translate for i18n:
+* Since it is entirely AngularJS based, this solution is particularly simple to integrate into Dashboard.
+* If locale changes are necessary, it is really flexible and the corresponding translation can be chosen dynamically without reload.
+* Therefore the server does not have to determine what the locale is (in contrast to Closure Templates).
+* Supports detection of the default locale out of the box.
+
+## Cons of angular-translate for i18n:
+* With this framework we cannot use the XLIFF standard. For human translators, that's usually considered an inconvenience, because they have to translate directly inside the JSON files. An alternative would be to find a tool that can convert from XLIFF to JS back and forth, then this consideration would not be a problem.
+* Due to the abuse of data bindings and tracking of UI elements, it can decrease performance.
+
+From my perspective, the angular-translate framework is easier to integrate into our project. The only major drawback is the missing link in the i18n & l10n chain (the XLIFF format), which makes it easier for human translators to localize.

--- a/docs/design/i18n.md
+++ b/docs/design/i18n.md
@@ -1,0 +1,27 @@
+# i18n & l10n in Dashboard
+
+This document describes the fundamental aspects of providing i18n & l10n support in the Dashboard project.
+
+## i18n
+
+The process of *internationalization* (i18n) requires the abstraction of all locale-specific application bits, so that they can be later properly populated with information for the given locale. Internationalization means writing the code in a way that it can be adapted to a locale easily.
+
+## l10n
+
+The process of *localization* (l10n) calls for mechanisms which can provide translation (and localized data) for the abstracted bits in the *i18n* step. Localization means actually adapting the application to the given locale (e.g. translating the text).
+
+Usually this step is done by translators. If the text which is to be localized is provided in a suitable format (i.e. XLIFF), a translator could use a translation program to efficiently do the localization. This is the best possibility. The other option is to directly translate the abstracted bits inside of a simple file (e.g. JSON file).
+
+## Approaches
+So far I have considered 2 possible approaches to localization:
+  * *Closure Templates* (Soy) - this approach creates multiples sets of .js files (e.g. `translation_de.js`, `translation_en.js`), which are pre-compiled and then served individually with respect to the locale. It requires build steps for this and can be integrated nicely in our build pipeline. A static solution, because the whole page must be re-served if the locale changes.
+
+  * *Angular Translate* - this is, in contrast, a dynamic solution. All the translations are loaded dynamically on the client side, there are no multiple pre-compiled files. It is written entirely based on AngularJS. However, the abuse of *data bindings* make it more demanding performance-wise. Locale changes are possible without reload.
+
+Note that locale changes are actually pretty rare.
+
+For a bit more detailed information on the two approaches, refer to the following docs:
+* Closude Templates - https://github.com/taimir/dashboard/blob/i18n-closure-soy/docs/design/i18n-soy.md
+* Angular Translate - https://github.com/taimir/dashboard/blob/i18n-angular-translate/docs/design/i18n-angular-translate.md
+
+These two tools are also the ones discussed in the following design document of AngularJS and are right now the two prominent options for i18n & l10n for AngularJS in the near future. Refer to the document at: https://docs.google.com/document/d/1mwyOFsAD-bPoXTk3Hthq0CAcGXCUw-BtTJMR4nGTY-0

--- a/src/app/externs/angular-translate.js
+++ b/src/app/externs/angular-translate.js
@@ -1,0 +1,43 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Externs for angular-translate.
+ *
+ * @externs
+ */
+
+/**
+ * @type {Object}
+ * @const
+ */
+angular.$translateProvider;
+
+/**
+ * @typedef {Object}
+ */
+let TranslateProvider;
+
+/**
+ * @param {string} langKey
+ * @return {!TranslateProvider}
+ */
+angular.$translateProvider.preferredLanguage = function(langKey) {};
+
+/**
+ * @param {string} langKey
+ * @param {Object} translationTable
+ * @return {!TranslateProvider}
+ */
+angular.$translateProvider.translations = function(langKey, translationTable) {};

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -30,7 +30,7 @@ limitations under the License.
     </ng-messages>
   </md-input-container>
   <kd-user-help>
-    An 'app' label with this value will be added to the Replica Set and Service that get deployed.
+    {{'deploy.userhelp.appName' | translate }}
   </kd-user-help>
 </kd-help-section>
 
@@ -202,7 +202,7 @@ limitations under the License.
       <a href="">Learn more</a>
     </kd-user-help>
   </kd-help-section>
-  
+
   <kd-help-section>
     <md-switch ng-model="ctrl.runAsPrivileged" class="md-primary">
       Run as privileged

--- a/src/app/frontend/i18n/translations.js
+++ b/src/app/frontend/i18n/translations.js
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default function translations() {
+  return {
+    en: {
+      'deploy': {
+        'userhelp': {
+          'appName':
+              "An 'app' label with this value will be added to the Replica Set and Service that get deployed.",
+        },
+      },
+    },
+    de: {
+      'deploy': {
+        'userhelp': {
+          'appName':
+              "Ein 'app' Label mit diesem Wert wird dem erzeugten Replica Set und Service beigefügt.",
+        },
+      },
+    },
+  };
+}

--- a/src/app/frontend/index_config.js
+++ b/src/app/frontend/index_config.js
@@ -11,12 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import translations from './i18n/translations';
 
 /**
  * @param {!md.$mdThemingProvider} $mdThemingProvider
+ * @param {!TranslateProvider} $translateProvider
  * @ngInject
  */
-export default function config($mdThemingProvider) {
+export default function config($mdThemingProvider, $translateProvider) {
   // Create a color palette that uses Kubernetes colors.
   let kubernetesColorPaletteName = 'kubernetesColorPalette';
   let kubernetesColorPalette = $mdThemingProvider.extendPalette('blue', {
@@ -26,4 +28,9 @@ export default function config($mdThemingProvider) {
   // Use the palette as default one.
   $mdThemingProvider.definePalette(kubernetesColorPaletteName, kubernetesColorPalette);
   $mdThemingProvider.theme('default').primaryPalette(kubernetesColorPaletteName);
+
+  // Angular translate configuration
+  $translateProvider.translations('en', translations().en);
+  $translateProvider.translations('de', translations().de);
+  $translateProvider.preferredLanguage('de');
 }

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -34,6 +34,7 @@ export default angular.module(
                             'ngMessages',
                             'ngResource',
                             'ngSanitize',
+                            'pascalprecht.translate',
                             'ui.router',
                             chromeModule.name,
                             deployModule.name,


### PR DESCRIPTION
### DO NOT MERGE - ONLY MEANT FOR DISCUSSION

With this pull request I want to start the discussion for the i18n & l10n of the Dashboard project, using 2 concrete tools as a "proof of concept" of sorts:

* angular-translate
* Google Closure Templates for translation

I've summarized my knowledge on those two frameworks in the following design document:
https://github.com/taimir/dashboard/blob/i18n-angular-translate/docs/design/i18n.md

They are also discussed in this AngularJS design document, dealing with i18n:
https://docs.google.com/document/d/1mwyOFsAD-bPoXTk3Hthq0CAcGXCUw-BtTJMR4nGTY-0

This pull request contains a simple integration of angular-translate, please check the changes in the code to get an idea of the basic usage. For a Closure Templates example, please refer to this pull request: https://github.com/kubernetes/dashboard/pull/252

From my perspective, angular-translate is easier to integrate in our project, but lacks message extraction (into XLIFF files, good for human translators). Closure Templates has this, but does not fit our project that nicely. I really want to hear other opinions on this topic and am open for other tools I could try out.

@bryk @cheld @floreks @maciaszczykm @SebastianM 