### PR TITLE
Fix compiler and angular warnings/issues before update

### DIFF
--- a/src/app/frontend/common/components/labels/labels_controller.js
+++ b/src/app/frontend/common/components/labels/labels_controller.js
@@ -21,7 +21,7 @@ export default class LabelsController {
    * @ngInject
    */
   constructor() {
-    /** @export {Object<string, string>} Initialized from the scope. */
+    /** @export {!Object<string, string>} Initialized from the scope. */
     this.labels;
   }
 }

--- a/src/app/frontend/common/filters/cores_filter.js
+++ b/src/app/frontend/common/filters/cores_filter.js
@@ -21,7 +21,7 @@ const powerSuffixes = ['m', '', 'k', 'M', 'G'];
 /**
  * Returns filter function that formats cores usage.
  * @param {function(number): string} numberFilter
- * @return {Function}
+ * @return {function(number): string}
  * @ngInject
  */
 export default function coresFilter(numberFilter) {

--- a/src/app/frontend/common/filters/memory_filter.js
+++ b/src/app/frontend/common/filters/memory_filter.js
@@ -21,7 +21,7 @@ const powerSuffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
 /**
  * Returns filter function that formats memory in bytes.
  * @param {function(number): string} numberFilter
- * @return {Function}
+ * @return {function(number): string}
  * @ngInject
  */
 export default function memoryFilter(numberFilter) {

--- a/src/app/frontend/common/filters/middleellipsis_filter.js
+++ b/src/app/frontend/common/filters/middleellipsis_filter.js
@@ -14,7 +14,7 @@
 
 /**
  * Returns filter function to apply middle ellipsis when string is longer then max parameter.
- * @return {Function}
+ * @return {function(string, number): string}
  */
 export default function middleEllipsisFilter() {
   /**

--- a/src/app/frontend/common/filters/relativetime_filter.js
+++ b/src/app/frontend/common/filters/relativetime_filter.js
@@ -50,7 +50,7 @@ const TimeConstants = {
 
 /**
  * Returns filter function to display relative time since given date.
- * @return {Function}
+ * @return {function(string): string}
  */
 export default function relativeTimeFilter() {
   /**

--- a/src/app/frontend/deploy/createnamespace_controller.js
+++ b/src/app/frontend/deploy/createnamespace_controller.js
@@ -60,7 +60,7 @@ export default class NamespaceDialogController {
 
     /**
      * Pattern validation rule for namespace
-     * @export {RegExp}
+     * @export {!RegExp}
      */
     this.namespacePattern = new RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
 

--- a/src/app/frontend/deploy/deploy_controller.js
+++ b/src/app/frontend/deploy/deploy_controller.js
@@ -23,14 +23,12 @@ import {
  */
 export default class DeployController {
   /**
-   * @param {!angular.$resource} $resource
-   * @param {!angular.$log} $log
    * @param {!ui.router.$state} $state
    * @param {!backendApi.NamespaceList} namespaces
    * @param {!backendApi.Protocols} protocols
    * @ngInject
    */
-  constructor($resource, $log, $state, namespaces, protocols) {
+  constructor($state, namespaces, protocols) {
     /** @export {!angular.FormController} Initialized from the template */
     this.deployForm;
 
@@ -59,12 +57,6 @@ export default class DeployController {
      * @export {string}
      */
     this.selection = "Settings";
-
-    /** @private {!angular.$resource} */
-    this.resource_ = $resource;
-
-    /** @private {!angular.$log} */
-    this.log_ = $log;
 
     /** @private {!ui.router.$state} */
     this.state_ = $state;

--- a/src/app/frontend/deploy/deployfromfile_controller.js
+++ b/src/app/frontend/deploy/deployfromfile_controller.js
@@ -27,7 +27,10 @@ export default class DeployFromFileController {
    * @param {!ui.router.$state} $state
    * @param {!angular.$resource} $resource
    * @param {!angular.$q} $q
-   * @ngInject */
+   * TODO (cheld) Set correct type after fixing issue #159
+   * @param {!Object} errorDialog
+   * @ngInject
+   */
   constructor($log, $state, $resource, $q, errorDialog) {
     /**
      * It initializes the scope output parameter
@@ -66,7 +69,7 @@ export default class DeployFromFileController {
    * Deploys the application based on the state of the controller.
    *
    * @export
-   * @return {angular.$q.Promise}
+   * @return {!angular.$q.Promise}
    */
   deploy() {
     /** @type {!backendApi.AppDeploymentFromFileSpec} */

--- a/src/app/frontend/deploy/deployfromfile_directive.js
+++ b/src/app/frontend/deploy/deployfromfile_directive.js
@@ -14,6 +14,10 @@
 
 import DeployFromFileController from './deployfromfile_controller';
 
+/**
+ * Returns directive definition object for the deploy from file directive.
+ * @return {!angular.Directive}
+ */
 export default function deployFromFileDirective() {
   return {
     scope: {},

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -125,7 +125,7 @@ export default class DeployFromSettingsController {
      * Checks that a name begins and ends with a lowercase letter
      * and contains nothing but lowercase letters and hyphens ("-")
      * (leading and trailing spaces are ignored by default)
-     * @export {RegExp}
+     * @export {!RegExp}
      */
     this.namePattern = new RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
 
@@ -176,7 +176,7 @@ export default class DeployFromSettingsController {
   /**
    * Deploys the application based on the state of the controller.
    *
-   * @return {angular.$q.Promise}
+   * @return {!angular.$q.Promise}
    * @export
    */
   deploy() {

--- a/src/app/frontend/deploy/deploylabel.js
+++ b/src/app/frontend/deploy/deploylabel.js
@@ -22,7 +22,7 @@ export default class DeployLabel {
    * @param {string} key
    * @param {string} value
    * @param {boolean} editable
-   * @param {function(string): string} derivedValueGetterFn - callback
+   * @param {function(string): string|undefined} derivedValueGetterFn - callback
    */
   constructor(key = '', value = '', editable = true, derivedValueGetterFn = undefined) {
     /** @export {boolean} */
@@ -39,7 +39,7 @@ export default class DeployLabel {
   }
 
   /**
-   * @param {string} [newValue]
+   * @param {string=} [newValue]
    * @return {string}
    * @export
    */

--- a/src/app/frontend/deploy/deploylabel_controller.js
+++ b/src/app/frontend/deploy/deploylabel_controller.js
@@ -127,14 +127,6 @@ export default class DeployLabelController {
   }
 
   /**
-   * Returns true if label key and value are empty, false otherwise.
-   * @param {!DeployLabel} label
-   * @return {boolean}
-   * @private
-   */
-  isEmpty_(label) { return label.key.length === 0 && label.value().length === 0; }
-
-  /**
    * Returns true if label key and value are not empty, false otherwise.
    * @param {!DeployLabel} label
    * @return {boolean}

--- a/src/app/frontend/deploy/filereader_directive.js
+++ b/src/app/frontend/deploy/filereader_directive.js
@@ -30,7 +30,7 @@ export default function fileReaderDirective($log) {
       uploadController.registerBrowseFileFunction(() => (element[0].click()));
 
       element.bind('change', (changeEvent) => {
-        /** @type {File} */
+        /** @type {?File} */
         let file = changeEvent.target.files[0];
         if (!file) {
           $log.error('Error invalid file: ', file);

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -30,17 +30,15 @@ const EVENT_SOURCE_SYSTEM = 'System';
 export default class ReplicationControllerDetailController {
   /**
    * @param {function(string):boolean} $mdMedia Angular Material $mdMedia service
-   * @param {!md.$dialog} $mdDialog
    * @param {!./replicationcontrollerdetail_state.StateParams} $stateParams
    * @param {!ui.router.$state} $state
-   * @param {!angular.$resource} $resource
    * @param {!angular.$log} $log
    * @param {!backendApi.ReplicationControllerDetail} replicationControllerDetail
    * @param {!backendApi.Events} replicationControllerEvents
    * @ngInject
    */
   constructor(
-      $mdMedia, $mdDialog, $stateParams, $state, $resource, $log, replicationControllerDetail,
+      $mdMedia, $stateParams, $state, $resource, $log, replicationControllerDetail,
       replicationControllerEvents) {
     /** @export {function(string):boolean} */
     this.mdMedia = $mdMedia;
@@ -71,12 +69,6 @@ export default class ReplicationControllerDetailController {
 
     /** @private {!ui.router.$state} */
     this.state_ = $state;
-
-    /** @private {!md.$dialog} */
-    this.mdDialog_ = $mdDialog;
-
-    /** @private {!angular.$resource} */
-    this.resource_ = $resource;
 
     /** @private {!angular.$log} */
     this.log_ = $log;
@@ -139,6 +131,7 @@ export default class ReplicationControllerDetailController {
   }
 
   /**
+   * @param {!backendApi.ReplicationControllerPod} pod
    * @export
    */
   getPodLogsHref(pod) {

--- a/src/app/frontend/replicationcontrollerdetail/sortedheader_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/sortedheader_controller.js
@@ -29,6 +29,9 @@ export const DOWNWARDS = true;
  * @final
  */
 export default class SortedHeaderController {
+  /**
+   * @ngInject
+   */
   constructor() {
     /**
      * Tooltip message for current header column. Initialized from the scope (read-only).

--- a/src/app/frontend/replicationcontrollerdetail/updatereplicas_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/updatereplicas_controller.js
@@ -26,7 +26,6 @@ export default class UpdateReplicasDialogController {
    * @param {!angular.$log} $log
    * @param {!ui.router.$state} $state
    * @param {!angular.$resource} $resource
-   * @param {!angular.$q} $q
    * @param {string} namespace
    * @param {string} replicationController
    * @param {number} currentPods
@@ -34,7 +33,7 @@ export default class UpdateReplicasDialogController {
    * @ngInject
    */
   constructor(
-      $mdDialog, $log, $state, $resource, $q, namespace, replicationController, currentPods,
+      $mdDialog, $log, $state, $resource, namespace, replicationController, currentPods,
       desiredPods) {
     /** @export {number} */
     this.replicas;
@@ -62,9 +61,6 @@ export default class UpdateReplicasDialogController {
 
     /** @private {!angular.$resource} */
     this.resource_ = $resource;
-
-    /** @private {!angular.$q} */
-    this.q_ = $q;
   }
 
   /**

--- a/src/app/frontend/replicationcontrollerlist/logsmenu_controller.js
+++ b/src/app/frontend/replicationcontrollerlist/logsmenu_controller.js
@@ -58,7 +58,7 @@ export default class LogsMenuController {
 
   /**
    * Opens menu with pods and link to logs.
-   * @param  {!function(MouseEvent)} $mdOpenMenu
+   * @param  {!function(!MouseEvent)} $mdOpenMenu
    * @param  {!MouseEvent} $event
    * @export
    */

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercardmenu_controller.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercardmenu_controller.js
@@ -23,13 +23,12 @@ import {stateName} from 'replicationcontrollerdetail/replicationcontrollerdetail
 export default class ReplicationControllerCardMenuController {
   /**
    * @param {!ui.router.$state} $state
-   * @param {!angular.$log} $log
    * @param
    * {!./../replicationcontrollerdetail/replicationcontroller_service.ReplicationControllerService}
    * kdReplicationControllerService
    * @ngInject
    */
-  constructor($state, $log, kdReplicationControllerService) {
+  constructor($state, kdReplicationControllerService) {
     /**
      * Initialized from the scope.
      * @export {!backendApi.ReplicationController}
@@ -39,9 +38,6 @@ export default class ReplicationControllerCardMenuController {
     /** @private {!ui.router.$state} */
     this.state_ = $state;
 
-    /** @private {!angular.$log} */
-    this.log_ = $log;
-
     /** @private
      * {!./../replicationcontrollerdetail/replicationcontroller_service.ReplicationControllerService}
      */
@@ -49,7 +45,7 @@ export default class ReplicationControllerCardMenuController {
   }
 
   /**
-   * @param {!function(MouseEvent)} $mdOpenMenu
+   * @param {!function(!MouseEvent)} $mdOpenMenu
    * @param {!MouseEvent} $event
    * @export
    */

--- a/src/test/frontend/deploy/deploy_controller_test.js
+++ b/src/test/frontend/deploy/deploy_controller_test.js
@@ -36,7 +36,7 @@ describe('Deploy controller', () => {
           DeployFromSettingController, {},
           {namespaces: [], protocols: [], secrets: [], deploy: () => $q.defer().promise});
       ctrl = $controller(
-          DeployController, {namespaces: [], protocols: [], secrets: []},
+          DeployController, {namespaces: [], protocols: []},
           {detail: settingsCtrl, deployForm: {$valid: true}});
     });
   });


### PR DESCRIPTION
In next PR I plan to update Angular to 1.5 and compiler to a new
release. This is a cleanup that is prerequired to do this. There's a
bunch of small fixes here, like unused variables removal or documenting
with JSDoc.