### PR TITLE
Fixed state transition when on zerostate and replica set is added

### DIFF
--- a/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
@@ -43,7 +43,6 @@ export default function stateConfig($stateProvider) {
         templateUrl: 'replicasetlist/zerostate/zerostate.html',
       },
     },
-    url: '/zerostate',
   });
 }
 


### PR DESCRIPTION
Fix for issue #314 

This way user won't be able to manually switch to zerostate. He will be transitioned only if cluster is empty.