### PR TITLE
Fix edit pod count button

### DIFF
--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -47,10 +47,9 @@ limitations under the License.
         </span>
       </div>
       <div flex="nogrow">
-        <md-button class="md-icon-button md-primary">
-          <md-icon class="material-icons" ng-click="infoCtrl.handleUpdateReplicasDialog()">
-            mode_edit
-          </md-icon>
+        <md-button class="md-icon-button md-primary"
+                   ng-click="infoCtrl.handleUpdateReplicasDialog()">
+          <md-icon class="material-icons">mode_edit</md-icon>
         </md-button>
       </div>
     </div>


### PR DESCRIPTION
Fixes #437 bug.

It seems, that Firefox and IE don't care about `ng-click` if it's under `<md-button>`. Moving `ng-click` to `<md-button>` fixes issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/459)
<!-- Reviewable:end -->
