### PR TITLE
Load apiserver config the same way kubectl does it

### DIFF
--- a/src/app/backend/client/apiserverclient.go
+++ b/src/app/backend/client/apiserverclient.go
@@ -47,7 +47,7 @@ func CreateApiserverClient(apiserverHost string) (*client.Client, clientcmd.Clie
 	}
 
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{}, overrides)
+		clientcmd.NewDefaultClientConfigLoadingRules(), overrides)
 
 	cfg, err := clientConfig.ClientConfig()
 	cfg.QPS = defaultQPS


### PR DESCRIPTION
Now it parses kubeconfig files when present

Try running `./dist/amd64/dashboard`. It should get info from your
kubectl file and use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/710)
<!-- Reviewable:end -->
