### PR TITLE
Unify maxlength validation through the app

### DIFF
--- a/src/app/frontend/deploy/createnamespace.html
+++ b/src/app/frontend/deploy/createnamespace.html
@@ -28,13 +28,17 @@ limitations under the License.
             ng-pattern="ctrl.namespacePattern"
             required>
         <div ng-messages="ctrl.namespaceForm.namespace.$error">
-            <div ng-message="pattern">Name must be alphanumeric and may contain dashes</div>
-            <div ng-message="md-maxlength">Name is too long</div>
-            <div ng-message="required">Name is required</div>
+            <div ng-message="pattern">Name must be alphanumeric and may contain dashes.</div>
+            <div ng-message="maxlength">
+              Name must be up to {{ctrl.namespaceMaxLength}} characters long.
+            </div>
+            <div ng-message="required">Name is required.</div>
         </div>
       </md-input-container>
       <md-dialog-actions layout="row">
-        <md-button ng-disabled="ctrl.isDisabled()" class="md-primary" type="submit">OK</md-button>
+        <md-button ng-disabled="ctrl.isDisabled()" class="md-primary" type="submit">
+          Create
+        </md-button>
         <md-button ng-click="ctrl.cancel()">Cancel</md-button>
       </md-dialog-actions>
     </form>

--- a/src/app/frontend/deploy/createsecret.html
+++ b/src/app/frontend/deploy/createsecret.html
@@ -23,13 +23,17 @@ limitations under the License.
       <kd-help-section>
         <md-input-container class="md-block" layout-wrap>
           <label>Secret name</label>
-          <!-- TODO:(taimir) the name of the secret needs to be validated -->
           <input name="secretName" ng-model="ctrl.secretName"
-                 md-maxlength="{{ctrl.secretNameMaxLength}}" ng-pattern="ctrl.secretNamePattern" required>
+                 md-maxlength="{{ctrl.secretNameMaxLength}}" ng-pattern="ctrl.secretNamePattern"
+                 required>
           <div ng-messages="ctrl.secretForm.secretName.$error" role="alert" multiple>
-            <div ng-message="pattern">Name must follow the DNS domain name syntax <br>(e.g. new.image-pull.secret)</div>
-            <div ng-message="md-maxlength">Name length cannot exceed {{ctrl.secretNameMaxLength}} characters</div>
-            <div ng-message="required">Name is required</div>
+            <div ng-message="pattern">
+              Name must follow the DNS domain name syntax (e.g., new.image-pull.secret).
+            </div>
+            <div ng-message="md-maxlength">
+                Name must be up to {{ctrl.secretNameMaxLength}} characters long.
+            </div>
+            <div ng-message="required">Name is required.</div>
           </div>
         </md-input-container>
         <kd-user-help>

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -18,21 +18,28 @@ limitations under the License.
   <md-input-container class="md-block" md-is-error="ctrl.isNameError()">
     <label>App name</label>
     <div class="kd-deploy-form-name-container">
-      <input ng-model="ctrl.name" name="name" namespace="ctrl.namespace" required ng-pattern="ctrl.namePattern"
-             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }" kd-unique-name
-             ng-maxlength="ctrl.nameMaxLength">
+      <input ng-model="ctrl.name" name="name" namespace="ctrl.namespace" required
+             ng-pattern="ctrl.namePattern"
+             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
+             kd-unique-name md-maxlength="{{ctrl.nameMaxLength}}">
       <div class="kd-deploy-form-name-validation-container">
         <ng-messages for="ctrl.form.name.$error" role="alert" multiple>
           <ng-message when="required">Application name is required.</ng-message>
-          <ng-message when="uniqueName">Application with this name
-            already exists within namespace <i>{{ctrl.namespace}}</i>.</ng-message>
-          <ng-message when="pattern">Application name should start with a lowercase letter
-            , and contain only lowercase letters, numbers, and '-' between words
+          <ng-message when="uniqueName">
+            Application with this name
+            already exists within namespace <i>{{ctrl.namespace}}</i>.
           </ng-message>
-          <ng-message when="maxlength">Application name should have no more than 24 characters</ng-message>
+          <ng-message when="pattern">
+            Application name must start with a lowercase letter
+            and contain only lowercase letters, numbers, and '-' between words.
+          </ng-message>
+          <ng-message when="maxlength">
+            Name must be up to {{ctrl.nameMaxLength}} characters long.
+          </ng-message>
         </ng-messages>
 
-        <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate" ng-show="ctrl.form.name.$pending">
+        <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate"
+            ng-show="ctrl.form.name.$pending">
         </md-progress-linear>
       </div>
     </div>


### PR DESCRIPTION
This unifies error messages and makes use of md-maxlength for validation
(eg., to show 0/24 length counter).

Fixes #444

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/469)
<!-- Reviewable:end -->
