### PR TITLE
Fix test of fileupload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 # Use Node.js as primary language because Gulp is the build system used in the project.
 language: node_js
 node_js:
-  - 4.2.2
+  - 5.1.1
 
 addons:
   # Run tests that require a browser on SauceLabs CI provider. Learn more at: https://saucelabs.com

--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -14,8 +14,8 @@ logic and fetches raw data from the various Kubernetes APIs.
 Make sure the following software is installed and added to the `$PATH` variable:
 * Docker (1.3+)
 * go (1.5+)
-* nodejs (4.2.2+)
-* npm (1.3+)
+* nodejs (5.1.1+)
+* npm (3+)
 * java (7+)
 * gulp (3.9+)
 

--- a/src/app/frontend/replicationcontrollerdetail/deletereplicationcontroller.html
+++ b/src/app/frontend/replicationcontrollerdetail/deletereplicationcontroller.html
@@ -30,8 +30,8 @@ limitations under the License.
       </md-icon>
     </md-checkbox>
     <md-dialog-actions>
-      <md-button class="md-primary" ng-click="ctrl.cancel()">Cancel</md-button>
-      <md-button class="md-primary" ng-click="ctrl.remove()">Delete</md-button>
+      <md-button class="md-primary kd-cancel-btn" ng-click="ctrl.cancel()">Cancel</md-button>
+      <md-button class="md-primary kd-delete-btn" ng-click="ctrl.remove()">Delete</md-button>
     </md-dialog-actions>
   </md-dialog-content>
 </md-dialog>

--- a/src/test/integration/deploy/deployfromfile_po.js
+++ b/src/test/integration/deploy/deployfromfile_po.js
@@ -27,9 +27,29 @@ export default class DeployFromFilePageObject {
     this.inputContainer = element(this.inputContainerQuery);
 
     this.filePickerQuery = by.css('.kd-upload-file-picker');
-    this.filePicker = element(this.filePickerQuery);
+    this.filePicker_ = element(this.filePickerQuery);
 
     this.mdDialogQuery = by.tagName('md-dialog');
     this.mdDialog = element(this.mdDialogQuery);
   }
+
+  /**
+   * Make filePicker input field visible
+   * Firefox does not allow sendKeys to invisible input[type=file] element
+   */
+  makeInputVisible() {
+    browser.driver.executeScript(function() {
+      /* global document */
+      let filePickerDomElement = document.getElementsByClassName('kd-upload-file-picker')[0];
+      filePickerDomElement.style.visibility = 'visible';
+      filePickerDomElement.style.height = '1px';
+      filePickerDomElement.style.width = '1px';
+    });
+  }
+
+  /**
+   * Sets filepath on the filePicker input field
+   * @param {string} filePath
+   */
+  setFile(filePath) { this.filePicker_.sendKeys(filePath); }
 }

--- a/src/test/integration/replicationcontrollerdetail/deletereplicationcontroller_po.js
+++ b/src/test/integration/replicationcontrollerdetail/deletereplicationcontroller_po.js
@@ -14,15 +14,10 @@
 
 export default class DeleteReplicationControllerDialogObject {
   constructor() {
-    let deleteDialogXPath = '//md-dialog[@aria-label=\'Delete Replication Controller\']';
-    this.deleteDialogQuery = by.xpath(deleteDialogXPath);
-    this.deleteDialog = element(this.deleteDialogQuery);
-
-    this.deleteAppButtonQuery =
-        by.xpath(`${deleteDialogXPath}//md-dialog-actions//span[text() = 'Delete']/..`);
+    this.deleteAppButtonQuery = by.css('.kd-delete-btn');
     this.deleteAppButton = element(this.deleteAppButtonQuery);
 
-    this.deleteServicesCheckboxQuery = by.xpath(`${deleteDialogXPath}//md-checkbox`);
+    this.deleteServicesCheckboxQuery = by.css('.kd-deletedialog-services-checkbox');
     this.deleteServicesCheckbox = element(this.deleteServicesCheckboxQuery);
   }
 }

--- a/src/test/integration/stories/deploy_from_invalid_file_test.js
+++ b/src/test/integration/stories/deploy_from_invalid_file_test.js
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 import path from 'path';
+import remote from 'selenium-webdriver/remote';
 
 import DeployFromFilePageObject from '../deploy/deployfromfile_po';
 
 // Test assumes, that there are no replication controllers in the cluster at the beginning.
-// TODO(#494): Reenable this test when fixed.
-xdescribe('Deploy from invalid file user story test', () => {
+describe('Deploy from invalid file user story test', () => {
 
   /** @type {!DeployFromFilePageObject} */
   let deployFromFilePage;
 
   beforeAll(() => {
+    browser.driver.setFileDetector(new remote.FileDetector());
     deployFromFilePage = new DeployFromFilePageObject();
     browser.get('#/deploy');
     // switches to deploy from file
@@ -36,7 +37,8 @@ xdescribe('Deploy from invalid file user story test', () => {
     let absolutePath = path.resolve(__dirname, fileToUpload);
 
     // when
-    deployFromFilePage.filePicker.sendKeys(absolutePath);
+    deployFromFilePage.makeInputVisible();
+    deployFromFilePage.setFile(absolutePath);
     deployFromFilePage.deployButton.click();
 
     // then

--- a/src/test/integration/stories/deploy_from_valid_file_test.js
+++ b/src/test/integration/stories/deploy_from_valid_file_test.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import path from 'path';
+import remote from 'selenium-webdriver/remote';
 
 import DeployFromFilePageObject from '../deploy/deployfromfile_po';
 import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
@@ -20,8 +21,7 @@ import DeleteReplicationControllerDialogObject from '../replicationcontrollerdet
 import ZeroStatePageObject from '../zerostate/zerostate_po';
 
 // Test assumes, that there are no replication controllers in the cluster at the beginning.
-// TODO(#494): Reenable this test when fixed.
-xdescribe('Deploy from valid file user story test', () => {
+describe('Deploy from valid file user story test', () => {
 
   /** @type {!DeployFromFilePageObject} */
   let deployFromFilePage;
@@ -39,6 +39,7 @@ xdescribe('Deploy from valid file user story test', () => {
   let appName = 'integration-test-valid-rc';
 
   beforeAll(() => {
+    browser.driver.setFileDetector(new remote.FileDetector());
     deployFromFilePage = new DeployFromFilePageObject();
     replicationControllersPage = new ReplicationControllersPageObject();
     deleteDialog = new DeleteReplicationControllerDialogObject();
@@ -54,7 +55,8 @@ xdescribe('Deploy from valid file user story test', () => {
     let absolutePath = path.resolve(__dirname, fileToUpload);
 
     // when
-    deployFromFilePage.filePicker.sendKeys(absolutePath);
+    deployFromFilePage.makeInputVisible();
+    deployFromFilePage.setFile(absolutePath);
     deployFromFilePage.deployButton.click();
 
     // then


### PR DESCRIPTION
I added FileDetector setting to test file upload in saucelabs.
FileDetector locates selenium-webdriver/remote/index.js.
But the file path is different between npm2 and npm3.
https://docs.npmjs.com/how-npm-works/npm3-nondet

npm in travis is v2.
If we want to use v3 in travis, we need to install npm3.

.travis.yaml
```yaml
before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
```

Which version is better?
Do you have a good idea to support both versions?

@bryk  @floreks  @maciaszczykm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/515)
<!-- Reviewable:end -->
