### PR TITLE
build: include URL scheme in host configuration

### DIFF
--- a/build/cluster.js
+++ b/build/cluster.js
@@ -24,12 +24,12 @@ import conf from './conf';
 /**
  * The healthz URL of the cluster to check that it is running.
  */
-const clusterHealthzUrl = `http://${conf.backend.apiServerHost}/healthz`;
+const clusterHealthzUrl = `${conf.backend.apiServerHost}/healthz`;
 
 /**
  * The validate URL of the heapster to check that it is running.
  */
-const heapsterValidateUrl = `http://${conf.backend.heapsterServerHost}/api/v1/model/stats/`;
+const heapsterValidateUrl = `${conf.backend.heapsterServerHost}/api/v1/model/stats/`;
 
 /**
  * A Number, representing the ID value of the timer that is set for function which periodically
@@ -143,7 +143,7 @@ gulp.task('wait-for-cluster', function(doneFn) {
     if (counter % 10 === 0) {
       gulpUtil.log(
           gulpUtil.colors.magenta(
-              `Waiting for a Kubernetes cluster on ${conf.backend.apiServerHost}...`));
+              `Waiting for a Kubernetes cluster at ${conf.backend.apiServerHost}...`));
     }
     counter += 1;
 

--- a/build/conf.js
+++ b/build/conf.js
@@ -45,11 +45,12 @@ export default {
     /**
     * Address for the Kubernetes API server.
     */
-    apiServerHost: 'localhost:8080',
+    apiServerHost: 'http://localhost:8080',
     /**
-     * Address for the Heapster API server.
+     * Address for the Heapster API server. If blank, the dashboard
+     * will attempt to connect to Heapster via a service proxy.
      */
-    heapsterServerHost: 'localhost:8082',
+    heapsterServerHost: 'http://localhost:8082',
   },
 
   /**

--- a/build/serve.js
+++ b/build/serve.js
@@ -36,9 +36,9 @@ export const browserSyncInstance = browserSync.create();
  * @type {!Array<string>}
  */
 const backendDevArgs = [
-  `--apiserver-host=http://${conf.backend.apiServerHost}`,
+  `--apiserver-host=${conf.backend.apiServerHost}`,
   `--port=${conf.backend.devServerPort}`,
-  `--heapster-host=http://${conf.backend.heapsterServerHost}`,
+  `--heapster-host=${conf.backend.heapsterServerHost}`,
 ];
 
 /**
@@ -47,9 +47,9 @@ const backendDevArgs = [
  * @type {!Array<string>}
  */
 const backendArgs = [
-  `--apiserver-host=http://${conf.backend.apiServerHost}`,
+  `--apiserver-host=${conf.backend.apiServerHost}`,
   `--port=${conf.frontend.serverPort}`,
-  `--heapster-host=http://${conf.backend.heapsterServerHost}`,
+  `--heapster-host=${conf.backend.heapsterServerHost}`,
 ];
 
 /**


### PR DESCRIPTION
This change allows passing empty strings to the dashboard backend
process, which in turn allows developers to run the dashboard using a
heapster service proxy.

I'm proposing it so that I can more easily develop against Heapster while running a dashboard that isn't inside of my cluster, bu setting heapsterServerHost to the empty string in my build.