### PR TITLE
Fix heapster client config to make it work when master moves

### DIFF
--- a/src/app/backend/replicationcontrollerpodsmetrics.go
+++ b/src/app/backend/replicationcontrollerpodsmetrics.go
@@ -89,8 +89,7 @@ func createMetricPath(namespace string, podNames []string, metricName string) st
 
 // Retrieves raw metrics from Heapster.
 func getRawMetrics(heapsterClient HeapsterClient, metricPath string) ([]byte, error) {
-
-	resultRaw, err := heapsterClient.Get().Suffix(metricPath).DoRaw()
+	resultRaw, err := heapsterClient.Get(metricPath).DoRaw()
 
 	if err != nil {
 		return make([]byte, 0), err


### PR DESCRIPTION
Previously the heapster client would always talk to the same IP, even
when the master moved somewhere. Now it reuses apiserver client and
abstracts service proxy. This makes is always work when the apiserver
client is correct.