### PR TITLE
Add go report card and gofmt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Dashboard
 [![Build Status](https://travis-ci.org/kubernetes/dashboard.svg?branch=master)](https://travis-ci.org/kubernetes/dashboard)
 [![Coverage Status](https://codecov.io/github/bryk/dashboard/coverage.svg?branch=master)](https://codecov.io/github/bryk/dashboard?branch=master)
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/dashboard)](https://goreportcard.com/badge/github.com/kubernetes/dashboard)
 
 Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters. It allows users to
 manage applications running in the cluster and troubleshoot them, as well as manage the cluster

--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -26,7 +26,10 @@ import (
 )
 
 const (
+	// RequestLogString is a template for request log message.
 	RequestLogString  = "Incoming %s %s %s request from %s"
+
+	// ResponseLogString is a template for response log message.
 	ResponseLogString = "Outcoming response to %s with %d status code"
 )
 
@@ -37,7 +40,7 @@ func wsLogger(req *restful.Request, resp *restful.Response, chain *restful.Filte
 	log.Printf(FormatResponseLog(resp, req))
 }
 
-// Formats request log string.
+// FormatRequestLog formats request log string.
 // TODO(maciaszczykm): Display request body.
 func FormatRequestLog(req *restful.Request) string {
 	reqURI := ""
@@ -49,13 +52,13 @@ func FormatRequestLog(req *restful.Request) string {
 		reqURI, req.Request.RemoteAddr)
 }
 
-// Formats response log string.
+// FormatResponseLog formats response log string.
 // TODO(maciaszczykm): Display response content.
 func FormatResponseLog(resp *restful.Response, req *restful.Request) string {
 	return fmt.Sprintf(ResponseLogString, req.Request.RemoteAddr, resp.StatusCode())
 }
 
-// Creates a new HTTP handler that handles all requests to the API of the backend.
+// CreateHttpApiHandler creates a new HTTP handler that handles all requests to the API of the backend.
 func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 	clientConfig clientcmd.ClientConfig) http.Handler {
 
@@ -252,13 +255,13 @@ func (apiHandler *ApiHandler) handleNameValidity(request *restful.Request, respo
 }
 
 // Handles image reference validation API call.
-func (ApiHandler *ApiHandler) handleImageReferenceValidity(request *restful.Request, response *restful.Response){
+func (ApiHandler *ApiHandler) handleImageReferenceValidity(request *restful.Request, response *restful.Response) {
 	spec := new(ImageReferenceValiditySpec)
 	if err := request.ReadEntity(spec); err != nil {
 		handleInternalError(response, err)
 		return
 	}
-	
+
 	validity, err := ValidateImageReference(spec)
 	if err != nil {
 		handleInternalError(response, err)

--- a/src/app/backend/apiserverclient.go
+++ b/src/app/backend/apiserverclient.go
@@ -29,7 +29,7 @@ import (
 // apiserverHost param is in the format of protocol://address:port/pathPrefix, e.g.,
 // http://localhost:8001.
 //
-// Returns created client and its configuration.
+// CreateApiserverClient returns created client and its configuration.
 func CreateApiserverClient(apiserverHost string) (*client.Client, clientcmd.ClientConfig, error) {
 
 	overrides := &clientcmd.ConfigOverrides{}

--- a/src/app/backend/events.go
+++ b/src/app/backend/events.go
@@ -33,7 +33,7 @@ type Events struct {
 	Events []Event `json:"events"`
 }
 
-// Single event representation.
+// Event is a single event representation.
 type Event struct {
 	// A human-readable description of the status of related object.
 	Message string `json:"message"`
@@ -67,7 +67,7 @@ type Event struct {
 	Type string `json:"type"`
 }
 
-// Return events for particular namespace and replication controller or error if occurred.
+// GetEvents returns events for particular namespace and replication controller or error if occurred.
 func GetEvents(client *client.Client, namespace, replicationControllerName string) (*Events, error) {
 	log.Printf("Getting events related to %s replication controller in %s namespace", replicationControllerName,
 		namespace)
@@ -103,7 +103,7 @@ func GetEvents(client *client.Client, namespace, replicationControllerName strin
 	return &events, nil
 }
 
-// Gets events associated to replication controller.
+// GetReplicationControllerEvents gets events associated to replication controller.
 func GetReplicationControllerEvents(client *client.Client, namespace, replicationControllerName string) ([]api.Event,
 	error) {
 	fieldSelector, err := fields.ParseSelector("involvedObject.name=" + replicationControllerName)
@@ -124,7 +124,7 @@ func GetReplicationControllerEvents(client *client.Client, namespace, replicatio
 	return list.Items, nil
 }
 
-// Gets events associated to pods in replication controller.
+// GetReplicationControllerPodsEvents gets events associated to pods in replication controller.
 func GetReplicationControllerPodsEvents(client *client.Client, namespace, replicationControllerName string) ([]api.Event,
 	error) {
 	replicationController, err := client.ReplicationControllers(namespace).Get(replicationControllerName)
@@ -151,7 +151,7 @@ func GetReplicationControllerPodsEvents(client *client.Client, namespace, replic
 	return events, nil
 }
 
-// Gets events associated to given list of pods
+// GetPodsEvents gets events associated to given list of pods
 // TODO(floreks): refactor this to make single API call instead of N api calls
 func GetPodsEvents(client *client.Client, pods *api.PodList) ([]api.Event, error) {
 	events := make([]api.Event, 0, 0)
@@ -172,7 +172,7 @@ func GetPodsEvents(client *client.Client, pods *api.PodList) ([]api.Event, error
 	return events, nil
 }
 
-// Gets events associated to given pod
+// GetPodEvents gets events associated to given pod
 func GetPodEvents(client client.Interface, pod api.Pod) (*api.EventList, error) {
 	fieldSelector, err := fields.ParseSelector("involvedObject.name=" + pod.Name)
 
@@ -192,7 +192,7 @@ func GetPodEvents(client client.Interface, pod api.Pod) (*api.EventList, error) 
 	return list, nil
 }
 
-// Appends events from source slice to target events representation.
+// AppendEvents appends events from source slice to target events representation.
 func AppendEvents(source []api.Event, target Events) Events {
 	for _, event := range source {
 		target.Events = append(target.Events, Event{

--- a/src/app/backend/eventscommon.go
+++ b/src/app/backend/eventscommon.go
@@ -119,7 +119,7 @@ func isFailedReason(reason string, partials ...string) bool {
 
 // Based on event Reason fills event Type in order to allow correct filtering by Type.
 func fillEventsType(events []api.Event) []api.Event {
-	for i, _ := range events {
+	for i := range events {
 		if isFailedReason(events[i].Reason, FailedReasonPartials...) {
 			events[i].Type = api.EventTypeWarning
 		} else {

--- a/src/app/backend/heapsterclient.go
+++ b/src/app/backend/heapsterclient.go
@@ -60,13 +60,13 @@ func CreateHeapsterRESTClient(heapsterHost string, apiclient *client.Client) (
 	if heapsterHost == "" {
 		log.Printf("Creating in-cluster Heapster client")
 		return InClusterHeapsterClient{client: apiclient}, nil
-	} else {
-		cfg := &client.Config{Host: heapsterHost}
-		restClient, err := client.New(cfg)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("Creating remote Heapster client for %s", heapsterHost)
-		return RemoteHeapsterClient{client: restClient.RESTClient}, nil
 	}
+
+	cfg := &client.Config{Host: heapsterHost}
+	restClient, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Creating remote Heapster client for %s", heapsterHost)
+	return RemoteHeapsterClient{client: restClient.RESTClient}, nil
 }

--- a/src/app/backend/logs.go
+++ b/src/app/backend/logs.go
@@ -24,7 +24,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
-// Log response structure
+// Logs is a representation of logs response structure.
 type Logs struct {
 	// Pod name.
 	PodId string `json:"podId"`
@@ -39,8 +39,8 @@ type Logs struct {
 	Container string `json:"container"`
 }
 
-// Return logs for particular pod and container or error when occurred. When container is null,
-// logs for the first one are returned.
+// GetPodLogs returns logs for particular pod and container or error when occurred. When container
+// is null, logs for the first one are returned.
 func GetPodLogs(client *client.Client, namespace, podId string, container string) (*Logs, error) {
 	log.Printf("Getting logs from %s container from %s pod in %s namespace", container, podId,
 		namespace)

--- a/src/app/backend/namespaces.go
+++ b/src/app/backend/namespaces.go
@@ -23,19 +23,19 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-// Specification of namespace to be created.
+// NamespaceSpec is a specification of namespace to create.
 type NamespaceSpec struct {
 	// Name of the namespace.
 	Name string `json:"name"`
 }
 
-// List of Namespaces in the cluster.
+// NamespaceList is a list of namespaces in the cluster.
 type NamespaceList struct {
 	// Unordered list of Namespaces.
 	Namespaces []string `json:"namespaces"`
 }
 
-// Creates namespace based on given specification.
+// CreateNamespace creates namespace based on given specification.
 func CreateNamespace(spec *NamespaceSpec, client *client.Client) error {
 	log.Printf("Creating namespace %s", spec.Name)
 
@@ -50,7 +50,7 @@ func CreateNamespace(spec *NamespaceSpec, client *client.Client) error {
 	return err
 }
 
-// Returns a list of all namespaces in the cluster.
+// GetNamespaceList returns a list of all namespaces in the cluster.
 func GetNamespaceList(client *client.Client) (*NamespaceList, error) {
 	log.Printf("Getting namespace list")
 

--- a/src/app/backend/replicationcontrollercommon.go
+++ b/src/app/backend/replicationcontrollercommon.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
+// ReplicationControllerWithPods is a structure representing replication controller and its pods.
 type ReplicationControllerWithPods struct {
 	ReplicationController *api.ReplicationController
 	Pods                  *api.PodList

--- a/src/app/backend/replicationcontrollerdetail.go
+++ b/src/app/backend/replicationcontrollerdetail.go
@@ -55,7 +55,7 @@ type ReplicationControllerDetail struct {
 	HasMetrics bool `json:"hasMetrics"`
 }
 
-// Detailed information about a Pod that belongs to a Replication Controller.
+// ReplicationControllerPod is a representation of a Pod that belongs to a Replication Controller.
 type ReplicationControllerPod struct {
 	// Name of the Pod.
 	Name string `json:"name"`
@@ -79,7 +79,7 @@ type ReplicationControllerPod struct {
 	Metrics *PodMetrics `json:"metrics"`
 }
 
-// Detailed information about a Service connected to Replication Controller.
+// ServiceDetail is a representation of a Service connected to Replication Controller.
 type ServiceDetail struct {
 	// Name of the service.
 	Name string `json:"name"`
@@ -98,7 +98,7 @@ type ServiceDetail struct {
 	Selector map[string]string `json:"selector"`
 }
 
-// Port and protocol pair of, e.g., a service endpoint.
+// ServicePort is a pair of port and protocol, e.g. a service endpoint.
 type ServicePort struct {
 	// Positive port number.
 	Port int `json:"port"`
@@ -107,7 +107,7 @@ type ServicePort struct {
 	Protocol api.Protocol `json:"protocol"`
 }
 
-// Describes an endpoint that is host and a list of available ports for that host.
+// Endpoint describes an endpoint that is host and a list of available ports for that host.
 type Endpoint struct {
 	// Hostname, either as a domain name or IP address.
 	Host string `json:"host"`

--- a/src/app/backend/replicationcontrollerlist.go
+++ b/src/app/backend/replicationcontrollerlist.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-// Callback function in order to get the pod status errors
+// GetPodsEventWarningsFunc is a callback function used to get the pod status errors.
 type GetPodsEventWarningsFunc func(pods []api.Pod) ([]Event, error)
 
-// Callback function in order to get node by name.
+// GetNodeFunc is a callback function used to get nodes by names.
 type GetNodeFunc func(nodeName string) (*api.Node, error)
 
 // ReplicationControllerList contains a list of Replication Controllers in the cluster.

--- a/src/app/backend/validateimagereference.go
+++ b/src/app/backend/validateimagereference.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"log"
 	distreference "github.com/docker/distribution/reference"
+	"log"
 )
 
 // Specification for image referecne validation request.

--- a/src/app/backend/validateprotocol.go
+++ b/src/app/backend/validateprotocol.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// Specification for protocol validation request.
+// ProtocolValiditySpec is a specification of protocol validation request.
 type ProtocolValiditySpec struct {
 	// Protocol type
 	Protocol api.Protocol `json:"protocol"`
@@ -29,15 +29,17 @@ type ProtocolValiditySpec struct {
 	IsExternal bool `json:"isExternal"`
 }
 
-// Describes validity of the protocol.
+// ProtocolValidity describes validity of the protocol.
 type ProtocolValidity struct {
 	// True when the selected protocol is valid for selected service type.
 	Valid bool `json:"valid"`
 }
 
-// Validates protocol based on whether created service is set to NodePort or NodeBalancer type.
+// ValidateProtocol validates protocol based on whether created service is set to NodePort or
+// NodeBalancer type.
 func ValidateProtocol(spec *ProtocolValiditySpec) *ProtocolValidity {
-	log.Printf("Validating %s protocol for service with external set to %v", spec.Protocol, spec.IsExternal)
+	log.Printf("Validating %s protocol for service with external set to %v", spec.Protocol,
+		spec.IsExternal)
 
 	isValid := true
 

--- a/src/test/backend/deploy_test.go
+++ b/src/test/backend/deploy_test.go
@@ -123,9 +123,9 @@ func TestDeployShouldPopulateEnvVars(t *testing.T) {
 
 	rc := createAction.GetObject().(*api.ReplicationController)
 	container := rc.Spec.Template.Spec.Containers[0]
-	if !reflect.DeepEqual(container.Env, []api.EnvVar{api.EnvVar{Name: "foo", Value: "bar"}}) {
+	if !reflect.DeepEqual(container.Env, []api.EnvVar{{Name: "foo", Value: "bar"}}) {
 		t.Errorf("Expected environment variables to be %#v but got %#v",
-			[]api.EnvVar{api.EnvVar{Name: "foo", Value: "bar"}}, container.Env)
+			[]api.EnvVar{{Name: "foo", Value: "bar"}}, container.Env)
 	}
 }
 

--- a/src/test/backend/replicationcontrollerdetail_test.go
+++ b/src/test/backend/replicationcontrollerdetail_test.go
@@ -518,7 +518,7 @@ func TestGetLocalhostEndpoints(t *testing.T) {
 					Host: "localhost",
 					Ports: []ServicePort{
 						{
-							Port: 30100,
+							Port:     30100,
 							Protocol: "TCP",
 						},
 					},
@@ -527,7 +527,7 @@ func TestGetLocalhostEndpoints(t *testing.T) {
 					Host: "localhost",
 					Ports: []ServicePort{
 						{
-							Port: 30101,
+							Port:     30101,
 							Protocol: "TCP",
 						},
 					},

--- a/src/test/backend/validateimagereference_test.go
+++ b/src/test/backend/validateimagereference_test.go
@@ -20,8 +20,8 @@ import (
 
 func TestValidateImageReference(t *testing.T) {
 	cases := []struct {
-		reference  string
-		expected   bool
+		reference string
+		expected  bool
 	}{
 		{
 			"test",
@@ -86,7 +86,7 @@ func TestValidateImageReference(t *testing.T) {
 		{
 			"test image:1",
 			false,
-		},			
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Added `Go Report Card` badge to `README.md` with following link: https://goreportcard.com/report/github.com/kubernetes/dashboard

Used `gofmt` on unformatted files. Fixed few `golint` issues.

Kubernetes core also uses `Go Report Card`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/500)
<!-- Reviewable:end -->
