### PR TITLE
deploy links fix

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -45,7 +45,7 @@ limitations under the License.
   <kd-user-help>
     An 'app' label with this value will be added to the Replication Controller and Service that get
     deployed.
-    <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+    <a href="http://kubernetes.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
       Learn more <i class="material-icons">open_in_new</i>
     </a>
   </kd-user-help>
@@ -67,7 +67,7 @@ limitations under the License.
   <kd-user-help>
     Enter the URL of a public image on any registry, or a private image hosted on Docker Hub or
     Google Container Registry.
-    <a href="http://kubernetes.github.io/docs/user-guide/images/" target="_blank" tabindex="-1">
+    <a href="http://kubernetes.io/docs/user-guide/images/" target="_blank" tabindex="-1">
       Learn more <i class="material-icons">open_in_new</i>
     </a>
   </kd-user-help>
@@ -90,7 +90,7 @@ limitations under the License.
   <kd-user-help>
     A Replication Controller will be created to maintain the desired number of pods across your
     cluster.
-    <a href="http://kubernetes.github.io/docs/user-guide/replication-controller/" target="_blank"
+    <a href="http://kubernetes.io/docs/user-guide/replication-controller/" target="_blank"
        tabindex="-1">
       Learn more <i class="material-icons">open_in_new</i>
     </a>
@@ -107,7 +107,7 @@ limitations under the License.
     <span ng-if="ctrl.name">
       The internal DNS name for this Service will be: <span class="kd-emphasized">{{ctrl.name}}</span>.
     </span>
-    <a href="http://kubernetes.github.io/docs/user-guide/services/" target="_blank" tabindex="-1">
+    <a href="http://kubernetes.io/docs/user-guide/services/" target="_blank" tabindex="-1">
       Learn more <i class="material-icons">open_in_new</i>
     </a>
   </kd-user-help>
@@ -154,7 +154,7 @@ limitations under the License.
     <kd-user-help>
       The specified labels will be applied to the created Replication Controller, Service (if any)
       and Pods. Common labels include release, environment, tier, partition and track.
-      <a href="http://kubernetes.github.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -174,7 +174,7 @@ limitations under the License.
     </md-input-container>
     <kd-user-help>
       Namespaces let you partition resources into logically named groups.
-      <a href="http://kubernetes.github.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -195,7 +195,7 @@ limitations under the License.
     <kd-user-help>
       The specified image could require a pull secret credential if it is private. You may choose an
       existing secret or create a new one.
-      <a href="http://kubernetes.github.io/docs/user-guide/secrets/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/user-guide/secrets/" target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -223,7 +223,7 @@ limitations under the License.
     </div>
     <kd-user-help>
       You can specify minimum CPU and memory requirements for the container.
-      <a href="http://kubernetes.io/v1.1/docs/admin/limitrange/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/admin/limitrange/" target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -244,7 +244,7 @@ limitations under the License.
     <kd-user-help>
       By default, your containers run the selected image's default entrypoint command. You can
       use the command options to override the default.
-      <a href="http://kubernetes.github.io/docs/user-guide/containers/" target="_blank"
+      <a href="http://kubernetes.io/docs/user-guide/containers/" target="_blank"
          tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
@@ -259,7 +259,7 @@ limitations under the License.
     </div>
     <kd-user-help>
       Processes in privileged containers are equivalent to processes running as root on the host.
-      <a href="http://kubernetes.github.io/docs/user-guide/pods/#privileged-mode-for-pod-containers"
+      <a href="http://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers"
          target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
@@ -272,8 +272,8 @@ limitations under the License.
     <kd-user-help>
       Environment variables available for use in the container. Values can reference other variables
       using $(VAR_NAME) syntax.
-      <a href="http://kubernetes.github.io/docs/docs/design/expansion/" target="_blank"
-         tabindex="-1">
+      <a href="http://kubernetes.io/docs/user-guide/configuring-containers/#environment-variables-and-variable-expansion"
+         target="_blank" tabindex="-1">
         Learn more <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>


### PR DESCRIPTION
fixed links on deploy page user-help sections #637

402 links fixed
`kubernetes.github.io` changed to `kubernetes.io`