### PR TITLE
Fixed issue with unit test fail on IE

### DIFF
--- a/src/app/frontend/common/validators/types/type_factory.js
+++ b/src/app/frontend/common/validators/types/type_factory.js
@@ -23,9 +23,10 @@ export class TypeFactory {
    */
   constructor() {
     /** @private {Map<Array<string, !./type.Type>>} */
-    this.typeMap_ = new Map([
-      ['integer', new IntegerType()],
-    ]);
+    this.typeMap_ = new Map();
+
+    // Initialize map with supported types
+    this.typeMap_.set('integer', new IntegerType());
   }
 
   /**


### PR DESCRIPTION
Lovely IE implements only constructor without parameters for the `Map`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/486)
<!-- Reviewable:end -->
