### PR TITLE
Set first release version and fix gulp release pipeline

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -59,7 +59,7 @@ export default {
     /**
      * The release version of the image.
      */
-    versionRelease: '0.0.1',
+    versionRelease: 'v0.1.0',
     /**
      * The canary version name of the image. Canary is an image that is frequently published,
      * and has no release schedule.

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -105,7 +105,7 @@ gulp.task('push-to-gcr:canary', ['docker-image:canary'], function(doneFn) {
  * Pushes release image to GCR.
  */
 gulp.task('push-to-gcr:release', ['docker-image:release'], function(doneFn) {
-  pushToGcr(conf.deploy.versionCanary, doneFn);
+  pushToGcr(conf.deploy.versionRelease, doneFn);
 });
 
 /**


### PR DESCRIPTION
I propose that we start with version 0.1 and use semantic versioning. 