### PR TITLE
fix jitter on name validation

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -17,20 +17,24 @@ limitations under the License.
 <kd-help-section>
   <md-input-container class="md-block" md-is-error="ctrl.isNameError()">
     <label>App name</label>
-    <input ng-model="ctrl.name" name="name" namespace="ctrl.namespace" required ng-pattern="ctrl.namePattern"
-           ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }" kd-unique-name
-           ng-maxlength="ctrl.nameMaxLength">
-    <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate" ng-show="ctrl.form.name.$pending">
-    </md-progress-linear>
-    <ng-messages for="ctrl.form.name.$error" role="alert" multiple>
-      <ng-message when="required">Application name is required.</ng-message>
-      <ng-message when="uniqueName">Application with this name
-        already exists within namespace <i>{{ctrl.namespace}}</i>.</ng-message>
-      <ng-message when="pattern">Application name should contain only lowercase letters, numbers, and '-' between words
-      </ng-message>
-      <ng-message when="maxlength">Application name should have no more than 63 characters</ng-message>
-    </ng-messages>
+    <div class="kd-deploy-form-name-container">
+      <input ng-model="ctrl.name" name="name" namespace="ctrl.namespace" required ng-pattern="ctrl.namePattern"
+             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }" kd-unique-name
+             ng-maxlength="ctrl.nameMaxLength">
+      <div class="kd-deploy-form-name-validation-container">
+        <ng-messages for="ctrl.form.name.$error" role="alert" multiple>
+          <ng-message when="required">Application name is required.</ng-message>
+          <ng-message when="uniqueName">Application with this name
+            already exists within namespace <i>{{ctrl.namespace}}</i>.</ng-message>
+          <ng-message when="pattern">Application name should contain only lowercase letters, numbers, and '-' between words
+          </ng-message>
+          <ng-message when="maxlength">Application name should have no more than 63 characters</ng-message>
+        </ng-messages>
 
+        <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate" ng-show="ctrl.form.name.$pending">
+        </md-progress-linear>
+      </div>
+    </div>
   </md-input-container>
 
   <kd-user-help>

--- a/src/app/frontend/deploy/deployfromsettings.scss
+++ b/src/app/frontend/deploy/deployfromsettings.scss
@@ -29,3 +29,11 @@ md-progress-linear {
   margin-bottom: $baseline-grid;
   margin-top: $baseline-grid;
 }
+
+.kd-deploy-form-name-container {
+  margin-bottom: $baseline-grid * 8;
+}
+
+.kd-deploy-form-name-validation-container {
+  height: $bar-height;
+}


### PR DESCRIPTION
fixes #367 

- container class created to increase bottom margin to allow for pattern validation (2 lines, gets squashed to following input field if not, and pushes rest of form down causing jitter)

- container class created for validation message and progress bar preventing jitter when progress bar appears