### PR TITLE
Make docker build pipeline always use clean env and actaully work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,25 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Do not include the Docker build pipeline itself.
+build/Dockerfile
+build/run-gulp-in-docker.sh
+
+# Ignore all development artifacts so that the build is always clean.
 .git
+.tmp/
+.tools/
+bower_components/
+dist/
+node_modules/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,17 +14,17 @@
 
 # This is a Dockerfile for running and building Kubernetes dashboard
 # It installs all deps in the container and adds the dashboard source
-# This way it abstracts all required build tools away and lets the user run gulp tasks on the code with only docker installed
+# This way it abstracts all required build tools away and lets the user
+# run gulp tasks on the code with only docker installed
 
 # golang is based on debian:jessie
-FROM golang:1.5.3
+FROM golang
 
-# Install python, java and nodejs. go is already installed
-# A small tweak, apt-get update is already run by the nodejs setup script, so there's no need to run it again
+# Install java and nodejs. go is already installed
+# A small tweak, apt-get update is already run by the nodejs setup script,
+# so there's no need to run it again
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
   && apt-get install -y --no-install-recommends \
-	file \
-	python \
 	openjdk-7-jre \
 	nodejs \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -37,13 +37,8 @@ RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin
 # Current directory is always /dashboard
 WORKDIR /dashboard
 
-# Copy over package.json bower.json and postinstall.sh.
-# Why? Because of docker caching, npm install will only run again if one of these have changed
-COPY package.json bower.json ./
-COPY build/postinstall.sh build/
+# Copy entire source tree.
+COPY ./ ./
 
 # Install all npm deps, bower deps and godep. This will take a while.
 RUN npm install --unsafe-perm
-
-# Copy over the rest of the source
-COPY ./ ./

--- a/build/run-gulp-in-docker.sh
+++ b/build/run-gulp-in-docker.sh
@@ -19,9 +19,11 @@
 DOCKER_RUN_OPTS=${DOCKER_RUN_OPTS:-}
 DASHBOARD_IMAGE_NAME="kubernetes-dashboard-build-image"
 DEFAULT_COMMAND=${DEFAULT_COMMAND:-"node_modules/.bin/gulp"}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Always test if the image is up-to-date. If nothing has changed since last build, it'll just use the already-built image
-docker build -t ${DASHBOARD_IMAGE_NAME} .
+# Always test if the image is up-to-date. If nothing has changed since last build,
+# it'll just use the already-built image
+docker build -t ${DASHBOARD_IMAGE_NAME} -f ${DIR}/Dockerfile ${DIR}/../
 
 # Run gulp in the container in interactive mode and expose necessary ports automatically
 docker run \


### PR DESCRIPTION
Previously it didn't always work because my local env was overriding
what was previously baked into image. Now the image bases only on source
code and is brand new each time.

It is also a lot faster when dockerignore excludes more files.

This also moves Dockerfile to build/ directory to avoid confusion from developers about its purpose.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/479)
<!-- Reviewable:end -->
