### PR TITLE
Fixed event warning icon not displayed in events table

### DIFF
--- a/src/app/backend/replicationcontrollercommon.go
+++ b/src/app/backend/replicationcontrollercommon.go
@@ -45,7 +45,7 @@ type ReplicationControllerPodInfo struct {
 	Failed int `json:"failed"`
 
 	// Unique warning messages related to pods in this Replication Controller.
-	Warnings []PodEvent `json:"warnings"`
+	Warnings []Event `json:"warnings"`
 }
 
 // Returns structure containing ReplicationController and Pods for the given replication controller.

--- a/src/app/backend/replicationcontrollerlist.go
+++ b/src/app/backend/replicationcontrollerlist.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Callback function in order to get the pod status errors
-type GetPodsEventWarningsFunc func(pods []api.Pod) ([]PodEvent, error)
+type GetPodsEventWarningsFunc func(pods []api.Pod) ([]Event, error)
 
 // Callback function in order to get node by name.
 type GetNodeFunc func(nodeName string) (*api.Node, error)
@@ -51,7 +51,7 @@ type ReplicationController struct {
 	// Label of this Replication Controller.
 	Labels map[string]string `json:"labels"`
 
-	// Aggregate information about pods belonging to this repolica set.
+	// Aggregate information about pods belonging to this Replication Controller.
 	Pods ReplicationControllerPodInfo `json:"pods"`
 
 	// Container images of the Replication Controller.
@@ -97,7 +97,7 @@ func GetReplicationControllerList(client *client.Client) (*ReplicationController
 	// Anonymous callback function to get pods warnings.
 	// Function fulfils GetPodsEventWarningsFunc type contract.
 	// Based on list of api pods returns list of pod related warning events
-	getPodsEventWarningsFn := func(pods []api.Pod) ([]PodEvent, error) {
+	getPodsEventWarningsFn := func(pods []api.Pod) ([]Event, error) {
 		errors, err := GetPodsEventWarnings(client, pods)
 
 		if err != nil {

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -108,20 +108,12 @@ backendApi.ReplicationControllerList;
 
 /**
  * @typedef {{
- *   reason: string,
- *   message: string
- * }}
- */
-backendApi.PodEvent;
-
-/**
- * @typedef {{
  *   current: number,
  *   desired: number,
  *   running: number,
  *   pending: number,
  *   failed: number,
- *   warnings: !Array<!backendApi.PodEvent>
+ *   warnings: !Array<!backendApi.Event>
  * }}
  */
 backendApi.ReplicationControllerPodInfo;

--- a/src/test/backend/replicationcontrollerlist_test.go
+++ b/src/test/backend/replicationcontrollerlist_test.go
@@ -83,8 +83,8 @@ func TestGetMatchingServices(t *testing.T) {
 }
 
 func TestGetReplicationControllerList(t *testing.T) {
-	getPodsErrorFnMock := func(pods []api.Pod) ([]PodEvent, error) {
-		return []PodEvent{}, nil
+	getPodsErrorFnMock := func(pods []api.Pod) ([]Event, error) {
+		return []Event{}, nil
 	}
 
 	cases := []struct {
@@ -227,7 +227,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 							Failed:   2,
 							Pending:  1,
 							Running:  1,
-							Warnings: []PodEvent{},
+							Warnings: []Event{},
 						},
 					}, {
 						Name:              "my-app-2",
@@ -235,7 +235,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 						ContainerImages:   []string{"my-container-image-2"},
 						InternalEndpoints: []Endpoint{{Host: "my-app-2.namespace-2"}},
 						Pods: ReplicationControllerPodInfo{
-							Warnings: []PodEvent{},
+							Warnings: []Event{},
 						},
 					},
 				},


### PR DESCRIPTION
Related to #380 

I've changed approach to empty event Type issue a little. When it is not filled now, I'm adding the type based on event reason message. Also I've deleted PodEvent structure as it's not really needed. Events struct can be used instead and there is no need for additional structure.

@maciaszczykm @bryk PTAL