### PR TITLE
Fix serve:prod styling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-useref": "~3.0.4",
     "gulp-util": "~3.0.7",
     "gulp-watch": "~4.3.5",
+    "html-minifier": "~1.2.0",
     "isparta": "~4.0.0",
     "karma": "0.13.19",
     "karma-browserify": "~5.0.1",


### PR DESCRIPTION
Fixes #546 

It appears that new `gulp-htmlmin` depends on `html-minifier` `1.3.0` which produces invalid output. Setting `includeAutoGeneratedTags` option to `false` only partially solves the problem. I've changed version of `html-minifier` to `1.2.0` which fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/557)
<!-- Reviewable:end -->
