### PR TITLE
Fix typo in update dependencies message

### DIFF
--- a/build/dependencies.js
+++ b/build/dependencies.js
@@ -92,7 +92,7 @@ function checkDependencies(packageManager) {
             gulputil.log(
                 gulputil.colors.yellow(
                     `Dependencies needed to update:\n${dependenciesStr}\n` +
-                    'Run: \'gulp update-npm-dependencies\', then \'npm install\' to update' +
+                    `Run: 'gulp update-${packageManager}-dependencies', then '${packageManager} install' to update` +
                     ' dependencies.\n'));
           }
 


### PR DESCRIPTION
Message for bower/npm check/update dependencies was always the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/551)
<!-- Reviewable:end -->
