### PR TITLE
'Expose service externally' checkbox clickable area fix

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -114,10 +114,14 @@ limitations under the License.
 </kd-help-section>
 
 <kd-help-section>
-  <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
-               ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
-    Expose service externally
-  </md-checkbox>
+  <div class="md-block">
+    <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
+                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
+      Expose service externally
+    </md-checkbox>
+  </div>
+  <kd-user-help>
+  </kd-user-help>
 </kd-help-section>
 
 <!-- advanced options -->


### PR DESCRIPTION
Expose service externally checkbox: restrict clickable area to label and checkbox #636 

- div added to contain checkbox to enforce desired behaviour, 

- empty kd-user-help section added to make formatting consistent with rest of page ('no padding' which otherwise would require a new css class)