### PR TITLE
Added directive to validate different types on input field values

### DIFF
--- a/src/app/frontend/common/validators/types/integertype.js
+++ b/src/app/frontend/common/validators/types/integertype.js
@@ -1,0 +1,32 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Type} from './type';
+
+/**
+ * @final
+ * @extends {Type}
+ */
+export class IntegerType extends Type {
+  constructor() { super(); }
+
+  /**
+   * Returns true if given value is a correct integer value, false otherwise.
+   * When value is undefined or empty then it is considered as correct value in order
+   * to not conflict with other validations like 'required'.
+   *
+   * @override
+   */
+  isValid(value) { return (Number(value) === value && value % 1 === 0) || !value; }
+}

--- a/src/app/frontend/common/validators/types/type.js
+++ b/src/app/frontend/common/validators/types/type.js
@@ -1,0 +1,39 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// As this is abstract class then we have to allow unused variables in methods
+/*eslint no-unused-vars: 0*/
+
+/**
+ * Abstract class representing Type that needs to be validated.
+ *
+ * @class
+ */
+export class Type {
+  constructor() {
+    if (this.constructor === Type) {
+      throw new TypeError('Abstract class "Type" cannot be instantiated directly.');
+    }
+  }
+
+  /**
+   * Should be implemented to return true when the given value meets the requirements
+   * of the expected Type or given value is undefined|empty in order to not conflict with
+   * other check such as 'required', false otherwise.
+   *
+   * @param {*} value
+   * @return {boolean}
+   */
+  isValid(value) {}
+}

--- a/src/app/frontend/common/validators/types/type_factory.js
+++ b/src/app/frontend/common/validators/types/type_factory.js
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {IntegerType} from './integertype';
+
+/**
+ * @final
+ */
+export class TypeFactory {
+  /**
+   * @constructs TypeFactory
+   */
+  constructor() {
+    /** @private {Map<Array<string, !./type.Type>>} */
+    this.typeMap_ = new Map([
+      ['integer', new IntegerType()],
+    ]);
+  }
+
+  /**
+   * Returns specific Type class based on given type name.
+   *
+   * @method
+   * @param typeName
+   * @returns {!./type.Type}
+   */
+  getType(typeName) {
+    let typeObject = this.typeMap_.get(typeName);
+
+    if (!typeObject) {
+      throw new Error(`Given type '${typeName}' is not supported.`);
+    }
+
+    return typeObject;
+  }
+}

--- a/src/app/frontend/common/validators/validate_directive.js
+++ b/src/app/frontend/common/validators/validate_directive.js
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * description:
+ * `<input kd-validate>` can be used to validate if value of the input field meets given Type
+ * restrictions
+ *
+ * Params:
+ *    - kdValidate {string} Information about type of data that can be provided to related input
+ *    field i.e.: integer, appName, pullSecret
+ *
+ * usage:
+ *  `<input type="number" kd-validate="integer">`
+ *
+ * @param {!./types/type_factory.TypeFactory} kdTypeFactory
+ * @return {!angular.Directive}
+ * @ngInject
+ */
+export default function validateDirective(kdTypeFactory) {
+  const validateType = 'kdValidate';
+
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    /**
+     * @param {!angular.Scope} scope
+     * @param {!angular.JQLite} element
+     * @param {!angular.Attributes} attrs
+     * @param {!angular.NgModelController} ctrl
+     */
+    link: (scope, element, attrs, ctrl) => {
+      /** @type {!./types/type.Type} */
+      let type = kdTypeFactory.getType(attrs[validateType]);
+
+      ctrl.$validators['kdValid'] = (value) => { return type.isValid(value); };
+    },
+  };
+}

--- a/src/app/frontend/common/validators/validators_module.js
+++ b/src/app/frontend/common/validators/validators_module.js
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import validateDirective from './validate_directive';
+import {TypeFactory} from './types/type_factory';
+
+/**
+ * Module containing validators for the application.
+ */
+export default angular
+    .module(
+        'kubernetesDashboard.common.validators',
+        [
+          'ngMaterial',
+        ])
+    .service('kdTypeFactory', TypeFactory)
+    .directive('kdValidate', validateDirective);

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -24,6 +24,7 @@ import uploadDirective from './upload_directive';
 import uniqueNameDirective from './uniquename_directive';
 import validProtocolDirective from './validprotocol_directive';
 import helpSectionModule from './helpsection/helpsection_module';
+import validatorsModule from '../common/validators/validators_module';
 
 /**
  * Angular module for the deploy view.
@@ -39,6 +40,7 @@ export default angular
           'ui.router',
           helpSectionModule.name,
           errorHandlingModule.name,
+          validatorsModule.name,
         ])
     .config(stateConfig)
     .directive('deployFromSettings', deployFromSettingsDirective)

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -69,10 +69,10 @@ limitations under the License.
 <kd-help-section>
   <md-input-container class="md-block">
     <label>Number of pods</label>
-    <input ng-model="ctrl.replicas" type="number" required min="1" name="replicas">
+    <input ng-model="ctrl.replicas" type="number" required min="1" name="replicas" kd-validate="integer">
     <ng-messages for="ctrl.form.replicas.$error" role="alert" multiple>
       <ng-message when="required">Number of pods is required.</ng-message>
-      <ng-message when="number">Number of pods must be a positive integer.</ng-message>
+      <ng-message when="number, kdValid">Number of pods must be a positive integer.</ng-message>
       <ng-message when="min">Number of pods must be at least 1.</ng-message>
     </ng-messages>
   </md-input-container>

--- a/src/test/frontend/common/validators/types/integertype_test.js
+++ b/src/test/frontend/common/validators/types/integertype_test.js
@@ -1,0 +1,38 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {IntegerType} from 'common/validators/types/integertype';
+
+describe('Integer type', () => {
+  /** @type {!IntegerType} */
+  let integerType;
+
+  beforeEach(() => { angular.mock.inject(() => { integerType = new IntegerType(); }); });
+
+  it('should return true when valid integer', () => {
+    // given
+    let number = 5;
+
+    // then
+    expect(integerType.isValid(number)).toBeTruthy();
+  });
+
+  it('should return false when invalid integer', () => {
+    // given
+    let number = 5.1;
+
+    // then
+    expect(integerType.isValid(number)).toBeFalsy();
+  });
+});

--- a/src/test/frontend/common/validators/types/type_factory_test.js
+++ b/src/test/frontend/common/validators/types/type_factory_test.js
@@ -1,0 +1,48 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import validatorsModule from 'common/validators/validators_module';
+import {IntegerType} from 'common/validators/types/integertype';
+
+describe('Type factory', () => {
+  /** @type {!TypeFactory} */
+  let typeFactory;
+
+  beforeEach(() => {
+    angular.mock.module(validatorsModule.name);
+
+    angular.mock.inject((kdTypeFactory) => { typeFactory = kdTypeFactory; });
+  });
+
+  it('should return integer type', () => {
+    // given
+    let typeName = 'integer';
+
+    // when
+    let typeObject = typeFactory.getType(typeName);
+
+    // then
+    expect(typeObject).toEqual(jasmine.any(IntegerType));
+  });
+
+  it('should throw an error', () => {
+    // given
+    let typeName = 'notExistingType';
+
+    // then
+    expect(() => {
+      typeFactory.getType(typeName);
+    }).toThrow(new Error(`Given type '${typeName}' is not supported.`));
+  });
+});

--- a/src/test/frontend/common/validators/types/type_test.js
+++ b/src/test/frontend/common/validators/types/type_test.js
@@ -1,0 +1,23 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Type} from 'common/validators/types/type';
+
+describe('Type', () => {
+  it('should not be instantiable', () => {
+    expect(() => {
+      new Type();
+    }).toThrow(new TypeError('Abstract class "Type" cannot be instantiated directly.'));
+  });
+});

--- a/src/test/frontend/common/validators/validate_directive_test.js
+++ b/src/test/frontend/common/validators/validate_directive_test.js
@@ -1,0 +1,69 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import validatorsModule from 'common/validators/validators_module';
+
+describe('Validate directive', () => {
+  /** @type {!angular.Scope} */
+  let scope;
+  /** @type {!angular.$compile} */
+  let compile;
+
+  beforeEach(() => {
+    angular.mock.module(validatorsModule.name);
+
+    angular.mock.inject(($rootScope, $compile) => {
+      scope = $rootScope.$new();
+      compile = $compile;
+    });
+  });
+
+  it('should validate integer as valid', () => {
+    // given
+    scope.replicas = 5;
+    let compileFn = compile('<input ng-model="replicas" type="number" kd-validate="integer">');
+
+    // when
+    let element = compileFn(scope)[0];
+    scope.$digest();
+
+    // then
+    expect(element.classList).toContain('ng-valid');
+  });
+
+  it('should validate integer as invalid', () => {
+    // given
+    scope.replicas = 5.1;
+    let compileFn = compile('<input ng-model="replicas" type="number" kd-validate="integer">');
+
+    // when
+    let element = compileFn(scope)[0];
+    scope.$digest();
+
+    // then
+    expect(element.classList).toContain('ng-invalid');
+  });
+
+  it('should throw an error when wrong type is provided', () => {
+    // given
+    let typeName = 'invalid';
+    let compileFn = compile(`<input ng-model="replicas" type="number"kd-validate="${typeName}">`);
+
+    // when and then
+    expect(() => {
+      compileFn(scope)[0];
+      scope.$digest();
+    }).toThrow(new TypeError(`Given type '${typeName}' is not supported.`));
+  });
+});


### PR DESCRIPTION
Fixes #433

I've prepared some generic solution for input field data validation. Later on we can refactor it and add more 'types' recognition i.e.: pullSecret, appName... Basically all input fields with some regex or other restrictions.

Review this for now and I'll add some tests in the meantime.

@maciaszczykm @bryk

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/472)
<!-- Reviewable:end -->
