### PR TITLE
Refactor go code and fix link to go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Dashboard
 [![Build Status](https://travis-ci.org/kubernetes/dashboard.svg?branch=master)](https://travis-ci.org/kubernetes/dashboard)
 [![Coverage Status](https://codecov.io/github/bryk/dashboard/coverage.svg?branch=master)](https://codecov.io/github/bryk/dashboard?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/dashboard)](https://goreportcard.com/badge/github.com/kubernetes/dashboard)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/dashboard)](https://goreportcard.com/report/github.com/kubernetes/dashboard)
 
 Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters. It allows users to
 manage applications running in the cluster and troubleshoot them, as well as manage the cluster

--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// RequestLogString is a template for request log message.
-	RequestLogString  = "Incoming %s %s %s request from %s"
+	RequestLogString = "Incoming %s %s %s request from %s"
 
 	// ResponseLogString is a template for response log message.
 	ResponseLogString = "Outcoming response to %s with %d status code"
@@ -189,6 +189,8 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 	return wsContainer
 }
 
+// ApiHandler is a representation of API handler. Structure contains client, Heaptster client and
+// client configuration.
 type ApiHandler struct {
 	client         *client.Client
 	heapsterClient HeapsterClient

--- a/src/app/backend/apiserverclient.go
+++ b/src/app/backend/apiserverclient.go
@@ -22,14 +22,12 @@ import (
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
-// Creates new Kubernetes Apiserver client. When apiserverHost param is empty string the function
-// assumes that it is running inside a Kubernetes cluster and attempts to discover the Apiserver.
-// Otherwise, it connects to the Apiserver specified.
+// CreateApiserverClient creates new Kubernetes Apiserver client. When apiserverHost param is empty
+// string the function assumes that it is running inside a Kubernetes cluster and attempts to
+// discover the Apiserver. Otherwise, it connects to the Apiserver specified.
 //
 // apiserverHost param is in the format of protocol://address:port/pathPrefix, e.g.,
 // http://localhost:8001.
-//
-// CreateApiserverClient returns created client and its configuration.
 func CreateApiserverClient(apiserverHost string) (*client.Client, clientcmd.ClientConfig, error) {
 
 	overrides := &clientcmd.ConfigOverrides{}

--- a/src/app/backend/deploy.go
+++ b/src/app/backend/deploy.go
@@ -29,10 +29,11 @@ import (
 )
 
 const (
+	// DescriptionAnnotationKey is annotation key for a description.
 	DescriptionAnnotationKey = "description"
 )
 
-// Specification for an app deployment.
+// AppDeploymentSpec is a specification for an app deployment.
 type AppDeploymentSpec struct {
 	// Name of the application.
 	Name string `json:"name"`
@@ -82,7 +83,7 @@ type AppDeploymentSpec struct {
 	RunAsPrivileged bool `json:"runAsPrivileged"`
 }
 
-// Specification for deployment from file
+// AppDeploymentFromFileSpec is a specification for deployment from file
 type AppDeploymentFromFileSpec struct {
 	// Name of the file
 	Name string `json:"name"`
@@ -91,7 +92,7 @@ type AppDeploymentFromFileSpec struct {
 	Content string `json:"content"`
 }
 
-// Specification for deployment from file
+// AppDeploymentFromFileResponse is a specification for deployment from file
 type AppDeploymentFromFileResponse struct {
 	// Name of the file
 	Name string `json:"name"`
@@ -103,7 +104,7 @@ type AppDeploymentFromFileResponse struct {
 	Error string `json:"error"`
 }
 
-// Port mapping for an application deployment.
+// PortMapping is a specification of port mapping for an application deployment.
 type PortMapping struct {
 	// Port that will be exposed on the service.
 	Port int `json:"port"`
@@ -124,7 +125,7 @@ type EnvironmentVariable struct {
 	Value string `json:"value"`
 }
 
-// Structure representing label assignable to Pod/RC/Service
+// Label is a structure representing label assignable to Pod/RC/Service
 type Label struct {
 	// Label key
 	Key string `json:"key"`
@@ -133,15 +134,15 @@ type Label struct {
 	Value string `json:"value"`
 }
 
-// Structure representing supported protocol types for a service
+// Protocols is a structure representing supported protocol types for a service
 type Protocols struct {
 	// Array containing supported protocol types e.g., ["TCP", "UDP"]
 	Protocols []api.Protocol `json:"protocols"`
 }
 
-// Deploys an app based on the given configuration. The app is deployed using the given client.
-// App deployment consists of a replication controller and an optional service. Both of them share
-// common labels.
+// DeployApp deploys an app based on the given configuration. The app is deployed using the given
+// client. App deployment consists of a replication controller and an optional service. Both of them
+// share common labels.
 func DeployApp(spec *AppDeploymentSpec, client client.Interface) error {
 	log.Printf("Deploying %s application into %s namespace", spec.Name, spec.Namespace)
 
@@ -247,6 +248,7 @@ func DeployApp(spec *AppDeploymentSpec, client client.Interface) error {
 	}
 }
 
+// GetAvailableProtocols returns list of available protocols. Currently it is TCP and UDP.
 func GetAvailableProtocols() *Protocols {
 	return &Protocols{Protocols: []api.Protocol{api.ProtocolTCP, api.ProtocolUDP}}
 }
@@ -279,13 +281,13 @@ func getLabelsMap(labels []Label) map[string]string {
 
 type createObjectFromInfo func(info *kubectlResource.Info) (bool, error)
 
-// Implementation of createObjectFromInfo
+// CreateObjectFromInfoFn is a implementation of createObjectFromInfo
 func CreateObjectFromInfoFn(info *kubectlResource.Info) (bool, error) {
 	createdResource, err := kubectlResource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
 	return createdResource != nil, err
 }
 
-// Deploys an app based on the given yaml or json file.
+// DeployAppFromFile deploys an app based on the given yaml or json file.
 func DeployAppFromFile(spec *AppDeploymentFromFileSpec,
 	createObjectFromInfoFn createObjectFromInfo, clientConfig clientcmd.ClientConfig) (bool, error) {
 	const (

--- a/src/app/backend/eventscommon.go
+++ b/src/app/backend/eventscommon.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// Partial strings to correctly filter warning events.
+// FailedReasonPartials  is an array of partial strings to correctly filter warning events.
 // Have to be lower case for correct case insensitive comparison.
 // Based on k8s official events reason file:
 // https://github.com/kubernetes/kubernetes/blob/53f0f9d59860131c2be301a0054adfc86e43945d/pkg/kubelet/container/event.go
@@ -30,7 +30,7 @@ import (
 var FailedReasonPartials = []string{"failed", "err", "exceeded", "invalid", "unhealthy",
 	"mismatch", "insufficient", "conflict", "outof", "nil"}
 
-// Returns warning pod events based on given list of pods.
+// GetPodsEventWarnings returns warning pod events based on given list of pods.
 // TODO(floreks) : Import and use Set instead of custom function to get rid of duplicates
 func GetPodsEventWarnings(client client.Interface, pods []api.Pod) (result []Event, err error) {
 	for _, pod := range pods {

--- a/src/app/backend/heapsterclient.go
+++ b/src/app/backend/heapsterclient.go
@@ -20,7 +20,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
-// Clients for making requests to a Heapster instance.
+// HeapsterClient  is a client used to make requests to a Heapster instance.
 type HeapsterClient interface {
 	// Creates a new GET HTTP request to heapster, specified by the path param, to the V1 API
 	// endpoint. The path param is without the API prefix, e.g.,
@@ -29,11 +29,13 @@ type HeapsterClient interface {
 	Get(path string) *client.Request
 }
 
-// In-cluster implementation of heapster client. Talks with heapster through service proxy.
+// InClusterHeapsterClient is an in-cluster implementation of a Heapster client. Talks with Heapster
+// through service proxy.
 type InClusterHeapsterClient struct {
 	client *client.Client
 }
 
+// InClusterHeapsterClient.Get creates request to given path.
 func (c InClusterHeapsterClient) Get(path string) *client.Request {
 	return c.client.Get().Prefix("proxy").
 		Namespace("kube-system").
@@ -42,18 +44,21 @@ func (c InClusterHeapsterClient) Get(path string) *client.Request {
 		Suffix("/api/v1" + path)
 }
 
-// Remote heapster client based implementation. Talks with heapster through raw RESTClient.
+// RemoteHeapsterClient is an implementation of a remote Heapster client. Talks with Heapster
+// through raw RESTClient.
 type RemoteHeapsterClient struct {
 	client *client.RESTClient
 }
 
+// RemoteHeapsterClient.Get creates request to given path.
 func (c RemoteHeapsterClient) Get(path string) *client.Request {
 	return c.client.Get().Suffix(path)
 }
 
-// Creates new Heapster REST client. When heapsterHost param is empty string the function
-// assumes that it is running inside a Kubernetes cluster and connects via service proxy.
-// heapsterHost param is in the format of protocol://address:port, e.g., http://localhost:8002.
+// CreateHeapsterRESTClient creates new Heapster REST client. When heapsterHost param is empty
+// string the function assumes that it is running inside a Kubernetes cluster and connects via
+// service proxy. heapsterHost param is in the format of protocol://address:port,
+// e.g., http://localhost:8002.
 func CreateHeapsterRESTClient(heapsterHost string, apiclient *client.Client) (
 	HeapsterClient, error) {
 

--- a/src/app/backend/replicationcontrollerdetail.go
+++ b/src/app/backend/replicationcontrollerdetail.go
@@ -84,13 +84,13 @@ type ServiceDetail struct {
 	// Name of the service.
 	Name string `json:"name"`
 
-	// Internal endpoints of all Kubernetes services that have the same label selector as connected
-	// Replication Controller.
+	// Internal endpoints of all Kubernetes services that have the same label selector as
+	// connected Replication Controller.
 	// Endpoint is DNS name merged with ports.
 	InternalEndpoint Endpoint `json:"internalEndpoint"`
 
-	// External endpoints of all Kubernetes services that have the same label selector as connected
-	// Replication Controller.
+	// External endpoints of all Kubernetes services that have the same label selector as
+	// connected Replication Controller.
 	// Endpoint is external IP address name merged with ports.
 	ExternalEndpoints []Endpoint `json:"externalEndpoints"`
 
@@ -116,13 +116,14 @@ type Endpoint struct {
 	Ports []ServicePort `json:"ports"`
 }
 
-// Information needed to update replication controller
+// ReplicationControllerSpec contains information needed to update replication controller.
 type ReplicationControllerSpec struct {
 	// Replicas (pods) number in replicas set
 	Replicas int `json:"replicas"`
 }
 
-// Returns detailed information about the given replication controller in the given namespace.
+// GetReplicationControllerDetail returns detailed information about the given replication
+// controller in the given namespace.
 func GetReplicationControllerDetail(client client.Interface, heapsterClient HeapsterClient,
 	namespace, name string) (*ReplicationControllerDetail, error) {
 	log.Printf("Getting details of %s replication controller in %s namespace", name, namespace)
@@ -194,8 +195,8 @@ func GetReplicationControllerDetail(client client.Interface, heapsterClient Heap
 }
 
 // TODO(floreks): This should be transactional to make sure that RC will not be deleted without pods
-// Deletes replication controller with given name in given namespace and related pods.
-// Also deletes services related to replication controller if deleteServices is true.
+// DeleteReplicationController deletes replication controller with given name in given namespace and
+// related pods. Also deletes services related to replication controller if deleteServices is true.
 func DeleteReplicationController(client client.Interface, namespace, name string,
 	deleteServices bool) error {
 
@@ -227,7 +228,8 @@ func DeleteReplicationController(client client.Interface, namespace, name string
 	return nil
 }
 
-// Deletes services related to replication controller with given name in given namespace.
+// DeleteReplicationControllerServices deletes services related to replication controller with given
+// name in given namespace.
 func DeleteReplicationControllerServices(client client.Interface, namespace, name string) error {
 	log.Printf("Deleting services related to %s replication controller from %s namespace", name,
 		namespace)
@@ -259,7 +261,8 @@ func DeleteReplicationControllerServices(client client.Interface, namespace, nam
 	return nil
 }
 
-// Updates number of replicas in Replication Controller based on Replication Controller Spec
+// UpdateReplicasCount updates number of replicas in Replication Controller based on Replication
+// Controller Spec
 func UpdateReplicasCount(client client.Interface, namespace, name string,
 	replicationControllerSpec *ReplicationControllerSpec) error {
 	log.Printf("Updating replicas count to %d for %s replication controller from %s namespace",

--- a/src/app/backend/replicationcontrollerpods.go
+++ b/src/app/backend/replicationcontrollerpods.go
@@ -32,7 +32,7 @@ func (a TotalRestartCountSorter) Less(i, j int) bool {
 	return a[i].TotalRestartCount > a[j].TotalRestartCount
 }
 
-// Information about a Container that belongs to a Pod.
+// PodContainer is a representation of a Container that belongs to a Pod.
 type PodContainer struct {
 	// Name of a Container.
 	Name string `json:"name"`
@@ -41,13 +41,15 @@ type PodContainer struct {
 	RestartCount int `json:"restartCount"`
 }
 
-// List of pods that belongs to a Replication Controller.
+// ReplicationControllerPods is a representation of pods list that belongs to a Replication
+// Controller.
 type ReplicationControllerPods struct {
 	// List of pods that belongs to a Replication Controller.
 	Pods []ReplicationControllerPodWithContainers `json:"pods"`
 }
 
-// Detailed information about a Pod that belongs to a Replication Controller.
+// ReplicationControllerPodWithContainers is a representation of a Pod that belongs to a Replication
+// Controller.
 type ReplicationControllerPodWithContainers struct {
 	// Name of the Pod.
 	Name string `json:"name"`
@@ -62,8 +64,9 @@ type ReplicationControllerPodWithContainers struct {
 	PodContainers []PodContainer `json:"podContainers"`
 }
 
-// Returns list of pods with containers for the given replication controller in the given namespace.
-// Limit specify the number of records to return. There is no limit when given value is zero.
+// GetReplicationControllerPods returns list of pods with containers for the given replication
+// controller in the given namespace. Limit specify the number of records to return. There is no
+// limit when given value is zero.
 func GetReplicationControllerPods(client *client.Client, namespace, name string, limit int) (
 	*ReplicationControllerPods, error) {
 	log.Printf("Getting list of pods from %s replication controller in %s namespace with limit %d", name,

--- a/src/app/backend/replicationcontrollerpodsmetrics.go
+++ b/src/app/backend/replicationcontrollerpodsmetrics.go
@@ -31,20 +31,21 @@ const (
 	memoryUsage = "memory-usage"
 )
 
-// Metrics map by pod name.
+// ReplicationControllerMetricsByPod is a metrics map by pod name.
 type ReplicationControllerMetricsByPod struct {
 	// Metrics map by pod name
 	MetricsMap map[string]PodMetrics `json:"metricsMap"`
 }
 
-// Some sample measurement of a non-negative, integer quantity
+// MetricResult is a some sample measurement of a non-negative, integer quantity
 // (for example, memory usage in bytes observed at some moment)
 type MetricResult struct {
 	Timestamp time.Time `json:"timestamp"`
 	Value     uint64    `json:"value"`
 }
 
-// Pod metrics structure.
+// PodMetrics is a structure representing pods metrics, contains information about CPU and memory
+// usage.
 type PodMetrics struct {
 	// Most recent measure of CPU usage on all cores in nanoseconds.
 	CpuUsage *uint64 `json:"cpuUsage"`

--- a/src/app/backend/validateappname.go
+++ b/src/app/backend/validateappname.go
@@ -21,7 +21,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
-// Specification for application name validation request.
+// AppNameValiditySpec is a specification for application name validation request.
 type AppNameValiditySpec struct {
 	// Name of the application.
 	Name string `json:"name"`
@@ -30,13 +30,14 @@ type AppNameValiditySpec struct {
 	Namespace string `json:"namespace"`
 }
 
-// Describes validity of the application name.
+// AppNameValidity describes validity of the application name.
 type AppNameValidity struct {
 	// True when the application name is valid.
 	Valid bool `json:"valid"`
 }
 
-// Validates application name. When error is returned, name validity could not be determined.
+// ValidateAppName validates application name. When error is returned, name validity could not be
+// determined.
 func ValidateAppName(spec *AppNameValiditySpec, client client.Interface) (*AppNameValidity, error) {
 	log.Printf("Validating %s application name in %s namespace", spec.Name, spec.Namespace)
 

--- a/src/test/backend/events_test.go
+++ b/src/test/backend/events_test.go
@@ -60,10 +60,10 @@ func TestAppendEvents(t *testing.T) {
 					},
 					Count: 7,
 					FirstTimestamp: unversioned.Time{
-						time.Date(2015, 1, 1, 0, 0, 0, 0, location),
+						Time: time.Date(2015, 1, 1, 0, 0, 0, 0, location),
 					},
 					LastTimestamp: unversioned.Time{
-						time.Date(2015, 1, 1, 0, 0, 0, 0, location),
+						Time: time.Date(2015, 1, 1, 0, 0, 0, 0, location),
 					},
 					Reason: "my-event-reason",
 					Type:   api.EventTypeNormal,
@@ -86,10 +86,12 @@ func TestAppendEvents(t *testing.T) {
 						SubObject:       "my-event-subobject",
 						Count:           7,
 						FirstSeen: unversioned.Time{
-							time.Date(2015, 1, 1, 0, 0, 0, 0, location),
+							Time: time.Date(2015, 1, 1, 0, 0, 0, 0,
+								location),
 						},
 						LastSeen: unversioned.Time{
-							time.Date(2015, 1, 1, 0, 0, 0, 0, location),
+							Time: time.Date(2015, 1, 1, 0, 0, 0, 0,
+								location),
 						},
 						Reason: "my-event-reason",
 						Type:   api.EventTypeNormal,


### PR DESCRIPTION
Continuation of #500. Didn't resolve issues like:

```
Line 136: warning: can probably use "var result []Event" instead (golint)
```

Because simple change of declaration break tests. 

Moreover, issues like:

```
Line 76: warning: struct field CpuRequirement should be CPURequirement (golint)
```

Weren't fixed, because it's probably too much changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/504)
<!-- Reviewable:end -->
