### PR TITLE
Redirect to zerostate if there are only RCs in namespace "kube-system"

### DIFF
--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
@@ -15,6 +15,7 @@
 import {stateName as zerostate} from './zerostate/zerostate_state';
 import {stateName as replicationcontrollers} from './replicationcontrollerlist_state';
 import {stateUrl as replicationcontrollersUrl} from './replicationcontrollerlist_state';
+import {StateParams} from './zerostate/zerostate_state';
 import ReplicationControllerListController from './replicationcontrollerlist_controller';
 import ZeroStateController from './zerostate/zerostate_controller';
 
@@ -43,22 +44,39 @@ export default function stateConfig($stateProvider) {
         templateUrl: 'replicationcontrollerlist/zerostate/zerostate.html',
       },
     },
+    // this is to declare non-url state params
+    params: new StateParams(false),
   });
 }
 
 /**
- * Avoids entering replication controller list page when there are no replication controllers.
- * Used f.e. when last replication controller gets deleted.
+ * Avoids entering replication controller list page when there are no replication controllers
+ * or when the only replication controllers are in the kube-system namespace.
+ * Used f.e. when last replication controller that is not in the kube-system namespace gets
+ * deleted.
  * Transition to: zerostate
  * @param {!ui.router.$state} $state
  * @param {!angular.$timeout} $timeout
  * @param {!backendApi.ReplicationControllerList} replicationControllers
  * @ngInject
  */
-function redirectIfNeeded($state, $timeout, replicationControllers) {
-  if (replicationControllers.replicationControllers.length === 0) {
+export function redirectIfNeeded($state, $timeout, replicationControllers) {
+  /** @type {boolean} */
+  let isEmpty = replicationControllers.replicationControllers.length === 0;
+  // should only display RC list if RCs exist that are not in the kube-system namespace,
+  // otherwise should redirect to zero state
+  let containsOnlyKubeSystemRCs =
+      !isEmpty && replicationControllers.replicationControllers.every((rc) => {
+        return rc.namespace === 'kube-system';
+      });
+
+  if (isEmpty || containsOnlyKubeSystemRCs) {
     // allow original state change to finish before redirecting to new state to avoid error
-    $timeout(() => { $state.go(zerostate); });
+
+    $timeout(() => {
+      let stateParams = new StateParams(containsOnlyKubeSystemRCs);
+      $state.go(zerostate, stateParams);
+    });
   }
 }
 

--- a/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
+++ b/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
@@ -28,6 +28,11 @@ limitations under the License.
         <md-button ui-sref="deploy" class="md-raised md-primary kd-zerostate-deploy-bt">Deploy an
           app
         </md-button>
+        <div></div>
+        <a class="md-raised md-primary kd-zerostate-deploy-bt" ng-if="ctrl.containsOnlyKubeSystemRCs"
+           ui-sref="replicationcontrollers">
+          There are replication controllers in namespace "kube-system" - click to show.
+        </a>
       </md-card-content>
     </md-card>
     <md-card flex="15" class="kd-zerostate-lm-card">

--- a/src/app/frontend/replicationcontrollerlist/zerostate/zerostate_controller.js
+++ b/src/app/frontend/replicationcontrollerlist/zerostate/zerostate_controller.js
@@ -19,9 +19,10 @@
  */
 export default class ZeroStateController {
   /**
+   * @param {!./zerostate_state.StateParams} $stateParams
    * @ngInject
    */
-  constructor() {
+  constructor($stateParams) {
     /** @export {!Array<{title:string, link:string}>} */
     this.learnMoreLinks = [
       {title: 'Dashboard Tour', link: "#"},
@@ -29,5 +30,8 @@ export default class ZeroStateController {
       {title: 'Monitoring your App', link: "#"},
       {title: 'Troubleshooting', link: "#"},
     ];
+
+    /** @export {boolean} */
+    this.containsOnlyKubeSystemRCs = $stateParams.containsOnlyKubeSystemRCs;
   }
 }

--- a/src/app/frontend/replicationcontrollerlist/zerostate/zerostate_state.js
+++ b/src/app/frontend/replicationcontrollerlist/zerostate/zerostate_state.js
@@ -16,3 +16,18 @@ import {stateName as replicationcontrollers} from './../replicationcontrollerlis
 
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = `${replicationcontrollers}.zero`;
+
+/**
+ * Parameters for this state.
+ * All properties are @exported and in sync with URL param names.
+ *
+ */
+export class StateParams {
+  /**
+   * @param containsOnlyKubeSystemRCs
+   */
+  constructor(containsOnlyKubeSystemRCs) {
+    /** @type {boolean} whether there are only RCs in namespace "kube-system" */
+    this.containsOnlyKubeSystemRCs = containsOnlyKubeSystemRCs;
+  }
+}

--- a/src/test/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig_test.js
+++ b/src/test/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig_test.js
@@ -1,0 +1,96 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
+import {redirectIfNeeded} from 'replicationcontrollerlist/replicationcontrollerlist_stateconfig';
+
+describe('StateConfig for replication controller list', () => {
+  /** @type {!ui.router.$state} */
+  let state;
+  /** @type {!angular.$timeout} */
+  let timeout;
+  beforeEach(() => {
+    angular.mock.module(replicationControllerListModule.name);
+
+    angular.mock.inject(($state, $timeout) => {
+      state = $state;
+      timeout = $timeout;
+    });
+  });
+
+  it('should redirect to zerostate when RCs exist only in namespace kube-system', () => {
+    // given
+    spyOn(state, 'go');
+    let replicationControllers = {
+      replicationControllers: [
+        {namespace: 'kube-system'},
+      ],
+    };
+
+    // when
+    redirectIfNeeded(state, timeout, replicationControllers);
+    timeout.flush();
+
+    // then
+    expect(state.go).toHaveBeenCalled();
+  });
+
+  it('should redirect to zerostate if no RCs exist', () => {
+    // given
+    spyOn(state, 'go');
+    let replicationControllers = {replicationControllers: []};
+
+    // when
+    redirectIfNeeded(state, timeout, replicationControllers);
+    timeout.flush();
+
+    // then
+    expect(state.go).toHaveBeenCalled();
+  });
+
+  it('should not redirect to zerostate when RCs only exist in namespaces other than kube-system',
+     () => {
+       // given
+       spyOn(state, 'go');
+       let replicationControllers = {
+         replicationControllers: [
+           {namespace: 'foo-namespace'},
+         ],
+       };
+
+       // when
+       redirectIfNeeded(state, timeout, replicationControllers);
+
+       // then
+       expect(state.go).not.toHaveBeenCalled();
+     });
+
+  it('should not redirect to zerostate when RCs exist both in namespace kube-system and other',
+     () => {
+       // given
+       spyOn(state, 'go');
+       let replicationControllers = {
+         replicationControllers: [
+           {namespace: 'foo-namespace'},
+           {namespace: 'kube-system'},
+         ],
+       };
+
+       // when
+       redirectIfNeeded(state, timeout, replicationControllers);
+
+       // then
+       expect(state.go).not.toHaveBeenCalled();
+     });
+});

--- a/src/test/frontend/replicationcontrollerlist/zerostate/zerostate_controller_test.js
+++ b/src/test/frontend/replicationcontrollerlist/zerostate/zerostate_controller_test.js
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
 import ZerostateController from 'replicationcontrollerlist/zerostate/zerostate_controller';
+import {StateParams} from 'replicationcontrollerlist/zerostate/zerostate_state';
 
 describe('Zerostate controller', () => {
   let ctrl;
 
-  beforeEach(angular.mock.inject(() => { ctrl = new ZerostateController(); }));
+  /** @type {!StateParams} */
+  let stateParams = new StateParams();
+
+  beforeEach(() => {
+    angular.mock.module(replicationControllerListModule.name);
+
+    angular.mock.inject(($controller) => { ctrl = $controller(ZerostateController, stateParams); });
+  });
 
   it('should do something', () => {
     expect(ctrl.learnMoreLinks).toEqual([
@@ -26,5 +35,6 @@ describe('Zerostate controller', () => {
       {title: 'Monitoring your App', link: "#"},
       {title: 'Troubleshooting', link: "#"},
     ]);
+    expect(ctrl.containsOnlyKubeSystemRCs).toEqual(stateParams.containsOnlyKubeSystemRCs);
   });
 });


### PR DESCRIPTION
- Redirect to zerostate when there are only RCs in namespace "kube-system"
- Show link to RC list in zerostate when there are only RCs in namespace "kube-system"

Fixes #331

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/414)
<!-- Reviewable:end -->
