### PR TITLE
Fixed test flakiness on application deploy in IE

### DIFF
--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -45,7 +45,8 @@ limitations under the License.
         </deploy-from-file>
       </div>
 
-      <md-button class="md-raised md-primary" type="submit" ng-disabled="ctrl.isDeployDisabled()">
+      <md-button id="kd-deploy-btn" class="md-raised md-primary" type="submit"
+                 ng-disabled="ctrl.isDeployDisabled()">
         Deploy
       </md-button>
       <md-button class="md-raised" ng-click="ctrl.cancel()">Cancel</md-button>

--- a/src/test/integration/deploy/deploy_po.js
+++ b/src/test/integration/deploy/deploy_po.js
@@ -14,7 +14,7 @@
 
 export default class DeployPageObject {
   constructor() {
-    this.deployButtonQuery = by.buttonText('Deploy');
+    this.deployButtonQuery = by.id('kd-deploy-btn');
     this.deployButton = element(this.deployButtonQuery);
 
     this.appNameFieldQuery = by.model('ctrl.name');

--- a/src/test/integration/stories/deploy_and_delete_replication_controller.js
+++ b/src/test/integration/stories/deploy_and_delete_replication_controller.js
@@ -64,10 +64,10 @@ describe('Deploy and delete replication controller user story test', () => {
   });
 
   it('should deploy replication controller', () => {
-    deployPage.deployButton.click();
-
-    expect(browser.getCurrentUrl()).toContain('replicationcontrollers');
-    expect(element(by.xpath(applicationCardXPath))).not.toBeNull();
+    deployPage.deployButton.click().then(() => {
+      expect(browser.getCurrentUrl()).toContain('replicationcontrollers');
+      expect(element(by.xpath(applicationCardXPath))).not.toBeNull();
+    });
   });
 
   it('should open delete replication controller dialog', () => {

--- a/src/test/integration/stories/deploy_not_existing_img_test.js
+++ b/src/test/integration/stories/deploy_not_existing_img_test.js
@@ -80,10 +80,10 @@ describe('Deploy not existing image story', () => {
     deployPage.containerImageField.sendKeys(containerImage);
 
     // when
-    deployPage.deployButton.click();
-
-    // then
-    expect(browser.getCurrentUrl()).toContain('replicationcontrollers');
+    deployPage.deployButton.click().then(() => {
+      // then
+      expect(browser.getCurrentUrl()).toContain('replicationcontrollers');
+    });
   });
 
   it('should wait for card to be in error state', () => {


### PR DESCRIPTION
Fixes #494

I've changed some button queries to use xpath and moved expect block to be executed after click promise is resolved.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/508)
<!-- Reviewable:end -->
