### PR TITLE
Fixed logs button placement issue on replica set card

### DIFF
--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.scss
@@ -70,6 +70,7 @@
   &.kd-replicationcontroller-card-logs-button {
     font-size: inherit;
     font-weight: inherit;
+    height: 2 * $baseline-grid;
     line-height: 0;
     margin: 0;
     min-height: inherit;


### PR DESCRIPTION
Fixes #442 

For some reason on firefox on button click height of element was changed from 16px to 10px. This fixes problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/462)
<!-- Reviewable:end -->
