### PR TITLE
Have help displayed in separate browser tab

### DIFF
--- a/src/app/frontend/deploy/createsecret.html
+++ b/src/app/frontend/deploy/createsecret.html
@@ -34,7 +34,7 @@ limitations under the License.
         </md-input-container>
         <kd-user-help>
           A secret with the specified name will be added to the cluster in the namespace <span class="kd-emphasized">{{ctrl.namespace}}.</span>
-          <a href="http://kubernetes.io/v1.1/docs/user-guide/secrets.html">Learn more</a>
+          <a href="http://kubernetes.io/v1.1/docs/user-guide/secrets.html" target="_blank">Learn more</a>
         </kd-user-help>
       </kd-help-section>
 
@@ -51,7 +51,7 @@ limitations under the License.
         <kd-user-help>
           Specify the data for your secret to hold. The value is the Base64 encoded content of a
           .dockercfg file.
-          <a href="http://kubernetes.io/v1.1/docs/user-guide/images.html#specifying-imagepullsecrets-on-a-pod">Learn more</a>
+          <a href="http://kubernetes.io/v1.1/docs/user-guide/images.html#specifying-imagepullsecrets-on-a-pod" target="_blank">Learn more</a>
         </kd-user-help>
       </kd-help-section>
 

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -31,7 +31,7 @@ limitations under the License.
   </md-input-container>
   <kd-user-help>
     An 'app' label with this value will be added to the Replication Controller and Service that get deployed.
-    <a href="http://kubernetes.io/v1.1/docs/user-guide/labels.html">Learn more</a>
+    <a href="http://kubernetes.io/v1.1/docs/user-guide/labels.html" target="_blank">Learn more</a>
   </kd-user-help>
 </kd-help-section>
 
@@ -46,7 +46,7 @@ limitations under the License.
   <kd-user-help>
     Enter the URL of a public image on any registry, or a private image hosted on Docker Hub or
     Google Container Registry.
-    <a href="http://kubernetes.io/v1.1/docs/user-guide/images.html">Learn more</a>
+    <a href="http://kubernetes.io/v1.1/docs/user-guide/images.html" target="_blank">Learn more</a>
   </kd-user-help>
 </kd-help-section>
 
@@ -61,7 +61,7 @@ limitations under the License.
   </md-input-container>
   <kd-user-help>
     A Replication Controller will be created to maintain the desired number of pods across your cluster.
-    <a href="http://kubernetes.io/v1.1/docs/user-guide/replication-controller.html">Learn more</a>
+    <a href="http://kubernetes.io/v1.1/docs/user-guide/replication-controller.html" target="_blank">Learn more</a>
   </kd-user-help>
 </kd-help-section>
 
@@ -75,7 +75,7 @@ limitations under the License.
     <span ng-if="ctrl.name">
       The internal DNS name for this Service will be: <span class="kd-emphasized">{{ctrl.name}}</span>.
     </span>
-    <a href="http://kubernetes.io/v1.1/docs/user-guide/services.html">Learn more</a>
+    <a href="http://kubernetes.io/v1.1/docs/user-guide/services.html" target="_blank">Learn more</a>
   </kd-user-help>
 </kd-help-section>
 
@@ -114,7 +114,7 @@ limitations under the License.
     <kd-user-help>
       The specified labels will be applied to the created Replication Controller, Service (if any) and Pods.
       Common labels include release, environment, tier, partition and track.
-      <a href="http://kubernetes.io/v1.1/docs/user-guide/labels.html">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/user-guide/labels.html" target="_blank">Learn more</a>
     </kd-user-help>
   </kd-help-section>
 
@@ -132,7 +132,7 @@ limitations under the License.
     </md-input-container>
     <kd-user-help>
       Namespaces let you partition resources into logically named groups.
-      <a href="http://kubernetes.io/v1.1/docs/admin/namespaces.html">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/admin/namespaces.html" target="_blank">Learn more</a>
     </kd-user-help>
   </kd-help-section>
 
@@ -151,7 +151,7 @@ limitations under the License.
     <kd-user-help>
       The specified image could require a pull secret credential if it is private. You may choose an
       existing secret or create a new one.
-      <a href="http://kubernetes.io/v1.1/docs/user-guide/secrets.html">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/user-guide/secrets.html" target="_blank">Learn more</a>
     </kd-user-help>
   </kd-help-section>
 
@@ -176,7 +176,7 @@ limitations under the License.
     </div>
     <kd-user-help>
       You can specify minimum CPU and memory requirements for the container.
-      <a href="http://kubernetes.io/v1.1/docs/admin/limitrange/README.html">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/admin/limitrange/README.html" target="_blank">Learn more</a>
     </kd-user-help>
   </kd-help-section>
 
@@ -195,7 +195,7 @@ limitations under the License.
     <kd-user-help>
       By default, your containers run the selected image's default entrypoint command. You can
       use the command options to override the default.
-      <a href="http://kubernetes.io/v1.1/docs/user-guide/containers.html">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/user-guide/containers.html" target="_blank">Learn more</a>
     </kd-user-help>
   </kd-help-section>
 

--- a/src/app/frontend/deploy/upload.html
+++ b/src/app/frontend/deploy/upload.html
@@ -38,6 +38,6 @@ limitations under the License.
   </div>
   <kd-user-help>
     Select a YAML or JSON file, specifying the resources to deploy.
-    <a href="http://kubernetes.io/v1.1/docs/user-guide/kubectl/kubectl_create.html">Learn more</a>
+    <a href="http://kubernetes.io/v1.1/docs/user-guide/kubectl/kubectl_create.html" target="_blank">Learn more</a>
   </kd-user-help>
 </kd-help-section>


### PR DESCRIPTION
Added target="_blank" to the <a href> links for references to help topics so that documentation is displayed in a new browser tab.