### PR TITLE
API endpoint for CPU and Memory usage history

### DIFF
--- a/src/app/backend/replicationcontrollerpodsmetrics.go
+++ b/src/app/backend/replicationcontrollerpodsmetrics.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	heapster "k8s.io/heapster/api/v1/types"
 	"k8s.io/kubernetes/pkg/api"
@@ -36,12 +37,23 @@ type ReplicationControllerMetricsByPod struct {
 	MetricsMap map[string]PodMetrics `json:"metricsMap"`
 }
 
+// Some sample measurement of a non-negative, integer quantity
+// (for example, memory usage in bytes observed at some moment)
+type MetricResult struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     uint64    `json:"value"`
+}
+
 // Pod metrics structure.
 type PodMetrics struct {
-	// Cumulative CPU usage on all cores in nanoseconds.
+	// Most recent measure of CPU usage on all cores in nanoseconds.
 	CpuUsage *uint64 `json:"cpuUsage"`
 	// Pod memory usage in bytes.
 	MemoryUsage *uint64 `json:"memoryUsage"`
+	// Timestamped samples of CpuUsage over some short period of history
+	CpuUsageHistory []MetricResult `json:"cpuUsageHistory"`
+	// Timestamped samples of pod memory usage over some short period of history
+	MemoryUsageHistory []MetricResult `json:"memoryUsageHistory"`
 }
 
 // Return Pods metrics for Replication Controller or error when occurred.
@@ -118,15 +130,33 @@ func createResponse(cpuMetrics []heapster.MetricResult, memMetrics []heapster.Me
 			var cpuValue *uint64
 			memMetricsList := memMetrics[iterator].Metrics
 			cpuMetricsList := cpuMetrics[iterator].Metrics
+
 			if len(memMetricsList) > 0 {
 				memValue = &memMetricsList[0].Value
 			}
+
 			if len(cpuMetricsList) > 0 {
 				cpuValue = &cpuMetricsList[0].Value
 			}
+
+			cpuHistory := make([]MetricResult, len(cpuMetricsList))
+			memHistory := make([]MetricResult, len(memMetricsList))
+
+			for i, cpuMeasure := range cpuMetricsList {
+				cpuHistory[i].Value = cpuMeasure.Value
+				cpuHistory[i].Timestamp = cpuMeasure.Timestamp
+			}
+
+			for i, memMeasure := range memMetricsList {
+				memHistory[i].Value = memMeasure.Value
+				memHistory[i].Timestamp = memMeasure.Timestamp
+			}
+
 			podResources := PodMetrics{
-				CpuUsage:    cpuValue,
-				MemoryUsage: memValue,
+				CpuUsage:           cpuValue,
+				MemoryUsage:        memValue,
+				CpuUsageHistory:    cpuHistory,
+				MemoryUsageHistory: memHistory,
 			}
 			replicationControllerPodsResources[podName] = podResources
 		}

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -108,6 +108,32 @@ backendApi.ReplicationControllerList;
 
 /**
  * @typedef {{
+ *   timestamp: string,
+ *   value: number
+ * }}
+ */
+backendApi.MetricResult;
+
+/**
+ * @typedef {{
+ *   reason: string,
+ *   message: string
+ * }}
+ */
+backendApi.PodEvent;
+
+/**
+ * @typedef {{
+ *   cpuUsage: ?number,
+ *   memoryUsage: ?number,
+ *   cpuUsageHistory: !Array<!backendApi.MetricResult>,
+ *   memoryUsageHistory: !Array<!backendApi.MetricResult>
+ * }}
+ */
+backendApi.PodMetrics;
+
+/**
+ * @typedef {{
  *   current: number,
  *   desired: number,
  *   running: number,
@@ -170,7 +196,7 @@ backendApi.DeleteReplicationControllerSpec;
  *   podIP: string,
  *   nodeName: string,
  *   restartCount: number,
- *   metrics: {cpuUsage: ?number, memoryUsage: ?number}
+ *   metrics: backendApi.PodMetrics
  * }}
  */
 backendApi.ReplicationControllerPod;

--- a/src/test/backend/replicationcontrollerpodsmetrics_test.go
+++ b/src/test/backend/replicationcontrollerpodsmetrics_test.go
@@ -107,11 +107,23 @@ func TestCreateResponse(t *testing.T) {
 			&ReplicationControllerMetricsByPod{
 				MetricsMap: map[string]PodMetrics{
 					"a": {
-						CpuUsage:    &cpuUsage1,
+						CpuUsage: &cpuUsage1,
+						CpuUsageHistory: []MetricResult{
+							{Value: cpuUsage1},
+						},
 						MemoryUsage: &memoryUsage,
+						MemoryUsageHistory: []MetricResult{
+							{Value: memoryUsage},
+						},
 					}, "b": {
-						CpuUsage:    &cpuUsage2,
+						CpuUsage: &cpuUsage2,
+						CpuUsageHistory: []MetricResult{
+							{Value: cpuUsage2},
+						},
 						MemoryUsage: &memoryUsage,
+						MemoryUsageHistory: []MetricResult{
+							{Value: memoryUsage},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This pull request proposes an additive change to the front end API, that will allow us to present sparkline-style mini-charts along with CPU and Memory usage statistics.  It includes a change to the now-versioned API. The change won't break clients that accept and/or ignore new fields in expected JSON objects (like go or browser JSON parsers), but please comment if you're worried that these changes might break other clients.
