### PR TITLE
Add shadow to action bar on scroll and make content cards full width

### DIFF
--- a/src/app/frontend/common/components/actionbar/actionbar_component.js
+++ b/src/app/frontend/common/components/actionbar/actionbar_component.js
@@ -13,6 +13,54 @@
 // limitations under the License.
 
 /**
+ * @final
+ */
+export class ActionbarComponent {
+  /**
+   * @param {!angular.JQLite} $document
+   * @param {!angular.JQLite} $element
+   * @param {!angular.Scope} $scope
+   * @param {!angular.$window} $window
+   * @ngInject
+   */
+  constructor($document, $element, $scope, $window) {
+    /** @private {!angular.JQLite} */
+    this.document_ = $document;
+    /** @private {!angular.JQLite}} */
+    this.element_ = $element;
+    /** @private {!angular.Scope} */
+    this.scope_ = $scope;
+    /** @private {!angular.$window} */
+    this.window_ = $window;
+  }
+
+  /**
+   * @export
+   */
+  $onInit() {
+    this.computeScrollClass_();
+
+    let computeScrollClassCallback = () => { this.computeScrollClass_(); };
+
+    this.document_.on('scroll', computeScrollClassCallback);
+    this.scope_.$on(
+        '$destroy', () => { this.document_.off('scroll', computeScrollClassCallback); });
+  }
+
+  /**
+   * Computes scroll class based on scroll position and applies it to current element.
+   * @private
+   */
+  computeScrollClass_() {
+    if (this.window_.scrollY > 0) {
+      this.element_.removeClass('kd-actionbar-not-scrolled');
+    } else {
+      this.element_.addClass('kd-actionbar-not-scrolled');
+    }
+  }
+}
+
+/**
  * Returns actionbar component.
  *
  * @return {!angular.Directive}
@@ -20,4 +68,5 @@
 export const actionbarComponent = {
   templateUrl: 'common/components/actionbar/actionbar.html',
   transclude: true,
+  controller: ActionbarComponent,
 };

--- a/src/app/frontend/common/components/actionbar/actionbar_module.js
+++ b/src/app/frontend/common/components/actionbar/actionbar_module.js
@@ -12,29 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../../../variables';
+import {actionbarComponent} from './actionbar_component';
 
-.kd-toolbar {
-  &.kd-actionbar {
-    background: $content-background;
-    color: $muted;
-    height: $toolbar-height-size-base;
-    top: $toolbar-height-size-base;
-
-    @media only screen and (min-width: 0) and (max-width: $layout-breakpoint-sm) {
-      height: $toolbar-height-size-base-sm;
-    }
-  }
-}
-
-.kd-actionbar-not-scrolled {
-  .kd-actionbar {
-    border-bottom: 1px solid $border;
-    box-shadow: none;
-  }
-}
-
-.kd-actionbar-breadcrumbs {
-  flex-grow: 2;
-  white-space: nowrap;
-}
+/**
+ * Module containing common actionbar.
+ */
+export default angular
+    .module(
+        'kubernetesDashboard.common.components.actionbar',
+        [
+          'ngMaterial',
+        ])
+    .component('kdActionbar', actionbarComponent);

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {actionbarComponent} from './actionbar/actionbar_component';
 import {breadcrumbsComponent} from './breadcrumbs/breadcrumbs_component';
 import filtersModule from '../filters/filters_module';
 import labelsDirective from './labels/labels_directive';
 import middleEllipsisDirective from './middleellipsis/middleellipsis_directive';
 import contentCardModule from './contentcard/contentcard_module';
 import resourceCardModule from './resourcecard/resourcecard_module';
+import actionbarModule from './actionbar/actionbar_module';
 import sparklineDirective from './sparkline/sparkline_directive';
 import warnThresholdDirective from './warnthreshold/warnthreshold_directive';
 
@@ -32,6 +32,7 @@ export default angular
           'ngMaterial',
           'ui.router',
           filtersModule.name,
+          actionbarModule.name,
           contentCardModule.name,
           resourceCardModule.name,
         ])
@@ -39,5 +40,4 @@ export default angular
     .directive('kdMiddleEllipsis', middleEllipsisDirective)
     .directive('kdSparkline', sparklineDirective)
     .directive('kdWarnThreshold', warnThresholdDirective)
-    .component('kdActionbar', actionbarComponent)
     .component('kdBreadcrumbs', breadcrumbsComponent);

--- a/src/app/frontend/common/components/contentcard/contentcard.scss
+++ b/src/app/frontend/common/components/contentcard/contentcard.scss
@@ -21,7 +21,7 @@
 }
 
 .kd-content-card {
-  padding: $baseline-grid;
+  padding-bottom: 4 * $baseline-grid;
 }
 
 .kd-content-card-content-title {

--- a/src/test/frontend/common/components/actionbar/actionbar_component_test.js
+++ b/src/test/frontend/common/components/actionbar/actionbar_component_test.js
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import actionbarCardModule from 'common/components/actionbar/actionbar_module';
+
+describe('Action bar', () => {
+  beforeEach(() => angular.mock.module(actionbarCardModule.name));
+
+  it('should add shadow on scroll',
+     angular.mock.inject(($rootScope, $window, $document, $compile) => {
+       let elem = $compile('<kd-actionbar></kd-actionbar>')($rootScope);
+
+       // Start with no state.
+       expect(elem[0].classList).not.toContain('kd-actionbar-not-scrolled');
+
+       $rootScope.$digest();
+       // On initial load go with not scrolled state.
+       expect(elem[0].classList).toContain('kd-actionbar-not-scrolled');
+
+       $window.scrollY = 70;
+       $document.trigger('scroll');
+       $rootScope.$digest();
+       // Now it is scrolled
+       expect(elem[0].classList).not.toContain('kd-actionbar-not-scrolled');
+
+       $window.scrollY = 0;
+       $document.trigger('scroll');
+       $rootScope.$digest();
+       // Go back.
+       expect(elem[0].classList).toContain('kd-actionbar-not-scrolled');
+
+       $rootScope.$destroy();
+       $window.scrollY = 70;
+       $document.trigger('scroll');
+       $rootScope.$digest();
+       // After $destroy - nothing happens.
+       expect(elem[0].classList).toContain('kd-actionbar-not-scrolled');
+     }));
+});


### PR DESCRIPTION
This looks consistent across all our pages. Best pull this branch to
test.
![selection_069](https://cloud.githubusercontent.com/assets/1159999/14852056/4fea7348-0c84-11e6-9804-243993269077.png)


![selection_070](https://cloud.githubusercontent.com/assets/1159999/14852058/52dc5e2c-0c84-11e6-9913-24073d35ad40.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/683)
<!-- Reviewable:end -->
