### PR TITLE
implemented validation for expose service

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -114,12 +114,15 @@ limitations under the License.
 </kd-help-section>
 
 <kd-help-section>
-  <div class="md-block">
-    <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
-                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
-      Expose service externally
-    </md-checkbox>
-  </div>
+  <md-input-container class="md-block">
+      <md-checkbox ng-model="ctrl.isExternal" class="md-primary md-align-top-left" name="exposeService"
+                   ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }"
+                   ng-change="ctrl.validateExposeService()">
+        Expose service externally<br/>
+      <ng-messages for="ctrl.form.exposeService.$error" role="alert" multiple  >
+        <ng-message when="portMappingRequired">Expose service externally cannot be selected without a port mapping.</ng-message>
+      </ng-messages>
+  </md-input-container>
   <kd-user-help>
   </kd-user-help>
 </kd-help-section>

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -173,6 +173,8 @@ export default class DeployFromSettingsController {
 
     /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
+
+    $scope.$watch('ctrl.portMappings', () => { this.validateExposeService(); }, true);
   }
 
   /**
@@ -368,4 +370,13 @@ export default class DeployFromSettingsController {
    * @export
    */
   switchMoreOptions() { this.detail.showMoreOptions_ = !this.detail.showMoreOptions_; }
+
+  validateExposeService() {
+    let noPortMapping =
+        (this.portMappings !== undefined &&
+         this.portMappings.filter(this.isPortMappingFilled_).length === 0);
+    let isValid = !(this.isExternal && noPortMapping);
+
+    this.form['exposeService'].$setValidity('portMappingRequired', isValid);
+  }
 }


### PR DESCRIPTION
Not ready to be merged. I just like to here an opinion.

Basically, the validation works. Error message is shown, however, the elements below move down a few pixels when the error message appears. Not sure how to fix that.

I added a watch to run validation when port-mapping is changed. We have now 2 cyclic watches from port-mapping --> expose service and expose-service --> port-mapping. 

We could think about refactoring and move the expose service into the port mapping directive. In this case we could couple the logic stronger and remove the watches. Not sure if we want this.

@maciaszczykm please have a review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/663)
<!-- Reviewable:end -->
