### PR TITLE
Framework for setting up action bar in views

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -14,19 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-content class="kd-content">
-  <md-toolbar class="kd-toolbar">
-    <div class="md-toolbar-tools kd-toolbar-tools">
-      <a ui-sref="replicationcontrollers" ui-sref-opts="{ reload: true }" tabindex="-1">
-        <md-icon md-svg-icon="assets/images/kubernetes-logo.svg" class="kd-toolbar-logo"></md-icon>
-      </a>
-      <h2>
-        <span>kubernetes</span>
-      </h2>
-      <div flex="auto" ui-view="toolbar"></div>
-    </div>
-  </md-toolbar>
-  <div class="kd-app-content-wrapper" ng-switch="ctrl.showLoadingSpinner" flex="auto" >
+<md-toolbar class="kd-toolbar">
+  <div class="md-toolbar-tools kd-toolbar-tools">
+    <a ui-sref="replicationcontrollers" ui-sref-opts="{ reload: true }" tabindex="-1">
+      <md-icon md-svg-icon="assets/images/kubernetes-logo.svg" class="kd-toolbar-logo"></md-icon>
+    </a>
+    <h2>
+      <span>kubernetes</span>
+    </h2>
+    <div flex="auto" ui-view="toolbar"></div>
+  </div>
+</md-toolbar>
+
+<md-toolbar ng-if="ctrl.isActionbarVisible()" ui-view="actionbar"
+    class="kd-toolbar kd-chrome-actionbar md-hue-1">
+</md-toolbar>
+
+<md-content
+    ng-class="{'kd-chrome-content': true, 'kd-chrome-has-actionbar': ctrl.isActionbarVisible()}">
+  <div ng-switch="ctrl.showLoadingSpinner" flex="auto" >
     <div ng-switch-when="true" class="kd-center-fixed">
       <md-progress-circular md-mode="indeterminate" md-diameter="96">
       </md-progress-circular>

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -24,7 +24,18 @@
   box-shadow: $whiteframe-shadow-1dp;
   height: $toolbar-height-size-base;
   position: fixed !important;
-  top: 0;
+}
+
+.kd-chrome-actionbar {
+  top: $toolbar-height-size-base;
+}
+
+.kd-chrome-content {
+  padding-top: $toolbar-height-size-base;
+}
+
+.kd-chrome-has-actionbar {
+  padding-top: 2 * $toolbar-height-size-base;
 }
 
 body {
@@ -45,11 +56,8 @@ a {
   margin: auto;
 }
 
-.kd-app-content-wrapper {
-  margin-top: $toolbar-height-size-base;
-}
-
 .kd-app-content {
+  background-color: $body;
   position: relative;
 }
 

--- a/src/app/frontend/chrome/chrome_controller.js
+++ b/src/app/frontend/chrome/chrome_controller.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {actionbarViewName} from './chrome_state';
+
 /**
  * Controller for the chrome directive.
  *
@@ -19,14 +21,27 @@
  */
 export default class ChromeController {
   /**
+   * @param {!ui.router.$state} $state
    * @ngInject
    */
-  constructor() {
+  constructor($state) {
     /**
      * By default this is true to show loading for the first page.
      * @export {boolean}
      */
     this.showLoadingSpinner = true;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  isActionbarVisible() {
+    return !!this.state_.current && !!this.state_.current.views &&
+        !!this.state_.current.views[actionbarViewName] && !this.showLoadingSpinner;
   }
 
   /**

--- a/src/app/frontend/chrome/chrome_state.js
+++ b/src/app/frontend/chrome/chrome_state.js
@@ -14,3 +14,9 @@
 
 /** Name of the view. Can be used in state config to define toolbar view */
 export const toolbarViewName = 'toolbar';
+
+/**
+ * Name of the action bar view. Action bar is the second toolbar in the application and can
+ * be used for, e.g., breadcrumbs or view-specific action buttons.
+ */
+export const actionbarViewName = 'actionbar';

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
@@ -27,14 +27,18 @@ import ZeroStateController from './zerostate/zerostate_controller';
  */
 export default function stateConfig($stateProvider) {
   $stateProvider.state(replicationcontrollers, {
-    controller: ReplicationControllerListController,
-    controllerAs: 'ctrl',
     url: replicationcontrollersUrl,
     resolve: {
       'replicationControllers': resolveReplicationControllers,
     },
-    templateUrl: 'replicationcontrollerlist/replicationcontrollerlist.html',
     onEnter: redirectIfNeeded,
+    views: {
+      '': {
+        controller: ReplicationControllerListController,
+        controllerAs: 'ctrl',
+        templateUrl: 'replicationcontrollerlist/replicationcontrollerlist.html',
+      },
+    },
   });
   $stateProvider.state(zerostate, {
     views: {

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer.scss
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlistcontainer.scss
@@ -1,15 +1,15 @@
-// Copyright 2015 Google Inc. All Rights Reserved.    
-//   
-// Licensed under the Apache License, Version 2.0 (the "License");   
-// you may not use this file except in compliance with the License.    
-// You may obtain a copy of the License at   
-//   
-//     http://www.apache.org/licenses/LICENSE-2.0    
-//   
-// Unless required by applicable law or agreed to in writing, software   
-// distributed under the License is distributed on an "AS IS" BASIS,   
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    
-// See the License for the specific language governing permissions and   
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 @import '../variables';
@@ -19,5 +19,4 @@
   align-items: center;
   display: flex;
   flex-flow: column wrap;
-  margin-top: $toolbar-height-size-base;
 }

--- a/src/test/frontend/chrome/chrome_controller_test.js
+++ b/src/test/frontend/chrome/chrome_controller_test.js
@@ -14,18 +14,22 @@
 
 import ChromeController from 'chrome/chrome_controller';
 import chromeModule from 'chrome/chrome_module';
+import {actionbarViewName} from 'chrome/chrome_state';
 
 describe('Chrome controller', () => {
   /** @type {ChromeController} */
   let ctrl;
   /** @type {!angular.Scope} */
   let scope;
+  /** @type {!ui.router.$state} */
+  let state;
 
   beforeEach(() => {
     angular.mock.module(chromeModule.name);
-    angular.mock.inject(($controller, $rootScope) => {
+    angular.mock.inject(($controller, $rootScope, $state) => {
       ctrl = $controller(ChromeController);
       scope = $rootScope;
+      state = $state;
     });
   });
 
@@ -61,5 +65,34 @@ describe('Chrome controller', () => {
 
     // then
     expect(ctrl.showLoadingSpinner).toBe(false);
+  });
+
+  it('should show and hide toolbar based on view state', () => {
+    // Initially no action bar;
+    expect(ctrl.isActionbarVisible()).toBe(false);
+
+    // Even when loaded.
+    ctrl.showLoadingSpinner = false;
+    expect(ctrl.isActionbarVisible()).toBe(false);
+
+    // No view loaded.
+    state.current = null;
+    expect(ctrl.isActionbarVisible()).toBe(false);
+
+    // Dummy view loaded.
+    state.current = {};
+    expect(ctrl.isActionbarVisible()).toBe(false);
+
+    // Simple view loaded.
+    state.current.views = {};
+    expect(ctrl.isActionbarVisible()).toBe(false);
+
+    // View with action bar loaded.
+    state.current.views[actionbarViewName] = {};
+    expect(ctrl.isActionbarVisible()).toBe(true);
+
+    // Transitioning to another view.
+    ctrl.showLoadingSpinner = true;
+    expect(ctrl.isActionbarVisible()).toBe(false);
   });
 });


### PR DESCRIPTION
This is initial framework with dummy example of an action bar. It'll be
extended further later. But it works now.

Having actionbar in a view of a state forces separation of concerns.
I.e., devs will not put action bar and a list of resources in one
place.

Example: 

![selection_058](https://cloud.githubusercontent.com/assets/1159999/14249480/39b37398-fa7a-11e5-92fb-e0a90111adfc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/611)
<!-- Reviewable:end -->
