### PR TITLE
fix link to CONTRIBUTING.md at repository root

### DIFF
--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -109,4 +109,4 @@ It's possible to run `gulp` and all the dependencies inside a development contai
 
 ## Contribute
 
-Wish to contribute !! Great start [here](CONTRIBUTING.md).
+Wish to contribute !! Great start [here](../../CONTRIBUTING.md).


### PR DESCRIPTION
This change just fixes a link from the developer getting started guide to the CONTRIBUTING.md document.