### PR TITLE
Changed condition when to show full pod status (desired, running, created, etc.)

### DIFF
--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -71,14 +71,11 @@ a {
 }
 
 .kd-comma-separated-item {
-  &:after {
-    content: ',';
-  }
-
-  &:last-child {
+  &:not(:last-child) {
     &:after {
-      content: '';
+      content: ',';
     }
+
   }
 }
 

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -52,11 +52,14 @@ limitations under the License.
         <div layout="row" layout-align="start end">
           <div flex="nogrow">
             <span class="kd-replicasetdetail-sidebar-line">Pods</span>
-            <span class="kd-replicasetdetail-sidebar-subline">
+            <span class="kd-replicasetdetail-sidebar-subline" ng-if="!ctrl.areDesiredPodsRunning()">
               {{::ctrl.replicaSetDetail.podInfo.current}} created,
               {{::ctrl.replicaSetDetail.podInfo.desired}} desired
             </span>
-            </div>
+            <span class="kd-replicasetdetail-sidebar-subline" ng-if="ctrl.areDesiredPodsRunning()">
+              {{::ctrl.replicaSetDetail.podInfo.running}} running
+            </span>
+          </div>
           <div flex="nogrow">
             <md-button  class="md-icon-button md-primary">
               <md-icon class="material-icons"
@@ -66,18 +69,20 @@ limitations under the License.
             </md-button>
           </div>
         </div>
-        <span class="kd-replicasetdetail-sidebar-line">Pods status</span>
-        <span class="kd-replicasetdetail-sidebar-subline">
-          <span ng-if="::ctrl.replicaSetDetail.podInfo.pending" class="kd-comma-separated-item">
-            {{::ctrl.replicaSetDetail.podInfo.pending}} pending<!-- Collapse whitespace
-          --></span>
-          <span ng-if="::ctrl.replicaSetDetail.podInfo.failed" class="kd-comma-separated-item">
-            {{::ctrl.replicaSetDetail.podInfo.failed}} failed<!-- Collapse whitespace
-          --></span>
-          <span ng-if="::ctrl.replicaSetDetail.podInfo.running" class="kd-comma-separated-item">
-            {{::ctrl.replicaSetDetail.podInfo.running}} running
+        <div ng-if="!ctrl.areDesiredPodsRunning()">
+          <span class="kd-replicasetdetail-sidebar-line">Pods status</span>
+          <span class="kd-replicasetdetail-sidebar-subline">
+            <span ng-if="::ctrl.replicaSetDetail.podInfo.pending" class="kd-comma-separated-item">
+              {{::ctrl.replicaSetDetail.podInfo.pending}} pending<!-- Collapse whitespace
+            --></span>
+            <span ng-if="::ctrl.replicaSetDetail.podInfo.failed" class="kd-comma-separated-item">
+              {{::ctrl.replicaSetDetail.podInfo.failed}} failed<!-- Collapse whitespace
+            --></span>
+            <span ng-if="::ctrl.replicaSetDetail.podInfo.running" class="kd-comma-separated-item">
+              {{::ctrl.replicaSetDetail.podInfo.running}} running
+            </span>
           </span>
-        </span>
+        </div>
         <span class="kd-replicasetdetail-sidebar-line">Label selector</span>
         <span class="kd-replicasetdetail-sidebar-subline kd-has-labels">
           <kd-labels labels="::ctrl.replicaSetDetail.labelSelector"></kd-labels>

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -178,6 +178,14 @@ export default class ReplicaSetDetailController {
   }
 
   /**
+   * @return {boolean}
+   * @export
+   */
+  areDesiredPodsRunning() {
+    return this.replicaSetDetail.podInfo.running === this.replicaSetDetail.podInfo.desired;
+  }
+
+  /**
    * Handles update of replicas count in replica set dialog.
    * @export
    */

--- a/src/app/frontend/replicasetlist/replicasetcard.html
+++ b/src/app/frontend/replicasetlist/replicasetcard.html
@@ -33,9 +33,9 @@ limitations under the License.
     <div class="md-caption">
       <div layout="row" layout-align="center end">
         <span flex="60">
-          <ng-pluralize class="kd-replicase-card-pods-stat" count="::ctrl.replicaSet.pods.running"
-                 when="{'one': '1 pod running,',
-                     'other': '{} pods running,'}">
+          <ng-pluralize class="kd-replicase-card-pods-stat kd-comma-separated-item"
+                        count="::ctrl.replicaSet.pods.running"
+                        when="{'one': '1 pod running', 'other': '{} pods running'}">
           </ng-pluralize>
           <span ng-if="::ctrl.replicaSet.pods.pending"
               class="kd-replicase-card-pods-stat kd-comma-separated-item">
@@ -45,7 +45,8 @@ limitations under the License.
               class="kd-replicase-card-pods-stat kd-comma-separated-item">
             {{::ctrl.replicaSet.pods.failed}} failed<!-- Collapse whitespace
           --></span>
-          <span class="kd-replicase-card-pods-stat kd-comma-separated-item">
+          <span ng-if="!ctrl.areDesiredPodsRunning()"
+                class="kd-replicase-card-pods-stat kd-comma-separated-item">
             {{::ctrl.replicaSet.pods.desired}} desired
           </span>
         </span>

--- a/src/app/frontend/replicasetlist/replicasetcard_controller.js
+++ b/src/app/frontend/replicasetlist/replicasetcard_controller.js
@@ -58,4 +58,10 @@ export default class ReplicaSetCardController {
     return this.state_.href(
         stateName, new StateParams(this.replicaSet.namespace, this.replicaSet.name));
   }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  areDesiredPodsRunning() { return this.replicaSet.pods.running === this.replicaSet.pods.desired; }
 }

--- a/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
+++ b/src/test/frontend/replicasetdetail/replicasetdetail_controller_test.js
@@ -143,4 +143,30 @@ describe('Replica Set Detail controller', () => {
     // then
     expect(result).toBeFalsy();
   });
+
+  it('should return true when all desired pods are running', () => {
+    // given
+    ctrl.replicaSetDetail = {
+      podInfo: {
+        running: 0,
+        desired: 0,
+      },
+    };
+
+    // then
+    expect(ctrl.areDesiredPodsRunning()).toBeTruthy();
+  });
+
+  it('should return false when not all desired pods are running', () => {
+    // given
+    ctrl.replicaSetDetail = {
+      podInfo: {
+        running: 0,
+        desired: 1,
+      },
+    };
+
+    // then
+    expect(ctrl.areDesiredPodsRunning()).toBeFalsy();
+  });
 });

--- a/src/test/frontend/replicasetlist/replicasetcard_controller_test.js
+++ b/src/test/frontend/replicasetlist/replicasetcard_controller_test.js
@@ -44,4 +44,30 @@ describe('Logs menu controller', () => {
     expect(ctrl.shouldTruncate('x'.repeat(33))).toBe(true);
     expect(ctrl.shouldTruncate('x'.repeat(100))).toBe(true);
   });
+
+  it('should return true when all desired pods are running', () => {
+    // given
+    ctrl.replicaSet = {
+      pods: {
+        running: 0,
+        desired: 0,
+      },
+    };
+
+    // then
+    expect(ctrl.areDesiredPodsRunning()).toBeTruthy();
+  });
+
+  it('should return false when not all desired pods are running', () => {
+    // given
+    ctrl.replicaSet = {
+      pods: {
+        running: 0,
+        desired: 1,
+      },
+    };
+
+    // then
+    expect(ctrl.areDesiredPodsRunning()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
On replica set list page:

* only pods running will be displayed if running == desired

On replica set detail page:

* same as on replica set list page + pod status part will be not displayed

Otherwise it is the same as it was before (running != desired)

PS. I need to add tests.