### PR TITLE
Revert gulp-filter to version ~3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-codecov.io": "~1.0.1",
     "gulp-concat": "~2.6.0",
     "gulp-eslint": "~2.0.0",
-    "gulp-filter": "~4.0.0",
+    "gulp-filter": "~3.0.0",
     "gulp-flatten": "~0.2.0",
     "gulp-htmlmin": "~2.0.0",
     "gulp-inject": "~4.0.0",


### PR DESCRIPTION
Closes #681 

It appears that in gulp-filter 4.0.0 there are some issues with resolving paths.

https://github.com/sindresorhus/gulp-filter/issues/62
https://github.com/sindresorhus/gulp-filter/issues/67

There is a PR open that should fix it so we can keep an eye on that and check again once it gets merged.

https://github.com/sindresorhus/gulp-filter/pull/61

For now I've changed version of gulp-filter back to v3 and that fixed filtering issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/711)
<!-- Reviewable:end -->
