### PR TITLE
Extended warning events recognition

### DIFF
--- a/src/test/backend/eventscommon_test.go
+++ b/src/test/backend/eventscommon_test.go
@@ -331,3 +331,25 @@ func TestFillEventsType(t *testing.T) {
 		}
 	}
 }
+
+func TestIsFailedReason(t *testing.T) {
+	cases := []struct {
+		reason         string
+		failedPartials []string
+		expected       bool
+	}{
+		{"", nil, false},
+		{"", []string{}, false},
+		{"FailedReason", []string{"failed"}, true},
+		{"ErrReason", []string{"failed"}, false},
+		{"ErrReason", []string{"failed", "err"}, true},
+	}
+
+	for _, c := range cases {
+		actual := isFailedReason(c.reason, c.failedPartials...)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("fillEventsType(%#v, %#v) == \n%#v\nexpected \n%#v\n",
+				c.reason, c.failedPartials, actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
I've added more partial strings indicating that event reason message is a warning or an error. It's based mostly on this file: 
https://github.com/kubernetes/kubernetes/blob/53f0f9d59860131c2be301a0054adfc86e43945d/pkg/kubelet/container/event.go

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/424)
<!-- Reviewable:end -->
