### PR TITLE
Added dynamic middle ellipsis formatting for long names

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -55,7 +55,11 @@ module.exports = function(config) {
 
     logLevel: 'WARN',
 
-    frameworks: ['jasmine', 'browserify'],
+    // Jasmine jquery is needed to allow angular to use JQuery in tests instead of JQLite.
+    // This allows to get elements by selector(angular.element('body')), use find function to
+    // search elements by class(element.find(class)) and the most important it allows to
+    // directly test DOM changes on elements, f.e. changes of element width/height.
+    frameworks: ['jasmine-jquery', 'jasmine', 'browserify'],
 
     browserNoActivityTimeout: 5 * 60 * 1000,  // 5 minutes.
 
@@ -74,6 +78,7 @@ module.exports = function(config) {
     plugins: [
       'karma-chrome-launcher',
       'karma-jasmine',
+      'karma-jasmine-jquery',
       'karma-coverage',
       'karma-ng-html2js-preprocessor',
       'karma-sourcemap-loader',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma-coverage": "~0.5.3",
     "karma-firefox-launcher": "^0.1.7",
     "karma-jasmine": "~0.3.6",
+    "karma-jasmine-jquery": "~0.1.1",
     "karma-ng-html2js-preprocessor": "~0.2.0",
     "karma-sauce-launcher": "^0.3.0",
     "karma-sourcemap-loader": "~0.3.6",

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import filtersModule from '../filters/filters_module';
 import labelsDirective from './labels/labels_directive';
+import middleEllipsisDirective from './middleellipsis/middleellipsis_directive';
 
 /**
  * Module containing common components for the application.
@@ -22,5 +24,7 @@ export default angular
         'kubernetesDashboard.common.components',
         [
           'ngMaterial',
+          filtersModule.name,
         ])
-    .directive('kdLabels', labelsDirective);
+    .directive('kdLabels', labelsDirective)
+    .directive('kdMiddleEllipsis', middleEllipsisDirective);

--- a/src/app/frontend/common/components/labels/labels.html
+++ b/src/app/frontend/common/components/labels/labels.html
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-labels" ng-repeat="(key, value) in ::labelsCtrl.labels">
-  {{key}}: {{value}}
+<div flex="95" class="kd-labels" ng-repeat="(key, value) in ::labelsCtrl.labels">
+  <kd-middle-ellipsis display-string="{{::key}}: {{::value}}">
+  </kd-middle-ellipsis>
 </div>

--- a/src/app/frontend/common/components/labels/labels.scss
+++ b/src/app/frontend/common/components/labels/labels.scss
@@ -26,7 +26,3 @@ $label-margin: 0 $baseline-grid ($baseline-grid / 2) 0;
   padding: ($baseline-grid / 4) $baseline-grid;
   vertical-align: middle;
 }
-
-.kd-labels-content {
-  background-color: inherit;
-}

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div>
-  <span ng-repeat="port in ::endpoint.ports">
-    <kd-middle-ellipsis display-string="{{::endpoint.host}}:{{::port.port}} {{::port.protocol}}">
-    </kd-middle-ellipsis>
-  </span>
+<div class="kd-middleellipsis-container">
+  <md-tooltip ng-if="::ellipsisCtrl.shouldTruncate()">
+    {{::ellipsisCtrl.displayString}}
+  </md-tooltip>
+  <span class="kd-middleellipsis"><!-- Collapse whitespace
+    -->{{::(ellipsisCtrl.displayString | middleEllipsis:ellipsisCtrl.maxLength)}}<!-- Collapse whitespace
+  --></span>
 </div>

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.js
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.js
@@ -1,0 +1,82 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Based on given container and its width calculates maximum text length.
+ * Filter is used to truncate string until binary search finds optimal length to use
+ * available space.
+ *
+ * Container is outer element of 'element' and is used as bounding box to allow stretching of
+ * inner element and not exceed boundaries of outer container. It's the best to style container
+ * with display: [block|inline-block] and width: 100% and disable text wrapping for the element.
+ *
+ * @param {!Element} container - outer element contains 'element'. Its role is to be bounding
+ * box of inner element.
+ * @param {!Element} element - inner element of document that contains text to be trimmed
+ * @param {!function(string, number): string} filter - middle ellipsis filter function used to
+ * truncate string
+ * @param {string} displayString - original display string (not truncated)
+ *
+ * @return {number}
+ */
+export default function computeTextLength(container, element, filter, displayString) {
+  let availableWidth = container.offsetWidth;
+  // Browsers are using floating numbers and element returns integer.
+  // Reduce by 1px in case of rounding problem.
+  let width = element.offsetWidth - 1;
+
+  // If it already fits then do not change
+  if (availableWidth >= width) {
+    return element.textContent.length;
+  }
+
+  return binarySearchLength(availableWidth, element, filter, displayString);
+}
+
+/**
+ * Does binary search to find minimal integer I such that given string with length I fits into
+ * available space and with length I + 1 it does not.
+ *
+ * @param {number} availableWidth - width to which length of text should be scaled to
+ * @param {!Element} element - element with text that should be truncated to fit available width
+ * @param {!function(string, number): string} filter - filter function used to truncate string
+ * @param {string} displayString - original display string (not truncated)
+ *
+ * @return {number}
+ */
+export function binarySearchLength(availableWidth, element, filter, displayString) {
+  let [left, right] = [0, displayString.length];
+  let [width, length] = [0, 0];
+
+  while (left <= right) {
+    length = Math.ceil((left + right) / 2);
+
+    element.textContent = filter(displayString, length);
+    width = element.offsetWidth;
+
+    if (width < availableWidth) {
+      left = length + 1;
+    } else if (width > availableWidth) {
+      right = length - 1;
+    } else {
+      break;
+    }
+
+    if (left > right && width > availableWidth && length > 0) {
+      element.textContent = filter(displayString, --length);
+    }
+  }
+
+  return length;
+}

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
@@ -12,25 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../../variables';
+.kd-middleellipsis {
+  white-space: nowrap;
+}
 
-.kd-user-help {
-  .kd-emphasized {
-    color: $emphasis;
-    word-wrap: break-word;
-  }
-
-  * {
-    color: $muted;
-  }
-
-  a {
-    color: $primary;
-    opacity: 1;
-    text-decoration: none;
-
-    &:hover {
-      color: $hover-primary;
-    }
-  }
+.kd-middleellipsis-container {
+  display: block;
+  width: 100%;
 }

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis_controller.js
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis_controller.js
@@ -12,25 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../../variables';
+/**
+ * @final
+ */
+export default class MiddleEllipsisController {
+  /**
+   * Constructs middle ellipsis controller.
+   * @ngInject
+   */
+  constructor() {
+    /** @export {string} Initialized from the scope. */
+    this.displayString;
 
-.kd-user-help {
-  .kd-emphasized {
-    color: $emphasis;
-    word-wrap: break-word;
+    /** @export {number} Calculated during directive linking phase. */
+    this.maxLength;
   }
 
-  * {
-    color: $muted;
-  }
-
-  a {
-    color: $primary;
-    opacity: 1;
-    text-decoration: none;
-
-    &:hover {
-      color: $hover-primary;
-    }
-  }
+  /**
+   * Checks whether text fulfills length restrictions. If it is too long then returns true, false
+   * otherwise.
+   *
+   * @return {boolean}
+   * @export
+   */
+  shouldTruncate() { return this.displayString.length > this.maxLength; }
 }

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis_directive.js
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis_directive.js
@@ -1,0 +1,65 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import MiddleEllipsisController from './middleellipsis_controller';
+import computeTextLength from './middleellipsis';
+
+/**
+ * Returns directive definition for middle ellipsis.
+ *
+ * @param {!function(string, number): string} middleEllipsisFilter
+ *
+ * @return {!angular.Directive}
+ * @ngInject
+ */
+export default function middleEllipsisDirective(middleEllipsisFilter) {
+  return {
+    controller: MiddleEllipsisController,
+    controllerAs: 'ellipsisCtrl',
+    templateUrl: 'common/components/middleellipsis/middleellipsis.html',
+    scope: {},
+    /**
+     * @param {!angular.Scope} scope
+     * @param {!angular.JQLite} jQLiteElem
+     * @param {!angular.Attributes} attr
+     * @param {!MiddleEllipsisController} ctrl
+     */
+    link: function(scope, jQLiteElem, attr, ctrl) {
+      /** @type {!Element} */
+      let element = jQLiteElem[0];
+      let container = element.querySelector('.kd-middleellipsis-container');
+      let ellipsisElem = element.querySelector('.kd-middleellipsis');
+
+      if (!container) {
+        throw new Error(
+            `Required parent element with class .kd-middleellipsis-container not found`);
+      }
+
+      if (!ellipsisElem) {
+        throw new Error('Required element with class .kd-middleellipsis-nowrap not found');
+      }
+
+      let nonNullContainer = container;
+      let nonNullElement = ellipsisElem;
+
+      scope.$watch(() => ctrl.displayString, (displayString) => {
+        ctrl.maxLength = computeTextLength(
+            nonNullContainer, nonNullElement, middleEllipsisFilter, displayString);
+      });
+    },
+    bindToController: {
+      'displayString': '@',
+    },
+  };
+}

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -24,8 +24,9 @@ limitations under the License.
         <md-button class="md-icon-button" ui-sref="replicationcontrollers">
           <md-icon md-font-library="material-icons">arrow_back</md-icon>
         </md-button>
-        <h1 flex class="md-title kd-replicationcontrollerdetail-app-name">
-          {{::ctrl.replicationControllerDetail.name}}
+        <h1 flex="85" class="md-title kd-replicationcontrollerdetail-app-name">
+          <kd-middle-ellipsis display-string="{{::ctrl.replicationControllerDetail.name}}">
+          </kd-middle-ellipsis>
         </h1>
       </div>
     </div>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -27,7 +27,8 @@ limitations under the License.
     </span>
     <span class="kd-replicationcontrollerinfo-line">Name</span>
     <span class="kd-replicationcontrollerinfo-subline">
-      {{infoCtrl.details.name}}
+      <kd-middle-ellipsis display-string="{{::infoCtrl.details.name}}">
+      </kd-middle-ellipsis>
     </span>
     <span class="kd-replicationcontrollerinfo-line">Namespace</span>
     <span class="kd-replicationcontrollerinfo-subline">
@@ -78,7 +79,7 @@ limitations under the License.
     <span class="kd-replicationcontrollerinfo-line">Images</span>
     <span class="kd-replicationcontrollerinfo-subline"
           ng-repeat="image in infoCtrl.details.containerImages">
-      {{image}}
+      <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
     </span>
   </div>
   <div flex layout="column" class="kd-replicationcontrollerinfo-info">

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
@@ -18,13 +18,8 @@ limitations under the License.
   <md-card-content>
     <div layout="column">
       <div flex layout="row" layout-align="space-between center"
-          class="kd-replicationcontroller-card-title-row">
-        <span layout="row" flex>
-          <a ng-href="{{::ctrl.getReplicationControllerDetailHref()}}" class="kd-replicationcontroller-card-name">
-            <span class="md-title kd-replicationcontroller-card-title">
-              {{::ctrl.replicationController.name}}
-            </span>
-          </a>
+            class="kd-replicationcontroller-card-title-row">
+        <span layout="row" flex="85">
           <md-icon class="material-icons md-warn kd-replicationcontroller-card-status-icon"
                    ng-if="::ctrl.hasWarnings()">
             error
@@ -35,10 +30,18 @@ limitations under the License.
             timelapse
             <md-tooltip>One or more pods are in pending state</md-tooltip>
           </md-icon>
+          <a ng-href="{{::ctrl.getReplicationControllerDetailHref()}}"
+             class="kd-replicationcontroller-card-name">
+            <span class="md-title kd-replicationcontroller-card-title">
+              <kd-middle-ellipsis display-string="{{::ctrl.replicationController.name}}">
+              </kd-middle-ellipsis>
+            </span>
+          </a>
         </span>
-        <kd-replication-controller-card-menu replication-controller="::ctrl.replicationController"></kd-replication-controller-card-menu>
+        <kd-replication-controller-card-menu replication-controller="::ctrl.replicationController">
+        </kd-replication-controller-card-menu>
       </div>
-      <div flex class="md-caption">
+      <div class="md-caption">
         <kd-labels labels="::ctrl.replicationController.labels"></kd-labels>
       </div>
     </div>
@@ -75,13 +78,10 @@ limitations under the License.
         </div>
 
         <div flex="60" layout="column" class="kd-replicationcontroller-card-section">
-          <span flex class="kd-replicationcontroller-card-section-title">Image</span>
-          <div flex>
-            <div ng-repeat="image in ::ctrl.replicationController.containerImages track by $index"
-                class="kd-replicationcontroller-card-section-image">
-              <md-tooltip ng-if="::ctrl.shouldTruncate(image)">{{::image}}</md-tooltip>
-              {{::(image | middleEllipsis:ctrl.imageMaxLength)}}
-            </div>
+          <span class="kd-replicationcontroller-card-section-title">Image</span>
+          <div ng-repeat="image in ::ctrl.replicationController.containerImages track by $index"
+               class="kd-replicationcontroller-card-section-image">
+            <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
           </div>
         </div>
 

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
@@ -21,8 +21,9 @@
 
 .kd-replicationcontroller-card-name {
   color: inherit;
-  display: block;
+  display: inline-block;
   text-decoration: none;
+  width: 100%;
 
   &:visited {
     color: inherit;
@@ -30,7 +31,8 @@
 }
 
 .kd-replicationcontroller-card-status-icon {
-  margin-left: $baseline-grid;
+  margin-right: $baseline-grid;
+  vertical-align: top;
 }
 
 .kd-replicationcontroller-card-title {

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard_controller.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard_controller.js
@@ -32,23 +32,9 @@ export default class ReplicationControllerCardController {
      */
     this.replicationController;
 
-    /**
-     * Maximum length of container image before it is truncated.
-     * @const
-     * @export {number}
-     */
-    this.imageMaxLength = 32;
-
     /** @private {!ui.router.$state} */
     this.state_ = $state;
   }
-
-  /**
-   * @param {string} imageName
-   * @return {boolean}
-   * @export
-   */
-  shouldTruncate(imageName) { return imageName.length > this.imageMaxLength; }
 
   /**
    * @return {string}

--- a/src/test/frontend/common/components/labels/labels_directive_test.js
+++ b/src/test/frontend/common/components/labels/labels_directive_test.js
@@ -42,7 +42,7 @@ describe('Labels directive', () => {
     scope.$digest();
 
     // then
-    let labels = element.find('div');
+    let labels = element.find('span');
     expect(labels.length).toEqual(3);
     angular.forEach(
         (key, value, index) => { expect(labels.eq(index).text()).toBe(`${key}=${value}`); });

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import MiddleEllipsisController from 'common/components/middleellipsis/middleellipsis_controller';
+import componentsModule from 'common/components/components_module';
+
+describe('Middle ellipsis controller', () => {
+  /**
+   * @type {!MiddleEllipsisController}
+   */
+  let ctrl;
+
+  beforeEach(() => {
+    angular.mock.module(componentsModule.name);
+
+    angular.mock.inject(($controller) => { ctrl = $controller(MiddleEllipsisController); });
+  });
+
+  it('should truncate display string', () => {
+    // given
+    ctrl.displayString = new Array(32).join('x');
+    ctrl.maxLength = 16;
+
+    // then
+    expect(ctrl.shouldTruncate()).toBe(true);
+  });
+
+  it('should not truncate display string', () => {
+    // given
+    ctrl.displayString = new Array(16).join('x');
+    ctrl.maxLength = 32;
+
+    // then
+    expect(ctrl.shouldTruncate()).toBe(false);
+  });
+});

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_directive_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_directive_test.js
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import componentsModule from 'common/components/components_module';
+
+describe('Middle ellipsis directive', () => {
+  /** @type {!angular.Scope} */
+  let scope;
+  /** @type {function(!angular.Scope):!angular.JQLite} */
+  let compileFn;
+
+  beforeEach(() => {
+    angular.mock.module(componentsModule.name);
+
+    angular.mock.inject(($rootScope, $compile) => {
+      scope = $rootScope.$new();
+      compileFn = $compile(
+          '<kd-middle-ellipsis display-string="{{displayString}}" max-length="{{maxLength}}">' +
+          '</kd-middle-ellipsis>');
+    });
+  });
+
+  it('should show original display string', () => {
+    // given
+    let stringLength = 16;
+    scope.displayString = new Array(stringLength + 1).join('x');
+
+    // when
+    let element = compileFn(scope);
+    scope.$digest();
+
+    // then
+    let actual = element.text().trim();
+    expect(actual.length).toEqual(stringLength);
+  });
+});

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_test.js
@@ -1,0 +1,122 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import computeTextLength from 'common/components/middleellipsis/middleellipsis';
+import componentsModule from 'common/components/components_module';
+
+describe('Middle ellipsis', () => {
+  /** @type {!angular.Scope} */
+  let scope;
+  /** @type {!angular.$compile} */
+  let compile;
+  /** @type {!angular.$filter} */
+  let filter;
+
+  /**
+   * Creates fixture html element mock for the tests. If given string is 1 char wide then final
+   * string length will be extended by given text length number, otherwise given string will be
+   * used.
+   *
+   * @param {number} availableWidth
+   * @param {string} str
+   * @param {number} textLength
+   *
+   * @return {!angular.JQLite}
+   */
+  function getFixtureElement(availableWidth, str, textLength) {
+    let displayText;
+    if (str.length === 1) {
+      displayText = new Array(textLength + 1).join(str);
+    } else {
+      displayText = str;
+    }
+
+    return angular.element(`
+    <div style="width: ${availableWidth}px; display: block;" id="fixture">
+      <div style="width: 100%; display: block;" class="kd-middleellipsis-container">
+        <span class="kd-middleellipsis">${displayText}</span>
+      </div>
+    </div>`);
+  }
+
+  beforeEach(() => {
+    angular.mock.module(componentsModule.name);
+
+    angular.mock.inject(($compile, $rootScope, middleEllipsisFilter) => {
+      scope = $rootScope.$new();
+      compile = $compile;
+      filter = middleEllipsisFilter;
+    });
+  });
+
+  it('should compute optimal text length', () => {
+    // given
+
+    /**
+     * Test object contains:
+     *  - element - fixture element that contains kd-middleellipsis-container and
+     *  kd-middleellipsis elements.
+     *  - filterFn - filter function used to truncate string
+     *  - expected - expected length calculated by computeTextLength function
+     */
+    let testData = [
+      // One 'x' char takes approx. 8px. When result length is 0 string also won't be truncated.
+      // It's important to remember that '...' also take some space. One '.' take approx. 4px.
+      [getFixtureElement(0, 'x', 1), filter, 0],
+      [getFixtureElement(8, 'x', 1), filter, 1],
+
+      [getFixtureElement(14, 'x', 2), filter, 0],
+      [getFixtureElement(16, 'x', 2), filter, 2],
+
+      [getFixtureElement(22, 'x', 3), filter, 1],
+      [getFixtureElement(24, 'x', 3), filter, 3],
+
+      [getFixtureElement(24, 'x', 4), filter, 1],
+      [getFixtureElement(30, 'x', 4), filter, 2],
+      [getFixtureElement(32, 'x', 4), filter, 4],
+
+      [getFixtureElement(26, 'x', 33), filter, 1],
+      [getFixtureElement(30, 'x', 33), filter, 2],
+
+      [getFixtureElement(323, 'x', 66), filter, 38],
+      [getFixtureElement(324, 'x', 57), filter, 39],
+
+      [getFixtureElement(555, 'dashboard', 0), filter, 9],
+      [getFixtureElement(20, 'dashboard', 0), filter, 1],
+    ];
+
+    testData.forEach((testData) => {
+      // given
+      let [fixture, filter, expected] = testData;
+
+      fixture = compile(fixture)(scope);
+      angular.element('body').append(fixture);
+
+      let container = fixture.find('.kd-middleellipsis-container')[0];
+      let element = fixture.find('.kd-middleellipsis')[0];
+      let displayText = element.textContent;
+
+      // when
+      let actual = computeTextLength(container, element, filter, displayText);
+
+      // then
+      expect(actual).toBe(
+          expected,
+          `Expected length to be ${expected} but was ${actual} ` + `for text: ${displayText}`);
+
+      // Clean up
+      fixture.remove();
+    });
+  });
+});

--- a/src/test/frontend/replicationcontrollerlist/replicationcontrollercard_controller_test.js
+++ b/src/test/frontend/replicationcontrollerlist/replicationcontrollercard_controller_test.js
@@ -40,13 +40,6 @@ describe('Replication controller card controller', () => {
         .toEqual('#/replicationcontrollers/foo-namespace/foo-name');
   });
 
-  it('should truncate image name', () => {
-    expect(ctrl.shouldTruncate('x')).toBe(false);
-    expect(ctrl.shouldTruncate((new Array(33)).join('x'))).toBe(false);
-    expect(ctrl.shouldTruncate((new Array(34)).join('x'))).toBe(true);
-    expect(ctrl.shouldTruncate((new Array(100)).join('x'))).toBe(true);
-  });
-
   it('should return true when all desired pods are running', () => {
     // given
     ctrl.replicationController = {


### PR DESCRIPTION
Related to #345

Firstable please do some extensive testing for different cases to make sure that it works as it should.

Middle ellipsis will be applied to text that is too long to fit the outer container `middle-ellipsis-container`. Optimal width is calculated using binary search. There are still some polishing to do. I'll do that and you can test :)

@bryk: I was able to solve chrome browser problem. Could you check?

- [x] Add dynamic width calculation
- [x] Apply this where needed
- [x] Write tests
- [x] Document it properly!

@bryk @maciaszczykm @digitalfishpond