### PR TITLE
Fix middle ellipsis filter not applied to replication controller name

### DIFF
--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -22,7 +22,7 @@ limitations under the License.
       <span>Replication controller</span>
     </span>
     <div layout="row">
-      <div flex="nogrow">
+      <div class="kd-replicationcontrollerinfo-name">
         <span class="kd-replicationcontrollerinfo-line">Name</span>
         <span class="kd-replicationcontrollerinfo-subline">
           <kd-middle-ellipsis display-string="{{::infoCtrl.details.name}}">

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.scss
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.scss
@@ -26,6 +26,11 @@
   padding-top: $baseline-grid;
 }
 
+.kd-replicationcontrollerinfo-name {
+  // To allow middle ellipsis formatting for long names container width has to be limited
+  max-width: 90%;
+}
+
 .kd-replicationcontrollerinfo-line {
   color: $foreground-2;
   display: block;


### PR DESCRIPTION
Related to #576 issue with long name formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/608)
<!-- Reviewable:end -->
