### PR TITLE
Refactor action bar and add breadcrumbs framework

### DIFF
--- a/src/app/frontend/_variables.scss
+++ b/src/app/frontend/_variables.scss
@@ -26,6 +26,7 @@ $subhead-font-size-base:   rem(1.6) !default;
 $body-font-size-base:      rem(1.4) !default;
 $caption-font-size-base:   rem(1.2) !default;
 $toolbar-height-size-base: rem(6.4) !default;
+$toolbar-height-size-base-sm: rem(4.8) !default;
 
 $primary: #326de6;
 $secondary: #f51200;

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -26,9 +26,7 @@ limitations under the License.
   </div>
 </md-toolbar>
 
-<md-toolbar ng-if="ctrl.isActionbarVisible()" ui-view="actionbar"
-    class="kd-toolbar kd-chrome-actionbar md-hue-1">
-</md-toolbar>
+<kd-actionbar ng-if="ctrl.isActionbarVisible()"></kd-actionbar>
 
 <md-content
     ng-class="{'kd-chrome-content': true, 'kd-chrome-has-actionbar': ctrl.isActionbarVisible()}">

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -26,16 +26,16 @@
   position: fixed !important;
 }
 
-.kd-chrome-actionbar {
-  top: $toolbar-height-size-base;
-}
-
 .kd-chrome-content {
   padding-top: $toolbar-height-size-base;
 }
 
 .kd-chrome-has-actionbar {
   padding-top: 2 * $toolbar-height-size-base;
+
+  @media only screen and (max-width: $layout-breakpoint-sm) {
+    padding-top: $toolbar-height-size-base + $toolbar-height-size-base-sm;
+  }
 }
 
 body {

--- a/src/app/frontend/chrome/chrome_module.js
+++ b/src/app/frontend/chrome/chrome_module.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import chromeDirective from './chrome_directive';
+import componentsModule from 'common/components/components_module';
 
 /**
  * Angular module containing navigation chrome for the application.
@@ -23,5 +24,6 @@ export default angular
         [
           'ngMaterial',
           'ui.router',
+          componentsModule.name,
         ])
     .directive('chrome', chromeDirective);

--- a/src/app/frontend/common/components/actionbar/actionbar.html
+++ b/src/app/frontend/common/components/actionbar/actionbar.html
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-replication-controller-list-container-deprecated>
-  <kd-replication-controller-card-deprecated ng-repeat="replicationController in ::ctrl.replicationControllers"
-                                  replication-controller="::replicationController">
-  </kd-replication-controller-card-deprecated>
-</kd-replication-controller-list-container-deprecated>
+<md-toolbar class="kd-toolbar kd-actionbar">
+  <div class="md-toolbar-tools" layout="row">
+    <kd-breadcrumbs class="kd-actionbar-breadcrumbs" limit="2" flex></kd-breadcrumbs>
+    <span flex></span>
+    <ng-transclude ui-view="actionbar"></ng-transclude>
+  </div>
+</md-toolbar>

--- a/src/app/frontend/common/components/actionbar/actionbar.scss
+++ b/src/app/frontend/common/components/actionbar/actionbar.scss
@@ -12,25 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Controller for the replication controller info directive.
- * @final
- */
-export default class ReplicationControllerInfoController {
-  /**
-   * Constructs replication controller info object.
-   */
-  constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
-  }
+@import '../../../variables';
 
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
+md-toolbar {
+  &.kd-toolbar {
+    &.kd-actionbar {
+      background: $content-background;
+      color: $muted;
+      height: $toolbar-height-size-base;
+      top: $toolbar-height-size-base;
+
+      @media only screen and (min-width: 0) and (max-width: $layout-breakpoint-sm) {
+        height: $toolbar-height-size-base-sm;
+      }
+    }
+  }
+}
+
+.kd-actionbar-breadcrumbs {
+  flex-grow: 2;
+  white-space: nowrap;
 }

--- a/src/app/frontend/common/components/actionbar/actionbar_component.js
+++ b/src/app/frontend/common/components/actionbar/actionbar_component.js
@@ -13,24 +13,11 @@
 // limitations under the License.
 
 /**
- * Controller for the replication controller info directive.
- * @final
+ * Returns actionbar component.
+ *
+ * @return {!angular.Directive}
  */
-export default class ReplicationControllerInfoController {
-  /**
-   * Constructs replication controller info object.
-   */
-  constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
-  }
-
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
-}
+export const actionbarComponent = {
+  templateUrl: 'common/components/actionbar/actionbar.html',
+  transclude: true,
+};

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumb.js
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumb.js
@@ -13,24 +13,17 @@
 // limitations under the License.
 
 /**
- * Controller for the replication controller info directive.
  * @final
  */
-export default class ReplicationControllerInfoController {
+export default class Breadcrumb {
   /**
-   * Constructs replication controller info object.
+   * Constructs breadcrumb object.
    */
   constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
-  }
+    /** @export {string} - Label used instead of original state name */
+    this.label;
 
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
+    /** @export {string} - Link used to go to the given state */
+    this.stateLink;
+  }
 }

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
@@ -14,8 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-replication-controller-list-container-deprecated>
-  <kd-replication-controller-card-deprecated ng-repeat="replicationController in ::ctrl.replicationControllers"
-                                  replication-controller="::replicationController">
-  </kd-replication-controller-card-deprecated>
-</kd-replication-controller-list-container-deprecated>
+<span ng-switch="$last" ng-repeat="breadcrumb in ::ctrl.breadcrumbs">
+  <a ng-switch-when="false" href="{{::breadcrumb.stateLink}}">
+    {{::breadcrumb.label}}
+  </a>
+  <span ng-switch-when="true" class="kd-breadcrumbs-ellipsised">
+    <kd-middle-ellipsis display-string="{{::breadcrumb.label}}"></kd-middle-ellipsis>
+  </span>
+  <span ng-switch-when="false">></span>
+</span>

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs.scss
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs.scss
@@ -12,25 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Controller for the replication controller info directive.
- * @final
- */
-export default class ReplicationControllerInfoController {
-  /**
-   * Constructs replication controller info object.
-   */
-  constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
-  }
-
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
+.kd-breadcrumbs-ellipsised {
+  display: inline-block;
+  width: 100%;
 }

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
@@ -1,0 +1,213 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Breadcrumb from './breadcrumb';
+
+/**
+ * @final
+ */
+export default class BreadcrumbsController {
+  /**
+   * Constructs breadcrumbs controller.
+   *
+   * @param {!ui.router.$state} $state
+   * @param {!angular.$interpolate} $interpolate
+   * @ngInject
+   */
+  constructor($state, $interpolate) {
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+
+    /** @private {!angular.$interpolate} */
+    this.interpolate_ = $interpolate;
+
+    /** @export {number} - Initialized from template */
+    this.limit;
+
+    /** @export {!Array<!Breadcrumb>} - Initialized in $onInit method. Used in template */
+    this.breadcrumbs;
+  }
+
+  /**
+   * @export
+   */
+  $onInit() { this.breadcrumbs = this.initBreadcrumbs_(); }
+
+  /**
+   * Initializes breadcrumbs array by traversing states parents until none is found.
+   *
+   * @return {!Array<!Breadcrumb>}
+   * @private
+   */
+  initBreadcrumbs_() {
+    /** @type {!ui.router.$state} */
+    let state = this.state_['$current'];
+    /** @type {!Array<!Breadcrumb>} */
+    let breadcrumbs = [];
+
+    while (state && state['name'] && this.canAddBreadcrumb_(breadcrumbs)) {
+      /** @type {!Breadcrumb} */
+      let breadcrumb = this.getBreadcrumb_(state);
+
+      if (breadcrumb.label) {
+        breadcrumbs.push(breadcrumb);
+      }
+
+      state = this.getParentState_(state);
+    }
+
+    return breadcrumbs.reverse();
+  }
+
+  /**
+   * Returns true if limit is undefined or limit is defined and breadcrumbs count is smaller or
+   * equal to the limit.
+   *
+   * @param {!Array<!Breadcrumb>} breadcrumbs
+   * @return {boolean}
+   * @private
+   */
+  canAddBreadcrumb_(breadcrumbs) {
+    return this.limit === undefined || this.limit > breadcrumbs.length;
+  }
+
+  /**
+   * Returns breadcrumb config object if it is defined on state, undefined otherwise.
+   *
+   * @param {!ui.router.$state} state
+   * @return {Object}
+   * @private
+   */
+  getBreadcrumbConfig_(state) {
+    let conf = state['data'];
+
+    if (conf) {
+      conf = conf['kdBreadcrumbs'];
+    }
+
+    return conf;
+  }
+
+  /**
+   * Returns parent state of the given state based on defined state parent name or if it is not
+   * defined then based on direct parent state.
+   *
+   * @param {!ui.router.$state} state
+   * @return {!ui.router.$state}
+   * @private
+   */
+  getParentState_(state) {
+    let conf = this.getBreadcrumbConfig_(state);
+    let result = state['parent'];
+
+    if (conf && conf.parent) {
+      result = this.state_.get(conf.parent);
+    }
+
+    return result;
+  }
+
+  /**
+   * Creates breadcrumb object based on state object.
+   *
+   * @param {!ui.router.$state} state
+   * @return {!Breadcrumb}
+   * @private
+   */
+  getBreadcrumb_(state) {
+    let breadcrumb = new Breadcrumb();
+
+    breadcrumb.label = this.getDisplayName_(state);
+    breadcrumb.stateLink = this.state_.href(state['name']);
+
+    return breadcrumb;
+  }
+
+  /**
+   * Returns display name for given state.
+   *
+   * If label for the state is defined it is interpolated against given state default view scope.
+   * If interpolation fails then given label string is returned.
+   * If label string is empty then state name is returned.
+   *
+   * @param {!ui.router.$state} state
+   * @returns {string}
+   * @private
+   */
+  getDisplayName_(state) {
+    let conf = this.getBreadcrumbConfig_(state);
+    let areLocalsDefined = !!state['locals'];
+    let interpolationContext = state;
+
+    // When conf is undefined and label is undefined or empty then fallback to state name
+    if (!conf || !conf.label) {
+      return state['name'];
+    }
+
+    if (areLocalsDefined) {
+      // Set context to default view scope
+      interpolationContext = state['locals']['@'];
+    }
+
+    return this.interpolate_(conf.label)(interpolationContext).toString();
+  }
+}
+
+/**
+ * Returns breadcrumbs component. Should be used only withing actionbar component.
+ *
+ * In order to define custom label for the state add: `'kdBreadcrumbs':{'label':'myLabel'}`
+ * to the state config. This label will be used instead of default state name when displaying
+ * breadcrumbs.
+ *
+ * In order to define custom parent for the state add: `'kdBreadcrumbs`:{'parent':'myParentState'}`
+ * to the state config. Parent state will be looked up by this name if it's defined.
+ *
+ * Additionally labels can be interpolated. This applies only to the last state in the
+ * breadcrumb chain, i.e. for given state chain `StateA > StateB > StateC`, only StateC can use
+ * following convention: `'kdBreadcrumbs`:{'label':'{{$stateParams.paramX}}'}`
+ *
+ * Example state config:
+ * $stateProvider.state(stateName, {
+ *   url: '...',
+ *   data: {
+ *      'kdBreadcrumbs': {
+ *        'label': '{{$stateParams.paramX}}',
+ *        'parent': 'parentState',
+ *      },
+ *   },
+ *   views: {
+ *     '': {
+ *       controller: SomeCtrlA,
+ *       controllerAs: 'ctrl',
+ *       templateUrl: '...',
+ *     },
+ *     'actionbar': {
+ *       controller: SomeCtrlB,
+ *       controllerAs: 'ctrl',
+ *       templateUrl: '...',
+ *     },
+ *   },
+ * });
+ *
+ * @return {!angular.Component}
+ */
+export const breadcrumbsComponent = {
+  binding: {
+    'limit': '<',
+  },
+  controller: BreadcrumbsController,
+  controllerAs: 'ctrl',
+  templateUrl: 'common/components/breadcrumbs/breadcrumbs.html',
+};

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {actionbarComponent} from './actionbar/actionbar_component';
+import {breadcrumbsComponent} from './breadcrumbs/breadcrumbs_component';
 import filtersModule from '../filters/filters_module';
 import labelsDirective from './labels/labels_directive';
 import middleEllipsisDirective from './middleellipsis/middleellipsis_directive';
+import resourceCardModule from './resourcecard/resourcecard_module';
 import sparklineDirective from './sparkline/sparkline_directive';
 import warnThresholdDirective from './warnthreshold/warnthreshold_directive';
-import resourceCardModule from './resourcecard/resourcecard_module';
 
 /**
  * Module containing common components for the application.
@@ -27,10 +29,13 @@ export default angular
         'kubernetesDashboard.common.components',
         [
           'ngMaterial',
+          'ui.router',
           filtersModule.name,
           resourceCardModule.name,
         ])
     .directive('kdLabels', labelsDirective)
     .directive('kdMiddleEllipsis', middleEllipsisDirective)
     .directive('kdSparkline', sparklineDirective)
-    .directive('kdWarnThreshold', warnThresholdDirective);
+    .directive('kdWarnThreshold', warnThresholdDirective)
+    .component('kdActionbar', actionbarComponent)
+    .component('kdBreadcrumbs', breadcrumbsComponent);

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -14,47 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-content layout="row" layout-fill flex="auto" >
-  <div class="kd-replicationcontrollerdetail-sidebar" layout="column" flex="noshrink"
-       ng-show="ctrl.isSidebarVisible()">
-    <div class="kd-replicationcontrollerdetail-sidebar-header-wrapper kd-replicationcontrollerdetail-sidebar-item"
-        flex="nogrow">
-      <div class="kd-replicationcontrollerdetail-sidebar-header" layout-align="start center"
-           layout="row">
-        <div flex="none">
-          <md-button class="md-icon-button" ui-sref="replicationcontrollersdeprecated">
-            <md-icon md-font-library="material-icons">arrow_back</md-icon>
-          </md-button>
-        </div>
-        <div flex="auto" class="kd-replicationcontrollerdetail-no-overflow">
-          <h1 class="md-title kd-replicationcontrollerdetail-app-name">
-            <kd-middle-ellipsis display-string="{{::ctrl.replicationControllerDetail.name}}">
-            </kd-middle-ellipsis>
-          </h1>
-        </div>
-      </div>
-    </div>
-    <kd-replication-controller-info details="::ctrl.replicationControllerDetail">
-    </kd-replication-controller-info>
-  </div>
-  <div flex="auto" class="kd-replicationcontrollerdetail-no-overflow">
-    <div class="kd-replicationcontrollerdetail-sidebar-header-wrapper kd-replicationcontrollerdetail-sidebar-item"
-         flex="nogrow" ng-show="!ctrl.isSidebarVisible()">
-      <div class="kd-replicationcontrollerdetail-sidebar-header" layout-align="start center"
-           layout="row">
-        <div flex="none">
-          <md-button class="md-icon-button" ui-sref="replicationcontrollersdeprecated">
-            <md-icon md-font-library="material-icons">arrow_back</md-icon>
-          </md-button>
-        </div>
-        <div flex="auto" class="kd-replicationcontrollerdetail-no-overflow">
-          <h1 class="md-title kd-replicationcontrollerdetail-app-name">
-            <kd-middle-ellipsis display-string="{{::ctrl.replicationControllerDetail.name}}">
-            </kd-middle-ellipsis>
-          </h1>
-        </div>
-      </div>
-    </div>
+<md-content layout="row" layout-fill flex="auto">
+    <div flex="auto" class="kd-replicationcontrollerdetail-no-overflow">
     <md-tabs flex="auto" md-border-bottom md-dynamic-height>
       <md-tab label="Pods">
         <md-content>
@@ -302,7 +263,7 @@ limitations under the License.
           </div>
         </md-content>
       </md-tab>
-      <md-tab label="Details" ng-if="!ctrl.isSidebarVisible()">
+      <md-tab label="Details">
         <kd-replication-controller-info details="::ctrl.replicationControllerDetail">
         </kd-replication-controller-info>
       </md-tab>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.scss
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.scss
@@ -14,23 +14,10 @@
 
 @import '../variables';
 
-$replicationcontrollerdetails-sidebar-bg: #fafafa;
-$replicationcontrollerdetails-sidebar-width: 315px;
 
 .kd-replicationcontrollerdetail-app-name {
   color: $foreground-2;
   font-weight: $regular-font-weight;
-}
-
-.kd-replicationcontrollerdetail-sidebar {
-  background-color: $replicationcontrollerdetails-sidebar-bg;
-  max-width: $replicationcontrollerdetails-sidebar-width + 10 * $baseline-grid;
-  min-width: $replicationcontrollerdetails-sidebar-width;
-}
-
-.kd-replicationcontrollerdetail-sidebar-item {
-  padding-left: 2 * $baseline-grid;
-  padding-right: $baseline-grid;
 }
 
 .kd-replicationcontrollerdetail-table,
@@ -52,14 +39,6 @@ $replicationcontrollerdetails-sidebar-width: 315px;
 
 .kd-replicationcontrollerdetail-no-overflow {
   overflow: hidden;
-}
-
-.kd-replicationcontrollerdetail-sidebar-header {
-  height: $table-cell-height;
-}
-
-.kd-replicationcontrollerdetail-sidebar-header-wrapper {
-  border-bottom: 1px solid $border;
 }
 
 .kd-replicationcontrollerdetail-warning-icon {

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -99,13 +99,6 @@ export default class ReplicationControllerDetailController {
   }
 
   /**
-   * Returns true if sidebar is visible, false if it is hidden.
-   * @returns {boolean}
-   * @export
-   */
-  isSidebarVisible() { return this.mdMedia('gt-md'); }
-
-  /**
    * Returns true if event is a warning.
    * @param {!backendApi.Event} event
    * @return {boolean}

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 import ReplicationControllerDetailController from './replicationcontrollerdetail_controller';
+import ReplicationControllerDetailActionBarController from './replicationcontrollerdetailactionbar_controller';
 import {stateName} from './replicationcontrollerdetail_state';
+import {actionbarViewName} from 'chrome/chrome_state';
+import {stateName as replicationControllers} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_state';
 
 /**
  * Configures states for the service view.
@@ -23,15 +26,30 @@ import {stateName} from './replicationcontrollerdetail_state';
  */
 export default function stateConfig($stateProvider) {
   $stateProvider.state(stateName, {
-    controller: ReplicationControllerDetailController,
-    controllerAs: 'ctrl',
     url: '/replicationcontrollers/:namespace/:replicationController',
-    templateUrl: 'replicationcontrollerdetail/replicationcontrollerdetail.html',
     resolve: {
       'replicationControllerSpecPodsResource': getReplicationControllerSpecPodsResource,
       'replicationControllerDetailResource': getReplicationControllerDetailsResource,
       'replicationControllerDetail': resolveReplicationControllerDetails,
       'replicationControllerEvents': resolveReplicationControllerEvents,
+    },
+    data: {
+      'kdBreadcrumbs': {
+        'label': '{{$stateParams.replicationController}}',
+        'parent': replicationControllers,
+      },
+    },
+    views: {
+      '': {
+        controller: ReplicationControllerDetailController,
+        controllerAs: 'ctrl',
+        templateUrl: 'replicationcontrollerdetail/replicationcontrollerdetail.html',
+      },
+      [actionbarViewName]: {
+        controller: ReplicationControllerDetailActionBarController,
+        controllerAs: 'ctrl',
+        templateUrl: 'replicationcontrollerdetail/replicationcontrollerdetailactionbar.html',
+      },
     },
   });
 }

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar.html
@@ -1,0 +1,55 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div hide show-gt-sm>
+  <md-button class="md-icon-button" ng-click="ctrl.redirectToDeployPage()">
+    <md-icon class="kd-rc-detail-actionbar-icon">add</md-icon>
+    <md-tooltip md-direction="bottom">Deploy a containerized app</md-tooltip>
+  </md-button>
+  <md-button class="md-icon-button" ng-click="ctrl.handleUpdateReplicasDialog()">
+    <md-icon class="kd-rc-detail-actionbar-icon">mode_edit</md-icon>
+    <md-tooltip md-direction="bottom">Edit number of pods</md-tooltip>
+  </md-button>
+  <md-button class="md-icon-button" ng-click="ctrl.handleDeleteReplicationControllerDialog()">
+    <md-icon class="kd-rc-detail-actionbar-icon">delete</md-icon>
+    <md-tooltip md-direction="bottom">Delete replication controller</md-tooltip>
+  </md-button>
+</div>
+
+<div hide-gt-sm>
+  <md-fab-speed-dial md-direction="left" class="md-scale" md-open="ctrl.showFabIcons"
+                     ng-mouseenter="ctrl.showIcons()" ng-mouseleave="ctrl.hideIcons()">
+    <md-fab-trigger>
+      <md-button aria-label="menu" class="md-icon-button">
+        <md-icon class="kd-rc-detail-actionbar-icon">menu</md-icon>
+      </md-button>
+    </md-fab-trigger>
+    <md-fab-actions>
+      <md-button class="md-fab md-raised md-mini" ng-click="ctrl.handleDeleteReplicationControllerDialog()">
+        <md-icon class="kd-rc-detail-actionbar-icon">delete</md-icon>
+        <md-tooltip md-direction="bottom">Delete replication controller</md-tooltip>
+      </md-button>
+      <md-button class="md-fab md-raised md-mini" ng-click="ctrl.handleUpdateReplicasDialog()">
+        <md-icon class="kd-rc-detail-actionbar-icon">mode_edit</md-icon>
+        <md-tooltip md-direction="bottom">Edit number of pods</md-tooltip>
+      </md-button>
+      <md-button class="md-fab md-raised md-mini" ng-click="ctrl.redirectToDeployPage()">
+        <md-icon class="kd-rc-detail-actionbar-icon">add</md-icon>
+        <md-tooltip md-direction="bottom">Deploy a containerized app</md-tooltip>
+      </md-button>
+    </md-fab-actions>
+  </md-fab-speed-dial>
+</div>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar.scss
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar.scss
@@ -12,25 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Controller for the replication controller info directive.
- * @final
- */
-export default class ReplicationControllerInfoController {
-  /**
-   * Constructs replication controller info object.
-   */
-  constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
+@import '../variables';
+
+md-toolbar {
+  .md-button {
+    &.md-raised {
+      md-icon {
+        &.kd-rc-detail-actionbar-icon {
+          color: $muted;
+        }
+      }
+    }
   }
 
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
+  md-icon {
+    &.kd-rc-detail-actionbar-icon {
+      color: $muted;
+    }
+  }
 }

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar_controller.js
@@ -1,0 +1,103 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as deploy} from 'deploy/deploy_state';
+import {stateName as replicationcontrollers} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_state';
+
+/**
+ * @final
+ */
+export default class ReplicationControllerDetailActionBarController {
+  /**
+   * Constructs action bar on rc detail page.
+   *
+   * @param {ui.router.$state} $state
+   * @param {!./replicationcontrollerdetail_state.StateParams} $stateParams
+   * @param {!angular.$log} $log
+   * @param {!backendApi.ReplicationControllerDetail} replicationControllerDetail
+   * @param {!./replicationcontroller_service.ReplicationControllerService}
+   * kdReplicationControllerService
+   * @ngInject
+   */
+  constructor(
+      $state, $stateParams, $log, replicationControllerDetail, kdReplicationControllerService) {
+    /** @private {ui.router.$state} */
+    this.state_ = $state;
+
+    /** @private {!./replicationcontrollerdetail_state.StateParams} */
+    this.stateParams_ = $stateParams;
+
+    /** @private {!angular.$log} */
+    this.log_ = $log;
+
+    /** @private {!./replicationcontroller_service.ReplicationControllerService} */
+    this.kdReplicationControllerService_ = kdReplicationControllerService;
+
+    /** @private {!backendApi.ReplicationControllerDetail} */
+    this.details_ = replicationControllerDetail;
+
+    /** @export {boolean} */
+    this.showFabIcons = false;
+  }
+
+  /**
+   * @export
+   */
+  showIcons() { this.showFabIcons = true; }
+
+  /**
+   * @export
+   */
+  hideIcons() { this.showFabIcons = false; }
+
+  /**
+   * @export
+   */
+  redirectToDeployPage() { this.state_.go(deploy); }
+
+  /**
+   * Handles update of replicas count in replication controller dialog.
+   * @export
+   */
+  handleUpdateReplicasDialog() {
+    this.kdReplicationControllerService_.showUpdateReplicasDialog(
+        this.details_.namespace, this.details_.name, this.details_.podInfo.current,
+        this.details_.podInfo.desired);
+  }
+
+  /**
+   * Handles replication controller delete dialog.
+   * @export
+   */
+  handleDeleteReplicationControllerDialog() {
+    this.kdReplicationControllerService_
+        .showDeleteDialog(this.stateParams_.namespace, this.stateParams_.replicationController)
+        .then(this.onReplicationControllerDeleteSuccess_.bind(this));
+  }
+
+  /**
+   * Callbacks used after clicking dialog confirmation button in order to delete replication
+   * controller or log unsuccessful operation error.
+   */
+
+  /**
+   * Changes state back to replication controller list after successful deletion of replication
+   * controller.
+   * @private
+   */
+  onReplicationControllerDeleteSuccess_() {
+    this.log_.info('Replication controller successfully deleted.');
+    this.state_.go(replicationcontrollers);
+  }
+}

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -29,12 +29,6 @@ limitations under the License.
           </kd-middle-ellipsis>
         </div>
       </div>
-      <div flex="nogrow">
-        <md-button class="md-primary md-icon-button"
-            ng-click="infoCtrl.handleDeleteReplicationControllerDialog()">
-          <md-icon class="material-icons">delete</md-icon>
-        </md-button>
-      </div>
     </div>
     <span class="kd-replicationcontrollerinfo-line">Namespace</span>
     <span class="kd-replicationcontrollerinfo-subline">
@@ -51,12 +45,6 @@ limitations under the License.
         <span class="kd-replicationcontrollerinfo-subline" ng-if="infoCtrl.areDesiredPodsRunning()">
           {{::infoCtrl.details.podInfo.running}} running
         </span>
-      </div>
-      <div flex="nogrow">
-        <md-button class="md-icon-button md-primary"
-                   ng-click="infoCtrl.handleUpdateReplicasDialog()">
-          <md-icon class="material-icons">mode_edit</md-icon>
-        </md-button>
       </div>
     </div>
     <div ng-if="!infoCtrl.areDesiredPodsRunning()">

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.scss
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.scss
@@ -51,6 +51,5 @@
 }
 
 .kd-replicationcontrollerinfo-info {
-  // 6px needed to offset for md-button padding.
-  padding-left: $baseline-grid + 6px;
+  padding-top: $baseline-grid;
 }

--- a/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_controller.js
+++ b/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_controller.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {stateName as deploy} from 'deploy/deploy_state';
-
 /**
  * Controller for the replication controller list view.
  *
@@ -21,20 +19,11 @@ import {stateName as deploy} from 'deploy/deploy_state';
  */
 export default class ReplicationControllerListController {
   /**
-   * @param {!ui.router.$state} $state
    * @param {!backendApi.ReplicationControllerList} replicationControllers
    * @ngInject
    */
-  constructor($state, replicationControllers) {
+  constructor(replicationControllers) {
     /** @export {!Array<!backendApi.ReplicationController>} */
     this.replicationControllers = replicationControllers.replicationControllers;
-
-    /** @private {!ui.router.$state} */
-    this.state_ = $state;
   }
-
-  /**
-   * @export
-   */
-  redirectToDeployPage() { this.state_.go(deploy); }
 }

--- a/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig.js
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {actionbarViewName} from 'chrome/chrome_state';
 import {stateName as zerostate} from './zerostate/zerostate_state';
 import {stateName as replicationcontrollers} from './replicationcontrollerlist_state';
 import {stateUrl as replicationcontrollersUrl} from './replicationcontrollerlist_state';
 import {StateParams} from './zerostate/zerostate_state';
 import ReplicationControllerListController from './replicationcontrollerlist_controller';
+import ReplicationControllerListActionBarController from './replicationcontrollerlistactionbar_controller';
 import ZeroStateController from './zerostate/zerostate_controller';
 
 /**
@@ -31,12 +33,22 @@ export default function stateConfig($stateProvider) {
     resolve: {
       'replicationControllers': resolveReplicationControllers,
     },
+    data: {
+      'kdBreadcrumbs': {
+        'label': 'Replication Controllers',
+      },
+    },
     onEnter: redirectIfNeeded,
     views: {
       '': {
         controller: ReplicationControllerListController,
         controllerAs: 'ctrl',
         templateUrl: 'replicationcontrollerlistdeprecated/replicationcontrollerlist.html',
+      },
+      [actionbarViewName]: {
+        controller: ReplicationControllerListActionBarController,
+        controllerAs: 'ctrl',
+        templateUrl: 'replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar.html',
       },
     },
   });

--- a/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar.html
+++ b/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-replication-controller-list-container-deprecated>
-  <kd-replication-controller-card-deprecated ng-repeat="replicationController in ::ctrl.replicationControllers"
-                                  replication-controller="::replicationController">
-  </kd-replication-controller-card-deprecated>
-</kd-replication-controller-list-container-deprecated>
+<md-button class="md-icon-button" ng-click="ctrl.redirectToDeployPage()">
+  <md-icon class="kd-rc-detail-actionbar-icon">add</md-icon>
+  <md-tooltip md-direction="left">Deploy a containerized app</md-tooltip>
+</md-button>

--- a/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar_controller.js
+++ b/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar_controller.js
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as deploy} from 'deploy/deploy_state';
+
 /**
- * Controller for the replication controller info directive.
  * @final
  */
-export default class ReplicationControllerInfoController {
+export default class ReplicationControllerListActionBarController {
   /**
-   * Constructs replication controller info object.
+   * @param {!ui.router.$state} $state
+   * @ngInject
    */
-  constructor() {
-    /**
-     * Replication controller details. Initialized from the scope.
-     * @export {!backendApi.ReplicationControllerDetail}
-     */
-    this.details;
+  constructor($state) {
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
   }
 
   /**
-   * @return {boolean}
    * @export
    */
-  areDesiredPodsRunning() { return this.details.podInfo.running === this.details.podInfo.desired; }
+  redirectToDeployPage() { this.state_.go(deploy); }
 }

--- a/src/test/frontend/common/components/breadcrumbs/breadcrumbs_component_test.js
+++ b/src/test/frontend/common/components/breadcrumbs/breadcrumbs_component_test.js
@@ -1,0 +1,242 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import componentsModule from 'common/components/components_module';
+
+describe('Breadcrumbs controller ', () => {
+  /** @type {ui.router.$state} */
+  let state;
+  /** @type {angular.$interpolate} */
+  let interpolate;
+  /** @type {BreadcrumbsController} */
+  let ctrl;
+  /** @type {number} */
+  let breadcrumbsLimit = 3;
+
+  /**
+   * Create simple mock object for state.
+   *
+   * @param {string} stateName
+   * @param {string} stateLabel
+   * @return {{name: string, kdBreadcrumbs: {label: string}}}
+   */
+  function getStateMock(stateName, stateLabel) {
+    return {
+      name: stateName,
+      data: {
+        kdBreadcrumbs: {
+          label: stateLabel,
+        },
+      },
+    };
+  }
+
+  /**
+   * Adds specified number of mocked parents to given state with generated name based on given
+   * state name prefix, i.e. `parent-1`, `parent-2`, `parent-3` for prefix equal to `parent` and
+   * parents number equal to 3.
+   *
+   * @param {!ui.router.$state} state
+   * @param {number} parentsNr
+   * @param {string} stateNamePrefix
+   * @return {!ui.router.$state}
+   */
+  function addStateParents(state, parentsNr, stateNamePrefix) {
+    let parentState = state;
+    for (let i = 0; i < parentsNr; i++) {
+      state.parent = getStateMock(`${stateNamePrefix}-${i+1}`);
+      state = state.parent;
+    }
+
+    return parentState;
+  }
+
+  beforeEach(() => {
+    angular.mock.module(componentsModule.name);
+
+    angular.mock.inject(($componentController, $state, $interpolate) => {
+      state = $state;
+      interpolate = $interpolate;
+      ctrl = $componentController(
+          'kdBreadcrumbs', {
+            $state: state,
+            $interpolate: interpolate,
+          },
+          {
+            limit: breadcrumbsLimit,
+          });
+    });
+  });
+
+  it('should call init breadcrumbs', () => {
+    // given
+    spyOn(ctrl, 'initBreadcrumbs_');
+
+    // when
+    ctrl.$onInit();
+
+    // then
+    expect(ctrl.initBreadcrumbs_).toHaveBeenCalled();
+  });
+
+  it('should initialize breadcrumbs', () => {
+    // given
+    state['$current'] = getStateMock('testState');
+
+    // when
+    let breadcrumbs = ctrl.initBreadcrumbs_();
+
+    // then
+    expect(breadcrumbs.length).toEqual(1);
+    expect(breadcrumbs[0].label).toEqual('testState');
+  });
+
+  it('should not exceed the breadcrumbs limit on initialize breadcrumbs', () => {
+    // given
+    let workingState = state['$current'] = getStateMock('testState');
+    addStateParents(workingState, 3, 'parentState');
+
+    // when
+    let breadcrumbs = ctrl.initBreadcrumbs_();
+
+    //
+    expect(breadcrumbs.length).toEqual(breadcrumbsLimit);
+    for (let i = 0; i < breadcrumbs.length - 1; i++) {
+      expect(breadcrumbs[i].label).toEqual(`parentState-${breadcrumbsLimit-(i+1)}`);
+    }
+
+    expect(breadcrumbs[breadcrumbsLimit - 1].label).toEqual('testState');
+  });
+
+  it('should return true when breadcrumb can be added', () => {
+    // given
+    let breadcrumbs = [];
+    ctrl.limit = 1;
+
+    // when
+    let canBeAdded = ctrl.canAddBreadcrumb_(breadcrumbs);
+
+    // then
+    expect(canBeAdded).toBeTruthy();
+  });
+
+  it('should return false when breadcrumb can not be added', () => {
+    // given
+    let breadcrumbs = ['b1', 'b2', 'b3'];
+    ctrl.limit = 3;
+
+    // when
+    let canBeAdded = ctrl.canAddBreadcrumb_(breadcrumbs);
+
+    // then
+    expect(canBeAdded).toBeFalsy();
+  });
+
+  it('should return parent state when breadcrumb parent is not defined', () => {
+    // given
+    state.parent = getStateMock('parentState');
+
+    // when
+    let parent = ctrl.getParentState_(state);
+
+    // expect
+    expect(parent).toEqual(state.parent);
+  });
+
+  it('should return defined parent when breadcrumb parent is defined', () => {
+    // given
+    state.data = {kdBreadcrumbs: {parent: 'parentState'}};
+    let parent = getStateMock('parentState');
+    spyOn(state, 'get').and.returnValue(parent);
+
+    // when
+    let result = ctrl.getParentState_(state);
+
+    // expect
+    expect(result).toEqual(parent);
+  });
+
+  it('should return breadcrumb object', () => {
+    // given
+    spyOn(state, 'href').and.returnValue('stateLink');
+    let stateMock = getStateMock('testState');
+
+    // when
+    let breadcrumb = ctrl.getBreadcrumb_(stateMock);
+
+    // then
+    expect(breadcrumb.label).toEqual(stateMock.name);
+    expect(breadcrumb.stateLink).toEqual('stateLink');
+  });
+
+  it('should interpolated string as display name', () => {
+    // given
+    let stateContextVarName = 'stateLabel';
+    let stateName = 'Test state';
+    state.locals = {
+      '@': {
+        [stateContextVarName]: stateName,
+      },
+    };
+    state.data = {kdBreadcrumbs: {label: `{{${stateContextVarName}}}`}};
+
+    // when
+    let result = ctrl.getDisplayName_(state);
+
+    // then
+    expect(result).toEqual(stateName);
+  });
+
+  it('should return label when it is defined', () => {
+    // given
+    state.locals = {};
+    state.data = {kdBreadcrumbs: {label: 'Test state'}};
+
+    // when
+    let result = ctrl.getDisplayName_(state);
+
+    // then
+    expect(result).toEqual(state.data.kdBreadcrumbs.label);
+  });
+
+  it('should return state name when label is not defined', () => {
+    // given
+    state.name = 'testState';
+
+    // when
+    let result = ctrl.getDisplayName_(state);
+
+    // then
+    expect(result).toEqual(state.name);
+  });
+
+  it('should return breadcrumb config when it is defined', () => {
+    // given
+    let stateMock = getStateMock('testState');
+
+    // when
+    let result = ctrl.getBreadcrumbConfig_(stateMock);
+
+    // then
+    expect(result).toBeDefined();
+  });
+
+  it('should return undefined when breadcrumb config is not defined', () => {
+    // when
+    let result = ctrl.getBreadcrumbConfig_(state);
+
+    // then
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/test/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar_controller_test.js
+++ b/src/test/frontend/replicationcontrollerdetail/replicationcontrollerdetailactionbar_controller_test.js
@@ -1,0 +1,132 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ReplicationControllerDetailActionBarController from 'replicationcontrollerdetail/replicationcontrollerdetailactionbar_controller';
+import replicationControllerDetailModule from 'replicationcontrollerdetail/replicationcontrollerdetail_module';
+import {stateName as replicationcontrollers} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_state';
+import {stateName as deploy} from 'deploy/deploy_state';
+
+describe('Replication Controller Detail Action Bar controller', () => {
+  /**
+   * Replication Controller Detail controller.
+   * @type {!ReplicationControllerDetailController}
+   */
+  let ctrl;
+  /** @type
+   * {!replicationcontrollerdetail/replicationcontroller_service.ReplicationControllerService} */
+  let kdReplicationControllerService;
+  /** @type {!angular.$q} */
+  let q;
+  /** @type {!ui.router.$state} */
+  let state;
+  /** @type {!angular.$log} */
+  let log;
+
+  beforeEach(() => {
+    angular.mock.module(replicationControllerDetailModule.name);
+
+    angular.mock.inject(
+        ($controller, $state, $log, $resource, $q, _kdReplicationControllerService_) => {
+          q = $q;
+          state = $state;
+          log = $log;
+          kdReplicationControllerService = _kdReplicationControllerService_;
+
+          ctrl = $controller(ReplicationControllerDetailActionBarController, {
+            $state: state,
+            $stateParams:
+                {replicationController: 'foo-replicationcontroller', namespace: 'foo-namespace'},
+            replicationControllerDetail: {},
+            kdReplicationControllerService: _kdReplicationControllerService_,
+          });
+        });
+  });
+
+  it('should show edit replicas dialog', () => {
+    // given
+    ctrl.details_ = {
+      namespace: 'foo-namespace',
+      name: 'foo-name',
+      podInfo: {
+        current: 3,
+        desired: 3,
+      },
+    };
+    spyOn(kdReplicationControllerService, 'showUpdateReplicasDialog');
+
+    // when
+    ctrl.handleUpdateReplicasDialog();
+
+    // then
+    expect(kdReplicationControllerService.showUpdateReplicasDialog).toHaveBeenCalled();
+  });
+
+  it('should show delete replicas dialog', () => {
+    // given
+    let deferred = q.defer();
+    spyOn(kdReplicationControllerService, 'showDeleteDialog').and.returnValue(deferred.promise);
+
+    // when
+    ctrl.handleDeleteReplicationControllerDialog();
+
+    // then
+    expect(kdReplicationControllerService.showDeleteDialog).toHaveBeenCalled();
+  });
+
+  it('should change state to replication controller and log on delete success', () => {
+    // given
+    spyOn(state, 'go');
+    spyOn(log, 'info');
+
+    // when
+    ctrl.onReplicationControllerDeleteSuccess_();
+
+    // then
+    expect(state.go).toHaveBeenCalledWith(replicationcontrollers);
+    expect(log.info).toHaveBeenCalledWith('Replication controller successfully deleted.');
+  });
+
+  it('should redirect to deploy page', () => {
+    // given
+    spyOn(state, 'go');
+
+    // when
+    ctrl.redirectToDeployPage();
+
+    // then
+    expect(state.go).toHaveBeenCalledWith(deploy);
+  });
+
+  it('should show icons', () => {
+    // given
+    ctrl.showFabIcons = false;
+
+    // when
+    ctrl.showIcons();
+
+    // then
+    expect(ctrl.showFabIcons).toBeTruthy();
+  });
+
+  it('should hide icons', () => {
+    // given
+    ctrl.showFabIcons = true;
+
+    // when
+    ctrl.hideIcons();
+
+    // then
+    expect(ctrl.showFabIcons).toBeFalsy();
+  });
+});

--- a/src/test/frontend/replicationcontrollerdetail/replicationcontrollerinfo_controller_test.js
+++ b/src/test/frontend/replicationcontrollerdetail/replicationcontrollerinfo_controller_test.js
@@ -14,7 +14,6 @@
 
 import ReplicationControllerInfoController from 'replicationcontrollerdetail/replicationcontrollerinfo_controller';
 import replicationControllerDetailModule from 'replicationcontrollerdetail/replicationcontrollerdetail_module';
-import {stateName as replicationcontrollers} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_state';
 
 describe('Replication Controller Detail controller', () => {
   /**
@@ -22,63 +21,12 @@ describe('Replication Controller Detail controller', () => {
    * @type {!ReplicationControllerDetailController}
    */
   let ctrl;
-  /** @type
-   * {!replicationcontrollerdetail/replicationcontroller_service.ReplicationControllerService} */
-  let kdReplicationControllerService;
-  /** @type {!angular.$q} */
-  let q;
-  /** @type {!ui.router.$state} */
-  let state;
-  /** @type {!angular.$log} */
-  let log;
 
   beforeEach(() => {
     angular.mock.module(replicationControllerDetailModule.name);
 
     angular.mock.inject(
-        ($controller, $state, $log, $resource, $q, _kdReplicationControllerService_) => {
-          q = $q;
-          state = $state;
-          log = $log;
-          kdReplicationControllerService = _kdReplicationControllerService_;
-          ctrl = $controller(ReplicationControllerInfoController, {
-            replicationControllerDetail: {},
-            replicationControllerEvents: {},
-            replicationControllerDetailResource: $resource('/foo'),
-            replicationControllerSpecPodsResource: $resource('/bar'),
-          });
-        });
-  });
-
-  it('should show edit replicas dialog', () => {
-    // given
-    ctrl.details = {
-      namespace: 'foo-namespace',
-      name: 'foo-name',
-      podInfo: {
-        current: 3,
-        desired: 3,
-      },
-    };
-    spyOn(kdReplicationControllerService, 'showUpdateReplicasDialog');
-
-    // when
-    ctrl.handleUpdateReplicasDialog();
-
-    // then
-    expect(kdReplicationControllerService.showUpdateReplicasDialog).toHaveBeenCalled();
-  });
-
-  it('should show delete replicas dialog', () => {
-    // given
-    let deferred = q.defer();
-    spyOn(kdReplicationControllerService, 'showDeleteDialog').and.returnValue(deferred.promise);
-
-    // when
-    ctrl.handleDeleteReplicationControllerDialog();
-
-    // then
-    expect(kdReplicationControllerService.showDeleteDialog).toHaveBeenCalled();
+        ($controller) => { ctrl = $controller(ReplicationControllerInfoController, {}); });
   });
 
   it('should return true when all desired pods are running', () => {
@@ -106,18 +54,4 @@ describe('Replication Controller Detail controller', () => {
     // then
     expect(ctrl.areDesiredPodsRunning()).toBeFalsy();
   });
-
-  it('should change state to replication controller and log on delete success', () => {
-    // given
-    spyOn(state, 'go');
-    spyOn(log, 'info');
-
-    // when
-    ctrl.onReplicationControllerDeleteSuccess_();
-
-    // then
-    expect(state.go).toHaveBeenCalledWith(replicationcontrollers);
-    expect(log.info).toHaveBeenCalledWith('Replication controller successfully deleted.');
-  });
-
 });

--- a/src/test/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig_test.js
+++ b/src/test/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig_test.js
@@ -14,6 +14,7 @@
 
 import replicationControllerListModule from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_module';
 import {redirectIfNeeded} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig';
+
 describe('StateConfig for replication controller list', () => {
   /** @type {!ui.router.$state} */
   let state;

--- a/src/test/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar_controller_test.js
+++ b/src/test/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar_controller_test.js
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ReplicationControllerListController from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_controller';
+import ReplicationControllerListActionBarController from 'replicationcontrollerlistdeprecated/replicationcontrollerlistactionbar_controller';
 import replicationControllerListModule from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_module';
+import {stateName as deploy} from 'deploy/deploy_state';
 
-describe('Replication controller list controller', () => {
-  /** @type {!ReplicationControllerListController} */
+describe('Replication Controller List Action Bar controller', () => {
+  /**
+   * Replication Controller List controller.
+   * @type {!ReplicationControllerListController}
+   */
   let ctrl;
-  /** @type {!ui.router.$state} */
+  /** @type {ui.router.$state} */
   let state;
 
   beforeEach(() => {
@@ -26,13 +30,13 @@ describe('Replication controller list controller', () => {
 
     angular.mock.inject(($controller, $state) => {
       state = $state;
-      ctrl = $controller(
-          ReplicationControllerListController,
-          {replicationControllers: {replicationControllers: []}});
+      ctrl = $controller(ReplicationControllerListActionBarController, {
+        $state: state,
+      });
     });
   });
 
-  it('should change state to deploy view on plus button click', () => {
+  it('should redirect to deploy page', () => {
     // given
     spyOn(state, 'go');
 
@@ -40,6 +44,6 @@ describe('Replication controller list controller', () => {
     ctrl.redirectToDeployPage();
 
     // then
-    expect(state.go).toHaveBeenCalledWith('deploy');
+    expect(state.go).toHaveBeenCalledWith(deploy);
   });
 });


### PR DESCRIPTION
This has grown quite big. Sorry for that. I can move part that enables actionbar in the UI to different PR if needed.

## Important changes
- Refactored action bar
- Implemented simple breadcrumbs framework

### Actionbar
It is separated into 3 areas. Configurable area is defined per view and needs its own controller and template.

`[breadcrumbs (const width) | flex area | configurable (button) area ]`

### Breadcrumbs
- UI Router based
- Sets label that will be displayed instead of state name
- Sets parent state name without the need to define nested states
- Interpolates label name based on f.e. state params. This only works for the last state in chain for now to keep the implementation fairly simple.
- Limits breadcrumb chain lenght
- Supports middle ellipsis formatting for long breadcrumb labels

Example configuration:
```javascript
'kdBreadcrumbs': {
  'label': '{{$stateParams.replicationController}}',
  'parent': 'replicationcontrollers',
},
```

### Other changes
- Added actionbar to RC list page
- Added actionbar to RC details page
- Supports responsive design

### Update 1:
- Removed sidebar header on RC details page
- Style changes
- Changed buttons to icons on actionbar
- **Tests in progress...**

### Update 2:
 - Removed sidebar completely and enabled details tab
 - Configured icons and added tooltips on actionbar
 - Used angular components instead of directives
 - Added tests

RC details page:
![zrzut ekranu z 2016-04-22 13-10-57](https://cloud.githubusercontent.com/assets/2285385/14739873/d03a37f2-088a-11e6-8859-618454945ac0.png)
![zrzut ekranu z 2016-04-22 13-11-07](https://cloud.githubusercontent.com/assets/2285385/14739876/d3b1b3e2-088a-11e6-8591-c14f1b1bcf87.png)

RC list page:
![zrzut ekranu z 2016-04-22 13-10-06](https://cloud.githubusercontent.com/assets/2285385/14739851/ab450b34-088a-11e6-90f4-0a9e518744c0.png)




@bryk @maciaszczykm could you please review? :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/661)
<!-- Reviewable:end -->