### PR TITLE
Remove sauce access keys from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,7 @@ node_js:
 
 addons:
   # Run tests that require a browser on SauceLabs CI provider. Learn more at: https://saucelabs.com
-  sauce_connect:
-    username: k8s-dashboard-ci
-    access_key: "18b7e71b-60e9-4177-9a7f-e769977dbb39"
+  sauce_connect: true
 
 before_script:
   # Prepare environment for the Chrome browser. This is required for PRs from forks where

--- a/build/conf.js
+++ b/build/conf.js
@@ -143,8 +143,8 @@ export default {
     /**
      * Whether to use sauce labs for running tests that require a browser.
      */
-    useSauceLabs:
-        !!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY && !!process.env.TRAVIS,
+    useSauceLabs: !!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY &&
+        !!process.env.TRAVIS && process.env.TRAVIS_PULL_REQUEST === 'false',
   },
 
   /**


### PR DESCRIPTION
With that tests on sauce will not run on devs' forks, which will
hopefully make them less flaky.

I've added the key to travis config variable and made publicly
available.

Partially addresses: #494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/593)
<!-- Reviewable:end -->
