### PR TITLE
App name validation fix

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -26,9 +26,10 @@ limitations under the License.
           <ng-message when="required">Application name is required.</ng-message>
           <ng-message when="uniqueName">Application with this name
             already exists within namespace <i>{{ctrl.namespace}}</i>.</ng-message>
-          <ng-message when="pattern">Application name should contain only lowercase letters, numbers, and '-' between words
+          <ng-message when="pattern">Application name should start with a lowercase letter
+            , and contain only lowercase letters, numbers, and '-' between words
           </ng-message>
-          <ng-message when="maxlength">Application name should have no more than 63 characters</ng-message>
+          <ng-message when="maxlength">Application name should have no more than 24 characters</ng-message>
         </ng-messages>
 
         <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate" ng-show="ctrl.form.name.$pending">

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -127,13 +127,13 @@ export default class DeployFromSettingsController {
      * (leading and trailing spaces are ignored by default)
      * @export {!RegExp}
      */
-    this.namePattern = new RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
+    this.namePattern = new RegExp('^[a-z]([-a-z0-9]*[a-z0-9])?$');
 
     /**
      * Maximum length for Application name
      * @export {string}
      */
-    this.nameMaxLength = '63';
+    this.nameMaxLength = '24';
 
     /**
      * Whether to run the container as privileged user.

--- a/src/test/frontend/deploy/deployfromsettings_controller_test.js
+++ b/src/test/frontend/deploy/deployfromsettings_controller_test.js
@@ -362,18 +362,19 @@ describe('DeployFromSettings controller', () => {
 
   /**
    * The value entered for ‘App Name” is used implicitly as the name for several resources (pod, rc,
-   * svc, label). Therefore, the app-name validation pattern is based on the RC-pattern, but must
-   * conform with all validation patterns of all the created resources.
-   * Currently, the ui pattern that conforms with all patterns is alpha-numeric with dashes between.
+   * svc, label). Therefore, the app-name validation pattern is based on the servicePattern, but
+   * must conform with all validation patterns of all the created resources.
+   * Currently, the ui pattern that conforms with all patterns starts with a lowercase letter,
+   * is lowercase alpha-numeric with dashes between.
    */
   it('should allow strings that conform to the patterns of all created resources', () => {
     // given the pattern used by the App Name field in the UI
     let namePattern = ctrl.namePattern;
     // given the patterns of all the names that are implicitly created
     let allPatterns = {
-      servicePattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*',
+      servicePattern: '[a-z]([-a-z0-9]*[a-z0-9])?',
       labelPattern: '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?',
-      rcPattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?',
+      rcPattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*',
       appNamePattern: namePattern,
     };
 
@@ -388,7 +389,7 @@ describe('DeployFromSettings controller', () => {
   /**
    * The value entered for 'App Name' is used implicitly as the name for several resources (pod, rc,
    * svc, label).
-   * Remark: The app-name pattern excludes some service names and label values, which could be
+   * Remark: The app-name pattern excludes some RC names and label values, which could be
    * created manually. This is a restriction of the current design.
    */
   it('should reject names that fail to conform to appNamePattern', () => {
@@ -422,20 +423,20 @@ describe('DeployFromSettings controller', () => {
    * Service Name, Label Name and RC name. Pod names are truncated by the api server and therefore
    * ignored.
    * Remark: The maximum characters number should match all three, thereby excluding
-   * service names of more than 63 chars via this form, while it is possible to create service names
+   * service names of more than 24 chars via this form, while it is possible to RC pod names
    * of 253 chars manually. This is a restriction of the current design.
    *
-   * ctrl.maxNameLength = 63
+   * ctrl.maxNameLength = 24
    */
   it('should limit input that conforms to all created resources', () => {
 
-    // service names are max. 253 chars
-    expect(ctrl.maxNameLength <= 253);
+    // service names are max. 24 chars
+    expect(ctrl.maxNameLength <= 24);
 
     //  label are max. 63 chars. the 256 prefix cannot be entered
     expect(ctrl.maxNameLength <= 63);
 
-    // RC name are max. 63 chars.
-    expect(ctrl.maxNameLength <= 63);
+    // RC name are max. 253 chars.
+    expect(ctrl.maxNameLength <= 253);
   });
 });


### PR DESCRIPTION
#411 
App name is restricted to 24 chars and regex pattern now also restricts first char to lowercase letter

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/451)
<!-- Reviewable:end -->
