### PR TITLE
Responsive table style fix

### DIFF
--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -115,20 +115,29 @@ a {
 
     // Row data style.
     td {
-      border-bottom: 1px solid $border;
-      display: block;
+      align-items: center;
+      display: flex;
       height: auto;
-      line-height: $table-cell-height;
-      padding-left: 50%;
+      min-height: $table-cell-height - 2 * $baseline-grid;
+      padding: $baseline-grid $baseline-grid $baseline-grid 50%;
       position: relative;
+
+      // Adds border between rows.
+      &:not(:last-child) {
+        border-bottom: 1px solid $border;
+      }
 
       // Row title style.
       &::before {
+        align-items: center;
+        bottom: 0;
         content: attr(kd-responsive-header);
+        display: flex;
         font-weight: $bold-font-weight;
         left: $baseline-grid * 2;
         padding-right: $baseline-grid * 2;
         position: absolute;
+        top: 0;
         word-wrap: break-word;
       }
     }


### PR DESCRIPTION
Fixed stylesheet issues for responsive tables:

- added paddings
- centered texts
- centered warning icon
- fixed overlay issue
- removed too big spacing between lines

Fixes #438 issue.

![image](https://cloud.githubusercontent.com/assets/2823399/13391598/9d4f52f2-ded5-11e5-9fef-9f638528db9f.png)
