### PR TITLE
Fixed deploy from file on IE

### DIFF
--- a/src/app/frontend/deploy/filereader_directive.js
+++ b/src/app/frontend/deploy/filereader_directive.js
@@ -37,13 +37,13 @@ export default function fileReaderDirective($log) {
           return;
         }
         let reader = new FileReader();
-        reader.onload = () => {
+        reader.onload = (event) => {
           /** @type {!angular.NgModelController} */
           let ngModelController = ctrls[1];
-          ngModelController.$setViewValue({name: file.name, content: reader.result});
+          ngModelController.$setViewValue({name: file.name, content: event.target.result});
         };
         reader.onerror = (error) => $log.error('Error reading file:', error);
-        reader.readAsBinaryString(file);
+        reader.readAsText(file);
       });
     },
   };


### PR DESCRIPTION
Fixes #430 

According to documentation:
https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString

`reader.readAsBinaryString` is deprecated and should not be used. As we are reading text file I've changed it to `readAsText`. By default it assumes UTF-8 encoding.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/478)
<!-- Reviewable:end -->
