### PR TITLE
Refactor breadcrumbs configuration to use explicit config string

### DIFF
--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
@@ -14,6 +14,9 @@
 
 import Breadcrumb from './breadcrumb';
 
+/** Breadcrumbs config string used on state config. **/
+export const breadcrumbsConfig = 'kdBreadcrumbs';
+
 /**
  * @final
  */
@@ -93,7 +96,7 @@ export default class BreadcrumbsController {
     let conf = state['data'];
 
     if (conf) {
-      conf = conf['kdBreadcrumbs'];
+      conf = conf[breadcrumbsConfig];
     }
 
     return conf;

--- a/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import {actionbarViewName} from 'chrome/chrome_state';
-import {stateName, stateUrl} from './replicasetlist_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
 import {ReplicaSetListController} from './replicasetlist_controller';
+import {stateName, stateUrl} from './replicasetlist_state';
 import ReplicaSetListActionBarController from './replicasetlistactionbar_controller';
 
 /**
@@ -30,7 +31,7 @@ export default function stateConfig($stateProvider) {
       'replicaSets': resolveReplicaSets,
     },
     data: {
-      'kdBreadcrumbs': {
+      [breadcrumbsConfig]: {
         'label': 'Replica Sets',
       },
     },

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ReplicationControllerDetailController from './replicationcontrollerdetail_controller';
-import ReplicationControllerDetailActionBarController from './replicationcontrollerdetailactionbar_controller';
-import {stateName} from './replicationcontrollerdetail_state';
 import {actionbarViewName} from 'chrome/chrome_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
+import {stateName} from './replicationcontrollerdetail_state';
 import {stateName as replicationControllers} from 'replicationcontrollerlistdeprecated/replicationcontrollerlist_state';
+import ReplicationControllerDetailActionBarController from './replicationcontrollerdetailactionbar_controller';
+import ReplicationControllerDetailController from './replicationcontrollerdetail_controller';
 
 /**
  * Configures states for the service view.
@@ -34,7 +35,7 @@ export default function stateConfig($stateProvider) {
       'replicationControllerEvents': resolveReplicationControllerEvents,
     },
     data: {
-      'kdBreadcrumbs': {
+      [breadcrumbsConfig]: {
         'label': '{{$stateParams.replicationController}}',
         'parent': replicationControllers,
       },

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_stateconfig.js
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import {actionbarViewName} from 'chrome/chrome_state';
-import {stateName, stateUrl} from './replicationcontrollerlist_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
 import {ReplicationControllerListController} from './replicationcontrollerlist_controller';
+import {stateName, stateUrl} from './replicationcontrollerlist_state';
 import ReplicationControllerListActionBarController from './replicationcontrollerlistactionbar_controller';
 
 /**
@@ -30,7 +31,7 @@ export default function stateConfig($stateProvider) {
       'replicationControllers': resolveReplicationControllers,
     },
     data: {
-      'kdBreadcrumbs': {
+      [breadcrumbsConfig]: {
         'label': 'Replication Controllers',
       },
     },

--- a/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerlistdeprecated/replicationcontrollerlist_stateconfig.js
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 import {actionbarViewName} from 'chrome/chrome_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
 import {stateName as zerostate} from './zerostate/zerostate_state';
 import {stateName as replicationcontrollers} from './replicationcontrollerlist_state';
 import {stateUrl as replicationcontrollersUrl} from './replicationcontrollerlist_state';
 import {StateParams} from './zerostate/zerostate_state';
-import ReplicationControllerListController from './replicationcontrollerlist_controller';
 import ReplicationControllerListActionBarController from './replicationcontrollerlistactionbar_controller';
+import ReplicationControllerListController from './replicationcontrollerlist_controller';
 import ZeroStateController from './zerostate/zerostate_controller';
 
 /**
@@ -34,7 +35,7 @@ export default function stateConfig($stateProvider) {
       'replicationControllers': resolveReplicationControllers,
     },
     data: {
-      'kdBreadcrumbs': {
+      [breadcrumbsConfig]: {
         'label': 'Replication Controllers',
       },
     },

--- a/src/test/frontend/common/components/breadcrumbs/breadcrumbs_component_test.js
+++ b/src/test/frontend/common/components/breadcrumbs/breadcrumbs_component_test.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
 import componentsModule from 'common/components/components_module';
 
 describe('Breadcrumbs controller ', () => {
@@ -35,7 +36,7 @@ describe('Breadcrumbs controller ', () => {
     return {
       name: stateName,
       data: {
-        kdBreadcrumbs: {
+        [breadcrumbsConfig]: {
           label: stateLabel,
         },
       },


### PR DESCRIPTION
Closes #695

I've wanted to do it now before we create bunch of new pages and we'll have to refactor more code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/712)
<!-- Reviewable:end -->
