### PR TITLE
Fix relative time filter

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -36,6 +36,7 @@ function getFileList() {
   };
 
   return wiredep(wiredepOptions).js.concat([
+    path.join(conf.paths.frontendTest, '**/*.json'),
     path.join(conf.paths.frontendTest, '**/*.js'),
     path.join(conf.paths.frontendSrc, '**/*.js'),
     path.join(conf.paths.frontendSrc, '**/*.html'),

--- a/src/app/backend/confighandler.go
+++ b/src/app/backend/confighandler.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"text/template"
+	"time"
+)
+
+// AppHandler is a application handler.
+type AppHandler func(http.ResponseWriter, *http.Request) (int, error)
+
+// AppConfig is a global configuration of application.
+type AppConfig struct {
+	// ServerTime is current server time (milliseconds elapsed since 1 January 1970 00:00:00 UTC).
+	ServerTime int64 `json:"serverTime"`
+}
+
+const (
+	// ConfigTemplateName is a name of config template
+	ConfigTemplateName string = "appConfig"
+	// ConfigTemplate is a template of a config
+	ConfigTemplate string = "var appConfig_DO_NOT_USE_DIRECTLY = {{.}}"
+)
+
+// ServeHTTP serves HTTP endpoint with application configuration.
+func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if _, err := fn(w, r); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError),
+			http.StatusInternalServerError)
+	}
+}
+
+func getAppConfigJSON() string {
+	log.Printf("Getting application global configuration")
+
+	config := &AppConfig{
+		// TODO(maciaszczykm): Get time from API server instead directly from backend.
+		ServerTime: time.Now().UTC().UnixNano() / 1e6,
+	}
+
+	json, _ := json.Marshal(config)
+	log.Printf("Application configuration %s", json)
+	return string(json)
+}
+
+func configHandler(w http.ResponseWriter, r *http.Request) (int, error) {
+	template, err := template.New(ConfigTemplateName).Parse(ConfigTemplate)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, template.Execute(w, getAppConfigJSON())
+}

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -61,6 +61,8 @@ func main() {
 	// TODO(bryk): Disable directory listing.
 	http.Handle("/", http.FileServer(http.Dir("./public")))
 	http.Handle("/api/", CreateHttpApiHandler(apiserverClient, heapsterRESTClient, config))
+	// TODO(maciaszczykm): Move to /appConfig.json as it was discussed in #640.
+	http.Handle("/api/appConfig.json", AppHandler(configHandler))
 	log.Print(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
 }
 

--- a/src/app/backend/heapsterclient.go
+++ b/src/app/backend/heapsterclient.go
@@ -17,8 +17,8 @@ package main
 import (
 	"log"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 // HeapsterClient  is a client used to make requests to a Heapster instance.

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -344,3 +344,6 @@ backendApi.SecretSpec;
  * }}
  */
 backendApi.SecretsList;
+
+/** @typedef {{serverTime: number}} */
+const appConfig_DO_NOT_USE_DIRECTLY = {};

--- a/src/app/frontend/common/appconfig/appconfig_module.js
+++ b/src/app/frontend/common/appconfig/appconfig_module.js
@@ -1,3 +1,4 @@
+
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,23 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import coresFilter from './cores_filter';
-import memoryFilter from './memory_filter';
-import middleEllipsisFilter from './middleellipsis_filter';
-import relativeTimeFilter from './relativetime_filter';
-import appConfigModule from '../appconfig/appconfig_module';
+import appConfigServiceProvider from './appconfig_serviceprovider';
 
 /**
- * Module containing common filters for the application.
+ * Angular module containing application configuration.
  */
 export default angular
     .module(
-        'kubernetesDashboard.common.filters',
+        'kubernetesDashboard.appconfig',
         [
           'ngMaterial',
-          appConfigModule.name,
         ])
-    .filter('middleEllipsis', middleEllipsisFilter)
-    .filter('kdMemory', memoryFilter)
-    .filter('kdCores', coresFilter)
-    .filter('relativeTime', relativeTimeFilter);
+    .provider('kdAppConfigService', appConfigServiceProvider)
+    .value('appConfig', appConfig_DO_NOT_USE_DIRECTLY);

--- a/src/app/frontend/common/appconfig/appconfig_service.js
+++ b/src/app/frontend/common/appconfig/appconfig_service.js
@@ -1,0 +1,43 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Application configuration service.
+ *
+ * @final
+ */
+export class AppConfigService {
+  /**
+   * @param {!appConfig_DO_NOT_USE_DIRECTLY} appConfig
+   * @ngInject
+   */
+  constructor(appConfig) {
+    /** @private {!appConfig_DO_NOT_USE_DIRECTLY} */
+    this.appConfig_ = appConfig;
+  }
+
+  /**
+   * Returns current server time.
+   *
+   * @return {?Date}
+   * @export
+   */
+  getServerTime() {
+    if (!isNaN(this.appConfig_.serverTime)) {
+      return new Date(this.appConfig_.serverTime);
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/app/frontend/common/appconfig/appconfig_serviceprovider.js
+++ b/src/app/frontend/common/appconfig/appconfig_serviceprovider.js
@@ -1,0 +1,27 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AppConfigService} from './appconfig_service';
+
+/**
+ * Application configuration provider.
+ */
+export default class AppConfigServiceProvider {
+  /**
+   * @param {appConfig_DO_NOT_USE_DIRECTLY} appConfig
+   * @ngInject
+   * @export
+   */
+  $get(appConfig) { return new AppConfigService(appConfig || {}); }
+}

--- a/src/app/frontend/common/filters/relativetime_filter.js
+++ b/src/app/frontend/common/filters/relativetime_filter.js
@@ -14,6 +14,7 @@
 
 /**
  * Unit name constants (singular and plural form), that will be used by the filter.
+ *
  * @enum {!Array<string>}
  */
 const Units = {
@@ -27,6 +28,7 @@ const Units = {
 
 /**
  * Unit conversion constants.
+ *
  * @enum {number}
  */
 const UnitConversions = {
@@ -41,6 +43,7 @@ const UnitConversions = {
 
 /**
  * Time constants.
+ *
  * @enum {string}
  */
 const TimeConstants = {
@@ -50,17 +53,24 @@ const TimeConstants = {
 
 /**
  * Returns filter function to display relative time since given date.
+ *
+ * @param {!../appconfig/appconfig_service.AppConfigService} kdAppConfigService
  * @return {function(string): string}
+ * @ngInject
  */
-export default function relativeTimeFilter() {
+export default function relativeTimeFilter(kdAppConfigService) {
   /**
    * Filter function to display relative time since given date.
+   *
    * @param {string} value Filtered value.
    * @return {string}
    */
   let filterFunction = function(value) {
+    // Current server time.
+    let serverTime = kdAppConfigService.getServerTime();
+
     // Current and given times in miliseconds.
-    let currentTime = (new Date()).getTime();  // TODO(maciaszczykm): Use server time.
+    let currentTime = getCurrentTime(serverTime);
     let givenTime = (new Date(value)).getTime();
 
     // Time differences between current time and given time in specific units.
@@ -92,11 +102,25 @@ export default function relativeTimeFilter() {
       return formatOutputTimeString_(diffInYears, Units.YEAR);
     }
   };
+
   return filterFunction;
 }
 
 /**
+ * Returns current time. If appConfig.serverTime is provided then it will be returned, otherwise current
+ * client time will be used.
+ *
+ * @param {?Date} serverTime
+ * @return {number}
+ * @private
+ */
+function getCurrentTime(serverTime) {
+  return serverTime ? serverTime.getTime() : (new Date()).getTime();
+}
+
+/**
  * Formats relative time string. Sample results look following: 'a year', '2 days' or '14 hours'.
+ *
  * @param {number} timeValue Time value in specified unit.
  * @param {!Array<string>} timeUnit Specified unit.
  * @return {string} Formatted time string.

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -54,10 +54,14 @@ limitations under the License.
     <!-- endbower -->
     <!-- endbuild -->
 
+    <!-- Script with configuration generated at backend. -->
+    <script src="api/appConfig.json"></script>
+
     <!-- build:js static/app.js -->
     <!-- inject:js -->
     <!-- Application JS files are populated here. -->
     <!-- endinject -->
     <!-- endbuild -->
+
   </body>
 </html>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -38,7 +38,7 @@ export default class ReplicationControllerDetailController {
    * @ngInject
    */
   constructor(
-      $mdMedia, $stateParams, $state, $resource, $log, replicationControllerDetail,
+      $mdMedia, $stateParams, $state, $log, replicationControllerDetail,
       replicationControllerEvents) {
     /** @export {function(string):boolean} */
     this.mdMedia = $mdMedia;

--- a/src/test/frontend/common/filters/relativetime_filter_test.js
+++ b/src/test/frontend/common/filters/relativetime_filter_test.js
@@ -16,6 +16,10 @@ import filtersModule from 'common/filters/filters_module';
 
 describe('Relative time filter', () => {
 
+  /**
+   * Current time mock.
+   * @type {Date}
+   */
   const currentTime = new Date(
       2015,  // year
       11,    // month

--- a/src/test/frontend/fakeServerConfig.json
+++ b/src/test/frontend/fakeServerConfig.json
@@ -1,0 +1,16 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @typedef {{serverTime: number}} */
+const appConfig_DO_NOT_USE_DIRECTLY = {};


### PR DESCRIPTION
Relative time filter will now use server time as current time (if it will be provided, otherwise it works like before). It fixes issue with differences between client and server times. Set it up for filter on replication controller list and replication controller detail pages.

There is a way to make it work without need to pass time in HTML, but it will cause performance problems. Current implementation require only one time request per page refresh and if we will move whole logic to filter then we would have `n` requests, where `n` is number of cards on replication controller list page or number of pods on replication controller details page. I think in this case performance is more impotrant.

Fixes #427.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/542)
<!-- Reviewable:end -->
