### PR TITLE
Branding Proposal

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -25,6 +25,7 @@ import gulpUseref from 'gulp-useref';
 import gulpRev from 'gulp-rev';
 import gulpRevReplace from 'gulp-rev-replace';
 import uglifySaveLicense from 'uglify-save-license';
+import template from 'gulp-template';
 import path from 'path';
 
 import conf from './conf';
@@ -75,6 +76,7 @@ gulp.task('build-frontend', ['assets', 'index:prod', 'clean-dist'], function() {
         conservativeCollapse: true,
       }))
       .pipe(htmlFilter.restore)
+      .pipe(template(conf.branding))
       .pipe(gulp.dest(conf.paths.distPublic));
 });
 

--- a/build/conf.js
+++ b/build/conf.js
@@ -119,4 +119,11 @@ export default {
     src: path.join(basePath, 'src'),
     tmp: path.join(basePath, '.tmp'),
   },
+  branding: {
+    logo: 'kubernetes-logo.svg',
+    favicon: 'kubernetes-logo.png',
+    title: 'Kubernetes Dashboard',
+    toolbarTitle: 'kubernetes',
+    themeColor: '326de6'
+  },
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-sass-lint": "^1.1.0",
     "gulp-size": "~2.0.0",
     "gulp-sourcemaps": "~1.6.0",
+    "gulp-template": "~3.1.0",
     "gulp-uglify": "~1.5.1",
     "gulp-useref": "~3.0.4",
     "gulp-util": "~3.0.7",

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -18,10 +18,10 @@ limitations under the License.
   <md-toolbar class="kd-toolbar">
     <div class="md-toolbar-tools kd-toolbar-tools">
       <a ui-sref="replicationcontrollers" ui-sref-opts="{ reload: true }">
-        <md-icon md-svg-icon="assets/images/kubernetes-logo.svg" class="kd-toolbar-logo"></md-icon>
+        <md-icon md-svg-icon="assets/images/<%= logo %>" class="kd-toolbar-logo"></md-icon>
       </a>
       <h2>
-        <span>kubernetes</span>
+        <span><%= toolbarTitle %></span>
       </h2>
       <div flex ui-view="toolbar"></div>
     </div>

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -20,7 +20,7 @@ limitations under the License.
   <head>
     <meta charset="utf-8">
     <title>Kubernetes Dashboard</title>
-    <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png"/>
+    <link rel="icon" type="image/png" href="assets/images/<%= favicon %>"/>
     <meta name="viewport" content="width=device-width">
 
     <!-- build:css static/vendor.css -->

--- a/src/app/frontend/index_config.js
+++ b/src/app/frontend/index_config.js
@@ -13,6 +13,14 @@
 // limitations under the License.
 
 /**
+ * The template value is overwritten during the build process
+ * according to the branding configuration
+ *
+ * @type {string}
+ */
+const themeColor = '<%= themeColor %>';
+
+/**
  * @param {!md.$mdThemingProvider} $mdThemingProvider
  * @ngInject
  */
@@ -21,7 +29,7 @@ export default function config($mdThemingProvider) {
   let kubernetesColorPaletteName = 'kubernetesColorPalette';
   let kubernetesAccentPaletteName = 'kubernetesAccentPallete';
   let kubernetesColorPalette = $mdThemingProvider.extendPalette('blue', {
-    '500': '326de6',
+    '500': themeColor,
   });
 
   // Use the palette as default one.

--- a/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
+++ b/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
@@ -19,9 +19,9 @@ limitations under the License.
     <md-card flex="50" class="kd-zerostate-deploy-card">
       <md-toolbar layout="row" class="md-primary kd-zerostate-card-header"
                   layout-align="center center" flex>
-        <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
+        <md-icon md-svg-icon="assets/images/<%= logo %>"
                  class="kd-zerostate-card-logo"></md-icon>
-        <span class="md-padding" flex>The <b>Kubernetes Dashboard</b> lets you deploy, monitor
+        <span class="md-padding" flex>The <b><%= title %></b> lets you deploy, monitor
           and troubleshoot containerized apps and services</span>
       </md-toolbar>
       <md-card-content layout-align="center center">


### PR DESCRIPTION
## GUI-Branding Proposal (DO NOT MERGE)

Currently we consider branding options by which we can patch the theme colors, styles, titles and logos with least effort for dashboard project. In this example gulp templates are used to patch the code by using the configuration values in productive build. Unfortunately, it doesn't work for development mode because the source code is served as it is without any conversion process. Do you have a better idea or any suggestion to support branding in dashboard project? 