### PR TITLE
validate "expose service externally"

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -116,7 +116,8 @@ limitations under the License.
 <kd-help-section>
   <div class="md-block">
     <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
-                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
+                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }"
+                 ng-disabled="!ctrl.isExposeEnabled()">
       Expose service externally
     </md-checkbox>
   </div>

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -368,4 +368,15 @@ export default class DeployFromSettingsController {
    * @export
    */
   switchMoreOptions() { this.detail.showMoreOptions_ = !this.detail.showMoreOptions_; }
+
+  /**
+   * Returns true if at leat one port mapping has been defined and is completly filled.
+   * @return {boolean}
+   * @export
+   */
+  isExposeEnabled() {
+    return (
+        this.portMappings != undefined &&
+        this.portMappings.filter(this.isPortMappingFilled_).length > 0);
+  }
 }


### PR DESCRIPTION
I disable the expose service externally option if no port mapping is defined
![expose-service](https://cloud.githubusercontent.com/assets/7448799/14532577/cda80228-0261-11e6-853f-44153c8d8dcd.png)
