### PR TITLE
Add namespace restriction option

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -57,9 +58,10 @@ func FormatResponseLog(resp *restful.Response, req *restful.Request) string {
 
 // Creates a new HTTP handler that handles all requests to the API of the backend.
 func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
-	clientConfig clientcmd.ClientConfig) http.Handler {
+	clientConfig clientcmd.ClientConfig, namespace string) http.Handler {
 
-	apiHandler := ApiHandler{client, heapsterClient, clientConfig}
+	apiHandler := ApiHandler{client, heapsterClient, clientConfig, namespace}
+
 	wsContainer := restful.NewContainer()
 
 	deployWs := new(restful.WebService)
@@ -185,6 +187,7 @@ type ApiHandler struct {
 	client         *client.Client
 	heapsterClient HeapsterClient
 	clientConfig   clientcmd.ClientConfig
+	namespace      string
 }
 
 // Handles deploy API call.
@@ -193,6 +196,9 @@ func (apiHandler *ApiHandler) handleDeploy(request *restful.Request, response *r
 	if err := request.ReadEntity(appDeploymentSpec); err != nil {
 		handleInternalError(response, err)
 		return
+	}
+	if apiHandler.namespace != "" {
+		appDeploymentSpec.Namespace = apiHandler.namespace
 	}
 	if err := DeployApp(appDeploymentSpec, apiHandler.client); err != nil {
 		handleInternalError(response, err)
@@ -211,7 +217,7 @@ func (apiHandler *ApiHandler) handleDeployFromFile(request *restful.Request, res
 	}
 
 	isDeployed, err := DeployAppFromFile(
-		deploymentSpec, CreateObjectFromInfoFn, apiHandler.clientConfig)
+		deploymentSpec, CreateObjectFromInfoFn, apiHandler.clientConfig, apiHandler.namespace)
 	if !isDeployed {
 		handleInternalError(response, err)
 		return
@@ -266,7 +272,7 @@ func (apiHandler *ApiHandler) handleGetAvailableProcotols(request *restful.Reque
 func (apiHandler *ApiHandler) handleGetReplicationControllerList(
 	request *restful.Request, response *restful.Response) {
 
-	result, err := GetReplicationControllerList(apiHandler.client)
+	result, err := GetReplicationControllerList(apiHandler.client, apiHandler.namespace)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -280,6 +286,9 @@ func (apiHandler *ApiHandler) handleGetReplicationControllerDetail(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	replicationController := request.PathParameter("replicationController")
 	result, err := GetReplicationControllerDetail(apiHandler.client, apiHandler.heapsterClient, namespace, replicationController)
 	if err != nil {
@@ -295,6 +304,9 @@ func (apiHandler *ApiHandler) handleUpdateReplicasCount(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	replicationControllerName := request.PathParameter("replicationController")
 	replicationControllerSpec := new(ReplicationControllerSpec)
 
@@ -318,6 +330,9 @@ func (apiHandler *ApiHandler) handleDeleteReplicationController(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	replicationController := request.PathParameter("replicationController")
 	deleteServices, err := strconv.ParseBool(request.QueryParameter("deleteServices"))
 	if err != nil {
@@ -339,6 +354,9 @@ func (apiHandler *ApiHandler) handleGetReplicationControllerPods(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	replicationController := request.PathParameter("replicationController")
 	limit, err := strconv.Atoi(request.QueryParameter("limit"))
 	if err != nil {
@@ -356,6 +374,11 @@ func (apiHandler *ApiHandler) handleGetReplicationControllerPods(
 // Handles namespace creation API call.
 func (apiHandler *ApiHandler) handleCreateNamespace(request *restful.Request,
 	response *restful.Response) {
+	if apiHandler.namespace != "" {
+		err := errors.New("Namespace restriction enable server-side")
+		handleInternalError(response, err)
+		return
+	}
 	namespaceSpec := new(NamespaceSpec)
 	if err := request.ReadEntity(namespaceSpec); err != nil {
 		handleInternalError(response, err)
@@ -377,6 +400,14 @@ func (apiHandler *ApiHandler) handleGetNamespaces(
 	if err != nil {
 		handleInternalError(response, err)
 		return
+	}
+	if apiHandler.namespace != "" {
+		for _, namespaceName := range result.Namespaces {
+			if namespaceName == apiHandler.namespace {
+				result.Namespaces = []string{namespaceName}
+				fmt.Print(namespaceName)
+			}
+		}
 	}
 
 	response.WriteHeaderAndEntity(http.StatusCreated, result)
@@ -400,6 +431,9 @@ func (apiHandler *ApiHandler) handleCreateImagePullSecret(request *restful.Reque
 // Handles get secrets list API call.
 func (apiHandler *ApiHandler) handleGetSecrets(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	result, err := GetSecrets(apiHandler.client, namespace)
 	if err != nil {
 		handleInternalError(response, err)
@@ -411,6 +445,9 @@ func (apiHandler *ApiHandler) handleGetSecrets(request *restful.Request, respons
 // Handles log API call.
 func (apiHandler *ApiHandler) handleLogs(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	podId := request.PathParameter("podId")
 	container := request.PathParameter("container")
 	var containerPtr *string = nil
@@ -428,6 +465,9 @@ func (apiHandler *ApiHandler) handleLogs(request *restful.Request, response *res
 // Handles event API call.
 func (apiHandler *ApiHandler) handleEvents(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
+	if apiHandler.namespace != "" {
+		namespace = apiHandler.namespace
+	}
 	replicationController := request.PathParameter("replicationController")
 	result, err := GetEvents(apiHandler.client, namespace, replicationController)
 	if err != nil {

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -33,6 +33,7 @@ var (
 		"to connect to in the format of protocol://address:port, e.g., "+
 		"http://localhost:8082. If not specified, the assumption is that the binary runs inside a"+
 		"Kubernetes cluster and service proxy will be used.")
+	argNamespace = pflag.String("namespace", "", "Restrict the dashboard to the specified Namespace")
 )
 
 func main() {
@@ -54,6 +55,6 @@ func main() {
 	// Run a HTTP server that serves static public files from './public' and handles API calls.
 	// TODO(bryk): Disable directory listing.
 	http.Handle("/", http.FileServer(http.Dir("./public")))
-	http.Handle("/api/", CreateHttpApiHandler(apiserverClient, heapsterRESTClient, config))
+	http.Handle("/api/", CreateHttpApiHandler(apiserverClient, heapsterRESTClient, config, *argNamespace))
 	log.Print(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
 }

--- a/src/app/backend/deploy.go
+++ b/src/app/backend/deploy.go
@@ -287,7 +287,7 @@ func CreateObjectFromInfoFn(info *kubectlResource.Info) (bool, error) {
 
 // Deploys an app based on the given yaml or json file.
 func DeployAppFromFile(spec *AppDeploymentFromFileSpec,
-	createObjectFromInfoFn createObjectFromInfo, clientConfig clientcmd.ClientConfig) (bool, error) {
+	createObjectFromInfoFn createObjectFromInfo, clientConfig clientcmd.ClientConfig, namespace string) (bool, error) {
 	const (
 		validate      = true
 		emptyCacheDir = ""
@@ -301,10 +301,12 @@ func DeployAppFromFile(spec *AppDeploymentFromFileSpec,
 
 	mapper, typer := factory.Object()
 	reader := strings.NewReader(spec.Content)
-
+	if namespace == "" {
+		namespace = api.NamespaceDefault
+	}
 	r := kubectlResource.NewBuilder(mapper, typer, kubectlResource.ClientMapperFunc(factory.ClientForMapping), factory.Decoder(true)).
 		Schema(schema).
-		NamespaceParam(api.NamespaceDefault).DefaultNamespace().
+		NamespaceParam(namespace).DefaultNamespace().
 		Stream(reader, spec.Name).
 		Flatten().
 		Do()

--- a/src/app/backend/replicationcontrollerlist.go
+++ b/src/app/backend/replicationcontrollerlist.go
@@ -68,27 +68,30 @@ type ReplicationController struct {
 }
 
 // GetReplicationControllerList returns a list of all Replication Controllers in the cluster.
-func GetReplicationControllerList(client *client.Client) (*ReplicationControllerList, error) {
+func GetReplicationControllerList(client *client.Client, namespace string) (*ReplicationControllerList, error) {
 	log.Printf("Getting list of all replication controllers in the cluster")
+	if namespace == "" {
+		namespace = api.NamespaceAll
+	}
 
 	listEverything := api.ListOptions{
 		LabelSelector: labels.Everything(),
 		FieldSelector: fields.Everything(),
 	}
 
-	replicationControllers, err := client.ReplicationControllers(api.NamespaceAll).List(listEverything)
+	replicationControllers, err := client.ReplicationControllers(namespace).List(listEverything)
 
 	if err != nil {
 		return nil, err
 	}
 
-	services, err := client.Services(api.NamespaceAll).List(listEverything)
+	services, err := client.Services(namespace).List(listEverything)
 
 	if err != nil {
 		return nil, err
 	}
 
-	pods, err := client.Pods(api.NamespaceAll).List(listEverything)
+	pods, err := client.Pods(namespace).List(listEverything)
 
 	if err != nil {
 		return nil, err

--- a/src/test/backend/deploy_test.go
+++ b/src/test/backend/deploy_test.go
@@ -193,7 +193,7 @@ func TestDeployAppFromFileWithValidContent(t *testing.T) {
 	}
 	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
 
-	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
+	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil, "")
 	if err != nil {
 		t.Errorf("Expected return value to have %#v but got %#v", nil, err)
 	}
@@ -210,7 +210,7 @@ func TestDeployAppFromFileWithInvalidContent(t *testing.T) {
 	// return is set to true to check if the validation prior to this function really works
 	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
 
-	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
+	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil, "")
 	if err == nil {
 		t.Errorf("Expected return value to have an error but got %#v", nil)
 	}


### PR DESCRIPTION
Hello,
I just add a new option to dashboard backend to be able to limit queries to a specified namespace.
With this option we can provide a pod of kubernetes dashboard with all new k8s namespace.
Kuberntes Dashboard can be the user GUI for each namespaces.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/363)
<!-- Reviewable:end -->
