### PR TITLE
Remove leading slash from all XHR calls

### DIFF
--- a/src/app/frontend/deploy/createnamespace_controller.js
+++ b/src/app/frontend/deploy/createnamespace_controller.js
@@ -92,7 +92,7 @@ export default class NamespaceDialogController {
     let namespaceSpec = {name: this.namespace};
 
     /** @type {!angular.Resource<!backendApi.NamespaceSpec>} */
-    let resource = this.resource_('/api/namespaces');
+    let resource = this.resource_('api/namespaces');
 
     resource.save(
         namespaceSpec,

--- a/src/app/frontend/deploy/deploy_stateconfig.js
+++ b/src/app/frontend/deploy/deploy_stateconfig.js
@@ -40,7 +40,7 @@ export default function stateConfig($stateProvider) {
  */
 function resolveNamespaces($resource) {
   /** @type {!angular.Resource<!backendApi.NamespaceList>} */
-  let resource = $resource('/api/namespaces');
+  let resource = $resource('api/namespaces');
 
   return resource.get().$promise;
 }

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -167,7 +167,7 @@ export default class DeployFromSettingsController {
     let defer = this.q_.defer();
 
     /** @type {!angular.Resource<!backendApi.AppDeploymentSpec>} */
-    let resource = this.resource_('/api/appdeployments');
+    let resource = this.resource_('api/appdeployments');
     resource.save(
         appDeploymentSpec,
         (savedConfig) => {

--- a/src/app/frontend/deploy/uniquename_directive.js
+++ b/src/app/frontend/deploy/uniquename_directive.js
@@ -53,7 +53,7 @@ function validate(name, namespace, resource, q) {
   let deferred = q.defer();
 
   /** @type {!angular.Resource<!backendApi.AppNameValiditySpec>} */
-  let resourceClass = resource('/api/appdeployments/validate/name');
+  let resourceClass = resource('api/appdeployments/validate/name');
   /** @type {!backendApi.AppNameValiditySpec} */
   let spec = {name: name, namespace: namespace};
   resourceClass.save(

--- a/src/app/frontend/logs/logs_stateconfig.js
+++ b/src/app/frontend/logs/logs_stateconfig.js
@@ -56,7 +56,7 @@ export default function stateConfig($stateProvider) {
 function resolveReplicaSetPods($stateParams, $resource) {
   /** @type {!angular.Resource<!backendApi.ReplicaSetPods>} */
   let resource =
-      $resource(`/api/replicasets/pods/${$stateParams.namespace}/${$stateParams.replicaSet}`);
+      $resource(`api/replicasets/pods/${$stateParams.namespace}/${$stateParams.replicaSet}`);
 
   return resource.get().$promise;
 }
@@ -69,7 +69,7 @@ function resolveReplicaSetPods($stateParams, $resource) {
  */
 function resolvePodLogs($stateParams, $resource) {
   /** @type {!angular.Resource<!backendApi.Logs>} */
-  let resource = $resource(`/api/logs/${$stateParams.namespace}/${$stateParams.podId}/${$stateParams.container}`);
+  let resource = $resource(`api/logs/${$stateParams.namespace}/${$stateParams.podId}/${$stateParams.container}`);
 
   return resource.get().$promise;
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
@@ -43,7 +43,7 @@ export default function stateConfig($stateProvider) {
  * @ngInject
  */
 export function getReplicaSetDetailsResource($stateParams, $resource) {
-  return $resource('/api/replicasets/:namespace/:replicaSet', $stateParams);
+  return $resource(`api/replicasets/${$stateParams.namespace}/${$stateParams.replicaSet}`);
 }
 
 /**
@@ -53,7 +53,7 @@ export function getReplicaSetDetailsResource($stateParams, $resource) {
  * @ngInject
  */
 function getReplicaSetSpecPodsResource($stateParams, $resource) {
-  return $resource('/api/replicasets/:namespace/:replicaSet/update/pods', $stateParams);
+  return $resource(`api/replicasets/${$stateParams.namespace}/${$stateParams.replicaSet}/update/pods`);
 }
 
 /**
@@ -73,7 +73,7 @@ function resolveReplicaSetDetails(replicaSetDetailResource) {
  */
 function resolveReplicaSetEvents($stateParams, $resource) {
   /** @type {!angular.Resource<!backendApi.Events>} */
-  let resource = $resource('/api/events/:namespace/:replicaSet', $stateParams);
+  let resource = $resource(`api/events/${$stateParams.namespace}/${$stateParams.replicaSet}`);
 
   return resource.get().$promise;
 }

--- a/src/app/frontend/replicasetlist/logsmenu_controller.js
+++ b/src/app/frontend/replicasetlist/logsmenu_controller.js
@@ -78,7 +78,7 @@ export default class LogsMenuController {
   getReplicaSetPods_() {
     /** @type {!angular.Resource<!backendApi.ReplicaSetPods>} */
     let resource =
-        this.resource_(`/api/replicasets/pods/${this.namespace}/${this.replicaSetName}?limit=10`);
+        this.resource_(`api/replicasets/pods/${this.namespace}/${this.replicaSetName}?limit=10`);
 
     resource.get(
         (replicaSetPods) => {

--- a/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
@@ -70,7 +70,7 @@ function redirectIfNeeded($state, $timeout, replicaSets) {
  */
 function resolveReplicaSets($resource) {
   /** @type {!angular.Resource<!backendApi.ReplicaSetList>} */
-  let resource = $resource('/api/replicasets');
+  let resource = $resource('api/replicasets');
 
   return resource.get().$promise;
 }

--- a/src/test/frontend/deploy/uniquename_directive_test.js
+++ b/src/test/frontend/deploy/uniquename_directive_test.js
@@ -35,7 +35,7 @@ describe('DeployFromSettings controller', () => {
   it('should validate name asynchronosuly', () => {
     scope.name = 'foo-name';
     scope.namespace = 'foo-namespace';
-    let endpoint = httpBackend.when('POST', '/api/appdeployments/validate/name');
+    let endpoint = httpBackend.when('POST', 'api/appdeployments/validate/name');
 
     let elem = compileFn(scope)[0];
     expect(elem.classList).toContain('ng-valid');
@@ -67,7 +67,7 @@ describe('DeployFromSettings controller', () => {
     scope.namespace = 'foo-namespace';
 
     let elem = compileFn(scope)[0];
-    httpBackend.when('POST', '/api/appdeployments/validate/name').respond({
+    httpBackend.when('POST', 'api/appdeployments/validate/name').respond({
       valid: false,
     });
     httpBackend.flush();
@@ -83,7 +83,7 @@ describe('DeployFromSettings controller', () => {
     scope.namespace = 'foo-namespace';
 
     let elem = compileFn(scope)[0];
-    httpBackend.when('POST', '/api/appdeployments/validate/name').respond(503, '');
+    httpBackend.when('POST', 'api/appdeployments/validate/name').respond(503, '');
     httpBackend.flush();
     expect(elem.classList).not.toContain('ng-pending');
     expect(elem.classList).toContain('ng-invalid');

--- a/src/test/frontend/replicasetdetail/deletereplicaset_service_test.js
+++ b/src/test/frontend/replicasetdetail/deletereplicaset_service_test.js
@@ -39,7 +39,7 @@ describe('Delete replica set service', () => {
     // given
     let deferred = q.defer();
     spyOn(mdDialog, 'show').and.returnValue(deferred.promise);
-    httpBackend.when('DELETE', '/api/replicasets/foo-namespace/foo-name').respond({});
+    httpBackend.when('DELETE', 'api/replicasets/foo-namespace/foo-name').respond({});
 
     // when
     let promise = service.showDeleteDialog('foo-namespace', 'foo-name');
@@ -54,7 +54,7 @@ describe('Delete replica set service', () => {
     // given
     let deferred = q.defer();
     spyOn(mdDialog, 'show').and.returnValue(deferred.promise);
-    httpBackend.when('DELETE', '/api/replicasets/foo-namespace/foo-name').respond(404, 'Error');
+    httpBackend.when('DELETE', 'api/replicasets/foo-namespace/foo-name').respond(404, 'Error');
 
     // when
     let promise = service.showDeleteDialog('foo-namespace', 'foo-name');


### PR DESCRIPTION
This is to be able to run when the application is rooted not at the
domain name. E.g.,
http://localhost:8080/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#/replicasets