### PR TITLE
Fix logs view inconsistency between different k8s versions

### DIFF
--- a/src/app/backend/logs.go
+++ b/src/app/backend/logs.go
@@ -81,7 +81,7 @@ func getRawPodLogs(client *client.Client, namespace, podID string, logOptions *a
 
 	readCloser, err := req.Stream()
 	if err != nil {
-		return "", err
+		return err.Error(), nil
 	}
 
 	defer readCloser.Close()


### PR DESCRIPTION
Fixes #423

With this small change when kubernetes API returns error it will process it and show it as log and not internal error in the dashboard UI.

Before:
![zrzut ekranu z 2016-02-25 09-57-39](https://cloud.githubusercontent.com/assets/2285385/13314834/7ff616d6-dba7-11e5-9b4f-cc6167afbee4.png)

After:
![zrzut ekranu z 2016-03-21 10-07-52](https://cloud.githubusercontent.com/assets/2285385/13914173/024fdd02-ef4d-11e5-88b1-6a5e13759fbb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/552)
<!-- Reviewable:end -->
