### PR TITLE
Angular and Google Closure Compiler update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,17 +5,17 @@
   "name": "kubernetes-dashboard",
   "version": "0.0.1",
   "dependencies": {
-    "angular": "~1.4.8",
-    "angular-animate": "~1.4.8",
-    "angular-aria": "~1.4.8",
+    "angular": "~1.5.0",
+    "angular-animate": "~1.5.0",
+    "angular-aria": "~1.5.0",
     "angular-material": "~1.0.1",
-    "angular-messages": "~1.4.8",
+    "angular-messages": "~1.5.0",
     "angular-ui-router": "~0.2.15",
-    "angular-resource": "~1.4.8",
-    "angular-sanitize": "~1.4.8"
+    "angular-resource": "~1.5.0",
+    "angular-sanitize": "~1.5.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.8",
+    "angular-mocks": "~1.5.0",
     "google-closure-library": "*"
   }
 }

--- a/build/script.js
+++ b/build/script.js
@@ -62,17 +62,17 @@ gulp.task('scripts:prod', ['angular-templates'], function() {
     // "foo_flag: null" means that a flag is enabled.
     compilerFlags: {
       angular_pass: null,
-      closure_entry_point: 'module$index_module',
+      entry_point: 'index_module',
       compilation_level: 'ADVANCED_OPTIMIZATIONS',
       export_local_property_definitions: null,
       externs: [
-        path.join(conf.paths.nodeModules, 'google-closure-compiler/contrib/externs/angular-1.4.js'),
+        path.join(conf.paths.nodeModules, 'google-closure-compiler/contrib/externs/angular-1.5.js'),
         path.join(
             conf.paths.nodeModules,
-            'google-closure-compiler/contrib/externs/angular-1.4-http-promise_templated.js'),
+            'google-closure-compiler/contrib/externs/angular-1.5-http-promise_templated.js'),
         path.join(
             conf.paths.nodeModules,
-            'google-closure-compiler/contrib/externs/angular-1.4-q_templated.js'),
+            'google-closure-compiler/contrib/externs/angular-1.5-q_templated.js'),
         path.join(
             conf.paths.nodeModules, 'google-closure-compiler/contrib/externs/angular-material.js'),
         path.join(
@@ -92,10 +92,14 @@ gulp.task('scripts:prod', ['angular-templates'], function() {
         'inferredConstCheck',
         // Let ESLint handle all lint checks.
         'lintChecks',
+        // This checks aren't working with current google-closure-library version. Will be deleted
+        // once it's fixed there.
+        'unnecessaryCasts',
+        'analyzerChecks',
       ],
       language_in: 'ECMASCRIPT6_STRICT',
       language_out: 'ECMASCRIPT3',
-      manage_closure_dependencies: true,
+      dependency_mode: 'LOOSE',
       use_types_for_optimization: null,
     },
     compilerPath: path.join(conf.paths.nodeModules, 'google-closure-compiler/compiler.jar'),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "browserify-istanbul": "~0.2.1",
     "del": "~2.2.0",
     "eslint-plugin-angular": "~0.15.0",
-    "google-closure-compiler": "~20151216.2.0",
+    "google-closure-compiler": "~20160208.1.0",
     "gulp": "~3.9.0",
     "gulp-angular-templatecache": "~1.8.0",
     "gulp-autoprefixer": "~3.1.0",


### PR DESCRIPTION
I've updated:

- Google Closure Compiler to version `20160208.1.0`
- Angular to version `1.5.0`
- Angular-animate to version `1.5.0`
- Angular-aria to version `1.5.0`
- Angular messages to version `1.5.0`
- Angular-resource to version `1.5.0`
- Angular-sanitize to version `1.5.0`
- Angular-mocks to version `1.5.0`

Deprecated compiler flags were changed to newly added in favour of https://github.com/google/closure-compiler/issues/1319:
- `manage_closure_compiler` to `dependency_mode`
- `closure_entry_point` to `entry_point`

Additionally some compiler checks had to be turned off because newest `google-closure-library` has some JSDoc issues and compiler complains about that.

## IMPORTANT
It's best to remove current `bower_components` and do a clean install:
`rm -rf bower_components/ && bower install`
`npm install` should be enough to update closure compiler

@maciaszczykm @batikanu @digitalfishpond @cheld @taimir 