### PR TITLE
All time strings in UI in 24 hour UTC format with a suffix string: 'UTC'

### DIFF
--- a/src/app/frontend/logs/logstoolbar/logstoolbar.html
+++ b/src/app/frontend/logs/logstoolbar/logstoolbar.html
@@ -36,7 +36,7 @@ limitations under the License.
 
   <span class="kd-logs-toolbar-text" flex="auto">
     <span ng-if="ctrl.podCreationTime">
-      Running since {{ctrl.podCreationTime | date:'short'}}
+      Running since {{ctrl.podCreationTime | date:'d/M/yy HH:mm':'UTC'}} UTC
     </span>
     <span ng-if="!ctrl.podCreationTime">
       Not running

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -129,7 +129,7 @@ limitations under the License.
               <td kd-responsive-header="Age" class="kd-replicationcontrollerdetail-table-cell">
                 <span ng-if="::pod.startTime">
                   {{::pod.startTime | relativeTime}}
-                  <md-tooltip>Started at {{::(pod.startTime | date:'short')}}</md-tooltip>
+                  <md-tooltip>Started at {{::(pod.startTime | date:'d/M/yy HH:mm':'UTC')}} UTC</md-tooltip>
                 </span>
                 <span ng-if="::!pod.startTime">
                   -
@@ -271,10 +271,10 @@ limitations under the License.
               {{event.count}}
             </td>
             <td kd-responsive-header="First seen" class="kd-replicationcontrollerdetail-table-cell">
-              First seen at {{event.firstSeen | date:'short'}}
+              First seen at {{event.firstSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
             </td>
             <td kd-responsive-header="Last seen" class="kd-replicationcontrollerdetail-table-cell">
-              Last seen at {{event.lastSeen | date:'short'}}
+              Last seen at {{event.lastSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
             </td>
           </tr>
           </tbody>

--- a/src/app/frontend/replicationcontrollerlist/logsmenu.html
+++ b/src/app/frontend/replicationcontrollerlist/logsmenu.html
@@ -38,7 +38,7 @@ limitations under the License.
             ng-if="::ctrl.podContainerExists(pod)"
             target="_blank">
           <span ng-if="::pod.startTime">
-            {{::(pod.startTime | date:"short")}}
+            {{::(pod.startTime | date:'d/M/yy HH:mm':'UTC')}} UTC
           </span>
           <span ng-if="::!pod.startTime">
             Not running

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
@@ -90,7 +90,7 @@ limitations under the License.
           <span flex="nogrow">
             {{::ctrl.replicationController.creationTime | relativeTime}}
             <md-tooltip>
-              Created at {{::ctrl.replicationController.creationTime | date:'short'}}
+              Created at {{::ctrl.replicationController.creationTime | date:'d/M/yy HH:mm':'UTC'}} UTC
             </md-tooltip>
           </span>
         </div>


### PR DESCRIPTION
#561 
times throughout the UI are shown in 24hour format
times throughout the UI are shown in UTC 
times throughout the UI are followed buy suffix 'UTC'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/617)
<!-- Reviewable:end -->
