### PR TITLE
Word-break for events and pods tables and logs view

### DIFF
--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -15,8 +15,7 @@ limitations under the License.
 -->
 
 <div layout="row" flex layout-fill>
-  <md-content layout-padding flex layout-fill
-              ng-class=ctrl.getStyleClass()>
+  <md-content layout-padding flex layout-fill ng-class=ctrl.getStyleClass()>
     <div ng-repeat="n in ctrl.logsSet" class="kd-logs-element">
       <pre>{{n}}</pre>
     </div>

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -27,4 +27,5 @@ $logs-color-white: #fff;
 
 .kd-logs-element {
   padding: 0;
+  word-wrap: break-word;
 }

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -331,7 +331,7 @@ limitations under the License.
           </thead>
           <tbody>
           <tr ng-repeat="event in ctrl.events | orderBy:ctrl.sortEventsBy:ctrl.eventsOrder">
-            <td class="kd-replicasetdetail-table-cell">
+            <td class="kd-replicasetdetail-table-cell kd-replicasetdetail-message-table-cell">
               <i ng-if="ctrl.isEventWarning(event)"
                  class="material-icons kd-replicasetdetail-warning-icon">warning</i>
               {{event.message}}

--- a/src/app/frontend/replicasetdetail/replicasetdetail.scss
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.scss
@@ -118,6 +118,11 @@ $table-cell-height-half: $table-cell-height / 2;
   font-size: $body-font-size-base;
   height: $table-cell-height;
   padding: 0 0 0 (2 * $baseline-grid);
+
+  &.kd-replicasetdetail-message-table-cell {
+    white-space: normal;
+    word-break: break-all;
+  }
 }
 
 .kd-replicasetdetail-table-icon {


### PR DESCRIPTION
Added small fix for issue mentioned in pull request #263. Now message cells size shouldn't cause anymore problems. However, column widths are still an issue. The only solution which comes to my mind at the moment is making their values fixed (in percents). Do you have any suggestions?