### PR TITLE
Fix alignment on deploy page

### DIFF
--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div layout="column" layout-padding layout-padding-gt-md layout-align="center center" flex="auto">
+<div layout="column" layout-padding-gt-md layout-align="center center" flex="auto">
   <md-whiteframe class="kd-deploy-whiteframe md-whiteframe-5dp" flex="auto">
     <h3 class="md-headline kd-deploy-form-title">Deploy a Containerized App</h3>
 

--- a/src/app/frontend/deploy/helpsection/helpsection.scss
+++ b/src/app/frontend/deploy/helpsection/helpsection.scss
@@ -19,10 +19,9 @@
   flex: 1;
   flex-basis: auto;
   margin: $baseline-grid 0;
-  padding-right: 4 * $baseline-grid;
   width: 100%;
 
   &:last-child {
-    padding-right: 0;
+    padding-left: 4 * $baseline-grid;
   }
 }


### PR DESCRIPTION
Increased paddings by removing `layout-padding`, in this way `layout-padding-gt-md` is used. Fixed padding issues.

![image](https://cloud.githubusercontent.com/assets/2823399/13879103/e5768598-ed15-11e5-84fc-e79c390ea230.png)

Fixes #544.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/547)
<!-- Reviewable:end -->
