### PR TITLE
Add kd-responsive-table style for details page

### DIFF
--- a/src/app/frontend/_variables.scss
+++ b/src/app/frontend/_variables.scss
@@ -31,6 +31,7 @@ $primary: #326de6;
 $secondary: #f51200;
 $warning: #ffa500;
 $delicate: #aaa;
+$border: #ddd;
 $muted: #888;
 $hover-primary: #1254df;
 $hover-secondary: #ff1c19;
@@ -48,5 +49,8 @@ $regular-font-weight: 400;
 $bold-font-weight: 500;
 
 $layout-breakpoint-lg: 1280px;
+$layout-breakpoint-xs: 600px;
 $whiteframe-shadow-1dp: 0 1px 3px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12);
 $baseline-grid: 8px;
+$table-cell-height: 6 * $baseline-grid;
+$table-cell-height-half: $table-cell-height / 2;

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -84,3 +84,53 @@ a {
 [role='tabpanel'] {
   transition: none;
 }
+
+// Responsive table style.
+@media only screen and (max-width: $layout-breakpoint-xs) {
+  .kd-responsive-table {
+    width: 100%;
+
+    // Switches table to blocks.
+    thead,
+    tbody,
+    tr,
+    th {
+      display: block;
+    }
+
+    // Removes table headers.
+    thead {
+      tr,
+      th {
+        display: none;
+      }
+    }
+
+    // Adds border between records.
+    tr {
+      &:not(:last-child) {
+        border-bottom: $baseline-grid / 2 solid $border;
+      }
+    }
+
+    // Row data style.
+    td {
+      border-bottom: 1px solid $border;
+      display: block;
+      height: auto;
+      line-height: $table-cell-height;
+      padding-left: 50%;
+      position: relative;
+
+      // Row title style.
+      &::before {
+        content: attr(kd-responsive-header);
+        font-weight: $bold-font-weight;
+        left: $baseline-grid * 2;
+        padding-right: $baseline-grid * 2;
+        position: absolute;
+        word-wrap: break-word;
+      }
+    }
+  }
+}

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -49,7 +49,7 @@ limitations under the License.
   <md-tabs flex="grow" md-border-bottom md-dynamic-height>
     <md-tab label="Pods">
       <md-content>
-        <table class="kd-replicationcontrollerdetail-table" cellspacing="0">
+        <table class="kd-replicationcontrollerdetail-table kd-responsive-table" cellspacing="0">
           <thead>
             <tr>
               <th class="kd-replicationcontrollerdetail-table-header">
@@ -111,25 +111,22 @@ limitations under the License.
                 </kd-sorted-header>
               </th>
               <th class="kd-replicationcontrollerdetail-table-header">
-                <span>Logs
-                  <i class="material-icons kd-text-icon">
-                    help
-                    <md-tooltip>Logs from the pod</md-tooltip>
-                  </i>
-                </span>
+                <span>Logs</span>
               </th>
             </tr>
           </thead>
           <tbody>
             <tr ng-repeat="pod in ctrl.replicationControllerDetail.pods | orderBy:ctrl.sortPodsBy:ctrl.podsOrder">
-              <td class="kd-replicationcontrollerdetail-table-cell">{{pod.name}}</td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Pod" class="kd-replicationcontrollerdetail-table-cell">
+                {{pod.name}}
+              </td>
+              <td kd-responsive-header="Status" class="kd-replicationcontrollerdetail-table-cell">
                 {{::pod.podPhase}}
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Restarts" class="kd-replicationcontrollerdetail-table-cell">
                 {{::pod.restartCount}}<!-- TODO(maciaszczykm): Add info about last restart date. -->
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Age" class="kd-replicationcontrollerdetail-table-cell">
                 <span ng-if="::pod.startTime">
                   {{::pod.startTime | relativeTime}}
                   <md-tooltip>Started at {{::(pod.startTime | date:'short')}}</md-tooltip>
@@ -138,7 +135,7 @@ limitations under the License.
                   -
                 </span>
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell"
+              <td kd-responsive-header="CPU" class="kd-replicationcontrollerdetail-table-cell"
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics">
                 <span ng-if="::ctrl.hasCpuUsage(pod)">
                   {{::(pod.metrics.cpuUsage | kdCores)}}
@@ -147,7 +144,7 @@ limitations under the License.
                   -
                 </span>
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell"
+              <td kd-responsive-header="Memory" class="kd-replicationcontrollerdetail-table-cell"
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics">
                 <span ng-if="::ctrl.hasMemoryUsage(pod)">
                   {{::(pod.metrics.memoryUsage | kdMemory)}}
@@ -156,7 +153,7 @@ limitations under the License.
                   -
                 </span>
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Cluster IP" class="kd-replicationcontrollerdetail-table-cell">
                 <span ng-if="::pod.podIP">
                   {{::pod.podIP}}
                 </span>
@@ -164,7 +161,7 @@ limitations under the License.
                   -
                 </span>
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Node" class="kd-replicationcontrollerdetail-table-cell">
                 <span ng-if="::pod.nodeName">
                   {{::pod.nodeName}}
                 </span>
@@ -172,7 +169,7 @@ limitations under the License.
                   -
                 </span>
               </td>
-              <td class="kd-replicationcontrollerdetail-table-cell">
+              <td kd-responsive-header="Logs" class="kd-replicationcontrollerdetail-table-cell">
                 <span>
                   <a ng-href="{{::ctrl.getPodLogsHref(pod)}}" target="_blank">
                     Logs
@@ -198,10 +195,9 @@ limitations under the License.
               </md-option>
             </md-select>
           </md-input-container>
-          <!-- TODO(maciaszczykm): Add event filtering by source (all, system and user). -->
         </div>
-        <table class="kd-replicationcontrollerdetail-table" cellspacing="0" cellpadding="15"
-               ng-if="ctrl.hasEvents()">
+        <table class="kd-replicationcontrollerdetail-table kd-responsive-table" cellspacing="0"
+               cellpadding="15" ng-if="ctrl.hasEvents()">
           <thead>
           <tr>
             <th class="kd-replicationcontrollerdetail-table-header">
@@ -249,20 +245,25 @@ limitations under the License.
           </thead>
           <tbody>
           <tr ng-repeat="event in ctrl.events | orderBy:ctrl.sortEventsBy:ctrl.eventsOrder">
-            <td class="kd-replicationcontrollerdetail-table-cell kd-replicationcontrollerdetail-message-table-cell">
+            <td kd-responsive-header="Message"
+                class="kd-replicationcontrollerdetail-table-cell kd-replicationcontrollerdetail-message-table-cell">
               <i ng-if="ctrl.isEventWarning(event)"
                  class="material-icons kd-replicationcontrollerdetail-warning-icon">warning</i>
               {{event.message}}
             </td>
-            <td class="kd-replicationcontrollerdetail-table-cell">
+            <td kd-responsive-header="Source" class="kd-replicationcontrollerdetail-table-cell">
               {{event.sourceComponent}} {{event.sourceHost}}
             </td>
-            <td class="kd-replicationcontrollerdetail-table-cell">{{event.object}}</td>
-            <td class="kd-replicationcontrollerdetail-table-cell">{{event.count}}</td>
-            <td class="kd-replicationcontrollerdetail-table-cell">
+            <td kd-responsive-header="Sub-object" class="kd-replicationcontrollerdetail-table-cell">
+              {{event.object}}
+            </td>
+            <td kd-responsive-header="Count" class="kd-replicationcontrollerdetail-table-cell">
+              {{event.count}}
+            </td>
+            <td kd-responsive-header="First seen" class="kd-replicationcontrollerdetail-table-cell">
               First seen at {{event.firstSeen | date:'short'}}
             </td>
-            <td class="kd-replicationcontrollerdetail-table-cell">
+            <td kd-responsive-header="Last seen" class="kd-replicationcontrollerdetail-table-cell">
               Last seen at {{event.lastSeen | date:'short'}}
             </td>
           </tr>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.scss
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.scss
@@ -17,9 +17,6 @@
 $replicationcontrollerdetails-sidebar-bg: #fafafa;
 $replicationcontrollerdetails-sidebar-width: 315px;
 
-$table-cell-height: 6 * $baseline-grid;
-$table-cell-height-half: $table-cell-height / 2;
-
 .kd-replicationcontrollerdetail-app-name {
   color: $foreground-2;
   font-weight: $regular-font-weight;
@@ -45,7 +42,7 @@ $table-cell-height-half: $table-cell-height / 2;
 }
 
 .kd-replicationcontrollerdetail-sidebar-header-wrapper {
-  border-bottom: 1px solid $foreground-4;
+  border-bottom: 1px solid $border;
 }
 
 .kd-replicationcontrollerdetail-warning-icon {
@@ -65,7 +62,7 @@ $table-cell-height-half: $table-cell-height / 2;
 }
 
 .kd-replicationcontrollerdetail-table-header {
-  border-bottom: 1px solid $foreground-4;
+  border-bottom: 1px solid $border;
   color: $foreground-2;
   font-size: $body-font-size-base;
   font-weight: $regular-font-weight;
@@ -76,7 +73,7 @@ $table-cell-height-half: $table-cell-height / 2;
 }
 
 .kd-replicationcontrollerdetail-table-cell {
-  border-bottom: 1px solid $foreground-4;
+  border-bottom: 1px solid $border;
   font-size: $body-font-size-base;
   height: $table-cell-height;
   padding: 0 0 0 (2 * $baseline-grid);

--- a/src/app/frontend/replicationcontrollerdetail/sortedheader.scss
+++ b/src/app/frontend/replicationcontrollerdetail/sortedheader.scss
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../variables';
-
 .kd-replicationcontroller-detail-table-header-button {
   background: inherit;
   border: 0;


### PR DESCRIPTION
It makes details page more responsive, used it for both tables visible here. Fixes #334. Directive doesn't support tooltips, but do we need them on such small screens?