### PR TITLE
Make single API call to get events and filter them on backend

### DIFF
--- a/src/test/backend/replicationcontrollerlist_test.go
+++ b/src/test/backend/replicationcontrollerlist_test.go
@@ -83,8 +83,8 @@ func TestGetMatchingServices(t *testing.T) {
 }
 
 func TestGetReplicationControllerList(t *testing.T) {
-	getPodsErrorFnMock := func(pods []api.Pod) ([]Event, error) {
-		return []Event{}, nil
+	getPodsErrorFnMock := func(pods []api.Pod) []Event {
+		return []Event{}
 	}
 
 	cases := []struct {


### PR DESCRIPTION
This is my proposal to solve issue #443 as discussed with @bryk here: https://github.com/floreks/dashboard/commit/f050cf3d45373b69733a26757dcfac384184f720

This change will improve performance of both replication controllers list page and replication controller detail page. Now instead of making N api calls to get pod events there is only 1 API call that gets all events in given namespace and then filters events based on given list of pods.

This should be extended to all places where N api calls are made based on some resource i.e. RCs.

This also fixes #402. When last pod on the list didn't have error, card state was shown as pending.

@maciaszczykm @bryk @cheld PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/587)
<!-- Reviewable:end -->
