### PR TITLE
Add validation for port mapping on deploy page

### DIFF
--- a/src/app/frontend/deploy/deploylabel_controller.js
+++ b/src/app/frontend/deploy/deploylabel_controller.js
@@ -33,7 +33,6 @@ export default class DeployLabelController {
   /**
    * Calls checks on label:
    *  - adds label if last empty label has been filled
-   *  - removes label if some label in the middle has key and value empty
    *  - checks for duplicated key and sets validity of element
    * @param {!angular.FormController|undefined} labelForm
    * @export
@@ -96,7 +95,7 @@ export default class DeployLabelController {
   validateKey_(labelForm) {
     if (angular.isDefined(labelForm)) {
       /** @type {!angular.NgModelController} */
-      let elem = labelForm.key;
+      let elem = labelForm['key'];
 
       /** @type {boolean} */
       let isUnique = !this.isKeyDuplicated_();

--- a/src/app/frontend/deploy/portmappings.html
+++ b/src/app/frontend/deploy/portmappings.html
@@ -16,25 +16,28 @@ limitations under the License.
 
 <div ng-repeat="portMapping in ctrl.portMappings">
   <ng-form name="portMappingForm" layout="row">
-    <md-input-container flex="auto" class="kd-deploy-input-row">
+    <md-input-container flex="50" class="kd-deploy-input-row">
       <label>Port</label>
-      <input ng-model="portMapping.port" ng-change="ctrl.addProtocolIfNeeed()"
+      <input ng-model="portMapping.port" ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
              type="number" min="1" max="65535" name="port">
       <ng-messages for="portMappingForm.port.$error" role="alert" multiple>
         <ng-message when="number">Port must be an integer.</ng-message>
         <ng-message when="min">Port must greater than 0.</ng-message>
         <ng-message when="max">Port must less than 65536.</ng-message>
+        <ng-message when="empty">Port can't be empty when target port is specified.</ng-message>
       </ng-messages>
     </md-input-container>
     <div flex="5"></div>
-    <md-input-container flex="auto" class="kd-deploy-input-row">
+    <md-input-container flex="50" class="kd-deploy-input-row">
       <label>Target port</label>
-      <input ng-model="portMapping.targetPort" ng-change="ctrl.addProtocolIfNeeed()"
+      <input ng-model="portMapping.targetPort"
+             ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
              type="number" min="1" max="65535" name="targetPort">
       <ng-messages for="portMappingForm.targetPort.$error" role="alert" multiple>
         <ng-message when="number">Target port must be an integer.</ng-message>
         <ng-message when="min">Target port must greater than 0.</ng-message>
         <ng-message when="max">Target port must less than 65536.</ng-message>
+        <ng-message when="empty">Target port can't be empty when port is specified.</ng-message>
       </ng-messages>
     </md-input-container>
     <div flex="5"></div>

--- a/src/app/frontend/deploy/portmappings_controller.js
+++ b/src/app/frontend/deploy/portmappings_controller.js
@@ -40,6 +40,19 @@ export default class PortMappingsController {
   }
 
   /**
+   * Call checks on port mapping:
+   *  - adds new port mapping when last empty port mapping has been filled
+   *  - validates port mapping
+   * @param {!angular.FormController|undefined} portMappingForm
+   * @param {number} portMappingIndex
+   * @export
+   */
+  checkPortMapping(portMappingForm, portMappingIndex) {
+    this.addProtocolIfNeeed_();
+    this.validatePortMapping_(portMappingForm, portMappingIndex);
+  }
+
+  /**
    * @param {string} defaultProtocol
    * @return {!backendApi.PortMapping}
    * @private
@@ -51,10 +64,37 @@ export default class PortMappingsController {
   /**
    * @export
    */
-  addProtocolIfNeeed() {
+  addProtocolIfNeeed_() {
     let lastPortMapping = this.portMappings[this.portMappings.length - 1];
     if (this.isPortMappingFilled_(lastPortMapping)) {
       this.portMappings.push(this.newEmptyPortMapping_(this.protocols[0]));
+    }
+  }
+
+  /**
+   * Validates port mapping. In case when only one port is specified it is considered as invalid.
+   * @param {!angular.FormController|undefined} portMappingForm
+   * @param {number} portIndex
+   * @private
+   */
+  validatePortMapping_(portMappingForm, portIndex) {
+    if (angular.isDefined(portMappingForm)) {
+      /** @type {!backendApi.PortMapping} */
+      let portMapping = this.portMappings[portIndex];
+
+      /** @type {!angular.NgModelController} */
+      let portElem = portMappingForm['port'];
+      /** @type {!angular.NgModelController} */
+      let targetPortElem = portMappingForm['targetPort'];
+
+      /** @type {boolean} */
+      let isValidPort = this.isPortMappingFilledOrEmpty_(portMapping) || !!portMapping.port;
+      /** @type {boolean} */
+      let isValidTargetPort =
+          this.isPortMappingFilledOrEmpty_(portMapping) || !!portMapping.targetPort;
+
+      portElem.$setValidity('empty', isValidPort);
+      targetPortElem.$setValidity('empty', isValidTargetPort);
     }
   }
 
@@ -78,4 +118,12 @@ export default class PortMappingsController {
    * @private
    */
   isPortMappingFilled_(portMapping) { return !!portMapping.port && !!portMapping.targetPort; }
+
+  /**
+   * Returns true when the given port mapping is filled or empty (both ports), false otherwise.
+   * @param {!backendApi.PortMapping} portMapping
+   * @return {boolean}
+   * @private
+   */
+  isPortMappingFilledOrEmpty_(portMapping) { return !portMapping.port === !portMapping.targetPort; }
 }


### PR DESCRIPTION
Closes #590 

Added validation to prevent users from providing only 1 mapping as they may expect different outcome (creation of internal endpoint). 

![zrzut ekranu z 2016-04-04 16-25-20](https://cloud.githubusercontent.com/assets/2285385/14251117/bcf43a24-fa81-11e5-89fe-2de8ffff6cbd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/612)
<!-- Reviewable:end -->
