### PR TITLE
Update link to system applications on the zerostate page

### DIFF
--- a/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
+++ b/src/app/frontend/replicationcontrollerlist/zerostate/zerostate.html
@@ -37,10 +37,10 @@ limitations under the License.
             <i class="material-icons kd-zerostate-ext-link-icon">open_in_new</i>
           </a>
         </div>
-        <a class="md-raised md-primary kd-zerostate-rcs" ng-if="ctrl.containsOnlyKubeSystemRCs"
-           ui-sref="replicationcontrollers">
-          There are replication controllers in kube-system namespace,<br>click to show them
-        </a>
+        <p class="kd-zerostate-lm kd-zerostate-rcs" ng-if="ctrl.containsOnlyKubeSystemRCs">
+          Some system applications are running in the cluster.
+          <a class="md-raised md-primary" ui-sref="replicationcontrollers">Show them</a>
+        </p>
       </md-card-content>
     </md-card>
   </md-content>


### PR DESCRIPTION
* previosuly it was a multiline link -> changed this to text and lint
* changed wording to not expose our internal implementation details`

![selection_054](https://cloud.githubusercontent.com/assets/1159999/13947819/e71487e2-f01c-11e5-878f-ee2cc96acad1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/558)
<!-- Reviewable:end -->
