### PR TITLE
Fail and quit the binary when cannot connect to K8s master on startup

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -43,7 +43,7 @@ func main() {
 
 	apiserverClient, err := CreateApiserverClient(*argApiserverHost, new(ClientFactoryImpl))
 	if err != nil {
-		log.Print(err)
+		log.Fatalf("Error while initializing connection to Kubernetes master: %s. Quitting.", err)
 	}
 
 	heapsterRESTClient, err := CreateHeapsterRESTClient(*argHeapsterHost, apiserverClient)


### PR DESCRIPTION
This is to prevent false positives when admins think that the UI works
correctly, while it is not.

Fixes: #381