### PR TITLE
Improve validation framework

### DIFF
--- a/src/app/frontend/common/validators/validator.js
+++ b/src/app/frontend/common/validators/validator.js
@@ -16,7 +16,7 @@
 /*eslint no-unused-vars: 0*/
 
 /**
- * Abstract class representing Type that needs to be validated.
+ * Abstract class representing Validator.
  *
  * @class
  */

--- a/src/app/frontend/common/validators/validator_factory.js
+++ b/src/app/frontend/common/validators/validator_factory.js
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 import {IntegerValidator} from './integervalidator';
-import {LabelKeyNameLengthValidator} from 'deploy/validators/labelkeynamelengthvalidator';
-import {LabelKeyPrefixLengthValidator} from 'deploy/validators/labelkeyprefixlengthvalidator';
-import {LabelKeyNamePatternValidator} from 'deploy/validators/labelkeynamepatternvalidator';
-import {LabelKeyPrefixPatternValidator} from 'deploy/validators/labelkeyprefixpatternvalidator';
-import {LabelValuePatternValidator} from 'deploy/validators/labelvaluepatternvalidator';
 
 /**
+ * Validators factory allows to register component related validators on demand in place where
+ * they are used. Simply inject 'kdValidatorFactory' into controller and register validator
+ * using 'registerValidator' method.
+ *
+ * Validator object has to fulfill validator object contract which is to implement 'Validator'
+ * class and 'isValid(value)' method.
+ *
  * @final
  */
 export class ValidatorFactory {
@@ -27,23 +29,31 @@ export class ValidatorFactory {
    * @constructs ValidatorFactory
    */
   constructor() {
-    /** @private {Map<Array<string, !./validator.Validator>>} */
+    /** @private {Map<string, !./validator.Validator>} */
     this.validatorMap_ = new Map();
 
-    // Initialize map with supported types
-    this.validatorMap_.set('integer', new IntegerValidator());
-    this.validatorMap_.set('labelKeyNameLength', new LabelKeyNameLengthValidator());
-    this.validatorMap_.set('labelKeyPrefixLength', new LabelKeyPrefixLengthValidator());
-    this.validatorMap_.set('labelKeyNamePattern', new LabelKeyNamePatternValidator());
-    this.validatorMap_.set('labelKeyPrefixPattern', new LabelKeyPrefixPatternValidator());
-    this.validatorMap_.set('labelValuePattern', new LabelValuePatternValidator());
+    // Register common validators here
+    this.registerValidator('integer', new IntegerValidator());
+  }
+
+  /**
+   * Used to register validators on demand.
+   *
+   * @param {string} validatorName
+   * @param {!./validator.Validator} validatorObject
+   */
+  registerValidator(validatorName, validatorObject) {
+    if (this.validatorMap_.has(validatorName)) {
+      throw new Error(`Validator with name ${validatorName} is already registered.`);
+    }
+
+    this.validatorMap_.set(validatorName, validatorObject);
   }
 
   /**
    * Returns specific Type class based on given type name.
    *
-   * @method
-   * @param validatorName
+   * @param {string} validatorName
    * @returns {!./validator.Validator}
    */
   getValidator(validatorName) {

--- a/src/app/frontend/deploy/deploy_initconfig.js
+++ b/src/app/frontend/deploy/deploy_initconfig.js
@@ -1,0 +1,35 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {LabelKeyNameLengthValidator} from './validators/labelkeynamelengthvalidator';
+import {LabelKeyPrefixLengthValidator} from './validators/labelkeyprefixlengthvalidator';
+import {LabelKeyNamePatternValidator} from './validators/labelkeynamepatternvalidator';
+import {LabelKeyPrefixPatternValidator} from './validators/labelkeyprefixpatternvalidator';
+import {LabelValuePatternValidator} from './validators/labelvaluepatternvalidator';
+
+/**
+ * Configures deploy view related components.
+ *
+ * @param {!./../common/validators/validator_factory.ValidatorFactory} kdValidatorFactory
+ * @ngInject
+ */
+export default function initConfig(kdValidatorFactory) {
+  // Register label related validators
+  kdValidatorFactory.registerValidator('labelKeyNameLength', new LabelKeyNameLengthValidator());
+  kdValidatorFactory.registerValidator('labelKeyPrefixLength', new LabelKeyPrefixLengthValidator());
+  kdValidatorFactory.registerValidator('labelKeyNamePattern', new LabelKeyNamePatternValidator());
+  kdValidatorFactory.registerValidator(
+      'labelKeyPrefixPattern', new LabelKeyPrefixPatternValidator());
+  kdValidatorFactory.registerValidator('labelValuePattern', new LabelValuePatternValidator());
+}

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import stateConfig from './deploy_stateconfig';
+import initConfig from './deploy_initconfig';
 import errorHandlingModule from '../common/errorhandling/errorhandling_module';
 import deployFromSettingsDirective from './deployfromsettings_directive';
 import deployLabelDirective from './deploylabel_directive';
@@ -44,6 +45,7 @@ export default angular
           validatorsModule.name,
         ])
     .config(stateConfig)
+    .run(initConfig)
     .directive('deployFromSettings', deployFromSettingsDirective)
     .directive('deployFromFile', deployFromFileDirective)
     .directive('kdUniqueName', uniqueNameDirective)

--- a/src/test/frontend/common/validators/validator_factory_test.js
+++ b/src/test/frontend/common/validators/validator_factory_test.js
@@ -14,6 +14,8 @@
 
 import validatorsModule from 'common/validators/validators_module';
 import {IntegerValidator} from 'common/validators/integervalidator';
+import {LabelKeyNameLengthValidator} from 'deploy/validators/labelkeynamelengthvalidator';
+import {LabelKeyNamePatternValidator} from 'deploy/validators/labelkeynamepatternvalidator';
 
 describe('Validator factory', () => {
   /** @type {!ValidatorFactory} */
@@ -44,5 +46,30 @@ describe('Validator factory', () => {
     expect(() => {
       validatorFactory.getValidator(validatorName);
     }).toThrow(new Error(`Given validator '${validatorName}' is not supported.`));
+  });
+
+  it('should register validator', () => {
+    // given
+    let validator = new LabelKeyNameLengthValidator();
+
+    // when
+    validatorFactory.registerValidator('testValidator', validator);
+
+    // then
+    expect(validatorFactory.getValidator('testValidator')).toEqual(validator);
+  });
+
+  it('should throw an error when trying to override validator', () => {
+    // given
+    let nameValidator = new LabelKeyNameLengthValidator();
+    let patternValidator = new LabelKeyNamePatternValidator();
+
+    // when
+    validatorFactory.registerValidator('testValidator', nameValidator);
+
+    // then
+    expect(() => {
+      validatorFactory.registerValidator('testValidator', patternValidator);
+    }).toThrow(new Error(`Validator with name testValidator is already registered.`));
   });
 });

--- a/src/test/frontend/deploy/deploylabel_controller_test.js
+++ b/src/test/frontend/deploy/deploylabel_controller_test.js
@@ -14,21 +14,23 @@
 
 import DeployLabelController from 'deploy/deploylabel_controller';
 import DeployLabel from 'deploy/deploylabel';
+import deployModule from 'deploy/deploy_module';
 
 describe('DeployLabel controller', () => {
   let ctrl;
   let labelForm;
 
   beforeEach(() => {
-    ctrl = new DeployLabelController();
+    angular.mock.module(deployModule.name);
 
-    angular.mock.inject(($rootScope, $compile) => {
+    angular.mock.inject(($rootScope, $compile, $controller) => {
       let scope = $rootScope.$new();
       let template = angular.element(
           '<ng-form name="labelForm"><input name="key"' +
           ' ng-model="label"></ng-form>');
 
       $compile(template)(scope);
+      ctrl = $controller(DeployLabelController);
       labelForm = scope.labelForm;
     });
   });


### PR DESCRIPTION
Closes #537.

Introduced `registerValidator` method to allow using them on demand, closer to the place where they are used.

Should we register all validators in one place? Per page or per controller?

First would allow to check for overriding validators. Registering them in controller constructor does not allow that because it may be executed multiple times per page load.

Ideas? Concerns?

@bryk @maciaszczykm PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/603)
<!-- Reviewable:end -->
