### PR TITLE
Add: new routes for daemonsets

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/kubernetes/dashboard/client"
 	"github.com/kubernetes/dashboard/resource/common"
 	. "github.com/kubernetes/dashboard/resource/container"
+	"github.com/kubernetes/dashboard/resource/daemonset"
 	"github.com/kubernetes/dashboard/resource/deployment"
 	. "github.com/kubernetes/dashboard/resource/namespace"
 	"github.com/kubernetes/dashboard/resource/pod"
@@ -203,6 +204,23 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 			To(apiHandler.handleGetDeployments).
 			Writes(deployment.DeploymentList{}))
 	wsContainer.Add(deploymentsWs)
+	daemonSetWs := new(restful.WebService)
+	daemonSetWs.Filter(wsLogger)
+	daemonSetWs.Path("/api/v1/daemonsets").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+	daemonSetWs.Route(
+		daemonSetWs.GET("").
+			To(apiHandler.handleGetDaemonSetList).
+			Writes(daemonset.DaemonSetList{}))
+	daemonSetWs.Route(
+		daemonSetWs.GET("/{namespace}/{daemonSet}").
+			To(apiHandler.handleGetDaemonSetDetail).
+			Writes(daemonset.DaemonSetDetail{}))
+	daemonSetWs.Route(
+		daemonSetWs.DELETE("/{namespace}/{daemonSet}").
+			To(apiHandler.handleDeleteDaemonSet))
+	wsContainer.Add(daemonSetWs)
 
 	namespacesWs := new(restful.WebService)
 	namespacesWs.Filter(wsLogger)
@@ -659,4 +677,54 @@ func handleInternalError(response *restful.Response, err error) {
 	log.Print(err)
 	response.AddHeader("Content-Type", "text/plain")
 	response.WriteErrorString(http.StatusInternalServerError, err.Error()+"\n")
+}
+
+// Handles get Daemon Set list API call.
+func (apiHandler *ApiHandler) handleGetDaemonSetList(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	result, err := daemonset.GetDaemonSetList(apiHandler.client, namespace)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get Daemon Set detail API call.
+func (apiHandler *ApiHandler) handleGetDaemonSetDetail(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	daemonSet := request.PathParameter("daemonSet")
+	result, err := daemonset.GetDaemonSetDetail(apiHandler.client, apiHandler.heapsterClient, namespace, daemonSet)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles delete Daemon Set API call.
+func (apiHandler *ApiHandler) handleDeleteDaemonSet(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	daemonSet := request.PathParameter("daemonSet")
+	deleteServices, err := strconv.ParseBool(request.QueryParameter("deleteServices"))
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	if err := daemonset.DeleteDaemonSet(apiHandler.client, namespace,
+		daemonSet, deleteServices); err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeader(http.StatusOK)
 }

--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func FilterNamespacedPodsBySelector(pods []api.Pod, namespace string,
@@ -24,7 +25,7 @@ func FilterNamespacedPodsBySelector(pods []api.Pod, namespace string,
 	var matchingPods []api.Pod
 	for _, pod := range pods {
 		if pod.ObjectMeta.Namespace == namespace &&
-			IsLabelSelectorMatching(resourceSelector, pod.Labels) {
+			IsSelectorMatching(resourceSelector, pod.Labels) {
 			matchingPods = append(matchingPods, pod)
 		}
 	}
@@ -37,7 +38,18 @@ func FilterPodsBySelector(pods []api.Pod, resourceSelector map[string]string) []
 
 	var matchingPods []api.Pod
 	for _, pod := range pods {
-		if IsLabelSelectorMatching(resourceSelector, pod.Labels) {
+		if IsSelectorMatching(resourceSelector, pod.Labels) {
+			matchingPods = append(matchingPods, pod)
+		}
+	}
+	return matchingPods
+}
+
+func FilterPodsByLabelSelector(pods []api.Pod, labelSelector *unversioned.LabelSelector) []api.Pod {
+
+	var matchingPods []api.Pod
+	for _, pod := range pods {
+		if IsLabelSelectorMatching(pod.Labels, labelSelector) {
 			matchingPods = append(matchingPods, pod)
 		}
 	}

--- a/src/app/backend/resource/common/resourcechannels.go
+++ b/src/app/backend/resource/common/resourcechannels.go
@@ -43,6 +43,9 @@ type ResourceChannels struct {
 	// List and error channels to Deployments.
 	DeploymentList DeploymentListChannel
 
+	// List and error channels to Daemon Sets.
+	DaemonSetList DaemonSetListChannel
+
 	// List and error channels to Services.
 	ServiceList ServiceListChannel
 
@@ -272,6 +275,31 @@ func GetReplicaSetListChannel(client client.ReplicaSetsNamespacer, numReads int)
 
 	go func() {
 		rcs, err := client.ReplicaSets(api.NamespaceAll).List(listEverything)
+		for i := 0; i < numReads; i++ {
+			channel.List <- rcs
+			channel.Error <- err
+		}
+	}()
+
+	return channel
+}
+
+// List and error channels to Nodes.
+type DaemonSetListChannel struct {
+	List  chan *extensions.DaemonSetList
+	Error chan error
+}
+
+// Returns a pair of channels to a DaemonSet list and errors that both must be read
+// numReads times.
+func GetDaemonSetListChannel(client client.DaemonSetsNamespacer, numReads int) DaemonSetListChannel {
+	channel := DaemonSetListChannel{
+		List:  make(chan *extensions.DaemonSetList, numReads),
+		Error: make(chan error, numReads),
+	}
+
+	go func() {
+		rcs, err := client.DaemonSets(api.NamespaceAll).List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- rcs
 			channel.Error <- err

--- a/src/app/backend/resource/daemonset/daemonsetcommon.go
+++ b/src/app/backend/resource/daemonset/daemonsetcommon.go
@@ -1,0 +1,119 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"github.com/kubernetes/dashboard/resource/common"
+	//	"github.com/kubernetes/dashboard/resource/event"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+type DaemonSetWithPods struct {
+	DaemonSet *extensions.DaemonSet
+	Pods      *api.PodList
+}
+
+// Returns structure containing DaemonSet and Pods for the given daemon set.
+func getRawDaemonSetWithPods(client client.Interface, namespace, name string) (
+	*DaemonSetWithPods, error) {
+	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector, err := unversioned.LabelSelectorAsSelector(daemonSet.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := client.Pods(namespace).List(
+		api.ListOptions{
+			LabelSelector: labelSelector,
+			FieldSelector: fields.Everything(),
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	daemonSetAndPods := &DaemonSetWithPods{
+		DaemonSet: daemonSet,
+		Pods:      pods,
+	}
+	return daemonSetAndPods, nil
+}
+
+// Retrieves Pod list that belongs to a Daemon Set.
+func getRawDaemonSetPods(client client.Interface, namespace, name string) (*api.PodList, error) {
+	daemonSetAndPods, err := getRawDaemonSetWithPods(client, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	return daemonSetAndPods.Pods, nil
+}
+
+// Returns aggregate information about daemon set pods.
+func getDaemonSetPodInfo(daemonSet *extensions.DaemonSet, pods []api.Pod) common.PodInfo {
+	result := common.PodInfo{}
+	for _, pod := range pods {
+		switch pod.Status.Phase {
+		case api.PodRunning:
+			result.Running++
+		case api.PodPending:
+			result.Pending++
+		case api.PodFailed:
+			result.Failed++
+		}
+	}
+
+	return result
+}
+
+// Based on given selector returns list of services that are candidates for deletion.
+// Services are matched by daemon sets' label selector. They are deleted if given
+// label selector is targeting only 1 daemon set.
+func getServicesForDSDeletion(client client.Interface, labelSelector labels.Selector,
+	namespace string) ([]api.Service, error) {
+
+	daemonSet, err := client.Extensions().DaemonSets(namespace).List(api.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: fields.Everything(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// if label selector is targeting only 1 daemon set
+	// then we can delete services targeted by this label selector,
+	// otherwise we can not delete any services so just return empty list
+	if len(daemonSet.Items) != 1 {
+		return []api.Service{}, nil
+	}
+
+	services, err := client.Services(namespace).List(api.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: fields.Everything(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return services.Items, nil
+}

--- a/src/app/backend/resource/daemonset/daemonsetdetail.go
+++ b/src/app/backend/resource/daemonset/daemonsetdetail.go
@@ -1,0 +1,182 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/client"
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/pod"
+	resourceService "github.com/kubernetes/dashboard/resource/service"
+	"k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// DaemonSeDetail represents detailed information about a Daemon Set.
+type DaemonSetDetail struct {
+	ObjectMeta common.ObjectMeta `json:"objectMeta"`
+	TypeMeta   common.TypeMeta   `json:"typeMeta"`
+
+	// Label selector of the Daemon Set.
+	LabelSelector *unversioned.LabelSelector `json:"labelSelector,omitempty"`
+
+	// Container image list of the pod template specified by this Daemon Set.
+	ContainerImages []string `json:"containerImages"`
+
+	// Aggregate information about pods of this daemon set.
+	PodInfo common.PodInfo `json:"podInfo"`
+
+	// Detailed information about Pods belonging to this Daemon Set.
+	Pods pod.PodList `json:"pods"`
+
+	// Detailed information about service related to Daemon Set.
+	ServiceList resourceService.ServiceList `json:"serviceList"`
+
+	// True when the data contains at least one pod with metrics information, false otherwise.
+	HasMetrics bool `json:"hasMetrics"`
+}
+
+// Returns detailed information about the given daemon set in the given namespace.
+func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient,
+	namespace, name string) (*DaemonSetDetail, error) {
+	log.Printf("Getting details of %s daemon set in %s namespace", name, namespace)
+
+	daemonSetWithPods, err := getRawDaemonSetWithPods(client, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	daemonSet := daemonSetWithPods.DaemonSet
+	pods := daemonSetWithPods.Pods
+
+	services, err := client.Services(namespace).List(api.ListOptions{
+		LabelSelector: labels.Everything(),
+		FieldSelector: fields.Everything(),
+	})
+
+	nodes, err := client.Nodes().List(api.ListOptions{
+		LabelSelector: labels.Everything(),
+		FieldSelector: fields.Everything(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	daemonSetDetail := &DaemonSetDetail{
+		ObjectMeta:    common.NewObjectMeta(daemonSet.ObjectMeta),
+		TypeMeta:      common.NewTypeMeta(common.ResourceKindDaemonSet),
+		LabelSelector: daemonSet.Spec.Selector,
+		PodInfo:       getDaemonSetPodInfo(daemonSet, pods.Items),
+		ServiceList:   resourceService.ServiceList{Services: make([]resourceService.Service, 0)},
+	}
+
+	matchingServices := getMatchingServicesforDS(services.Items, daemonSet)
+
+	for _, service := range matchingServices {
+		daemonSetDetail.ServiceList.Services = append(daemonSetDetail.ServiceList.Services,
+			getService(service, *daemonSet, pods.Items, nodes.Items))
+	}
+
+	for _, container := range daemonSet.Spec.Template.Spec.Containers {
+		daemonSetDetail.ContainerImages = append(daemonSetDetail.ContainerImages,
+			container.Image)
+	}
+
+	daemonSetDetail.Pods = pod.CreatePodList(pods.Items, heapsterClient)
+
+	return daemonSetDetail, nil
+}
+
+// TODO(floreks): This should be transactional to make sure that DS will not be deleted without pods
+// Deletes daemon set with given name in given namespace and related pods.
+// Also deletes services related to daemon set if deleteServices is true.
+func DeleteDaemonSet(client k8sClient.Interface, namespace, name string,
+	deleteServices bool) error {
+
+	log.Printf("Deleting %s daemon set from %s namespace", name, namespace)
+
+	if deleteServices {
+		if err := DeleteDaemonSetServices(client, namespace, name); err != nil {
+			return err
+		}
+	}
+
+	pods, err := getRawDaemonSetPods(client, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	if err := client.Extensions().DaemonSets(namespace).Delete(name); err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		if err := client.Pods(namespace).Delete(pod.Name, &api.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("Successfully deleted %s daemon set from %s namespace", name, namespace)
+
+	return nil
+}
+
+// Deletes services related to daemon set with given name in given namespace.
+func DeleteDaemonSetServices(client k8sClient.Interface, namespace, name string) error {
+	log.Printf("Deleting services related to %s daemon set from %s namespace", name,
+		namespace)
+
+	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name)
+	if err != nil {
+		return err
+	}
+
+	labelSelector, err := unversioned.LabelSelectorAsSelector(daemonSet.Spec.Selector)
+	if err != nil {
+		return err
+	}
+
+	services, err := getServicesForDSDeletion(client, labelSelector, namespace)
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
+		if err := client.Services(namespace).Delete(service.Name); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("Successfully deleted services related to %s daemon set from %s namespace",
+		name, namespace)
+
+	return nil
+}
+
+// Returns detailed information about service from given service
+func getService(service api.Service, daemonSet extensions.DaemonSet,
+	pods []api.Pod, nodes []api.Node) resourceService.Service {
+
+	result := resourceService.ToService(&service)
+	// TODO: This may be wrong as we dont use all attributes from selector
+	result.ExternalEndpoints = common.GetExternalEndpoints(daemonSet.Spec.Selector.MatchLabels, pods, service, nodes)
+
+	return result
+}

--- a/src/app/backend/resource/daemonset/daemonsetlist.go
+++ b/src/app/backend/resource/daemonset/daemonsetlist.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/event"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// DaemonSetList contains a list of Daemon Sets in the cluster.
+type DaemonSetList struct {
+	// Unordered list of Daemon Sets
+	DaemonSets []DaemonSet `json:"daemonSets"`
+}
+
+// DaemonSet (aka. Daemon Set) plus zero or more Kubernetes services that
+// target the Daemon Set.
+type DaemonSet struct {
+	ObjectMeta common.ObjectMeta `json:"objectMeta"`
+	TypeMeta   common.TypeMeta   `json:"typeMeta"`
+
+	// Aggregate information about pods belonging to this Daemon Set.
+	Pods common.PodInfo `json:"pods"`
+
+	// Container images of the Daemon Set.
+	ContainerImages []string `json:"containerImages"`
+
+	// Internal endpoints of all Kubernetes services have the same label selector as this Daemon Set.
+	InternalEndpoints []common.Endpoint `json:"internalEndpoints"`
+
+	// External endpoints of all Kubernetes services have the same label selector as this Daemon Set.
+	ExternalEndpoints []common.Endpoint `json:"externalEndpoints"`
+}
+
+// GetDaemonSetList returns a list of all Daemon Set in the cluster.
+func GetDaemonSetList(client *client.Client, namespace string) (*DaemonSetList, error) {
+	log.Printf("Getting list of all daemon sets in the cluster")
+	channels := &common.ResourceChannels{
+		DaemonSetList: common.GetDaemonSetListChannel(client, 1),
+		ServiceList:   common.GetServiceListChannel(client, 1),
+		PodList:       common.GetPodListChannel(client, 1),
+		EventList:     common.GetEventListChannel(client, 1),
+		NodeList:      common.GetNodeListChannel(client, 1),
+	}
+
+	return GetDaemonSetListFromChannels(channels)
+}
+
+// GetDaemonSetList returns a list of all Daemon Seet in the cluster
+// reading required resource list once from the channels.
+func GetDaemonSetListFromChannels(channels *common.ResourceChannels) (
+	*DaemonSetList, error) {
+
+	daemonSets := <-channels.DaemonSetList.List
+	if err := <-channels.DaemonSetList.Error; err != nil {
+		return nil, err
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	pods := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	events := <-channels.EventList.List
+	if err := <-channels.EventList.Error; err != nil {
+		return nil, err
+	}
+
+	nodes := <-channels.NodeList.List
+	if err := <-channels.NodeList.Error; err != nil {
+		return nil, err
+	}
+
+	result := getDaemonSetList(daemonSets.Items, services.Items,
+		pods.Items, events.Items, nodes.Items)
+
+	return result, nil
+}
+
+// Returns a list of all Daemon Set model objects in the cluster, based on all Kubernetes
+// Daemon Set and Service API objects.
+// The function processes all Daemon Set API objects and finds matching Services for them.
+func getDaemonSetList(daemonSets []extensions.DaemonSet,
+	services []api.Service, pods []api.Pod, events []api.Event,
+	nodes []api.Node) *DaemonSetList {
+
+	daemonSetList := &DaemonSetList{DaemonSets: make([]DaemonSet, 0)}
+
+	for _, daemonSet := range daemonSets {
+
+		matchingServices := getMatchingServicesforDS(services, &daemonSet)
+		var internalEndpoints []common.Endpoint
+		var externalEndpoints []common.Endpoint
+		for _, service := range matchingServices {
+			internalEndpoints = append(internalEndpoints,
+				common.GetInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports))
+			// TODO: This may be wrong as we dont use all attributes from selector
+			externalEndpoints = common.GetExternalEndpoints(daemonSet.Spec.Selector.MatchLabels, pods, service, nodes)
+		}
+
+		matchingPods := make([]api.Pod, 0)
+		for _, pod := range pods {
+			if pod.ObjectMeta.Namespace == daemonSet.ObjectMeta.Namespace &&
+				common.IsLabelSelectorMatching(pod.ObjectMeta.Labels, daemonSet.Spec.Selector) {
+				matchingPods = append(matchingPods, pod)
+			}
+		}
+		podInfo := getDaemonSetPodInfo(&daemonSet, matchingPods)
+		podErrors := event.GetPodsEventWarnings(events, matchingPods)
+
+		podInfo.Warnings = podErrors
+
+		daemonSetList.DaemonSets = append(daemonSetList.DaemonSets,
+			DaemonSet{
+				ObjectMeta:        common.NewObjectMeta(daemonSet.ObjectMeta),
+				TypeMeta:          common.NewTypeMeta(common.ResourceKindDaemonSet),
+				Pods:              podInfo,
+				ContainerImages:   common.GetContainerImages(&daemonSet.Spec.Template.Spec),
+				InternalEndpoints: internalEndpoints,
+				ExternalEndpoints: externalEndpoints,
+			})
+	}
+
+	return daemonSetList
+}
+
+// Returns all services that target the same Pods (or subset) as the given Daemon Set.
+func getMatchingServicesforDS(services []api.Service,
+	daemonSet *extensions.DaemonSet) []api.Service {
+
+	var matchingServices []api.Service
+	for _, service := range services {
+		if service.ObjectMeta.Namespace == daemonSet.ObjectMeta.Namespace &&
+			common.IsLabelSelectorMatching(service.Spec.Selector, daemonSet.Spec.Selector) {
+
+			matchingServices = append(matchingServices, service)
+		}
+	}
+	return matchingServices
+}

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
@@ -126,7 +126,7 @@ func getReplicationControllerList(replicationControllers []api.ReplicationContro
 		matchingPods := make([]api.Pod, 0)
 		for _, pod := range pods {
 			if pod.ObjectMeta.Namespace == replicationController.ObjectMeta.Namespace &&
-				common.IsLabelSelectorMatching(replicationController.Spec.Selector, pod.ObjectMeta.Labels) {
+				common.IsSelectorMatching(replicationController.Spec.Selector, pod.ObjectMeta.Labels) {
 				matchingPods = append(matchingPods, pod)
 			}
 		}
@@ -156,7 +156,7 @@ func getMatchingServices(services []api.Service,
 	var matchingServices []api.Service
 	for _, service := range services {
 		if service.ObjectMeta.Namespace == replicationController.ObjectMeta.Namespace &&
-			common.IsLabelSelectorMatching(service.Spec.Selector, replicationController.Spec.Selector) {
+			common.IsSelectorMatching(service.Spec.Selector, replicationController.Spec.Selector) {
 
 			matchingServices = append(matchingServices, service)
 		}

--- a/src/test/backend/resource/common/types_test.go
+++ b/src/test/backend/resource/common/types_test.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"testing"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-func TestIsLabelSelectorMatching(t *testing.T) {
+func TestIsSelectorMatching(t *testing.T) {
 	cases := []struct {
 		serviceSelector, replicationControllerSelector map[string]string
 		expected                                       bool
@@ -25,10 +27,49 @@ func TestIsLabelSelectorMatching(t *testing.T) {
 			map[string]string{"app": "my-name", "version": "1.1"}, true},
 	}
 	for _, c := range cases {
-		actual := IsLabelSelectorMatching(c.serviceSelector, c.replicationControllerSelector)
+		actual := IsSelectorMatching(c.serviceSelector, c.replicationControllerSelector)
+		if actual != c.expected {
+			t.Errorf("isSelectorMatching(%+v, %+v) == %+v, expected %+v",
+				c.serviceSelector, c.replicationControllerSelector, actual, c.expected)
+		}
+	}
+}
+
+func TestIsLabelSelectorMatching(t *testing.T) {
+	cases := []struct {
+		serviceSelector   map[string]string
+		daemonSetselector *unversioned.LabelSelector
+		expected          bool
+	}{
+		{nil, nil, false},
+		{nil, &unversioned.LabelSelector{MatchLabels: map[string]string{}}, false},
+		{map[string]string{}, nil, false},
+		{map[string]string{}, &unversioned.LabelSelector{MatchLabels: map[string]string{}},
+			false},
+		{map[string]string{"app": "my-name"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{}},
+			false},
+		{map[string]string{"app": "my-name", "version": "2"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{"app": "my-name", "version": "1.1"}},
+			false},
+		{map[string]string{"app": "my-name", "env": "prod"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{"app": "my-name", "version": "1.1"}},
+			false},
+		{map[string]string{"app": "my-name"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{"app": "my-name"}},
+			true},
+		{map[string]string{"app": "my-name", "version": "1.1"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{"app": "my-name", "version": "1.1"}},
+			true},
+		{map[string]string{"app": "my-name"},
+			&unversioned.LabelSelector{MatchLabels: map[string]string{"app": "my-name", "version": "1.1"}},
+			true},
+	}
+	for _, c := range cases {
+		actual := IsLabelSelectorMatching(c.serviceSelector, c.daemonSetselector)
 		if actual != c.expected {
 			t.Errorf("isLabelSelectorMatching(%+v, %+v) == %+v, expected %+v",
-				c.serviceSelector, c.replicationControllerSelector, actual, c.expected)
+				c.serviceSelector, c.daemonSetselector, actual, c.expected)
 		}
 	}
 }

--- a/src/test/backend/resource/daemonset/daemonsetcommon_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetcommon_test.go
@@ -1,0 +1,146 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestGetDaemonSetPodInfo(t *testing.T) {
+	cases := []struct {
+		daemonset *extensions.DaemonSet
+		pods      []api.Pod
+		expected  common.PodInfo
+	}{
+		{
+			&extensions.DaemonSet{
+				Status: extensions.DaemonSetStatus{},
+				Spec:   extensions.DaemonSetSpec{},
+			},
+			[]api.Pod{
+				{
+					Status: api.PodStatus{
+						Phase: api.PodRunning,
+					},
+				},
+			},
+			common.PodInfo{
+				Running: 1,
+				Pending: 0,
+				Failed:  0,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := getDaemonSetPodInfo(c.daemonset, c.pods)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getReplicaSetPodInfo(%#v, %#v) == \n%#v\nexpected \n%#v\n",
+				c.daemonset, c.pods, actual, c.expected)
+		}
+	}
+}
+
+func TestGetServicesForDeletionforDS(t *testing.T) {
+	cases := []struct {
+		labelSelector   labels.Selector
+		DaemonSetList   *extensions.DaemonSetList
+		expected        *api.ServiceList
+		expectedActions []string
+	}{
+		{
+			labels.SelectorFromSet(map[string]string{"app": "test"}),
+			&extensions.DaemonSetList{
+				Items: []extensions.DaemonSet{
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					},
+				},
+			},
+			&api.ServiceList{
+				Items: []api.Service{
+					{Spec: api.ServiceSpec{Selector: map[string]string{"app": "test"}}},
+				},
+			},
+			[]string{"list", "list"},
+		},
+		{
+			labels.SelectorFromSet(map[string]string{"app": "test"}),
+			&extensions.DaemonSetList{
+				Items: []extensions.DaemonSet{
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					},
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					},
+				},
+			},
+			&api.ServiceList{
+				Items: []api.Service{
+					{Spec: api.ServiceSpec{Selector: map[string]string{"app": "test"}}},
+				},
+			},
+			[]string{"list"},
+		},
+		{
+			labels.SelectorFromSet(map[string]string{"app": "test"}),
+			&extensions.DaemonSetList{},
+			&api.ServiceList{
+				Items: []api.Service{
+					{Spec: api.ServiceSpec{Selector: map[string]string{"app": "test"}}},
+				},
+			},
+			[]string{"list"},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.DaemonSetList, c.expected)
+
+		getServicesForDSDeletion(fakeClient, c.labelSelector, "mock")
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+	}
+}

--- a/src/test/backend/resource/daemonset/daemonsetdetail_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetdetail_test.go
@@ -1,0 +1,130 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+func TestDeleteDaemonSetServices(t *testing.T) {
+	cases := []struct {
+		namespace, name string
+		DaemonSet       *extensions.DaemonSet
+		DaemonSetList   *extensions.DaemonSetList
+		serviceList     *api.ServiceList
+		expectedActions []string
+	}{
+		{
+			"test-namespace", "test-name",
+			&extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+			&extensions.DaemonSetList{
+				Items: []extensions.DaemonSet{
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+				},
+			},
+			&api.ServiceList{
+				Items: []api.Service{
+					{Spec: api.ServiceSpec{Selector: map[string]string{"app": "test"}}},
+				},
+			},
+			[]string{"get", "list", "list", "delete"},
+		},
+		{
+			"test-namespace", "test-name",
+			&extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				}},
+			&extensions.DaemonSetList{
+				Items: []extensions.DaemonSet{
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+				},
+			},
+			&api.ServiceList{
+				Items: []api.Service{
+					{Spec: api.ServiceSpec{Selector: map[string]string{"app": "test"}}},
+				},
+			},
+			[]string{"get", "list"},
+		},
+		{
+			"test-namespace", "test-name",
+			&extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				}},
+			&extensions.DaemonSetList{
+				Items: []extensions.DaemonSet{
+					{Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					}},
+				},
+			},
+			&api.ServiceList{},
+			[]string{"get", "list", "list"},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.DaemonSet,
+			c.DaemonSetList, c.serviceList)
+
+		DeleteDaemonSetServices(fakeClient, c.namespace, c.name)
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+	}
+}

--- a/src/test/backend/resource/daemonset/daemonsetlist_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetlist_test.go
@@ -1,0 +1,243 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+func TestGetMatchingServicesforDS(t *testing.T) {
+	cases := []struct {
+		services  []api.Service
+		DaemonSet *extensions.DaemonSet
+		expected  []api.Service
+	}{
+		{nil, nil, nil},
+		{
+			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
+			&extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{"app": "my-name"},
+					},
+				},
+			},
+			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
+		},
+		{
+			[]api.Service{
+				{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}},
+				{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name", "ver": "2"}}},
+			},
+			&extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{"app": "my-name"},
+					},
+				},
+			},
+			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
+		},
+	}
+	for _, c := range cases {
+		actual := getMatchingServicesforDS(c.services, c.DaemonSet)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getMatchingServices(%+v, %+v) == %+v, expected %+v",
+				c.services, c.DaemonSet, actual, c.expected)
+		}
+	}
+}
+
+func TestGetDaemonSetList(t *testing.T) {
+	events := []api.Event{}
+
+	cases := []struct {
+		daemonSets []extensions.DaemonSet
+		services   []api.Service
+		pods       []api.Pod
+		nodes      []api.Node
+		expected   *DaemonSetList
+	}{
+		{nil, nil, nil, nil, &DaemonSetList{DaemonSets: []DaemonSet{}}},
+		{
+			[]extensions.DaemonSet{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:      "my-app-1",
+						Namespace: "namespace-1",
+					},
+					Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "my-name-1"},
+						},
+						Template: api.PodTemplateSpec{
+							Spec: api.PodSpec{Containers: []api.Container{{Image: "my-container-image-1"}}},
+						},
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:      "my-app-2",
+						Namespace: "namespace-2",
+					},
+					Spec: extensions.DaemonSetSpec{
+						Selector: &unversioned.LabelSelector{
+							MatchLabels: map[string]string{"app": "my-name-2", "ver": "2"},
+						},
+						Template: api.PodTemplateSpec{
+							Spec: api.PodSpec{Containers: []api.Container{{Image: "my-container-image-2"}}},
+						},
+					},
+				},
+			},
+			[]api.Service{
+				{
+					Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name-1"}},
+					ObjectMeta: api.ObjectMeta{
+						Name:      "my-app-1",
+						Namespace: "namespace-1",
+					},
+				},
+				{
+					Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name-2", "ver": "2"}},
+					ObjectMeta: api.ObjectMeta{
+						Name:      "my-app-2",
+						Namespace: "namespace-2",
+					},
+				},
+			},
+			[]api.Pod{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodFailed,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodFailed,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodPending,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-2",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodPending,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodRunning,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodSucceeded,
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"app": "my-name-1"},
+					},
+					Status: api.PodStatus{
+						Phase: api.PodUnknown,
+					},
+				},
+			},
+			[]api.Node{{
+				Status: api.NodeStatus{
+					Addresses: []api.NodeAddress{
+						{
+							Type:    api.NodeExternalIP,
+							Address: "192.168.1.108",
+						},
+					},
+				},
+			},
+			},
+			&DaemonSetList{
+				DaemonSets: []DaemonSet{
+					{
+						ObjectMeta: common.ObjectMeta{
+							Name:      "my-app-1",
+							Namespace: "namespace-1",
+						},
+						TypeMeta:          common.TypeMeta{Kind: common.ResourceKindDaemonSet},
+						ContainerImages:   []string{"my-container-image-1"},
+						InternalEndpoints: []common.Endpoint{{Host: "my-app-1.namespace-1"}},
+						Pods: common.PodInfo{
+							Failed:   2,
+							Pending:  1,
+							Running:  1,
+							Warnings: []common.Event{},
+						},
+					}, {
+						ObjectMeta: common.ObjectMeta{
+							Name:      "my-app-2",
+							Namespace: "namespace-2",
+						},
+						TypeMeta:          common.TypeMeta{Kind: common.ResourceKindDaemonSet},
+						ContainerImages:   []string{"my-container-image-2"},
+						InternalEndpoints: []common.Endpoint{{Host: "my-app-2.namespace-2"}},
+						Pods: common.PodInfo{
+							Warnings: []common.Event{},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		actual := getDaemonSetList(c.daemonSets, c.services, c.pods,
+			events, c.nodes)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getDaemonSetList(%#v, %#v) == \n%#v\nexpected \n%#v\n",
+				c.daemonSets, c.services, actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I started to implement #509. 

I tried to keep it simple : the code is very similar to the replication controller one. Maybe we could refactor it but : 
* I'm not that good in Go. 
* Types are different in functions parameters, we may need to find a workaround (add an interface and cast object?) 

Feel free to comment!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/510)
<!-- Reviewable:end -->
