### PR TITLE
Fixed replica sed card placement issue on IE

### DIFF
--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer.scss
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer.scss
@@ -19,6 +19,5 @@
   align-items: center;
   display: flex;
   flex-flow: column wrap;
-  justify-content: top;
   margin-top: $toolbar-height-size-base;
 }

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer_directive.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer_directive.js
@@ -40,6 +40,8 @@ export default function replicationControllerListContainerDirective($mdMedia) {
       let nonNullContainer = container;
       scope.$watch(() => computeContainerHeight(nonNullContainer, $mdMedia), (newHeight) => {
         container.style.height = `${newHeight}px`;
+        // This is needed to make it work on IE
+        container.style.minHeight = `${newHeight + 1}px`;
       });
     },
     templateUrl: 'replicationcontrollerlist/replicationcontrollerlistcontainer.html',


### PR DESCRIPTION
Fixes #431 

According to this: https://css-tricks.com/snippets/css/a-guide-to-flexbox/ `top` is actually not a valid option for `justify-content`. Default value for justify-content is `flex-start` and it works like `top` so it's not needed at all.

As for the IE bug it's described here: http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/ in the **The min-height bug** section and in order to make flex container work in the column direction `min-height` needs to be also defined.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/463)
<!-- Reviewable:end -->
