### PR TITLE
Update kubernetes-dashboard.yaml

### DIFF
--- a/src/deploy/kubernetes-dashboard.yaml
+++ b/src/deploy/kubernetes-dashboard.yaml
@@ -36,6 +36,7 @@ items:
         labels:
           app: kubernetes-dashboard
       spec:
+        hostNetwork: true
         containers:
         - name: kubernetes-dashboard
           image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.0.1


### PR DESCRIPTION
kubernetes-dashboard service should query the kube api server, without the hostNetwork set to true (default is false), it may fail to connect the api server, which will cause the error "kubernetes /api/v1/replicationcontrollers: dial tcp: i/o timeout"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/675)
<!-- Reviewable:end -->
