### PR TITLE
Add services backend

### DIFF
--- a/src/app/backend/apihandler.go
+++ b/src/app/backend/apihandler.go
@@ -33,6 +33,14 @@ const (
 	ResponseLogString = "Outcoming response to %s with %d status code"
 )
 
+// ApiHandler is a representation of API handler. Structure contains client, Heapster client and
+// client configuration.
+type ApiHandler struct {
+	client         *client.Client
+	heapsterClient HeapsterClient
+	clientConfig   clientcmd.ClientConfig
+}
+
 // Web-service filter function used for request and response logging.
 func wsLogger(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 	log.Printf(FormatRequestLog(req))
@@ -186,15 +194,45 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 			Writes(Secret{}))
 	wsContainer.Add(secretsWs)
 
+	servicesWs := new(restful.WebService)
+	servicesWs.Filter(wsLogger)
+	servicesWs.Path("/api/v1/services").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+	servicesWs.Route(
+		servicesWs.GET("").
+			To(apiHandler.handleGetServiceList).
+			Writes(ServiceList{}))
+	servicesWs.Route(
+		servicesWs.GET("/{namespace}/{service}").
+			To(apiHandler.handleGetService).
+			Writes(Service{}))
+	wsContainer.Add(servicesWs)
+
 	return wsContainer
 }
 
-// ApiHandler is a representation of API handler. Structure contains client, Heaptster client and
-// client configuration.
-type ApiHandler struct {
-	client         *client.Client
-	heapsterClient HeapsterClient
-	clientConfig   clientcmd.ClientConfig
+// Handles get Replication Controller list API call.
+func (apiHandler *ApiHandler) handleGetServiceList(request *restful.Request, response *restful.Response) {
+	result, err := GetServiceList(apiHandler.client)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get service detail API call.
+func (apiHandler *ApiHandler) handleGetService(request *restful.Request, response *restful.Response) {
+	namespace := request.PathParameter("namespace")
+	service := request.PathParameter("service")
+	result, err := GetService(apiHandler.client, apiHandler.heapsterClient, namespace, service)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
 }
 
 // Handles deploy API call.

--- a/src/app/backend/replicationcontrollerdetail.go
+++ b/src/app/backend/replicationcontrollerdetail.go
@@ -19,7 +19,7 @@ import (
 	"log"
 
 	"k8s.io/kubernetes/pkg/api"
-	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -49,7 +49,7 @@ type ReplicationControllerDetail struct {
 	Pods []ReplicationControllerPod `json:"pods"`
 
 	// Detailed information about service related to Replication Controller.
-	Services []ServiceDetail `json:"services"`
+	Services []Service `json:"services"`
 
 	// True when the data contains at least one pod with metrics information, false otherwise.
 	HasMetrics bool `json:"hasMetrics"`
@@ -77,25 +77,6 @@ type ReplicationControllerPod struct {
 
 	// Pod metrics.
 	Metrics *PodMetrics `json:"metrics"`
-}
-
-// ServiceDetail is a representation of a Service connected to Replication Controller.
-type ServiceDetail struct {
-	// Name of the service.
-	Name string `json:"name"`
-
-	// Internal endpoints of all Kubernetes services that have the same label selector as
-	// connected Replication Controller.
-	// Endpoint is DNS name merged with ports.
-	InternalEndpoint Endpoint `json:"internalEndpoint"`
-
-	// External endpoints of all Kubernetes services that have the same label selector as
-	// connected Replication Controller.
-	// Endpoint is external IP address name merged with ports.
-	ExternalEndpoints []Endpoint `json:"externalEndpoints"`
-
-	// Label selector of the service.
-	Selector map[string]string `json:"selector"`
 }
 
 // ServicePort is a pair of port and protocol, e.g. a service endpoint.
@@ -288,8 +269,8 @@ func UpdateReplicasCount(client client.Interface, namespace, name string,
 
 // Returns detailed information about service from given service
 func getServiceDetail(service api.Service, replicationController api.ReplicationController,
-	pods []api.Pod, getNodeFn GetNodeFunc) ServiceDetail {
-	return ServiceDetail{
+	pods []api.Pod, getNodeFn GetNodeFunc) Service {
+	return Service{
 		Name: service.ObjectMeta.Name,
 		InternalEndpoint: getInternalEndpoint(service.Name, service.Namespace,
 			service.Spec.Ports),

--- a/src/app/backend/service.go
+++ b/src/app/backend/service.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// Service is a representation of a service.
+type Service struct {
+	// Name of the service.
+	Name string `json:"name"`
+
+	// Namespace of the service.
+	Namespace string `json:"namespace"`
+
+	// CreationTimestamp of the service.
+	CreationTimestamp unversioned.Time `json:"creationTimestamp"`
+
+	// Label mapping of the service.
+	Labels map[string]string `json:"labels"`
+
+	// InternalEndpoint of all Kubernetes services that have the same label selector as connected Replication
+	// Controller. Endpoint is DNS name merged with ports.
+	InternalEndpoint Endpoint `json:"internalEndpoint"`
+
+	// ExternalEndpoints of all Kubernetes services that have the same label selector as connected Replication
+	// Controller. Endpoint is external IP address name merged with ports.
+	ExternalEndpoints []Endpoint `json:"externalEndpoints"`
+
+	// Label selector of the service.
+	Selector map[string]string `json:"selector"`
+}
+
+// ServiceList contains a list of services in the cluster.
+type ServiceList struct {
+	// Unordered list of services.
+	Services []Service `json:"services"`
+}
+
+// GetService gets service details.
+func GetService(client client.Interface, heapsterClient HeapsterClient, namespace, name string) (*Service, error) {
+	log.Printf("Getting details of %s service in %s namespace", name, namespace)
+
+	// TODO(maciaszczykm): Use channels.
+	serviceData, err := client.Services(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	service := getServiceDetails(serviceData)
+	return &service, nil
+}
+
+// GetServiceList returns a list of all services in the cluster.
+func GetServiceList(client *client.Client) (*ServiceList, error) {
+	log.Printf("Getting list of all services in the cluster")
+
+	channels := &ResourceChannels{
+		ServiceList: getServiceListChannel(client, 1),
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	serviceList := &ServiceList{Services: make([]Service, 0)}
+	for _, service := range services.Items {
+		serviceList.Services = append(serviceList.Services, getServiceDetails(&service))
+	}
+
+	return serviceList, nil
+}
+
+func getServiceDetails(service *api.Service) Service {
+	return Service{
+		Name:              service.Name,
+		Namespace:         service.Namespace,
+		CreationTimestamp: service.CreationTimestamp,
+		Labels:            service.Labels,
+		InternalEndpoint:  getInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports),
+		ExternalEndpoints: []Endpoint{}, // TODO(maciaszczykm): Fill it with data.
+		Selector:          service.Spec.Selector,
+	}
+}


### PR DESCRIPTION
Added initial version of services backend logic:

- `http://localhost:9091/api/v1/services/` lists all services within the cluster
- `http://localhost:9091/api/v1/services/{namespace}/{service}` returns `{service}` service details from `{namespace}` namespace

Placed all logic in one file, it can change later, but at the moment I think it's not necessary.

I'm open to your suggestions as this is only proposal at the moment.

Connected to #659.

CC @floreks @bryk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/670)
<!-- Reviewable:end -->
