### PR TITLE
Fix travis setup for pull requests from form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,14 @@ addons:
     username: k8s-dashboard-ci
     access_key: "18b7e71b-60e9-4177-9a7f-e769977dbb39"
 
+before_script:
+  # Prepare environment for the Chrome browser. This is required for PRs from forks where
+  # tests do not run on Saucelabs.
+  # TODO(bryk): Make tests run only on Saucelabs.
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
 # Docker is required to set up a simple, single node Kubernetes cluster.
 # Local Docker-based cluster is the simplest way to create kubernetes on the host machine.
 services:

--- a/build/protractor.conf.js
+++ b/build/protractor.conf.js
@@ -65,7 +65,7 @@ function createConfig() {
     ];
 
   } else {
-    config.capabilities = {'browserName': 'chrome'};
+    config.capabilities = {'browserName': 'firefox'};
   }
 
   return config;

--- a/build/test.js
+++ b/build/test.js
@@ -138,7 +138,8 @@ gulp.task('integration-test:prod', ['serve:prod', 'webdriver-update'], runProtra
  * Runs application integration tests. Uses production version of the application.
  */
 gulp.task(
-    'local-cluster-integration-test:prod', ['serve:prod', 'local-up-cluster'], runProtractorTests);
+    'local-cluster-integration-test:prod', ['serve:prod', 'local-up-cluster', 'webdriver-update'],
+    runProtractorTests);
 
 /**
  * Downloads and updates webdriver. Required to keep it up to date.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma-browserify": "~5.0.1",
     "karma-chrome-launcher": "~0.2.2",
     "karma-coverage": "~0.5.3",
+    "karma-firefox-launcher": "^0.1.7",
     "karma-jasmine": "~0.3.6",
     "karma-ng-html2js-preprocessor": "~0.2.0",
     "karma-sauce-launcher": "^0.3.0",


### PR DESCRIPTION
For now let the tests run on chrome-on-travis. This is becuase
sauce_connect addon is not available on forks:
https://docs.travis-ci.com/user/sauce-connect/

Tests on all browsers will work when you push changes to your local repo
fork, though.