### PR TITLE
Add external endpoint for cluster IP services

### DIFF
--- a/src/test/backend/replicationcontrollerdetail_test.go
+++ b/src/test/backend/replicationcontrollerdetail_test.go
@@ -493,6 +493,57 @@ func TestGetNodePortEndpoints(t *testing.T) {
 	}
 }
 
+func TestGetLocalhostEndpoints(t *testing.T) {
+	cases := []struct {
+		service  api.Service
+		expected []Endpoint
+	}{
+		{
+			api.Service{
+				Spec: api.ServiceSpec{
+					Ports: []api.ServicePort{
+						{
+							Protocol: "TCP",
+							NodePort: 30100,
+						},
+						{
+							Protocol: "TCP",
+							NodePort: 30101,
+						},
+					},
+				},
+			},
+			[]Endpoint{
+				{
+					Host: "localhost",
+					Ports: []ServicePort{
+						{
+							Port: 30100,
+							Protocol: "TCP",
+						},
+					},
+				},
+				{
+					Host: "localhost",
+					Ports: []ServicePort{
+						{
+							Port: 30101,
+							Protocol: "TCP",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		actual := getLocalhostEndpoints(c.service)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getLocalhostEndpoints(%+v) == %+v, expected %+v", c.service, actual,
+				c.expected)
+		}
+	}
+}
+
 func TestGetInternalEndpoint(t *testing.T) {
 	cases := []struct {
 		serviceName, namespace string


### PR DESCRIPTION
Connected to discussion from pull request #320 and issue #313:

> I am not fully happy with leaving the link empty on local cluster. What about putting "localhost:nodeport" into the link as a fallback if no IP is available? First, I would help us for writing click-tests, because using external link would make the test work on local cluster (CI) and real cluster. Second, the link is an important UI feature, it shouldn't be missing on local cluster

I've set `localhost:targetport` as a external endpoint for cluster IP services. I've used target port instead of nodeport, because it was always 0 during tests. Is it correct?

Please take a look and say your opinion about it. Change is not big, so I can quickly adapt it (for example use node port instead of target port).

CC @cheld @bryk