### PR TITLE
Cross compilation build pipeline

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -23,6 +23,40 @@ import path from 'path';
 const basePath = path.join(__dirname, '../');
 
 /**
+ * Compilation architecture configuration.
+ */
+const arch = {
+  /**
+   * Default architecture that the project is compiled to. Used for local development and testing.
+   * TODO(bryk): Dynamically determine this based on current arch.
+   */
+  default: 'amd64',
+  /**
+   * List of all supported architectures by this project.
+   */
+  list: ['amd64', 'arm', 'arm64', 'ppc64le'],
+};
+
+/**
+ * Package version information.
+ */
+const version = {
+  /**
+   * Current release version of the project.
+   */
+  release: 'v0.1.0',
+  /**
+   * Version name of the canary release of the project.
+   */
+  canary: 'canary',
+};
+
+/**
+ * Base name for the docker image.
+ */
+const imageNameBase = 'gcr.io/google_containers/kubernetes-dashboard';
+
+/**
  * Exported configuration object with common constants used in build pipeline.
  */
 export default {
@@ -54,22 +88,38 @@ export default {
   },
 
   /**
+   * Project compilation architecture info.
+   */
+  arch: arch,
+
+  /**
    * Deployment constants configuration.
    */
   deploy: {
     /**
-     * The release version of the image.
+     * Project version info.
      */
-    versionRelease: 'v0.1.0',
+    version: version,
+
     /**
-     * The canary version name of the image. Canary is an image that is frequently published,
-     * and has no release schedule.
+     * Image name for the canary release for current architecture.
      */
-    versionCanary: 'canary',
+    canaryImageName: `${imageNameBase}-${arch.default}:${version.canary}`,
+
     /**
-     * The name of the Docker image with the application.
+     * Image name for the versioned release for current architecture.
      */
-    imageName: 'gcr.io/google_containers/kubernetes-dashboard',
+    releaseImageName: `${imageNameBase}-${arch.default}:${version.release}`,
+
+    /**
+     * Image name for the canary release for all supported architecture.
+     */
+    canaryImageNames: arch.list.map((arch) => `${imageNameBase}-${arch}:${version.canary}`),
+
+    /**
+     * Image name for the versioned release for all supported architecture.
+     */
+    releaseImageNames: arch.list.map((arch) => `${imageNameBase}-${arch}:${version.release}`),
   },
 
   /**
@@ -113,8 +163,11 @@ export default {
     coverage: path.join(basePath, 'coverage'),
     coverageReport: path.join(basePath, 'coverage/lcov'),
     deploySrc: path.join(basePath, 'src/deploy'),
-    dist: path.join(basePath, 'dist'),
-    distPublic: path.join(basePath, 'dist/public'),
+    dist: path.join(basePath, 'dist', arch.default),
+    distCross: arch.list.map((arch) => path.join(basePath, 'dist', arch)),
+    distPublic: path.join(basePath, 'dist', arch.default, 'public'),
+    distPublicCross: arch.list.map((arch) => path.join(basePath, 'dist', arch, 'public')),
+    distRoot: path.join(basePath, 'dist'),
     externs: path.join(basePath, 'src/app/externs'),
     frontendSrc: path.join(basePath, 'src/app/frontend'),
     frontendTest: path.join(basePath, 'src/test/frontend'),

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -17,9 +17,11 @@
  */
 import child from 'child_process';
 import gulp from 'gulp';
+import lodash from 'lodash';
 import path from 'path';
 
 import conf from './conf';
+import {multiDest} from './multidest';
 
 /**
  * @param {!Array<string>} args
@@ -40,20 +42,89 @@ function spawnDockerProcess(args, doneFn) {
 }
 
 /**
- * @param {string} version
- * @param {function(?Error=)} doneFn
+ * Creates canary Docker image for the application for current architecture.
+ * The image is tagged with the image name configuration constant.
  */
-function buildDockerImage(version, doneFn) {
-  spawnDockerProcess(
-      [
-        'build',
-        // Remove intermediate containers after a successful build.
-        '--rm=true',
-        '--tag',
-        `${conf.deploy.imageName}:${version}`,
-        conf.paths.dist,
-      ],
-      doneFn);
+gulp.task('docker-image:canary', ['build', 'docker-file'], function(doneFn) {
+  buildDockerImage([[conf.deploy.canaryImageName, conf.paths.dist]], doneFn);
+});
+
+/**
+ * Creates release Docker image for the application for current architecture.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:release', ['build', 'docker-file'], function(doneFn) {
+  buildDockerImage([[conf.deploy.releaseImageName, conf.paths.dist]], doneFn);
+});
+
+/**
+ * Creates canary Docker image for the application for all architectures.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:canary:cross', ['build:cross', 'docker-file:cross'], function(doneFn) {
+  buildDockerImage(lodash.zip(conf.deploy.canaryImageNames, conf.paths.distCross), doneFn);
+});
+
+/**
+ * Creates release Docker image for the application for all architectures.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:release:cross', ['build:cross', 'docker-file:cross'], function(doneFn) {
+  buildDockerImage(lodash.zip(conf.deploy.releaseImageNames, conf.paths.distCross), doneFn);
+});
+
+/**
+ * Pushes cross-compiled canary images to GCR.
+ */
+gulp.task('push-to-gcr:canary', ['docker-image:canary:cross'], function(doneFn) {
+  pushToGcr(conf.deploy.versionCanary, doneFn);
+});
+
+/**
+ * Pushes cross-compiled release images to GCR.
+ */
+gulp.task('push-to-gcr:release', ['docker-image:release:cross'], function(doneFn) {
+  pushToGcr(conf.deploy.versionRelease, doneFn);
+});
+
+/**
+ * Processes the Docker file and places it in the dist folder for building.
+ */
+gulp.task('docker-file', ['clean-dist'], function() { dockerFile(conf.paths.dist); });
+
+/**
+ * Processes the Docker file and places it in the dist folder for all architectures.
+ */
+gulp.task('docker-file:cross', ['clean-dist'], function() { dockerFile(conf.paths.distCross); });
+
+/**
+ * @param {!Array<!Array<string>>} imageNamesAndDirs (image name, directory) pairs
+ * @return {!Promise}
+ */
+function buildDockerImage(imageNamesAndDirs) {
+  let spawnPromises = imageNamesAndDirs.map((imageNameAndDir) => {
+    let [imageName, dir] = imageNameAndDir;
+    return new Promise((resolve, reject) => {
+      spawnDockerProcess(
+          [
+            'build',
+            // Remove intermediate containers after a successful build.
+            '--rm=true',
+            '--tag',
+            imageName,
+            dir,
+          ],
+          (err) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+    });
+  });
+
+  return Promise.all(spawnPromises);
 }
 
 /**
@@ -75,42 +146,9 @@ function pushToGcr(version, doneFn) {
 }
 
 /**
- * Creates Docker image for the application. The image is tagged with the image name configuration
- * constant.
- *
- * In order to run the image on a Kubernates cluster, it has to be deployed to a registry.
+ * @param {string|!Array<string>} outputDirs
+ * @return {stream}
  */
-gulp.task('docker-image:canary', ['build', 'docker-file'], function(doneFn) {
-  buildDockerImage(conf.deploy.versionCanary, doneFn);
-});
-
-/**
- * Creates Docker image for the application. The image is tagged with the image name configuration
- * constant.
- *
- * In order to run the image on a Kubernates cluster, it has to be deployed to a registry.
- */
-gulp.task('docker-image:release', ['build', 'docker-file'], function(doneFn) {
-  buildDockerImage(conf.deploy.versionRelease, doneFn);
-});
-
-/**
- * Pushes canary image to GCR.
- */
-gulp.task('push-to-gcr:canary', ['docker-image:canary'], function(doneFn) {
-  pushToGcr(conf.deploy.versionCanary, doneFn);
-});
-
-/**
- * Pushes release image to GCR.
- */
-gulp.task('push-to-gcr:release', ['docker-image:release'], function(doneFn) {
-  pushToGcr(conf.deploy.versionRelease, doneFn);
-});
-
-/**
- * Processes the Docker file and places it in the dist folder for building.
- */
-gulp.task('docker-file', ['clean-dist'], function() {
-  return gulp.src(path.join(conf.paths.deploySrc, 'Dockerfile')).pipe(gulp.dest(conf.paths.dist));
-});
+function dockerFile(outputDirs) {
+  return gulp.src(path.join(conf.paths.deploySrc, 'Dockerfile')).pipe(multiDest(outputDirs));
+}

--- a/build/multidest.js
+++ b/build/multidest.js
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import gulp from 'gulp';
+import through from 'through2';
+
+/**
+ * Utility function for specifying multiple gulp.dest destinations.
+ * @param {string|!Array<string>} outputDirs destinations for the gulp dest function calls
+ * @return {stream}
+ */
+export function multiDest(outputDirs) {
+  if (!Array.isArray(outputDirs)) {
+    outputDirs = [outputDirs];
+  }
+  let outputs = outputDirs.map((dir) => gulp.dest(dir));
+  let outputStream = through.obj();
+
+  outputStream.on('data', (data) => outputs.forEach((dest) => { dest.write(data); }));
+  outputStream.on('end', () => outputs.forEach((dest) => { dest.end(); }));
+
+  return outputStream;
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "proxy-middleware": "~0.15.0",
     "q": "~1.4.1",
     "semver": "~5.1.0",
+    "through2": "^2.0.1",
     "uglify-save-license": "~0.4.1",
     "watchify": "^3.7.0",
     "webpack-stream": "~3.1.0",


### PR DESCRIPTION
With this we can cross compile. The build usage is backwards compatible,
everything works as before. The addition is that there are some tasks
with :cross suffix that do cross compilation.

Now dist folder is separated by architecture.

Sample output from ./build/run-gulp-in-docker.sh
docker-image:canary:cross

```
gcr.io/google_containers/kubernetes-dashboard-arm64          canary
241c95709a4b        About an hour ago   35.04 MB
gcr.io/google_containers/kubernetes-dashboard-amd64          canary
3ccd83107b69        About an hour ago   35.37 MB
gcr.io/google_containers/kubernetes-dashboard-arm            canary
4533431c6a73        About an hour ago   29.03 MB
gcr.io/google_containers/kubernetes-dashboard-ppc64le        canary
3bfa0191f041        About an hour ago   35.53 MB
gcr.io/google_containers/kubernetes-dashboard-amd64          v0.1.0
3351515d6e5e        About an hour ago   35.44 MB
gcr.io/google_containers/kubernetes-dashboard-arm64          v0.1.0
45e4a971bfc3        About an hour ago   35.44 MB
gcr.io/google_containers/kubernetes-dashboard-arm            v0.1.0
1057ae5d74e5        About an hour ago   35.44 MB
gcr.io/google_containers/kubernetes-dashboard-ppc64le        v0.1.0
d587f991ac08        About an hour ago   35.44 MB
```

Fixes #327