### PR TITLE
Fixed card status text overflow on IE

### DIFF
--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
@@ -47,8 +47,9 @@
 
 .kd-replicationcontroller-card-error {
   color: $secondary;
+  display: inline-block;
   margin-top: $baseline-grid / 2;
-  word-wrap: break-word;
+  word-break: break-all;
 }
 
 .kd-replicationcontroller-card-description {


### PR DESCRIPTION
Fixes #426 

All words will be able to break at any point now. This is how it looks on IE now.
![zrzut ekranu z 2016-02-25 12-13-53](https://cloud.githubusercontent.com/assets/2285385/13318139/40c0e45c-dbb9-11e5-8a07-057e31929828.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/428)
<!-- Reviewable:end -->
