### PR TITLE
[WIP] Add deploy plugin KPM

### DIFF
--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -27,6 +27,9 @@ limitations under the License.
           <md-radio-button value="File" class="md-primary">
             Upload a YAML or JSON file
           </md-radio-button>
+          <md-radio-button value="KPM" class="md-primary">
+            Use an external package manager (Helm, KPM...)
+          </md-radio-button>
         </md-radio-group>
         <kd-user-help>
           To learn more,
@@ -43,14 +46,18 @@ limitations under the License.
         <deploy-from-file ng-switch-when="File" class="md-body-1" name="ctrl.name" detail="ctrl.detail"
             form="ctrl.deployForm">
         </deploy-from-file>
+        <deploy-from-kpm ng-switch-when="KPM" class="md-body-1" name="ctrl.name"
+            namespaces="ctrl.namespaces" detail="ctrl.detail" form="ctrl.deployForm" protocols="ctrl.protocols">
+        </deploy-from-kpm>
       </div>
 
       <md-button class="md-raised md-primary kd-deploy-btn" type="submit"
-                 ng-disabled="ctrl.isDeployDisabled()">
+                 ng-disabled="ctrl.isDeployDisbaled()" ng-if="ctrl.selection != 'KPM'">
         Deploy
       </md-button>
-      <md-button class="md-raised" ng-click="ctrl.cancel()">Cancel</md-button>
-
+      <md-button class="md-raised" ng-click="ctrl.cancel()" ng-if="ctrl.selection != 'KPM'">
+        Cancel
+      </md-button>
     </form>
   </md-whiteframe>
 </div>

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -17,6 +17,7 @@ import errorHandlingModule from '../common/errorhandling/errorhandling_module';
 import deployFromSettingsDirective from './deployfromsettings_directive';
 import deployLabelDirective from './deploylabel_directive';
 import deployFromFileDirective from './deployfromfile_directive';
+import deployFromKpmDirective from './deployfromkpm_directive';
 import fileReaderDirective from './filereader_directive';
 import portMappingsDirective from './portmappings_directive';
 import environmentVariablesDirective from './environmentvariables_directive';
@@ -46,6 +47,7 @@ export default angular
     .config(stateConfig)
     .directive('deployFromSettings', deployFromSettingsDirective)
     .directive('deployFromFile', deployFromFileDirective)
+    .directive('deployFromKpm', deployFromKpmDirective)
     .directive('kdUniqueName', uniqueNameDirective)
     .directive('kdValidImagereference', validImageReferenceDirective)
     .directive('kdValidProtocol', validProtocolDirective)

--- a/src/app/frontend/deploy/deployfromkpm.html
+++ b/src/app/frontend/deploy/deployfromkpm.html
@@ -1,0 +1,120 @@
+<div class="kpm-query" ng-switch="ctrl.deployStatus">
+  <div ng-switch-when="none">
+    <kd-help-section>
+      <md-autocomplete
+        md-search-text="ctrl.packageName"
+        md-selected-item="ctrl.package"
+        md-items="item in ctrl.querySearch(ctrl.packageName)"
+        md-item-text="item.name"
+        md-floating-label="Package name">
+        <md-item-template>
+          <span md-highlight-text="ctrl.packageName" md-highlight-flags="^i">
+            {{item.name}}
+          </span>
+        </md-item-template>
+        <md-not-found>
+          No packages matching "{{ctrl.packageName}}" were found.
+        </md-not-found>
+      </md-autocomplete>
+      <kd-user-help>
+        Package to deploy.
+        <a href="http://github.com/kubespray/kpm" target="_blank" tabindex="-1">
+          learn more about KPM<i class="material-icons">open_in_new</i>
+        </a>
+      </kd-user-help>
+    </kd-help-section>
+
+    <kd-help-section ng-if="ctrl.package">
+      <md-input-container>
+        <label>Version</label>
+        <md-select ng-model="ctrl.package.version">
+          <md-option ng-repeat="version in ctrl.package.available_versions" value="{{version}}">
+            {{version}}
+          </md-option>
+        </md-select>
+      </md-input-container>
+      <kd-user-help>
+        Select the package version you want to deploy.
+      </kd-user-help>
+    </kd-help-section>
+
+    <kd-help-section>
+      <md-input-container class="md-block">
+        <label>Namespace</label>
+        <md-select ng-model="ctrl.namespace" ng-click="ctrl.resetImagePullSecret()" required>
+          <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
+            {{namespace}}
+          </md-option>
+          <md-option ng-click="ctrl.handleNamespaceDialog($event)">
+            Create a new namespace...
+          </md-option>
+        </md-select>
+      </md-input-container>
+      <kd-user-help>
+        Namespaces let you partition resources into logically named groups.
+        <a href="http://kubernetes.github.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
+          Learn more
+        </a>
+      </kd-user-help>
+    </kd-help-section>
+
+    <kd-help-section>
+      <md-input-container class="md-block">
+      <md-checkbox ng-model="ctrl.dryRun" class="md-primary"
+        ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
+        Dry run
+      </md-checkbox>
+      </md-input-container>
+      <kd-user-help>
+        Dry run, verify changes that would be perform without applying them.
+      </kd-user-help>
+    </kd-help-section>
+
+  </div>
+  <div ng-switch-when="ongoing" class="loader">
+    <md-progress-circular md-mode="indeterminate" md-diameter="96">
+    </md-progress-circular>
+  </div>
+  <table ng-switch-when="success" class="kpm-results">
+    <tr>
+      <th>Order</th>
+      <th>Kind</th>
+      <th>Name</th>
+      <th>Namespace</th>
+      <th>Package</th>
+      <th>Status</th>
+      <th>Version</th>
+    </tr>
+    <tr ng-repeat="resource in ctrl.resources">
+      <td>{{$index + 1}}</td>
+      <td>{{resource.kind}}</td>
+      <td>{{resource.name}}</td>
+      <td>{{resource.namespace}}</td>
+      <td>{{resource.package}}</td>
+      <td>
+        <span class="status {{resource.status}}">{{resource.status}}</span>
+      </td>
+      <td>{{resource.version}}</td>
+    </tr>
+  </table>
+  <div ng-switch-when="error">
+    Sorry, but something went wrong.
+  </div>
+</div>
+<div ng-if="ctrl.deployStatus != 'success'">
+  <md-button class="md-raised md-primary kd-deploy-btn" ng-click="ctrl.deploy()"
+    ng-disabled="ctrl.isdeploydisabled()">
+    Deploy
+  </md-button>
+  <md-button class="md-raised md-warn" ng-click="ctrl.remove()">
+    Remove
+  </md-button>
+  <md-button class="md-raised" ng-click="ctrl.cancel()">
+    Cancel
+  </md-button>
+</div>
+<div ng-if="ctrl.deployStatus == 'success'">
+  <md-button class="md-raised md-primary" ng-click="ctrl.back()">
+    Next
+  </md-button>
+</div>

--- a/src/app/frontend/deploy/deployfromkpm.scss
+++ b/src/app/frontend/deploy/deployfromkpm.scss
@@ -1,0 +1,38 @@
+div.kpm-query {
+  font-size: 1.2em;
+  div.loader {
+    display: flex;
+    justify-content: center;
+  }
+  md-input-container {
+    padding-bottom: 26px;
+  }
+  table.kpm-results {
+    width: 100%;
+    border-collapse: collpase;
+    margin-bottom: 1em;
+    th {
+      text-align: left;
+      padding: 4px;
+    }
+    td {
+      border-top: 1px solid #f0f0f0;
+      padding: 4px;
+    }
+    span.status {
+      display: inline-block;
+      color: white;
+      font-size: 0.9em;
+      font-weight: bold;
+      text-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+      border-radius: 2px;
+      padding: 0 8px;
+      &.ok        { background: #4CAF50; }
+      &.created   { background: #F0A000; }
+      &.updated   { background: #F0A000; }
+      &.absent    { background: #4CAF50; }
+      &.deleted   { background: #FF8A65; }
+      &.protected { background: #64B5F6; }
+    }
+  }
+}

--- a/src/app/frontend/deploy/deployfromkpm_controller.js
+++ b/src/app/frontend/deploy/deployfromkpm_controller.js
@@ -1,0 +1,174 @@
+import showNamespaceDialog from './createnamespace_dialog';
+
+/**
+ * Controller for the deploy from kpm directive.
+ *
+ * @final
+ */
+export default class DeployFromKpmController {
+  /**
+   * @param {!angular.$log} $log
+   * @param {!ui.router.$state} $state
+   * @param {!angular.$resource} $resource
+   * @param {!angular.$q} $q
+   * @param {!md.$dialog} $mdDialog
+   * @ngInject
+   */
+  constructor($log, $http, $state, $resource, $q, $mdDialog) {
+    // Dependencies
+
+
+    this._http = $http;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+
+    /** @private {!angular.$q} */
+    this.q_ = $q;
+
+    /** @private {!angular.$log} */
+    this.log_= $log
+
+    /** @private {!angular.$resource} */
+    this.resource_ = $resource;
+
+    /** @private {!md.$dialog} */
+    this.mdDialog_ = $mdDialog;
+
+    /** @export */
+    this.package = null;
+
+    /**
+     * List of available namespaces.
+     *
+     * Initialized from the scope.
+     * @export {!Array<string>}
+     */
+    this.namespaces;
+
+    /**
+     * Currently chosen namespace.
+     * @export {string}
+     */
+    this.namespace = this.namespaces[0];
+
+    /** @export {boolean} */
+    this.dryRun = false;
+
+    /** @export {string} */
+    this.deployStatus = 'none';
+
+    /** @export  */
+    this.resources = [];
+  }
+
+  /**
+   * Perform POST request on KPM backend
+   * @export
+   */
+  deploy() {
+    return this.performQuery('deploy');
+  }
+
+  /**
+   * Perform DELETE request on KPM backend
+   * @export
+   */
+  remove() {
+    return this.performQuery('delete');
+  }
+
+  /**
+   * Displays new namespace creation dialog.
+   *
+   * @param {!angular.Scope.Event} event
+   * @export
+   */
+  handleNamespaceDialog(event) {
+    showNamespaceDialog(this.mdDialog_, event, this.namespaces)
+    .then(
+      /**
+       * Handles namespace dialog result. If namespace was created successfully then it
+       * will be selected, otherwise first namespace will be selected.
+       *
+       * @param {string|undefined} answer
+       */
+      (answer) => {
+        if (answer) {
+          this.namespace = answer;
+          this.namespaces = this.namespaces.concat(answer);
+        }
+        else {
+          this.namespace = this.namespaces[0];
+        }
+      },
+      () => { this.namespace = this.namespaces[0]; });
+  }
+
+
+  /**
+   * Queries all secrets for the given namespace.
+   * @param {string} method
+   * @export
+   */
+  performQuery(method) {
+    var url = this.backend_url(method);
+    var self = this;
+    this.deployStatus = 'ongoing';
+    this._http({
+      method: 'POST',
+      url:  url,
+      params: {
+        dryRun: this.dryRun,
+        version: this.package.version
+      },
+      data: {}
+    })
+    .success(function(data) {
+      self.deployStatus = 'success';
+      self.resources = data.result;
+    })
+    .error(function(data) {
+      self.deployStatus = 'error';
+      self.resources = [];
+    });
+    return console.log("deploy " + this.package.name);
+  }
+
+  /**
+   * Queries all secrets for the given namespace.
+   * @param {string} method
+   * @return {string} url
+   * @export
+   */
+  backend_url(method) {
+    var url = "/api/v1/appdeploymentfromkpm/" + this.namespace +
+      "/" + this.package.name  + "/" + method;
+    return url;
+  }
+
+  /**
+   * Return to home
+   * @export
+   */
+  back() {
+    return this.state_.go('replicationcontrollers');
+  }
+
+  /**
+   * Search package names matching user input
+   * @return promise
+   * @export
+   */
+  querySearch(search) {
+    var deferred = this.q_.defer();
+    this._http({
+      method: 'GET',
+      url: 'https://api.kpm.sh/api/v1/packages.json?named_like=' + search
+    })
+    .success(function(data) {
+      deferred.resolve(data);
+    })
+    return deferred.promise;
+  }
+}

--- a/src/app/frontend/deploy/deployfromkpm_directive.js
+++ b/src/app/frontend/deploy/deployfromkpm_directive.js
@@ -1,0 +1,21 @@
+import DeployFromKpmController from './deployfromkpm_controller';
+
+/**
+ * Returns directive definition object for the deploy from kpm directive.
+ * @return {!angular.Directive}
+ */
+export default function deployFromKpmDirective() {
+  return {
+    scope: {},
+    bindToController: {
+      'name': '=',
+      'namespaces': '=',
+      'detail': '=',
+      'form': '=',
+      'protocols': '=',
+    },
+    controller: DeployFromKpmController,
+    controllerAs: 'ctrl',
+    templateUrl: 'deploy/deployfromkpm.html',
+  };
+}

--- a/src/deploy/kubernetes-dashboard-kpm.yaml
+++ b/src/deploy/kubernetes-dashboard-kpm.yaml
@@ -1,0 +1,78 @@
+---
+kind: List
+apiVersion: v1
+items:
+- kind: ReplicationController
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-kpm
+      version: kpm
+    name: kubernetes-dashboard-kpm
+  spec:
+    replicas: 1
+    selector:
+      app: kubernetes-dashboard-kpm
+      version: kpm
+    template:
+      metadata:
+        labels:
+          app: kubernetes-dashboard-kpm
+          version: kpm
+      spec:
+        containers:
+        - name: kubernetes-dashboard-kpm
+          image: quay.io/kubespray/kubernetes-dashboard:canary
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 9090
+            protocol: TCP
+            name: dashboard
+          args:
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          env:
+            - name: KPM_BACKEND_URL
+              value: http://localhost:5000
+
+          # The backend should/can run in an another RC/Pod
+        - name: kpm-backend
+          image: quay.io/kubespray/kpm-backend:canary
+          imagePullPolicy: Always
+          command:
+            - python
+            - kpmbackend/api/app.py
+          ports:
+            - name: kpm-backend
+              protocol: TCP
+              containerPort: 5000
+
+        - name: kubectl
+          image: quay.io/ant31/kubernetes-hyperkube:v1.2.0
+          imagePullPolicy: Always
+          command:
+            - /kubectl
+            - proxy
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-kpm
+    name: kubernetes-dashboard-kpm
+  spec:
+    type: NodePort
+    ports:
+    - port: 80
+      targetPort: 9090
+      name: dashboard
+    selector:
+      app: kubernetes-dashboard-kpm


### PR DESCRIPTION
Related to #556 
Not to be merged. 

it's an example of how kpm could be integrated to dashboard. 

There is an handler in the dashboard-backend to proxy calls to 'kpm-backend' that  performs the communication with the api-master to create/update resources.

kpm-backend has only 2 availables api endpoints:
- POST  /api/v1/deploy/packageName
- POST  /api/v1/delete/packageName

It returns a json with the 'deployment' results:

``` json
{
  "result": [
    {
      "kind": "namespace", 
      "name": "default", 
      "namespace": "default", 
      "package": "ant31/rocketchat", 
      "status": "ok", 
      "version": "1.6.0"
    }, 
    {
      "kind": "service", 
      "name": "rocketchat", 
      "namespace": "default", 
      "package": "ant31/rocketchat", 
      "status": "created", 
      "version": "1.6.0"
    }, 
    {
      "kind": "replicationcontroller", 
      "name": "rocketchat", 
      "namespace": "default", 
      "package": "ant31/rocketchat", 
      "status": "created", 
      "version": "1.6.0"
    }
  ]
}
```

The results is then returned to the dashboard front-end for display.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/562)

<!-- Reviewable:end -->
