### PR TITLE
Move metric units to table header to save space and disambiguate

### DIFF
--- a/src/app/frontend/common/filters/cores_filter.js
+++ b/src/app/frontend/common/filters/cores_filter.js
@@ -16,7 +16,7 @@
 const base = 1000;
 
 /** Names of the suffixes where I-th name is for base^I suffix. */
-const powerSuffixes = ['m', '', 'k', 'M', 'G'];
+const powerSuffixes = ['', 'k', 'M', 'G', 'T'];
 
 /**
  * Returns filter function that formats cores usage.
@@ -31,6 +31,9 @@ export default function coresFilter(numberFilter) {
    * @return {string}
    */
   let formatCores = function(value) {
+    // Convert millicores to cores.
+    value = value / 1000;
+
     let divider = 1;
     let power = 0;
 
@@ -39,7 +42,8 @@ export default function coresFilter(numberFilter) {
       power += 1;
     }
     let formatted = numberFilter(value / divider);
-    return `${formatted} ${powerSuffixes[power]}CPU`;
+    let suffix = powerSuffixes[power];
+    return suffix ? `${formatted} ${suffix}` : formatted;
   };
 
   return formatCores;

--- a/src/app/frontend/common/filters/memory_filter.js
+++ b/src/app/frontend/common/filters/memory_filter.js
@@ -39,7 +39,8 @@ export default function memoryFilter(numberFilter) {
       power += 1;
     }
     let formatted = numberFilter(value / divider);
-    return `${formatted} ${powerSuffixes[power]}B`;
+    let suffix = powerSuffixes[power];
+    return suffix ? `${formatted} ${suffix}` : formatted;
   };
 
   return formatMemory;

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -84,16 +84,16 @@ limitations under the License.
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics">
                 <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
                                   currently-selected-order="ctrl.podsOrder" column-name="cpu"
-                                  tooltip="CPU used by the pod">
-                  CPU
+                                  tooltip="CPU cores used by the pod">
+                  CPU (cores)
                 </kd-sorted-header>
               </th>
               <th class="kd-replicationcontrollerdetail-table-header"
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics">
                 <kd-sorted-header currently-selected-column="ctrl.sortPodsBy"
                                   currently-selected-order="ctrl.podsOrder" column-name="memory"
-                                  tooltip="Memory used by the pod">
-                  Memory
+                                  tooltip="Memory in bytes used by the pod">
+                  Memory (B)
                 </kd-sorted-header>
               </th>
               <th class="kd-replicationcontrollerdetail-table-header">
@@ -136,7 +136,7 @@ limitations under the License.
                 </span>
               </td>
               <!-- width=1 is a hack to shrink-wrap the column around its content -->
-              <td kd-responsive-header="CPU"
+              <td kd-responsive-header="CPU (cores)"
                   class="kd-replicationcontrollerdetail-table-cell kd-replicationcontrollerdetail-sparkline-table-cell"
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics"
                   ng-attr-width="{{ctrl.shouldShrinkSparklineCells()}}">
@@ -150,7 +150,7 @@ limitations under the License.
                 </span>
               </td>
               <!-- width=1 is a hack to shrink-wrap the column around its content -->
-              <td kd-responsive-header="Memory"
+              <td kd-responsive-header="Memory (B)"
                   class="kd-replicationcontrollerdetail-table-cell kd-replicationcontrollerdetail-sparkline-table-cell"
                   ng-if="::ctrl.replicationControllerDetail.hasMetrics"
                   ng-attr-width="{{ctrl.shouldShrinkSparklineCells()}}">

--- a/src/test/frontend/common/filters/cores_filter_test.js
+++ b/src/test/frontend/common/filters/cores_filter_test.js
@@ -24,17 +24,17 @@ describe('Cores filter', () => {
   });
 
   it('should format CPU', () => {
-    expect(filter(0)).toEqual('0 mCPU');
-    expect(filter(1)).toEqual('1 mCPU');
-    expect(filter(2)).toEqual('2 mCPU');
-    expect(filter(1000)).toEqual('1,000 mCPU');
-    expect(filter(1024)).toEqual('1.024 CPU');
-    expect(filter(1025)).toEqual('1.025 CPU');
-    expect(filter(7896)).toEqual('7.896 CPU');
-    expect(filter(109809)).toEqual('109.809 CPU');
-    expect(filter(768689899)).toEqual('768.690 kCPU');
-    expect(filter(768689899789)).toEqual('768.690 MCPU');
-    expect(filter(76868989978978)).toEqual('76.869 GCPU');
-    expect(filter(7686898997897878)).toEqual('7,686.899 GCPU');
+    expect(filter(0)).toEqual('0');
+    expect(filter(1)).toEqual('0.001');
+    expect(filter(2)).toEqual('0.002');
+    expect(filter(1000)).toEqual('1');
+    expect(filter(1024)).toEqual('1.024');
+    expect(filter(1025)).toEqual('1.025');
+    expect(filter(7896)).toEqual('7.896');
+    expect(filter(109809)).toEqual('109.809');
+    expect(filter(768689899)).toEqual('768.690 k');
+    expect(filter(768689899789)).toEqual('768.690 M');
+    expect(filter(76868989978978)).toEqual('76.869 G');
+    expect(filter(7686898997897878)).toEqual('7.687 T');
   });
 });

--- a/src/test/frontend/common/filters/memory_filter_test.js
+++ b/src/test/frontend/common/filters/memory_filter_test.js
@@ -24,18 +24,18 @@ describe('Memory filter', () => {
   });
 
   it('should format memory', () => {
-    expect(memoryFilter(0)).toEqual('0 B');
-    expect(memoryFilter(1)).toEqual('1 B');
-    expect(memoryFilter(2)).toEqual('2 B');
-    expect(memoryFilter(1000)).toEqual('1,000 B');
-    expect(memoryFilter(1024)).toEqual('1,024 B');
-    expect(memoryFilter(1025)).toEqual('1.001 KiB');
-    expect(memoryFilter(7896)).toEqual('7.711 KiB');
-    expect(memoryFilter(109809)).toEqual('107.235 KiB');
-    expect(memoryFilter(768689899)).toEqual('733.080 MiB');
-    expect(memoryFilter(768689899789)).toEqual('715.898 GiB');
-    expect(memoryFilter(76868989978978)).toEqual('69.912 TiB');
-    expect(memoryFilter(7686898997897878)).toEqual('6.827 PiB');
-    expect(memoryFilter(768689899789787867898766)).toEqual('682,733,780.435 PiB');
+    expect(memoryFilter(0)).toEqual('0');
+    expect(memoryFilter(1)).toEqual('1');
+    expect(memoryFilter(2)).toEqual('2');
+    expect(memoryFilter(1000)).toEqual('1,000');
+    expect(memoryFilter(1024)).toEqual('1,024');
+    expect(memoryFilter(1025)).toEqual('1.001 Ki');
+    expect(memoryFilter(7896)).toEqual('7.711 Ki');
+    expect(memoryFilter(109809)).toEqual('107.235 Ki');
+    expect(memoryFilter(768689899)).toEqual('733.080 Mi');
+    expect(memoryFilter(768689899789)).toEqual('715.898 Gi');
+    expect(memoryFilter(76868989978978)).toEqual('69.912 Ti');
+    expect(memoryFilter(7686898997897878)).toEqual('6.827 Pi');
+    expect(memoryFilter(768689899789787867898766)).toEqual('682,733,780.435 Pi');
   });
 });


### PR DESCRIPTION
With that we'll not have `kcores` (kilo-cores) neither `TCPU`
(tera-CPU). This also saves space since all numbers in a column have the
same unit.

Fixes #405 

Now it looks like this (using heapster with bad data):
![selection_043](https://cloud.githubusercontent.com/assets/1159999/13529656/9635defa-e21d-11e5-9601-ce2eefd499ac.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/493)
<!-- Reviewable:end -->
