### PR TITLE
Improve tabbing

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,7 +17,7 @@ limitations under the License.
 <md-content class="kd-content">
   <md-toolbar class="kd-toolbar">
     <div class="md-toolbar-tools kd-toolbar-tools">
-      <a ui-sref="replicationcontrollers" ui-sref-opts="{ reload: true }">
+      <a ui-sref="replicationcontrollers" ui-sref-opts="{ reload: true }" tabindex="-1">
         <md-icon md-svg-icon="assets/images/kubernetes-logo.svg" class="kd-toolbar-logo"></md-icon>
       </a>
       <h2>

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -30,7 +30,7 @@ limitations under the License.
         </md-radio-group>
         <kd-user-help>
           To learn more,
-          <a href="http://kubernetes.github.io/docs/user-guide/ui/" target="_blank">
+          <a href="http://kubernetes.github.io/docs/user-guide/ui/" target="_blank" tabindex="-1">
             take the Dashboard Tour <i class="material-icons">open_in_new</i>
           </a>
         </kd-user-help>

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -32,8 +32,8 @@ limitations under the License.
           <i>{{ctrl.namespace}}</i>.
         </ng-message>
         <ng-message when="pattern">
-          Application name must start with a lowercase letter
-          and contain only lowercase letters, numbers, and '-' between words.
+          Application name must start with a lowercase letter and contain only lowercase letters,
+          numbers, and '-' between words.
         </ng-message>
         <ng-message when="maxlength">
           Name must be up to {{ctrl.nameMaxLength}} characters long.
@@ -43,8 +43,11 @@ limitations under the License.
   </md-input-container>
 
   <kd-user-help>
-    An 'app' label with this value will be added to the Replication Controller and Service that get deployed.
-    <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank">Learn more</a>
+    An 'app' label with this value will be added to the Replication Controller and Service that get
+    deployed.
+    <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+      Learn more
+    </a>
   </kd-user-help>
 </kd-help-section>
 
@@ -56,20 +59,25 @@ limitations under the License.
            kd-valid-imagereference invalid-image-error-message="ctrl.containerImageErrorMessage">
     <ng-messages for="ctrl.form.containerImage.$error" role="alert" multiple>
       <ng-message when="required">Container image is required.</ng-message>
-      <ng-message when="validImageReference">Container image is invalid: {{ ctrl.containerImageErrorMessage }}</ng-message>
+      <ng-message when="validImageReference">
+        Container image is invalid: {{ ctrl.containerImageErrorMessage }}
+      </ng-message>
     </ng-messages>
   </md-input-container>
   <kd-user-help>
     Enter the URL of a public image on any registry, or a private image hosted on Docker Hub or
     Google Container Registry.
-    <a href="http://kubernetes.github.io/docs/user-guide/images/" target="_blank">Learn more</a>
+    <a href="http://kubernetes.github.io/docs/user-guide/images/" target="_blank" tabindex="-1">
+      Learn more
+    </a>
   </kd-user-help>
 </kd-help-section>
 
 <kd-help-section>
   <md-input-container class="md-block">
     <label>Number of pods</label>
-    <input ng-model="ctrl.replicas" type="number" required min="1" name="replicas" kd-validate="integer">
+    <input ng-model="ctrl.replicas" type="number" required min="1" name="replicas"
+           kd-validate="integer">
     <ng-messages for="ctrl.form.replicas.$error" role="alert" multiple>
       <ng-message when="required">Number of pods is required.</ng-message>
       <ng-message when="number, kdValid">Number of pods must be a positive integer.</ng-message>
@@ -77,8 +85,12 @@ limitations under the License.
     </ng-messages>
   </md-input-container>
   <kd-user-help>
-    A Replication Controller will be created to maintain the desired number of pods across your cluster.
-    <a href="http://kubernetes.github.io/docs/user-guide/replication-controller/" target="_blank">Learn more</a>
+    A Replication Controller will be created to maintain the desired number of pods across your
+    cluster.
+    <a href="http://kubernetes.github.io/docs/user-guide/replication-controller/" target="_blank"
+       tabindex="-1">
+      Learn more
+    </a>
   </kd-user-help>
 </kd-help-section>
 
@@ -92,7 +104,9 @@ limitations under the License.
     <span ng-if="ctrl.name">
       The internal DNS name for this Service will be: <span class="kd-emphasized">{{ctrl.name}}</span>.
     </span>
-    <a href="http://kubernetes.github.io/docs/user-guide/services/" target="_blank">Learn more</a>
+    <a href="http://kubernetes.github.io/docs/user-guide/services/" target="_blank" tabindex="-1">
+      Learn more
+    </a>
   </kd-user-help>
 </kd-help-section>
 
@@ -111,8 +125,8 @@ limitations under the License.
       <textarea ng-model="ctrl.description"></textarea>
     </md-input-container>
     <kd-user-help>
-      The description will be added as an annotation to the Replication Controller and displayed in the
-      application's details.
+      The description will be added as an annotation to the Replication Controller and displayed in
+      the application's details.
     </kd-user-help>
   </kd-help-section>
 
@@ -125,14 +139,17 @@ limitations under the License.
         <div flex="40">Value</div>
       </div>
       <div ng-repeat="label in ctrl.labels">
-         <kd-deploy-label layout="row" flex="auto" label="label" labels="ctrl.labels"></kd-deploy-label>
+         <kd-deploy-label layout="row" flex="auto" label="label" labels="ctrl.labels">
+         </kd-deploy-label>
       </div>
     </div>
 
     <kd-user-help>
-      The specified labels will be applied to the created Replication Controller, Service (if any) and Pods.
-      Common labels include release, environment, tier, partition and track.
-      <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank">Learn more</a>
+      The specified labels will be applied to the created Replication Controller, Service (if any)
+      and Pods. Common labels include release, environment, tier, partition and track.
+      <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -150,7 +167,9 @@ limitations under the License.
     </md-input-container>
     <kd-user-help>
       Namespaces let you partition resources into logically named groups.
-      <a href="http://kubernetes.github.io/docs/admin/namespaces/" target="_blank">Learn more</a>
+      <a href="http://kubernetes.github.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -169,7 +188,9 @@ limitations under the License.
     <kd-user-help>
       The specified image could require a pull secret credential if it is private. You may choose an
       existing secret or create a new one.
-      <a href="http://kubernetes.github.io/docs/user-guide/secrets/" target="_blank">Learn more</a>
+      <a href="http://kubernetes.github.io/docs/user-guide/secrets/" target="_blank" tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -195,7 +216,9 @@ limitations under the License.
     </div>
     <kd-user-help>
       You can specify minimum CPU and memory requirements for the container.
-      <a href="http://kubernetes.io/v1.1/docs/admin/limitrange/" target="_blank">Learn more</a>
+      <a href="http://kubernetes.io/v1.1/docs/admin/limitrange/" target="_blank" tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -214,7 +237,10 @@ limitations under the License.
     <kd-user-help>
       By default, your containers run the selected image's default entrypoint command. You can
       use the command options to override the default.
-      <a href="http://kubernetes.github.io/docs/user-guide/containers/" target="_blank">Learn more</a>
+      <a href="http://kubernetes.github.io/docs/user-guide/containers/" target="_blank"
+         tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -226,7 +252,10 @@ limitations under the License.
     </div>
     <kd-user-help>
       Processes in privileged containers are equivalent to processes running as root on the host.
-      <a href="http://kubernetes.github.io/docs/user-guide/pods/#privileged-mode-for-pod-containers" target="_blank">Learn more</a>
+      <a href="http://kubernetes.github.io/docs/user-guide/pods/#privileged-mode-for-pod-containers"
+         target="_blank" tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 
@@ -236,19 +265,20 @@ limitations under the License.
     <kd-user-help>
       Environment variables available for use in the container. Values can reference other variables
       using $(VAR_NAME) syntax.
-      <a href="http://kubernetes.github.io/docs/docs/design/expansion/" target="_blank">Learn more</a>
+      <a href="http://kubernetes.github.io/docs/docs/design/expansion/" target="_blank"
+         tabindex="-1">
+        Learn more
+      </a>
     </kd-user-help>
   </kd-help-section>
 </div>
 
 <!-- show/hide advanced options toggle -->
 <md-button class="md-primary kd-deploy-moreoptions-button" type="button"
-           ng-click="ctrl.switchMoreOptions()"
-           ng-hide="ctrl.isMoreOptionsEnabled()">
+           ng-click="ctrl.switchMoreOptions()" ng-hide="ctrl.isMoreOptionsEnabled()">
   <md-icon>arrow_drop_down</md-icon>show advanced options
 </md-button>
 <md-button class="md-primary kd-deploy-moreoptions-button" type="button"
-           ng-click="ctrl.switchMoreOptions()"
-           ng-show="ctrl.isMoreOptionsEnabled()">
+           ng-click="ctrl.switchMoreOptions()" ng-show="ctrl.isMoreOptionsEnabled()">
   <md-icon>arrow_drop_up</md-icon>hide advanced options
 </md-button>


### PR DESCRIPTION
Improved tabbing on deploy page by adding `tabindex="-1"` attributes. It made `Learn more` links not accessible via `TAB` button. It's preffered solution as it was described on https://www.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/.

Fixes #525.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/526)
<!-- Reviewable:end -->
