### PR TITLE
Clarify how users can change apiserver-host in canary deployment

### DIFF
--- a/src/deploy/kubernetes-dashboard-canary.yaml
+++ b/src/deploy/kubernetes-dashboard-canary.yaml
@@ -27,6 +27,11 @@ items:
           ports:
           - containerPort: 9090
             protocol: TCP
+          args:
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Fixes #484

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/489)
<!-- Reviewable:end -->
