### PR TITLE
Improve deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ itself.
 The Dashboard is currently under active development and is not ready for production use (yet!). To run the latest _unstable_ version execute the following command:
 
 ``
-kubectl create -f src/deploy/kubernetes-dashboard.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard-canary.yaml
 ``
-
-
 
 ## Documentation
 

--- a/src/deploy/kubernetes-dashboard-canary.yaml
+++ b/src/deploy/kubernetes-dashboard-canary.yaml
@@ -1,46 +1,49 @@
+kind: List
 apiVersion: v1
-kind: ReplicationController
-metadata:
-  labels:
-    app: kubernetes-dashboard-canary
-    version: canary
-  name: kubernetes-dashboard-canary
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    app: kubernetes-dashboard-canary
-    version: canary
-  template:
-    metadata:
-      labels:
-        app: kubernetes-dashboard-canary
-        version: canary
-    spec:
-      containers:
-      - name: kubernetes-dashboard-canary
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:canary
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 9090
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 9090
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: kubernetes-dashboard-canary
-  name: dashboard-canary
-  namespace: kube-system
-spec:
-  ports:
-  - port: 80
-    targetPort: 9090
-  selector:
-    app: kubernetes-dashboard-canary
+items:
+- kind: ReplicationController
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-canary
+      version: canary
+    name: kubernetes-dashboard-canary
+    namespace: kube-system
+  spec:
+    replicas: 1
+    selector:
+      app: kubernetes-dashboard-canary
+      version: canary
+    template:
+      metadata:
+        labels:
+          app: kubernetes-dashboard-canary
+          version: canary
+      spec:
+        containers:
+        - name: kubernetes-dashboard-canary
+          image: gcr.io/google_containers/kubernetes-dashboard-amd64:canary
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 9090
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+- kind: Service
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-canary
+    name: dashboard-canary
+    namespace: kube-system
+  spec:
+    type: NodePort
+    ports:
+    - port: 80
+      targetPort: 9090
+    selector:
+      app: kubernetes-dashboard-canary


### PR DESCRIPTION
Also, turns out that multi-doc YAML as it was didn't just work with URLs, not sure if that's a known upstream bug...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/416)
<!-- Reviewable:end -->
