### PR TITLE
Backend for workloads and replica set list pages

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -77,16 +77,7 @@ export default {
      */
     testCommandArgs: [
       'test',
-      'github.com/kubernetes/dashboard',
-      'github.com/kubernetes/dashboard/client',
-      'github.com/kubernetes/dashboard/handler',
-      'github.com/kubernetes/dashboard/resource/common',
-      'github.com/kubernetes/dashboard/resource/container',
-      'github.com/kubernetes/dashboard/resource/event',
-      'github.com/kubernetes/dashboard/resource/namespace',
-      'github.com/kubernetes/dashboard/resource/replicationcontroller',
-      'github.com/kubernetes/dashboard/resource/secret',
-      'github.com/kubernetes/dashboard/validation',
+      'github.com/kubernetes/dashboard/...',
     ],
     /**
      * Port number of the backend server. Only used during development.

--- a/src/app/backend/resource/common/resourcechannels.go
+++ b/src/app/backend/resource/common/resourcechannels.go
@@ -52,7 +52,7 @@ var listEverything api.ListOptions = api.ListOptions{
 
 // Returns a pair of channels to a Service list and errors that both must be read
 // numReads times.
-func GetServiceListChannel(client *client.Client, numReads int) ServiceListChannel {
+func GetServiceListChannel(client client.ServicesNamespacer, numReads int) ServiceListChannel {
 	channel := ServiceListChannel{
 		List:  make(chan *api.ServiceList, numReads),
 		Error: make(chan error, numReads),
@@ -77,7 +77,7 @@ type NodeListChannel struct {
 
 // Returns a pair of channels to a Node list and errors that both must be read
 // numReads times.
-func GetNodeListChannel(client *client.Client, numReads int) NodeListChannel {
+func GetNodeListChannel(client client.NodesInterface, numReads int) NodeListChannel {
 	channel := NodeListChannel{
 		List:  make(chan *api.NodeList, numReads),
 		Error: make(chan error, numReads),
@@ -103,7 +103,7 @@ type EventListChannel struct {
 
 // Returns a pair of channels to an Event list and errors that both must be read
 // numReads times.
-func GetEventListChannel(client *client.Client, numReads int) EventListChannel {
+func GetEventListChannel(client client.EventNamespacer, numReads int) EventListChannel {
 	channel := EventListChannel{
 		List:  make(chan *api.EventList, numReads),
 		Error: make(chan error, numReads),
@@ -129,7 +129,7 @@ type PodListChannel struct {
 
 // Returns a pair of channels to a Pod list and errors that both must be read
 // numReads times.
-func GetPodListChannel(client *client.Client, numReads int) PodListChannel {
+func GetPodListChannel(client client.PodsNamespacer, numReads int) PodListChannel {
 	channel := PodListChannel{
 		List:  make(chan *api.PodList, numReads),
 		Error: make(chan error, numReads),
@@ -155,7 +155,9 @@ type ReplicationControllerListChannel struct {
 
 // Returns a pair of channels to a Replication Controller list and errors that both must be read
 // numReads times.
-func GetReplicationControllerListChannel(client *client.Client, numReads int) ReplicationControllerListChannel {
+func GetReplicationControllerListChannel(client client.ReplicationControllersNamespacer,
+	numReads int) ReplicationControllerListChannel {
+
 	channel := ReplicationControllerListChannel{
 		List:  make(chan *api.ReplicationControllerList, numReads),
 		Error: make(chan error, numReads),
@@ -180,7 +182,7 @@ type ReplicaSetListChannel struct {
 
 // Returns a pair of channels to a ReplicaSet list and errors that both must be read
 // numReads times.
-func GetReplicaSetListChannel(client *client.Client, numReads int) ReplicaSetListChannel {
+func GetReplicaSetListChannel(client client.ReplicaSetsNamespacer, numReads int) ReplicaSetListChannel {
 	channel := ReplicaSetListChannel{
 		List:  make(chan *extensions.ReplicaSetList, numReads),
 		Error: make(chan error, numReads),

--- a/src/app/backend/resource/replicaset/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicaset
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/replicationcontroller"
+	"k8s.io/kubernetes/pkg/api"
+	k8serrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// ReplicationSetList contains a list of Replica Sets in the cluster.
+type ReplicaSetList struct {
+	// Unordered list of Replica Sets.
+	ReplicaSets []ReplicaSet `json:"replicaSets"`
+}
+
+// ReplicaSet is a presentation layer view of Kubernetes Replica Set resource. This means
+// it is Replica Set plus additional augumented data we can get from other sources
+// (like services that target the same pods).
+type ReplicaSet struct {
+	// Name of the Replica Set.
+	Name string `json:"name"`
+
+	// Namespace this Replica Set is in.
+	Namespace string `json:"namespace"`
+
+	// Label of this Replica Set.
+	Labels map[string]string `json:"labels"`
+
+	// Aggregate information about pods belonging to this Replica Set.
+	Pods replicationcontroller.ReplicationControllerPodInfo `json:"pods"`
+
+	// Container images of the Replica Set.
+	ContainerImages []string `json:"containerImages"`
+
+	// Time the replication controller was created.
+	CreationTime unversioned.Time `json:"creationTime"`
+}
+
+// GetReplicaSetList returns a list of all Replica Sets in the cluster.
+func GetReplicaSetList(client client.Interface) (*ReplicaSetList, error) {
+	log.Printf("Getting list of all replica sets in the cluster")
+
+	channels := &common.ResourceChannels{
+		ReplicaSetList: common.GetReplicaSetListChannel(client.Extensions(), 1),
+		ServiceList:    common.GetServiceListChannel(client, 1),
+		PodList:        common.GetPodListChannel(client, 1),
+		EventList:      common.GetEventListChannel(client, 1),
+		NodeList:       common.GetNodeListChannel(client, 1),
+	}
+
+	return GetReplicaSetListFromChannels(channels)
+}
+
+// GetReplicaSetList returns a list of all Replica Sets in the cluster
+// reading required resource list once from the channels.
+func GetReplicaSetListFromChannels(channels *common.ResourceChannels) (
+	*ReplicaSetList, error) {
+
+	replicaSets := <-channels.ReplicaSetList.List
+	if err := <-channels.ReplicaSetList.Error; err != nil {
+		statusErr, ok := err.(*k8serrors.StatusError)
+		if ok && statusErr.ErrStatus.Reason == "NotFound" {
+			// TODO(bryk): Comment this.
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	pods := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	events := <-channels.EventList.List
+	if err := <-channels.EventList.Error; err != nil {
+		return nil, err
+	}
+
+	nodes := <-channels.NodeList.List
+	if err := <-channels.NodeList.Error; err != nil {
+		return nil, err
+	}
+
+	return getReplicaSetList(replicaSets.Items, services.Items, pods.Items, events.Items,
+		nodes.Items), nil
+}
+
+func getReplicaSetList(replicaSets []extensions.ReplicaSet,
+	services []api.Service, pods []api.Pod, events []api.Event,
+	nodes []api.Node) *ReplicaSetList {
+
+	replicaSetList := &ReplicaSetList{
+		ReplicaSets: make([]ReplicaSet, 0),
+	}
+
+	for _, replicaSet := range replicaSets {
+		replicaSetList.ReplicaSets = append(replicaSetList.ReplicaSets,
+			ReplicaSet{
+				Name:            replicaSet.ObjectMeta.Name,
+				Namespace:       replicaSet.ObjectMeta.Namespace,
+				Labels:          replicaSet.ObjectMeta.Labels,
+				ContainerImages: replicationcontroller.GetContainerImages(&replicaSet.Spec.Template.Spec),
+				CreationTime:    replicaSet.ObjectMeta.CreationTimestamp,
+			})
+	}
+
+	return replicaSetList
+}

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
@@ -150,3 +150,12 @@ func getServicesForDeletion(client client.Interface, labelSelector labels.Select
 
 	return services.Items, nil
 }
+
+// GetContainerImages returns container image strings from the given pod spec.
+func GetContainerImages(podTemplate *api.PodSpec) []string {
+	var containerImages []string
+	for _, container := range podTemplate.Containers {
+		containerImages = append(containerImages, container.Image)
+	}
+	return containerImages
+}

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
@@ -160,7 +160,7 @@ func getReplicationControllerList(replicationControllers []api.ReplicationContro
 				Description:       replicationController.Annotations[DescriptionAnnotationKey],
 				Labels:            replicationController.ObjectMeta.Labels,
 				Pods:              podInfo,
-				ContainerImages:   getContainerImages(&replicationController.Spec.Template.Spec),
+				ContainerImages:   GetContainerImages(&replicationController.Spec.Template.Spec),
 				CreationTime:      replicationController.ObjectMeta.CreationTimestamp,
 				InternalEndpoints: internalEndpoints,
 				ExternalEndpoints: externalEndpoints,
@@ -168,15 +168,6 @@ func getReplicationControllerList(replicationControllers []api.ReplicationContro
 	}
 
 	return replicationControllerList
-}
-
-// getContainerImages returns container image strings from the given pod spec.
-func getContainerImages(podTemplate *api.PodSpec) []string {
-	var containerImages []string
-	for _, container := range podTemplate.Containers {
-		containerImages = append(containerImages, container.Image)
-	}
-	return containerImages
 }
 
 // Returns all services that target the same Pods (or subset) as the given Replication Controller.

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/replicaset"
+	"github.com/kubernetes/dashboard/resource/replicationcontroller"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// Workloads stucture contains all resource lists grouped into the workloads category.
+type Workloads struct {
+	ReplicaSetList replicaset.ReplicaSetList `json:"replicaSetList"`
+
+	ReplicationControllerList replicationcontroller.ReplicationControllerList `json:"replicationControllerList"`
+}
+
+// GetWorkloads returns a list of all workloads in the cluster.
+func GetWorkloads(client client.Interface) (*Workloads, error) {
+	log.Printf("Getting lists of all workloads")
+	channels := &common.ResourceChannels{
+		ReplicationControllerList: common.GetReplicationControllerListChannel(client, 1),
+		ReplicaSetList:            common.GetReplicaSetListChannel(client.Extensions(), 1),
+		ServiceList:               common.GetServiceListChannel(client, 2),
+		PodList:                   common.GetPodListChannel(client, 2),
+		EventList:                 common.GetEventListChannel(client, 2),
+		NodeList:                  common.GetNodeListChannel(client, 2),
+	}
+
+	return GetWorkloadsFromChannels(channels)
+}
+
+// GetWorkloadsFromChannels returns a list of all workloads in the cluster, from the
+// channel sources.
+func GetWorkloadsFromChannels(channels *common.ResourceChannels) (*Workloads, error) {
+	rsChan := make(chan *replicaset.ReplicaSetList)
+	rcChan := make(chan *replicationcontroller.ReplicationControllerList)
+	errChan := make(chan error, 2)
+
+	go func() {
+		rcList, err := replicationcontroller.GetReplicationControllerListFromChannels(channels)
+		errChan <- err
+		rcChan <- rcList
+	}()
+
+	go func() {
+		rsList, err := replicaset.GetReplicaSetListFromChannels(channels)
+		errChan <- err
+		rsChan <- rsList
+	}()
+
+	rcList := <-rcChan
+	err := <-errChan
+	if err != nil {
+		return nil, err
+	}
+
+	rsList := <-rsChan
+	err = <-errChan
+	if err != nil {
+		return nil, err
+	}
+
+	workloads := &Workloads{
+		ReplicaSetList:            *rsList,
+		ReplicationControllerList: *rcList,
+	}
+
+	return workloads, nil
+}

--- a/src/test/backend/resource/replicaset/replicasetlist_test.go
+++ b/src/test/backend/resource/replicaset/replicasetlist_test.go
@@ -1,0 +1,149 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicaset
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	k8serrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/event"
+	"github.com/kubernetes/dashboard/resource/replicationcontroller"
+)
+
+func TestGetReplicaSetListFromChannels(t *testing.T) {
+	cases := []struct {
+		k8sRs         extensions.ReplicaSetList
+		k8sRsError    error
+		expected      *ReplicaSetList
+		expectedError error
+	}{
+		{
+			extensions.ReplicaSetList{},
+			nil,
+			&ReplicaSetList{[]ReplicaSet{}},
+			nil,
+		},
+		{
+			extensions.ReplicaSetList{},
+			errors.New("MyCustomError"),
+			nil,
+			errors.New("MyCustomError"),
+		},
+		{
+			extensions.ReplicaSetList{},
+			&k8serrors.StatusError{},
+			nil,
+			&k8serrors.StatusError{},
+		},
+		{
+			extensions.ReplicaSetList{},
+			&k8serrors.StatusError{ErrStatus: unversioned.Status{}},
+			nil,
+			&k8serrors.StatusError{ErrStatus: unversioned.Status{}},
+		},
+		{
+			extensions.ReplicaSetList{},
+			&k8serrors.StatusError{ErrStatus: unversioned.Status{Reason: "foo-bar"}},
+			nil,
+			&k8serrors.StatusError{ErrStatus: unversioned.Status{Reason: "foo-bar"}},
+		},
+		{
+			extensions.ReplicaSetList{},
+			&k8serrors.StatusError{ErrStatus: unversioned.Status{Reason: "NotFound"}},
+			nil,
+			nil,
+		},
+		{
+			extensions.ReplicaSetList{
+				Items: []extensions.ReplicaSet{{
+					ObjectMeta: api.ObjectMeta{
+						Name:              "rs-name",
+						Namespace:         "rs-namespace",
+						Labels:            map[string]string{"key": "value"},
+						CreationTimestamp: unversioned.Unix(111, 222),
+					},
+				}},
+			},
+			nil,
+			&ReplicaSetList{
+				[]ReplicaSet{{
+					Name:         "rs-name",
+					Namespace:    "rs-namespace",
+					Labels:       map[string]string{"key": "value"},
+					CreationTime: unversioned.Unix(111, 222),
+					Pods: replicationcontroller.ReplicationControllerPodInfo{
+						Warnings: []event.Event(nil),
+					},
+				}},
+			},
+			nil,
+		},
+	}
+
+	for _, c := range cases {
+		channels := &common.ResourceChannels{
+			ReplicaSetList: common.ReplicaSetListChannel{
+				List:  make(chan *extensions.ReplicaSetList, 1),
+				Error: make(chan error, 1),
+			},
+			NodeList: common.NodeListChannel{
+				List:  make(chan *api.NodeList, 1),
+				Error: make(chan error, 1),
+			},
+			ServiceList: common.ServiceListChannel{
+				List:  make(chan *api.ServiceList, 1),
+				Error: make(chan error, 1),
+			},
+			PodList: common.PodListChannel{
+				List:  make(chan *api.PodList, 1),
+				Error: make(chan error, 1),
+			},
+			EventList: common.EventListChannel{
+				List:  make(chan *api.EventList, 1),
+				Error: make(chan error, 1),
+			},
+		}
+
+		channels.ReplicaSetList.Error <- c.k8sRsError
+		channels.ReplicaSetList.List <- &c.k8sRs
+
+		channels.NodeList.List <- &api.NodeList{}
+		channels.NodeList.Error <- nil
+
+		channels.ServiceList.List <- &api.ServiceList{}
+		channels.ServiceList.Error <- nil
+
+		channels.PodList.List <- &api.PodList{}
+		channels.PodList.Error <- nil
+
+		channels.EventList.List <- &api.EventList{}
+		channels.EventList.Error <- nil
+
+		actual, err := GetReplicaSetListFromChannels(channels)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetReplicaSetListChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
+		}
+		if !reflect.DeepEqual(err, c.expectedError) {
+			t.Errorf("GetReplicaSetListChannels() ==\n          %#v\nExpected: %#v", err, c.expectedError)
+		}
+	}
+}

--- a/src/test/backend/resource/workload/workloads_test.go
+++ b/src/test/backend/resource/workload/workloads_test.go
@@ -1,0 +1,146 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"github.com/kubernetes/dashboard/resource/event"
+	"github.com/kubernetes/dashboard/resource/replicaset"
+	"github.com/kubernetes/dashboard/resource/replicationcontroller"
+)
+
+func TestGetWorkloadsFromChannels(t *testing.T) {
+	cases := []struct {
+		k8sRs extensions.ReplicaSetList
+		k8sRc api.ReplicationControllerList
+		rcs   []replicationcontroller.ReplicationController
+		rs    []replicaset.ReplicaSet
+	}{
+		{
+			extensions.ReplicaSetList{},
+			api.ReplicationControllerList{},
+			[]replicationcontroller.ReplicationController{},
+			[]replicaset.ReplicaSet{},
+		},
+		{
+			extensions.ReplicaSetList{
+				Items: []extensions.ReplicaSet{{ObjectMeta: api.ObjectMeta{Name: "rs-name"}}},
+			},
+			api.ReplicationControllerList{
+				Items: []api.ReplicationController{{
+					ObjectMeta: api.ObjectMeta{Name: "rc-name"},
+					Spec: api.ReplicationControllerSpec{
+						Template: &api.PodTemplateSpec{},
+					},
+				}},
+			},
+			[]replicationcontroller.ReplicationController{{
+				Name: "rc-name",
+				Pods: replicationcontroller.ReplicationControllerPodInfo{
+					Warnings: []event.Event{},
+				},
+			}},
+			[]replicaset.ReplicaSet{{
+				Name: "rs-name",
+				Pods: replicationcontroller.ReplicationControllerPodInfo{
+					Warnings: []event.Event(nil),
+				},
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		expected := &Workloads{
+			ReplicationControllerList: replicationcontroller.ReplicationControllerList{
+				ReplicationControllers: c.rcs,
+			},
+			ReplicaSetList: replicaset.ReplicaSetList{
+				ReplicaSets: c.rs,
+			},
+		}
+		var expectedErr error = nil
+
+		channels := &common.ResourceChannels{
+			ReplicaSetList: common.ReplicaSetListChannel{
+				List:  make(chan *extensions.ReplicaSetList, 1),
+				Error: make(chan error, 1),
+			},
+			ReplicationControllerList: common.ReplicationControllerListChannel{
+				List:  make(chan *api.ReplicationControllerList, 1),
+				Error: make(chan error, 1),
+			},
+			NodeList: common.NodeListChannel{
+				List:  make(chan *api.NodeList, 2),
+				Error: make(chan error, 2),
+			},
+			ServiceList: common.ServiceListChannel{
+				List:  make(chan *api.ServiceList, 2),
+				Error: make(chan error, 2),
+			},
+			PodList: common.PodListChannel{
+				List:  make(chan *api.PodList, 2),
+				Error: make(chan error, 2),
+			},
+			EventList: common.EventListChannel{
+				List:  make(chan *api.EventList, 2),
+				Error: make(chan error, 2),
+			},
+		}
+
+		channels.ReplicaSetList.Error <- nil
+		channels.ReplicaSetList.List <- &c.k8sRs
+
+		channels.ReplicationControllerList.List <- &c.k8sRc
+		channels.ReplicationControllerList.Error <- nil
+
+		nodeList := &api.NodeList{}
+		channels.NodeList.List <- nodeList
+		channels.NodeList.Error <- nil
+		channels.NodeList.List <- nodeList
+		channels.NodeList.Error <- nil
+
+		serviceList := &api.ServiceList{}
+		channels.ServiceList.List <- serviceList
+		channels.ServiceList.Error <- nil
+		channels.ServiceList.List <- serviceList
+		channels.ServiceList.Error <- nil
+
+		podList := &api.PodList{}
+		channels.PodList.List <- podList
+		channels.PodList.Error <- nil
+		channels.PodList.List <- podList
+		channels.PodList.Error <- nil
+
+		eventList := &api.EventList{}
+		channels.EventList.List <- eventList
+		channels.EventList.Error <- nil
+		channels.EventList.List <- eventList
+		channels.EventList.Error <- nil
+
+		actual, err := GetWorkloadsFromChannels(channels)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("GetWorkloadsFromChannels() ==\n          %#v\nExpected: %#v", actual, expected)
+		}
+		if !reflect.DeepEqual(err, expectedErr) {
+			t.Errorf("error from GetWorkloadsFromChannels() == %#v, expected %#v", actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Initial, but working, implementation. Will evolve in future. You can
check this out on /api/v1/workloads

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/678)
<!-- Reviewable:end -->
