### PR TITLE
Fix to parse containerImage to get version

### DIFF
--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -55,6 +55,6 @@ export default class DockerImageIdentifier {
     if (index > -1) {
       return last_block.substring(index + 1);
     }
-    return ''
+    return '';
   }
 }

--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -1,0 +1,60 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Parser to get TAG from reference of Docker container image
+ *
+ * Docker Container image can be set with the following value:
+ *   [REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG]
+ * REGISTRY can be omitted and NAME can contain '/' as delimiters for NAMESPACE.
+ *
+ * So only TAG is specified.
+ *
+ */
+
+export default class DockerImageIdentifier {
+
+  /**
+   * Constructs DockerUri object.
+   *
+   * @param {string} identifier
+   */
+  constructor(identifier = '') { this.identifier = identifier; }
+
+  /**
+   * Returns tag
+   *
+   * TAG cannot contain ':' and '/'.
+   * Not if TAG is omitted, last block text(separated by '/') contains TAG.
+   * @return {string}
+   */
+  tag() {
+    /** @type {number} **/
+    let index = this.identifier.lastIndexOf('/');
+
+    /** @type {string} **/
+    let last_block;
+    if (index > -1) {
+      last_block = this.identifier.substring(index + 1);
+    } else {
+      last_block = this.identifier
+    }
+
+    index = last_block.lastIndexOf(':');
+    if (index > -1) {
+      return last_block.substring(index + 1);
+    }
+    return ''
+  }
+}

--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -19,8 +19,6 @@
  *   [REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG]
  * REGISTRY can be omitted and NAME can contain '/' as delimiters for NAMESPACE.
  *
- * So only TAG is specified.
- *
  */
 
 export default class DockerImageIdentifier {
@@ -29,18 +27,18 @@ export default class DockerImageIdentifier {
    *
    * @param {string} identifier
    */
-  constructor(identifier = '') { this.identifier = identifier; }
+  constructor(identifier) { this.identifier = identifier; }
 
   /**
    * Returns tag
    *
    * TAG cannot contain ':' and '/'.
-   * Not if TAG is omitted, last block text(separated by '/') contains TAG.
+   * If TAG is not omitted, last block text(separated by '/') contains TAG.
    * @return {string}
    */
   tag() {
     /** @type {number} **/
-    let index = this.identifier.lastIndexOf('/');
+    let index = (this.identifier || '').lastIndexOf('/');
 
     /** @type {string} **/
     let last_block = '';
@@ -50,7 +48,7 @@ export default class DockerImageIdentifier {
       last_block = this.identifier;
     }
 
-    index = last_block.lastIndexOf(':');
+    index = (last_block || '').lastIndexOf(':');
     if (index > -1) {
       return last_block.substring(index + 1);
     }

--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -24,7 +24,6 @@
  */
 
 export default class DockerImageIdentifier {
-
   /**
    * Constructs DockerUri object.
    *

--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -44,11 +44,11 @@ export default class DockerImageIdentifier {
     let index = this.identifier.lastIndexOf('/');
 
     /** @type {string} **/
-    let last_block;
+    let last_block = '';
     if (index > -1) {
       last_block = this.identifier.substring(index + 1);
     } else {
-      last_block = this.identifier
+      last_block = this.identifier;
     }
 
     index = last_block.lastIndexOf(':');

--- a/src/app/frontend/common/docker/dockerimagereference.js
+++ b/src/app/frontend/common/docker/dockerimagereference.js
@@ -21,13 +21,18 @@
  *
  */
 
-export default class DockerImageIdentifier {
+export default class DockerImageReference {
   /**
-   * Constructs DockerUri object.
+   * Constructs DockerImageReference object.
    *
-   * @param {string} identifier
+   * @param {string} reference
    */
-  constructor(identifier) { this.identifier = identifier; }
+  constructor(reference) {
+    /**
+     * @private {string}
+     */
+    this.reference_ = reference;
+  }
 
   /**
    * Returns tag
@@ -38,14 +43,14 @@ export default class DockerImageIdentifier {
    */
   tag() {
     /** @type {number} **/
-    let index = (this.identifier || '').lastIndexOf('/');
+    let index = (this.reference_ || '').lastIndexOf('/');
 
     /** @type {string} **/
     let last_block = '';
     if (index > -1) {
-      last_block = this.identifier.substring(index + 1);
+      last_block = this.reference_.substring(index + 1);
     } else {
-      last_block = this.identifier;
+      last_block = this.reference_;
     }
 
     index = (last_block || '').lastIndexOf(':');

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -19,6 +19,7 @@ import {
   stateName as replicationcontrollerliststate,
 } from 'replicationcontrollerlist/replicationcontrollerlist_state';
 import {uniqueNameValidationKey} from './uniquename_directive';
+import DockerImageReference from '../common/docker/dockerimagereference';
 
 // Label keys for predefined labels
 const APP_LABEL_KEY = 'app';
@@ -345,25 +346,7 @@ export default class DeployFromSettingsController {
    * @return {string}
    * @private
    */
-  getContainerImageVersion_() {
-    /** @type {number} */
-    let index = (this.containerImage || '').lastIndexOf('/');
-
-    let imagename;
-    if (index > -1) {
-      imagename = this.containerImage.substring(index + 1);
-    } else {
-      imagename = this.containerImage;
-    }
-
-    index = (imagename || '').lastIndexOf(':');
-
-    if (index > -1) {
-      return imagename.substring(index + 1);
-    }
-
-    return '';
-  }
+  getContainerImageVersion_() { return new DockerImageReference(this.containerImage).tag(); }
 
   /**
    * Returns application name.

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -351,9 +351,9 @@ export default class DeployFromSettingsController {
 
     let imagename;
     if (index > -1) {
-	imagename = this.containerImage.substring(index + 1);
+      imagename = this.containerImage.substring(index + 1);
     } else {
-	imagename = this.containerImage;
+      imagename = this.containerImage;
     }
 
     index = (imagename || '').lastIndexOf(':');

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -347,10 +347,19 @@ export default class DeployFromSettingsController {
    */
   getContainerImageVersion_() {
     /** @type {number} */
-    let index = (this.containerImage || '').lastIndexOf(':');
+    let index = (this.containerImage || '').lastIndexOf('/');
+
+    let imagename;
+    if (index > -1) {
+	imagename = this.containerImage.substring(index + 1);
+    } else {
+	imagename = this.containerImage;
+    }
+
+    index = (imagename || '').lastIndexOf(':');
 
     if (index > -1) {
-      return this.containerImage.substring(index + 1);
+      return imagename.substring(index + 1);
     }
 
     return '';

--- a/src/test/frontend/common/docker/dockerimagereference_test.js
+++ b/src/test/frontend/common/docker/dockerimagereference_test.js
@@ -1,0 +1,160 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import DockerImageReference from 'common/docker/dockerimagereference';
+
+describe('DokcerImageReference', () => {
+
+  it('should return empty string when containerImage is undefined', () => {
+    // given
+    let reference = undefined;
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should return empty string when containerImage is empty', () => {
+    // given
+    let reference = "";
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should return empty string when containerImage is not empty and does not contain `:`' +
+         ' delimiter',
+     () => {
+       // given
+       let reference = 'test';
+
+       // when
+       let result = new DockerImageReference(reference).tag();
+
+       // then
+       expect(result).toEqual('');
+     });
+
+  it('should return part of the string after `:` delimiter', () => {
+    // given
+    let reference = 'test:1';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('1');
+  });
+
+  it('should return part of the string after `:` delimiter', () => {
+    // given
+    let reference = 'test:1';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('1');
+  });
+
+  it('should return part of the string after `:` delimiter', () => {
+    // given
+    let reference = 'private.registry:5000/test:1';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('1');
+  });
+
+  it('should return empty string when containerImage is not empty and does not containe `:`' +
+         ' delimiter after `/` delimiter',
+     () => {
+       // given
+       let reference = 'private.registry:5000/test';
+
+       // when
+       let result = new DockerImageReference(reference).tag();
+
+       // then
+       expect(result).toEqual('');
+     });
+
+  it('should return part of the string after `:` delimiter when containerImage is not empty' +
+         'and containe two `/` delimiters',
+     () => {
+       // given
+       let reference = 'private.registry:5000/namespace/test:1';
+
+       // when
+       let result = new DockerImageReference(reference).tag();
+
+       // then
+       expect(result).toEqual('1');
+     });
+
+  it('should return part of the string after last `:` delimiter when containerImage is not empty' +
+         ' and containe two `:` delimiters',
+     () => {
+       // given
+       let reference = 'private.registry:5000/test:image:1';
+
+       // when
+       let result = new DockerImageReference(reference).tag();
+
+       // then
+       expect(result).toEqual('1');
+     });
+
+  it('should return empty string when containerImage is only `:` delimiter', () => {
+    // given
+    let reference = ':';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should return empty string when containerImage is only `/` delimiter', () => {
+    // given
+    let reference = '/';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should return empty string when containerImage is only `/` delimiter' +
+         ' and `:` delimiter',
+     () => {
+       // given
+       let reference = '/:';
+
+       // when
+       let result = new DockerImageReference(reference).tag();
+
+       // then
+       expect(result).toEqual('');
+     });
+});

--- a/src/test/frontend/common/docker/dockerimagereference_test.js
+++ b/src/test/frontend/common/docker/dockerimagereference_test.js
@@ -64,17 +64,6 @@ describe('DokcerImageReference', () => {
 
   it('should return part of the string after `:` delimiter', () => {
     // given
-    let reference = 'test:1';
-
-    // when
-    let result = new DockerImageReference(reference).tag();
-
-    // then
-    expect(result).toEqual('1');
-  });
-
-  it('should return part of the string after `:` delimiter', () => {
-    // given
     let reference = 'private.registry:5000/test:1';
 
     // when
@@ -157,4 +146,38 @@ describe('DokcerImageReference', () => {
        // then
        expect(result).toEqual('');
      });
+
+  it('should retrun empty when containerImage is `::`', () => {
+    // given
+    let reference = '::';
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should retrun empty when containerImage is not empty and ends with `:` delimiter', () => {
+    // given
+    let reference = "test:";
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
+  it('should retrun empty when containerImage is not empty and ends with `/` delimiter', () => {
+    // given
+    let reference = "test/";
+
+    // when
+    let result = new DockerImageReference(reference).tag();
+
+    // then
+    expect(result).toEqual('');
+  });
+
 });

--- a/src/test/frontend/deploy/deployfromsettings_controller_test.js
+++ b/src/test/frontend/deploy/deployfromsettings_controller_test.js
@@ -112,16 +112,17 @@ describe('DeployFromSettings controller', () => {
   });
 
   it('should return empty string when containerImage is not empty and does not containe `:`' +
-     ' delimiter after `/` delimiter', () => {
-    // given
-    ctrl.containerImage = 'private.registry:5000/test';
+         ' delimiter after `/` delimiter',
+     () => {
+       // given
+       ctrl.containerImage = 'private.registry:5000/test';
 
-    // when
-    let result = ctrl.getContainerImageVersion_();
+       // when
+       let result = ctrl.getContainerImageVersion_();
 
-    // then
-    expect(result).toEqual('');
-  });
+       // then
+       expect(result).toEqual('');
+     });
 
   it('should return empty array when labels array is empty', () => {
     // given

--- a/src/test/frontend/deploy/deployfromsettings_controller_test.js
+++ b/src/test/frontend/deploy/deployfromsettings_controller_test.js
@@ -100,6 +100,29 @@ describe('DeployFromSettings controller', () => {
     expect(result).toEqual('1');
   });
 
+  it('should return part of the string after `:` delimiter', () => {
+    // given
+    ctrl.containerImage = 'private.registry:5000/test:1';
+
+    // when
+    let result = ctrl.getContainerImageVersion_();
+
+    // then
+    expect(result).toEqual('1');
+  });
+
+  it('should return empty string when containerImage is not empty and does not containe `:`' +
+     ' delimiter after `/` delimiter', () => {
+    // given
+    ctrl.containerImage = 'private.registry:5000/test';
+
+    // when
+    let result = ctrl.getContainerImageVersion_();
+
+    // then
+    expect(result).toEqual('');
+  });
+
   it('should return empty array when labels array is empty', () => {
     // given
     let labels = [];


### PR DESCRIPTION
When I use private.registry:5000/nginx for container image, version label is set '5000/nginx' and it has error.
Fixed it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/403)
<!-- Reviewable:end -->
