### PR TITLE
Increase test timeouts and decrease concurrency to prevent fkaliness

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -136,6 +136,12 @@ module.exports = function(config) {
       sl_ie: {base: 'SauceLabs', browserName: 'internet explorer'},
     };
     configuration.browsers = Object.keys(configuration.customLaunchers);
+
+    // Set large capture timeout to prevent timeouts when executing on saucelabs.
+    configuration.captureTimeout = 5 * 60 * 1000;  // 5 minutes.
+
+    // Limit concurrency to not exhaust saucelabs resources for the CI user.
+    configuration.concurrency = 1;
   } else {
     configuration.browsers = ['Chrome'];
   }

--- a/build/protractor.conf.js
+++ b/build/protractor.conf.js
@@ -64,6 +64,9 @@ function createConfig() {
       },
     ];
 
+    // Limit concurrency to not exhaust saucelabs resources for the CI user.
+    config.maxSessions = 1;
+
   } else {
     config.capabilities = {'browserName': 'firefox'};
   }


### PR DESCRIPTION
With this tests running on saucelabs should be less flaky, as they
recently have been, e.g.,
https://saucelabs.com/beta/tests/a17cda7d243b4343aad1c83d54979b76/logs

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/417)
<!-- Reviewable:end -->
