### PR TITLE
WIP: Expose external

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -113,19 +113,6 @@ limitations under the License.
   </kd-user-help>
 </kd-help-section>
 
-<kd-help-section>
-  <md-input-container class="md-block">
-      <md-checkbox ng-model="ctrl.isExternal" class="md-primary md-align-top-left" name="exposeService"
-                   ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }"
-                   ng-change="ctrl.validateExposeService()">
-        Expose service externally<br/>
-      <ng-messages for="ctrl.form.exposeService.$error" role="alert" multiple  >
-        <ng-message when="portMappingRequired">Expose service externally cannot be selected without a port mapping.</ng-message>
-      </ng-messages>
-  </md-input-container>
-  <kd-user-help>
-  </kd-user-help>
-</kd-help-section>
 
 <!-- advanced options -->
 <div ng-show="ctrl.isMoreOptionsEnabled()">

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -114,12 +114,15 @@ limitations under the License.
 </kd-help-section>
 
 <kd-help-section>
-  <div class="md-block">
-    <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
-                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
-      Expose service externally
-    </md-checkbox>
-  </div>
+  <md-input-container class="md-block">
+      <md-checkbox ng-model="ctrl.isExternal" class="md-primary md-align-top-left" name="exposeService"
+                   ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }"
+                   ng-change="ctrl.validateExposeService()">
+        Expose service externally<br/>
+      <ng-messages for="ctrl.form.exposeService.$error" role="alert" multiple  >
+        <ng-message when="portMappingRequired">Expose service externally cannot be selected without a port mapping.</ng-message>
+      </ng-messages>
+  </md-input-container>
   <kd-user-help>
   </kd-user-help>
 </kd-help-section>

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -173,6 +173,8 @@ export default class DeployFromSettingsController {
 
     /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
+
+    $scope.$watch('ctrl.portMappings', () => { this.validateExposeService(); }, true);
   }
 
   /**
@@ -368,4 +370,13 @@ export default class DeployFromSettingsController {
    * @export
    */
   switchMoreOptions() { this.detail.showMoreOptions_ = !this.detail.showMoreOptions_; }
+
+  validateExposeService() {
+    let noPortMapping =
+        (this.portMappings !== undefined &&
+         this.portMappings.filter(this.isPortMappingFilled_).length === 0);
+    let isValid = !(this.isExternal && noPortMapping);
+
+    this.form['exposeService'].$setValidity('portMappingRequired', isValid);
+  }
 }

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -173,8 +173,6 @@ export default class DeployFromSettingsController {
 
     /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
-
-    $scope.$watch('ctrl.portMappings', () => { this.validateExposeService(); }, true);
   }
 
   /**
@@ -370,13 +368,4 @@ export default class DeployFromSettingsController {
    * @export
    */
   switchMoreOptions() { this.detail.showMoreOptions_ = !this.detail.showMoreOptions_; }
-
-  validateExposeService() {
-    let noPortMapping =
-        (this.portMappings !== undefined &&
-         this.portMappings.filter(this.isPortMappingFilled_).length === 0);
-    let isValid = !(this.isExternal && noPortMapping);
-
-    this.form['exposeService'].$setValidity('portMappingRequired', isValid);
-  }
 }

--- a/src/app/frontend/deploy/portmappings.html
+++ b/src/app/frontend/deploy/portmappings.html
@@ -13,9 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<ng-form name="exposeServiceForm">
 <div ng-repeat="portMapping in ctrl.portMappings">
-  <ng-form name="portMappingForm" layout="row">
+  <ng-form name="portMappingForm" layout="column">
+    <div layout="row">
     <md-input-container flex="50" class="kd-deploy-input-row">
       <label>Port</label>
       <input ng-model="portMapping.port" ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
@@ -58,10 +59,22 @@ limitations under the License.
     </md-input-container>
     <div flex="10">
       <md-button type="button" ng-if="ctrl.isRemovable($index)"
-                 ng-click="ctrl.remove($index)"
+                 ng-click="ctrl.remove(portMappingForm, $index)"
                  class="material-icons md-icon-button">
         delete
       </md-button>
     </div>
+  </div>
   </ng-form>
 </div>
+
+<md-input-container class="md-block">
+    <md-checkbox ng-model="ctrl.isExternal" class="md-primary md-align-top-left" name="exposeService"
+                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }"
+                 ng-change="ctrl.validateExposeService(exposeServiceForm)">
+      Expose service externally<br/>
+    <ng-messages for="exposeServiceForm.exposeService.$error" role="alert" multiple  >
+      <ng-message when="portMappingRequired">Expose service externally cannot be selected without a port mapping.</ng-message>
+    </ng-messages>
+</md-input-container>
+</ng-form>

--- a/src/app/frontend/deploy/portmappings_controller.js
+++ b/src/app/frontend/deploy/portmappings_controller.js
@@ -95,6 +95,8 @@ export default class PortMappingsController {
 
       portElem.$setValidity('empty', isValidPort);
       targetPortElem.$setValidity('empty', isValidTargetPort);
+
+      this.validateExposeService(portMappingForm.$$parentForm);
     }
   }
 
@@ -109,7 +111,10 @@ export default class PortMappingsController {
    * @param {number} index
    * @export
    */
-  remove(index) { this.portMappings.splice(index, 1); }
+  remove(portMappingForm, index) {
+    this.portMappings.splice(index, 1);
+    this.validateExposeService(portMappingForm.$$parentForm);
+  }
 
   /**
    * Returns true when the given port mapping is filled by the user, i.e., is not empty.
@@ -126,4 +131,16 @@ export default class PortMappingsController {
    * @private
    */
   isPortMappingFilledOrEmpty_(portMapping) { return !portMapping.port === !portMapping.targetPort; }
+
+  validateExposeService(exposeForm) {
+        if (angular.isDefined(exposeForm)) {
+    let noPortMapping =
+        (this.portMappings !== undefined &&
+         this.portMappings.filter(this.isPortMappingFilled_).length === 0);
+    let isValid = !(this.isExternal && noPortMapping);
+
+    exposeForm['exposeService'].$setValidity('portMappingRequired', isValid);
+    console.log('asdf'+isValid);
+  }
+  }
 }


### PR DESCRIPTION
Once again, not intended to be merged. I would like to get opinion. It kind of works, but it is just hacked. Code would need clean up and tests.

I refactored the code, but I am not sure, is it good or for bad?

Positive: moving the expose service checkbox into the directive. 
Negative: removing the watch requires to add direct function calls at any place the model might be changed. There would be still one watch to be removed and the code would get even more complicated, I assume.

Somehow, I feel we are doing something wrong. 

IMHO, the best option is to keep the checkbox in the directive but add a watch again. Or we think about handling the validation differently?

@maciaszczykm  can you please have a look and tell me your opinion?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/680)
<!-- Reviewable:end -->
