### PR TITLE
upgrade to latest heapster version to make the sparklines work

### DIFF
--- a/build/hyperkube.sh
+++ b/build/hyperkube.sh
@@ -19,7 +19,7 @@
 # Version of kubernetes to use.
 K8S_VERSION="1.1.2"
 # Version heapster to use.
-HEAPSTER_VERSION="0.18.3"
+HEAPSTER_VERSION="0.20.0-alpha9"
 # Port of the apiserver to serve on.
 PORT=8080
 # Port of the heapster to serve on.
@@ -49,5 +49,5 @@ docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v${K8S_
     /hyperkube proxy --master=http://127.0.0.1:${PORT} --v=2
 
 # Runs Heapster in standalone mode
-docker run --net=host -d kubernetes/heapster:v${HEAPSTER_VERSION} -port ${HEAPSTER_PORT} \
+docker run --net=host -d gcr.io/google_containers/heapster:v${HEAPSTER_VERSION} -port ${HEAPSTER_PORT} \
     --source=kubernetes:http://127.0.0.1:${PORT}?inClusterConfig=false&auth=""


### PR DESCRIPTION
I upgraded to latest heapster version. Seems to run stable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/475)
<!-- Reviewable:end -->
