### PR TITLE
WIP: Redesigned UI for correct validation when service must be created

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -98,11 +98,11 @@ limitations under the License.
 </kd-help-section>
 
 <kd-help-section>
-  <kd-port-mappings port-mappings="ctrl.portMappings" protocols="ctrl.protocols"
-      is-external="ctrl.isExternal">
-  </kd-port-mappings>
+    <kd-port-mappings port-mappings="ctrl.portMappings" protocols="ctrl.protocols"
+        is-external="ctrl.isExternal">
+    </kd-port-mappings>
   <kd-user-help>
-    Ports are optional. If specified, a Service will be created mapping the Port (incoming) to a
+    Service is optional. If specified, it will mapp the Port (incoming) to a
     target Port seen by the container.
     <span ng-if="ctrl.name">
       The internal DNS name for this Service will be: <span class="kd-emphasized">{{ctrl.name}}</span>.
@@ -113,16 +113,7 @@ limitations under the License.
   </kd-user-help>
 </kd-help-section>
 
-<kd-help-section>
-  <div class="md-block">
-    <md-checkbox ng-model="ctrl.isExternal" class="md-primary"
-                 ng-model-options="{ debounce: { 'default': 500, 'blur': 0 } }">
-      Expose service externally
-    </md-checkbox>
-  </div>
-  <kd-user-help>
-  </kd-user-help>
-</kd-help-section>
+
 
 <!-- advanced options -->
 <div ng-show="ctrl.isMoreOptionsEnabled()">

--- a/src/app/frontend/deploy/portmappings.html
+++ b/src/app/frontend/deploy/portmappings.html
@@ -13,18 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<div  class="kd-label-title md-body-2">Service</div>
+<md-input-container class="md-block">
+  <label>Type</label>
+<md-select ng-model="ctrl.serviceType" ng-change="ctrl.changeServiceType()">
+  <md-option>
+    None
+  </md-option>
+  <md-option>
+    Internal
+  </md-option>
+  <md-option>
+    External
+  </md-option>
+</md-select>
+</md-input-container>
 <div ng-repeat="portMapping in ctrl.portMappings">
   <ng-form name="portMappingForm" layout="row">
     <md-input-container flex="50" class="kd-deploy-input-row">
       <label>Port</label>
       <input ng-model="portMapping.port" ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
-             type="number" min="1" max="65535" name="port">
-      <ng-messages for="portMappingForm.port.$error" role="alert" multiple>
+             type="number" min="1" max="65535" name="port" ng-required="ctrl.isRequired($index)">
+      <ng-messages for="portMappingForm.port.$error" role="alert" >
         <ng-message when="number">Port must be an integer.</ng-message>
         <ng-message when="min">Port must greater than 0.</ng-message>
         <ng-message when="max">Port must less than 65536.</ng-message>
-        <ng-message when="empty">Port can't be empty when target port is specified.</ng-message>
+        <ng-message when="required">One port is required.</ng-message>
+        <ng-message when="incomplete">Port can't be empty when target port is specified.</ng-message>
       </ng-messages>
     </md-input-container>
     <div flex="5"></div>
@@ -32,15 +47,15 @@ limitations under the License.
       <label>Target port</label>
       <input ng-model="portMapping.targetPort"
              ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
-             type="number" min="1" max="65535" name="targetPort">
-      <ng-messages for="portMappingForm.targetPort.$error" role="alert" multiple>
+             type="number" min="1" max="65535" name="targetPort" ng-required="ctrl.isRequired($index)">
+      <ng-messages for="portMappingForm.targetPort.$error" role="alert" >
         <ng-message when="number">Target port must be an integer.</ng-message>
         <ng-message when="min">Target port must greater than 0.</ng-message>
         <ng-message when="max">Target port must less than 65536.</ng-message>
-        <ng-message when="empty">Target port can't be empty when port is specified.</ng-message>
+        <ng-message when="required">One target port is required.</ng-message>
+        <ng-message when="incomplete">Target port can't be empty when port is specified.</ng-message>
       </ng-messages>
     </md-input-container>
-    <div flex="5"></div>
     <md-input-container flex="none" class="kd-deploy-input-row">
       <label>Protocol</label>
       <md-select ng-model="portMapping.protocol" name="protocol" is-external="ctrl.isExternal"

--- a/src/app/frontend/deploy/portmappings_controller.js
+++ b/src/app/frontend/deploy/portmappings_controller.js
@@ -23,8 +23,9 @@ export default class PortMappingsController {
     /**
      * Two way data binding from the scope.
      * @export {!Array<!backendApi.PortMapping>}
+     *
      */
-    this.portMappings = [this.newEmptyPortMapping_(this.protocols[0])];
+    this.portMappings = [];
 
     /**
      * Initialized from the scope.
@@ -37,6 +38,8 @@ export default class PortMappingsController {
      * @export {boolean}
      */
     this.isExternal;
+
+    this.serviceType;
   }
 
   /**
@@ -93,8 +96,8 @@ export default class PortMappingsController {
       let isValidTargetPort =
           this.isPortMappingFilledOrEmpty_(portMapping) || !!portMapping.targetPort;
 
-      portElem.$setValidity('empty', isValidPort);
-      targetPortElem.$setValidity('empty', isValidTargetPort);
+      portElem.$setValidity('incomplete', isValidPort);
+      targetPortElem.$setValidity('incomplete', isValidTargetPort);
     }
   }
 
@@ -126,4 +129,30 @@ export default class PortMappingsController {
    * @private
    */
   isPortMappingFilledOrEmpty_(portMapping) { return !portMapping.port === !portMapping.targetPort; }
+
+  changeServiceType(){
+
+    // add or remove port mappings
+    if (this.serviceType==='None'){
+      this.portMappings = [];
+    } else if (this.portMappings.length ===0 ) {
+      this.portMappings = [this.newEmptyPortMapping_(this.protocols[0])];
+    }
+
+    // TODO use object & do some refactoring in parent controller
+    if (this.serviceType == 'External'){
+      this.isExternal = true;
+    } else {
+      this.isExternal = false;
+    }
+  }
+
+  // firt port mapping is required
+  // TODO better name
+  isRequired(portIndex){
+    if (portIndex == 0){
+      return true;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
I redesigned the UI as discussed in:

https://github.com/kubernetes/dashboard/pull/680

Code is quite easy ( No watch was used). Test and clean up is missing. I will do it if you like the proposal.

@floreks I am interested if you like the usability and the look and feel. 

First option with header to indicate that both fields belong together. Similar to labels.
![expose-externally-redesign](https://cloud.githubusercontent.com/assets/7448799/14954203/c8e2030c-1070-11e6-8669-44562425dce7.png)


Second option without header (I like better):
![expose-external3](https://cloud.githubusercontent.com/assets/7448799/14954223/f42655c2-1070-11e6-897c-64865a52dc08.png)

(UDP protocol check is not fully wired up)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/697)
<!-- Reviewable:end -->
