### PR TITLE
Add option to update and check npm/bower dependencies with gulp

### DIFF
--- a/build/dependencies.js
+++ b/build/dependencies.js
@@ -1,0 +1,102 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import gulp from 'gulp';
+import gulputil from 'gulp-util';
+import ncu from 'npm-check-updates';
+import path from 'path';
+import through from 'through2';
+
+import conf from './conf';
+
+/**
+ * Updates npm dependencies.
+ */
+gulp.task('update-npm-dependencies', function() {
+  return gulp.src([path.join(conf.paths.base, 'package.json')]).pipe(updateDependencies('npm'));
+});
+
+/**
+ * Checks npm dependencies which need to be updated.
+ */
+gulp.task('check-npm-dependencies', function() {
+  return gulp.src([path.join(conf.paths.base, 'package.json')]).pipe(checkDependencies('npm'));
+});
+
+/**
+ * Updates bower dependencies.
+ */
+gulp.task('update-bower-dependencies', function() {
+  return gulp.src([path.join(conf.paths.base, 'bower.json')]).pipe(updateDependencies('bower'));
+});
+
+/**
+ * Checks bower dependencies which need to be updated.
+ */
+gulp.task('check-bower-dependencies', function() {
+  return gulp.src([path.join(conf.paths.base, 'bower.json')]).pipe(checkDependencies('bower'));
+});
+
+/**
+ * Updates dependencies of given package manager by updating related package/bower json file.
+ *
+ * @param {string} packageManager
+ * @return {stream}
+ */
+function updateDependencies(packageManager) {
+  return through.obj(function(file, codec, cb) {
+    let relativePath = path.relative(process.cwd(), file.path);
+
+    ncu.run({
+         packageFile: relativePath,
+         packageManager: packageManager,
+         cli: true,
+         upgradeAll: true,
+         args: [],
+       })
+        .then(cb);
+  });
+}
+
+/**
+ * Checks and lists outdated dependencies if there are any.
+ *
+ * @param {string} packageManager
+ * @return {stream}
+ */
+function checkDependencies(packageManager) {
+  return through.obj(function(file, codec, cb) {
+    let relativePath = path.relative(process.cwd(), file.path);
+
+    ncu.run({
+         packageFile: relativePath,
+         packageManager: packageManager,
+       })
+        .then(function(toUpgrade) {
+          let dependenciesStr = Object.keys(toUpgrade)
+                                    .map((key) => { return `${key}: ${toUpgrade[key]}\n`; })
+                                    .join('');
+
+          if (dependenciesStr.length !== 0) {
+            gulputil.log(
+                gulputil.colors.yellow(
+                    `Dependencies needed to update:\n${dependenciesStr}\n` +
+                    'Run: \'gulp update-npm-dependencies\', then \'npm install\' to update' +
+                    ' dependencies.\n'));
+          }
+
+          cb();
+        });
+  });
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -22,6 +22,7 @@ import './build/check';
 import './build/cluster';
 import './build/backend';
 import './build/build';
+import './build/dependencies';
 import './build/deploy';
 import './build/index';
 import './build/script';

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "karma-sauce-launcher": "^0.3.0",
     "karma-sourcemap-loader": "~0.3.6",
     "lodash": "~4.1.0",
+    "npm-check-updates": "^2.5.8",
     "proxy-middleware": "~0.15.0",
     "q": "~1.4.1",
     "semver": "~5.1.0",


### PR DESCRIPTION
As discussed in #534 I've added `npm-check-updates` and integrated it with gulp.

Should we add check dependency to `gulp check` or just leave it this way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/540)
<!-- Reviewable:end -->
