### PR TITLE
Add services backend

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -26,10 +26,10 @@ import (
 	. "github.com/kubernetes/dashboard/resource/container"
 	. "github.com/kubernetes/dashboard/resource/event"
 	. "github.com/kubernetes/dashboard/resource/namespace"
-	. "github.com/kubernetes/dashboard/resource/service"
 	"github.com/kubernetes/dashboard/resource/replicaset"
 	. "github.com/kubernetes/dashboard/resource/replicationcontroller"
 	. "github.com/kubernetes/dashboard/resource/secret"
+	resourceService "github.com/kubernetes/dashboard/resource/service"
 	"github.com/kubernetes/dashboard/resource/workload"
 	. "github.com/kubernetes/dashboard/validation"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -235,19 +235,19 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 	servicesWs.Route(
 		servicesWs.GET("").
 			To(apiHandler.handleGetServiceList).
-			Writes(ServiceList{}))
+			Writes(resourceService.ServiceList{}))
 	servicesWs.Route(
 		servicesWs.GET("/{namespace}/{service}").
 			To(apiHandler.handleGetService).
-			Writes(Service{}))
+			Writes(resourceService.Service{}))
 	wsContainer.Add(servicesWs)
 
 	return wsContainer
 }
 
-// Handles get Replication Controller list API call.
+// Handles get service list API call.
 func (apiHandler *ApiHandler) handleGetServiceList(request *restful.Request, response *restful.Response) {
-	result, err := GetServiceList(apiHandler.client)
+	result, err := resourceService.GetServiceList(apiHandler.client)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -260,7 +260,7 @@ func (apiHandler *ApiHandler) handleGetServiceList(request *restful.Request, res
 func (apiHandler *ApiHandler) handleGetService(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	service := request.PathParameter("service")
-	result, err := GetService(apiHandler.client, apiHandler.heapsterClient, namespace, service)
+	result, err := resourceService.GetService(apiHandler.client, namespace, service)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/kubernetes/dashboard/resource/container"
 	. "github.com/kubernetes/dashboard/resource/event"
 	. "github.com/kubernetes/dashboard/resource/namespace"
+	. "github.com/kubernetes/dashboard/resource/service"
 	"github.com/kubernetes/dashboard/resource/replicaset"
 	. "github.com/kubernetes/dashboard/resource/replicationcontroller"
 	. "github.com/kubernetes/dashboard/resource/secret"
@@ -42,6 +43,14 @@ const (
 	// ResponseLogString is a template for response log message.
 	ResponseLogString = "Outcoming response to %s with %d status code"
 )
+
+// ApiHandler is a representation of API handler. Structure contains client, Heapster client and
+// client configuration.
+type ApiHandler struct {
+	client         *client.Client
+	heapsterClient HeapsterClient
+	clientConfig   clientcmd.ClientConfig
+}
 
 // Web-service filter function used for request and response logging.
 func wsLogger(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
@@ -218,15 +227,45 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 			Writes(Secret{}))
 	wsContainer.Add(secretsWs)
 
+	servicesWs := new(restful.WebService)
+	servicesWs.Filter(wsLogger)
+	servicesWs.Path("/api/v1/services").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+	servicesWs.Route(
+		servicesWs.GET("").
+			To(apiHandler.handleGetServiceList).
+			Writes(ServiceList{}))
+	servicesWs.Route(
+		servicesWs.GET("/{namespace}/{service}").
+			To(apiHandler.handleGetService).
+			Writes(Service{}))
+	wsContainer.Add(servicesWs)
+
 	return wsContainer
 }
 
-// ApiHandler is a representation of API handler. Structure contains client, Heaptster client and
-// client configuration.
-type ApiHandler struct {
-	client         *client.Client
-	heapsterClient HeapsterClient
-	clientConfig   clientcmd.ClientConfig
+// Handles get Replication Controller list API call.
+func (apiHandler *ApiHandler) handleGetServiceList(request *restful.Request, response *restful.Response) {
+	result, err := GetServiceList(apiHandler.client)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get service detail API call.
+func (apiHandler *ApiHandler) handleGetService(request *restful.Request, response *restful.Response) {
+	namespace := request.PathParameter("namespace")
+	service := request.PathParameter("service")
+	result, err := GetService(apiHandler.client, apiHandler.heapsterClient, namespace, service)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
 }
 
 // Handles deploy API call.

--- a/src/app/backend/resource/common/types.go
+++ b/src/app/backend/resource/common/types.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"bytes"
+)
+
+// Endpoint describes an endpoint that is host and a list of available ports for that host.
+type Endpoint struct {
+	// Hostname, either as a domain name or IP address.
+	Host string `json:"host"`
+
+	// List of ports opened for this endpoint on the hostname.
+	Ports []ServicePort `json:"ports"`
+}
+
+// ServicePort is a pair of port and protocol, e.g. a service endpoint.
+type ServicePort struct {
+	// Positive port number.
+	Port int `json:"port"`
+
+	// Protocol name, e.g., TCP or UDP.
+	Protocol api.Protocol `json:"protocol"`
+}
+
+// Returns internal endpoint name for the given service properties, e.g.,
+// "my-service.namespace 80/TCP" or "my-service 53/TCP,53/UDP".
+func GetInternalEndpoint(serviceName, namespace string, ports []api.ServicePort) Endpoint {
+
+	name := serviceName
+	if namespace != api.NamespaceDefault {
+		bufferName := bytes.NewBufferString(name)
+		bufferName.WriteString(".")
+		bufferName.WriteString(namespace)
+		name = bufferName.String()
+	}
+
+	return Endpoint{
+		Host:  name,
+		Ports: GetServicePorts(ports),
+	}
+}
+
+
+// Gets human readable name for the given service ports list.
+func GetServicePorts(apiPorts []api.ServicePort) []ServicePort {
+	var ports []ServicePort
+	for _, port := range apiPorts {
+		ports = append(ports, ServicePort{port.Port, port.Protocol})
+	}
+	return ports
+}

--- a/src/app/backend/resource/common/types.go
+++ b/src/app/backend/resource/common/types.go
@@ -15,8 +15,8 @@
 package common
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"bytes"
+	"k8s.io/kubernetes/pkg/api"
 )
 
 // Endpoint describes an endpoint that is host and a list of available ports for that host.
@@ -42,7 +42,7 @@ type ServicePort struct {
 func GetInternalEndpoint(serviceName, namespace string, ports []api.ServicePort) Endpoint {
 
 	name := serviceName
-	if namespace != api.NamespaceDefault {
+	if namespace != api.NamespaceDefault && len(namespace) > 0 && len(serviceName) > 0 {
 		bufferName := bytes.NewBufferString(name)
 		bufferName.WriteString(".")
 		bufferName.WriteString(namespace)
@@ -54,7 +54,6 @@ func GetInternalEndpoint(serviceName, namespace string, ports []api.ServicePort)
 		Ports: GetServicePorts(ports),
 	}
 }
-
 
 // Gets human readable name for the given service ports list.
 func GetServicePorts(apiPorts []api.ServicePort) []ServicePort {

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/kubernetes/dashboard/client"
 	"github.com/kubernetes/dashboard/resource/common"
-	. "github.com/kubernetes/dashboard/resource/service"
+	resourceService "github.com/kubernetes/dashboard/resource/service"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -51,7 +51,7 @@ type ReplicationControllerDetail struct {
 	Pods []ReplicationControllerPod `json:"pods"`
 
 	// Detailed information about service related to Replication Controller.
-	Services []Service `json:"services"`
+	Services []resourceService.Service `json:"services"`
 
 	// True when the data contains at least one pod with metrics information, false otherwise.
 	HasMetrics bool `json:"hasMetrics"`
@@ -253,8 +253,8 @@ func UpdateReplicasCount(client client.Interface, namespace, name string,
 
 // Returns detailed information about service from given service
 func getServiceDetail(service api.Service, replicationController api.ReplicationController,
-	pods []api.Pod, nodes []api.Node) Service {
-	return Service{
+	pods []api.Pod, nodes []api.Node) resourceService.Service {
+	return resourceService.Service{
 		Name: service.ObjectMeta.Name,
 		InternalEndpoint: common.GetInternalEndpoint(service.Name, service.Namespace,
 			service.Spec.Ports),

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
@@ -56,10 +56,10 @@ type ReplicationController struct {
 	CreationTime unversioned.Time `json:"creationTime"`
 
 	// Internal endpoints of all Kubernetes services have the same label selector as this Replication Controller.
-	InternalEndpoints []Endpoint `json:"internalEndpoints"`
+	InternalEndpoints []common.Endpoint `json:"internalEndpoints"`
 
 	// External endpoints of all Kubernetes services have the same label selector as this Replication Controller.
-	ExternalEndpoints []Endpoint `json:"externalEndpoints"`
+	ExternalEndpoints []common.Endpoint `json:"externalEndpoints"`
 }
 
 // GetReplicationControllerList returns a list of all Replication Controllers in the cluster.
@@ -127,11 +127,11 @@ func getReplicationControllerList(replicationControllers []api.ReplicationContro
 	for _, replicationController := range replicationControllers {
 
 		matchingServices := getMatchingServices(services, &replicationController)
-		var internalEndpoints []Endpoint
-		var externalEndpoints []Endpoint
+		var internalEndpoints []common.Endpoint
+		var externalEndpoints []common.Endpoint
 		for _, service := range matchingServices {
 			internalEndpoints = append(internalEndpoints,
-				getInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports))
+				common.GetInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports))
 			externalEndpoints = getExternalEndpoints(replicationController, pods, service, nodes)
 		}
 

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"sort"
 
-	api "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )

--- a/src/app/backend/resource/service/services.go
+++ b/src/app/backend/resource/service/services.go
@@ -18,7 +18,6 @@ import (
 	"log"
 
 	"github.com/kubernetes/dashboard/resource/common"
-	. "github.com/kubernetes/dashboard/client"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -57,7 +56,7 @@ type ServiceList struct {
 }
 
 // GetService gets service details.
-func GetService(client client.Interface, heapsterClient HeapsterClient, namespace, name string) (*Service, error) {
+func GetService(client client.Interface, namespace, name string) (*Service, error) {
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
 	// TODO(maciaszczykm): Use channels.
@@ -71,7 +70,7 @@ func GetService(client client.Interface, heapsterClient HeapsterClient, namespac
 }
 
 // GetServiceList returns a list of all services in the cluster.
-func GetServiceList(client *client.Client) (*ServiceList, error) {
+func GetServiceList(client client.Interface) (*ServiceList, error) {
 	log.Printf("Getting list of all services in the cluster")
 
 	channels := &common.ResourceChannels{
@@ -98,7 +97,7 @@ func getServiceDetails(service *api.Service) Service {
 		CreationTimestamp: service.CreationTimestamp,
 		Labels:            service.Labels,
 		InternalEndpoint:  common.GetInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports),
-		ExternalEndpoints: []common.Endpoint{}, // TODO(maciaszczykm): Fill it with data.
-		Selector:          service.Spec.Selector,
+		// TODO(maciaszczykm): Fill ExternalEndpoints with data.
+		Selector: service.Spec.Selector,
 	}
 }

--- a/src/app/backend/resource/service/services.go
+++ b/src/app/backend/resource/service/services.go
@@ -1,0 +1,104 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	. "github.com/kubernetes/dashboard/client"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// Service is a representation of a service.
+type Service struct {
+	// Name of the service.
+	Name string `json:"name"`
+
+	// Namespace of the service.
+	Namespace string `json:"namespace"`
+
+	// CreationTimestamp of the service.
+	CreationTimestamp unversioned.Time `json:"creationTimestamp"`
+
+	// Label mapping of the service.
+	Labels map[string]string `json:"labels"`
+
+	// InternalEndpoint of all Kubernetes services that have the same label selector as connected Replication
+	// Controller. Endpoint is DNS name merged with ports.
+	InternalEndpoint common.Endpoint `json:"internalEndpoint"`
+
+	// ExternalEndpoints of all Kubernetes services that have the same label selector as connected Replication
+	// Controller. Endpoint is external IP address name merged with ports.
+	ExternalEndpoints []common.Endpoint `json:"externalEndpoints"`
+
+	// Label selector of the service.
+	Selector map[string]string `json:"selector"`
+}
+
+// ServiceList contains a list of services in the cluster.
+type ServiceList struct {
+	// Unordered list of services.
+	Services []Service `json:"services"`
+}
+
+// GetService gets service details.
+func GetService(client client.Interface, heapsterClient HeapsterClient, namespace, name string) (*Service, error) {
+	log.Printf("Getting details of %s service in %s namespace", name, namespace)
+
+	// TODO(maciaszczykm): Use channels.
+	serviceData, err := client.Services(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	service := getServiceDetails(serviceData)
+	return &service, nil
+}
+
+// GetServiceList returns a list of all services in the cluster.
+func GetServiceList(client *client.Client) (*ServiceList, error) {
+	log.Printf("Getting list of all services in the cluster")
+
+	channels := &common.ResourceChannels{
+		ServiceList: common.GetServiceListChannel(client, 1),
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	serviceList := &ServiceList{Services: make([]Service, 0)}
+	for _, service := range services.Items {
+		serviceList.Services = append(serviceList.Services, getServiceDetails(&service))
+	}
+
+	return serviceList, nil
+}
+
+func getServiceDetails(service *api.Service) Service {
+	return Service{
+		Name:              service.Name,
+		Namespace:         service.Namespace,
+		CreationTimestamp: service.CreationTimestamp,
+		Labels:            service.Labels,
+		InternalEndpoint:  common.GetInternalEndpoint(service.Name, service.Namespace, service.Spec.Ports),
+		ExternalEndpoints: []common.Endpoint{}, // TODO(maciaszczykm): Fill it with data.
+		Selector:          service.Spec.Selector,
+	}
+}

--- a/src/test/backend/resource/common/types_test.go
+++ b/src/test/backend/resource/common/types_test.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestGetInternalEndpoint(t *testing.T) {
+	cases := []struct {
+		serviceName, namespace string
+		ports                  []api.ServicePort
+		expected               Endpoint
+	}{
+		{"my-service", api.NamespaceDefault, nil, Endpoint{Host: "my-service"}},
+		{"my-service", api.NamespaceDefault,
+			[]api.ServicePort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			Endpoint{Host: "my-service", Ports: []ServicePort{{Port: 8080, Protocol: "TCP"}}}},
+		{"my-service", "my-namespace", nil, Endpoint{Host: "my-service.my-namespace"}},
+		{"my-service", "my-namespace",
+			[]api.ServicePort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			Endpoint{Host: "my-service.my-namespace",
+				Ports: []ServicePort{{Port: 8080, Protocol: "TCP"}}}},
+	}
+	for _, c := range cases {
+		actual := GetInternalEndpoint(c.serviceName, c.namespace, c.ports)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getInternalEndpoint(%+v, %+v, %+v) == %+v, expected %+v",
+				c.serviceName, c.namespace, c.ports, actual, c.expected)
+		}
+	}
+}
+
+func TestGetServicePorts(t *testing.T) {
+	cases := []struct {
+		apiPorts []api.ServicePort
+		expected []ServicePort
+	}{
+		{[]api.ServicePort{}, nil},
+		{
+			[]api.ServicePort{
+				{Port: 123, Protocol: api.ProtocolTCP},
+				{Port: 1, Protocol: api.ProtocolUDP},
+				{Port: 5, Protocol: api.ProtocolUDP},
+			},
+			[]ServicePort{
+				{Port: 123, Protocol: api.ProtocolTCP},
+				{Port: 1, Protocol: api.ProtocolUDP},
+				{Port: 5, Protocol: api.ProtocolUDP},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := GetServicePorts(c.apiPorts)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetServicePorts(%#v) == \ngot %#v, \nexpected %#v",
+				c.apiPorts, actual, c.expected)
+		}
+	}
+}

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerdetail_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerdetail_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/kubernetes/dashboard/resource/common"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
@@ -208,7 +209,7 @@ func TestGetServicePortsName(t *testing.T) {
 			[]ServicePort{{Port: 8080, Protocol: "TCP"}, {Port: 9191, Protocol: "UDP"}}},
 	}
 	for _, c := range cases {
-		actual := getServicePorts(c.ports)
+		actual := GetServicePorts(c.ports)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getServicePortsName(%+v) == %+v, expected %+v", c.ports, actual, c.expected)
 		}
@@ -539,31 +540,6 @@ func TestGetLocalhostEndpoints(t *testing.T) {
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getLocalhostEndpoints(%+v) == %+v, expected %+v", c.service, actual,
 				c.expected)
-		}
-	}
-}
-
-func TestGetInternalEndpoint(t *testing.T) {
-	cases := []struct {
-		serviceName, namespace string
-		ports                  []api.ServicePort
-		expected               Endpoint
-	}{
-		{"my-service", api.NamespaceDefault, nil, Endpoint{Host: "my-service"}},
-		{"my-service", api.NamespaceDefault,
-			[]api.ServicePort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			Endpoint{Host: "my-service", Ports: []ServicePort{{Port: 8080, Protocol: "TCP"}}}},
-		{"my-service", "my-namespace", nil, Endpoint{Host: "my-service.my-namespace"}},
-		{"my-service", "my-namespace",
-			[]api.ServicePort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-			Endpoint{Host: "my-service.my-namespace",
-				Ports: []ServicePort{{Port: 8080, Protocol: "TCP"}}}},
-	}
-	for _, c := range cases {
-		actual := getInternalEndpoint(c.serviceName, c.namespace, c.ports)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("getInternalEndpoint(%+v, %+v, %+v) == %+v, expected %+v",
-				c.serviceName, c.namespace, c.ports, actual, c.expected)
 		}
 	}
 }

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
@@ -191,7 +191,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 						Name:              "my-app-1",
 						Namespace:         "namespace-1",
 						ContainerImages:   []string{"my-container-image-1"},
-						InternalEndpoints: []Endpoint{{Host: "my-app-1.namespace-1"}},
+						InternalEndpoints: []common.Endpoint{{Host: "my-app-1.namespace-1"}},
 						Pods: common.ControllerPodInfo{
 							Failed:   2,
 							Pending:  1,
@@ -202,7 +202,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 						Name:              "my-app-2",
 						Namespace:         "namespace-2",
 						ContainerImages:   []string{"my-container-image-2"},
-						InternalEndpoints: []Endpoint{{Host: "my-app-2.namespace-2"}},
+						InternalEndpoints: []common.Endpoint{{Host: "my-app-2.namespace-2"}},
 						Pods: common.ControllerPodInfo{
 							Warnings: []event.Event{},
 						},

--- a/src/test/backend/resource/service/services_test.go
+++ b/src/test/backend/resource/service/services_test.go
@@ -1,0 +1,161 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/resource/common"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+func TestGetService(t *testing.T) {
+	cases := []struct {
+		service         *api.Service
+		namespace, name string
+		expectedActions []string
+		expected        *Service
+	}{
+		{
+			service:   &api.Service{},
+			namespace: "test-namespace", name: "test-name",
+			expectedActions: []string{"get"},
+			expected:        &Service{},
+		}, {
+			service: &api.Service{ObjectMeta: api.ObjectMeta{
+				Name: "test-service", Namespace: "test-namespace",
+			}},
+			namespace: "test-namespace", name: "test-name",
+			expectedActions: []string{"get"},
+			expected: &Service{
+				Name:             "test-service",
+				Namespace:        "test-namespace",
+				InternalEndpoint: common.Endpoint{Host: "test-service.test-namespace"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.service)
+
+		actual, _ := GetService(fakeClient, c.namespace, c.name)
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetService(client, %#v, %#v) == \ngot %#v, \nexpected %#v", c.namespace,
+				c.name, actual, c.expected)
+		}
+	}
+}
+
+func TestGetServiceList(t *testing.T) {
+	cases := []struct {
+		serviceList     *api.ServiceList
+		expectedActions []string
+		expected        *ServiceList
+	}{
+		{
+			serviceList:   &api.ServiceList{},
+			expectedActions: []string{"list"},
+			expected:        &ServiceList{Services: make([]Service, 0)},
+		}, {
+			serviceList: &api.ServiceList{
+				Items: []api.Service{
+					{ObjectMeta: api.ObjectMeta{
+						Name: "test-service", Namespace: "test-namespace",
+					}},
+				}},
+			expectedActions: []string{"list"},
+			expected: &ServiceList{
+				Services: []Service{
+					{
+						Name:             "test-service",
+						Namespace:        "test-namespace",
+						InternalEndpoint: common.Endpoint{Host: "test-service.test-namespace"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.serviceList)
+
+		actual, _ := GetServiceList(fakeClient)
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetServiceList(client) == \ngot %#v, \nexpected %#v", actual, c.expected)
+		}
+	}
+}
+
+func TestGetServiceDetails(t *testing.T) {
+	cases := []struct {
+		service  *api.Service
+		expected Service
+	}{
+		{
+			service: &api.Service{}, expected: Service{},
+		}, {
+			service: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Name: "test-service", Namespace: "test-namespace",
+				}},
+			expected: Service{
+				Name:             "test-service",
+				Namespace:        "test-namespace",
+				InternalEndpoint: common.Endpoint{Host: "test-service.test-namespace"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := getServiceDetails(c.service)
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("getServiceDetails(%#v) == \ngot %#v, \nexpected %#v", c.service, actual,
+				c.expected)
+		}
+	}
+}


### PR DESCRIPTION
In behalf of @maciaszczykm 

> Added initial version of services backend logic:
>
> http://localhost:9091/api/v1/services/ lists all services within the cluster
> http://localhost:9091/api/v1/services/{namespace}/{service} returns {service} service details from {namespace} namespace
> Placed all logic in one file, it can change later, but at the moment I think it's not necessary.
> 
> I'm open to your suggestions as this is only proposal at the moment.
> 
> Connected to #659.

I've refactored code from #670 a bit. Moved `service.go` from `backend` to `backend/resource/service` and added tests.

@bryk could you review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/713)
<!-- Reviewable:end -->
