### PR TITLE
Frontend for deployment list and workloads

### DIFF
--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -196,6 +196,23 @@ backendApi.ReplicaSetList;
 
 /**
  * @typedef {{
+ *   objectMeta: !backendApi.ObjectMeta,
+ *   typeMeta: !backendApi.TypeMeta,
+ *   pods: !backendApi.PodInfo,
+ *   containerImages: !Array<string>,
+ * }}
+ */
+backendApi.Deployment;
+
+/**
+ * @typedef {{
+ *   deployments: !Array<!backendApi.Deployment>
+ * }}
+ */
+backendApi.DeploymentList;
+
+/**
+ * @typedef {{
  *   pods: !Array<!backendApi.Pod>
  * }}
  */

--- a/src/app/frontend/deploymentdetail/deploymentdetail_module.js
+++ b/src/app/frontend/deploymentdetail/deploymentdetail_module.js
@@ -12,28 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './workloads_stateconfig';
 import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
-import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
-import replicaSetListModule from 'replicasetlist/replicasetlist_module';
-import deploymentListModule from 'deploymentlist/deploymentlist_module';
+import stateConfig from './deploymentdetail_stateconfig';
 
 /**
- * Module with a view that displays resources categorized as workloads, e.g., Replica Sets or
- * Deployments.
+ * Angular module for the Deployment details view.
+ *
+ * The view shows detailed view of a Deployment.
  */
 export default angular
     .module(
-        'kubernetesDashboard.workloads',
+        'kubernetesDashboard.deploymentdetail',
         [
           'ngMaterial',
           'ngResource',
           'ui.router',
-          filtersModule.name,
           componentsModule.name,
-          replicationControllerListModule.name,
-          replicaSetListModule.name,
-          deploymentListModule.name,
+          filtersModule.name,
         ])
     .config(stateConfig);

--- a/src/app/frontend/deploymentdetail/deploymentdetail_state.js
+++ b/src/app/frontend/deploymentdetail/deploymentdetail_state.js
@@ -1,0 +1,36 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'deploymentdetail';
+
+/**
+ * Parameters for this state.
+ *
+ * All properties are @exported and in sync with URL param names.
+ * @final
+ */
+export class StateParams {
+  /**
+   * @param {string} namespace
+   * @param {string} deployment
+   */
+  constructor(namespace, deployment) {
+    /** @export {string} Namespace of this Deployment. */
+    this.namespace = namespace;
+
+    /** @export {string} Name of this Deployment. */
+    this.deployment = deployment;
+  }
+}

--- a/src/app/frontend/deploymentdetail/deploymentdetail_stateconfig.js
+++ b/src/app/frontend/deploymentdetail/deploymentdetail_stateconfig.js
@@ -1,0 +1,27 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName} from './deploymentdetail_state';
+
+/**
+ * Configures states for the replica set details view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    url: '/deployments/:namespace/:deployment',
+  });
+}

--- a/src/app/frontend/deploymentlist/deploymentcard.html
+++ b/src/app/frontend/deploymentlist/deploymentcard.html
@@ -1,0 +1,69 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-resource-card type-meta="$ctrl.deployment.typeMeta" object-meta="$ctrl.deployment.objectMeta">
+  <kd-resource-card-status layout="row">
+    <md-icon class="material-icons md-warn"
+             ng-if="::$ctrl.hasWarnings()">
+      error
+      <md-tooltip>One or more pods have errors</md-tooltip>
+    </md-icon>
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
+      timelapse
+      <md-tooltip>One or more pods are in pending state</md-tooltip>
+    </md-icon>
+
+    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+      beenhere
+    </md-icon>
+  </kd-resource-card-status>
+  <kd-resource-card-columns>
+    <kd-resource-card-column>
+      <div>
+        <a ng-href="{{::$ctrl.getDeploymentDetailHref()}}" style="display: block;">
+          <kd-middle-ellipsis display-string="{{$ctrl.deployment.objectMeta.name}}">
+          </kd-middle-ellipsis>
+        </a>
+      </div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-labels labels="::$ctrl.deployment.objectMeta.labels"></kd-labels>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <span class="kd-replicase-card-pods-stat">
+        {{::$ctrl.deployment.pods.running}} /
+        {{::$ctrl.deployment.pods.desired}}
+      </span>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.deployment.objectMeta.creationTime | relativeTime}}
+      <md-tooltip>
+        Created at {{::$ctrl.deployment.objectMeta.creationTime | date:'short'}}
+      </md-tooltip>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <div ng-repeat="image in ::$ctrl.deployment.containerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
+    </kd-resource-card-column>
+  </kd-resource-card-columns>
+  <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
+      <div ng-repeat="warning in ::$ctrl.deployment.pods.warnings">
+        <span class="kd-deployment-card-error">{{::warning.message}}</span>
+      </div>
+  </kd-resource-card-footer>
+</kd-resource-card>

--- a/src/app/frontend/deploymentlist/deploymentcard_component.js
+++ b/src/app/frontend/deploymentlist/deploymentcard_component.js
@@ -1,0 +1,80 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {StateParams} from 'deploymentdetail/deploymentdetail_state';
+import {stateName} from 'deploymentdetail/deploymentdetail_state';
+
+/**
+ * Controller for the replica set card.
+ *
+ * @final
+ */
+export default class DeploymentCardController {
+  /**
+   * @param {!ui.router.$state} $state
+   * @ngInject
+   */
+  constructor($state) {
+    /**
+     * Initialized from the scope.
+     * @export {!backendApi.Deployment}
+     */
+    this.deployment;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+  }
+
+  /**
+   * @return {string}
+   * @export
+   */
+  getDeploymentDetailHref() {
+    return this.state_.href(
+        stateName,
+        new StateParams(this.deployment.objectMeta.namespace, this.deployment.objectMeta.name));
+  }
+
+  /**
+   * Returns true if any of replica set pods has warning, false otherwise
+   * @return {boolean}
+   * @export
+   */
+  hasWarnings() { return this.deployment.pods.warnings.length > 0; }
+
+  /**
+   * Returns true if replica set pods have no warnings and there is at least one pod
+   * in pending state, false otherwise
+   * @return {boolean}
+   * @export
+   */
+  isPending() { return !this.hasWarnings() && this.deployment.pods.pending > 0; }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  isSuccess() { return !this.isPending() && !this.hasWarnings(); }
+}
+
+/**
+ * @return {!angular.Component}
+ */
+export const deploymentCardComponent = {
+  bindings: {
+    'deployment': '=',
+  },
+  controller: DeploymentCardController,
+  templateUrl: 'deploymentlist/deploymentcard.html',
+};

--- a/src/app/frontend/deploymentlist/deploymentcardlist.html
+++ b/src/app/frontend/deploymentlist/deploymentcardlist.html
@@ -1,0 +1,37 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-resource-card-list selectable="false" with-statuses="true">
+  <kd-resource-card-header-columns>
+    <kd-resource-card-header-column grow="2">
+      Name
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column grow="2">
+      Labels
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column grow="nogrow" size="small">
+      Pods
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column grow="nogrow" size="small">
+      Age
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column>
+      Images
+    </kd-resource-card-header-column>
+  </kd-resource-card-header-columns>
+  <kd-deployment-card ng-repeat="deployment in $ctrl.deployments" deployment="deployment">
+  </kd-deployment-card>
+</kd-resource-card-list>

--- a/src/app/frontend/deploymentlist/deploymentcardlist_component.js
+++ b/src/app/frontend/deploymentlist/deploymentcardlist_component.js
@@ -1,0 +1,24 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @return {!angular.Component}
+ */
+export const deploymentCardListComponent = {
+  transclude: true,
+  bindings: {
+    'deployments': '<',
+  },
+  templateUrl: 'deploymentlist/deploymentcardlist.html',
+};

--- a/src/app/frontend/deploymentlist/deploymentlist.html
+++ b/src/app/frontend/deploymentlist/deploymentlist.html
@@ -1,0 +1,21 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<kd-content-card>
+  <kd-content>
+    <kd-deployment-card-list deployments="$ctrl.deployments">
+    </kd-deployment-card-list>
+  </kd-content>
+</kd-content-card>

--- a/src/app/frontend/deploymentlist/deploymentlist_controller.js
+++ b/src/app/frontend/deploymentlist/deploymentlist_controller.js
@@ -1,0 +1,29 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Controller for the replica set list view.
+ *
+ * @final
+ */
+export class DeploymentListController {
+  /**
+   * @param {!backendApi.DeploymentList} deployments
+   * @ngInject
+   */
+  constructor(deployments) {
+    /** @export {!Array<!backendApi.Deployment>} */
+    this.deployments = deployments.deployments;
+  }
+}

--- a/src/app/frontend/deploymentlist/deploymentlist_module.js
+++ b/src/app/frontend/deploymentlist/deploymentlist_module.js
@@ -12,28 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './workloads_stateconfig';
+import stateConfig from './deploymentlist_stateconfig';
 import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
-import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
-import replicaSetListModule from 'replicasetlist/replicasetlist_module';
-import deploymentListModule from 'deploymentlist/deploymentlist_module';
+import {deploymentCardComponent} from './deploymentcard_component';
+import {deploymentCardListComponent} from './deploymentcardlist_component';
+import deploymentDetailModule from 'deploymentdetail/deploymentdetail_module';
 
 /**
- * Module with a view that displays resources categorized as workloads, e.g., Replica Sets or
- * Deployments.
+ * Angular module for the Replication Controller list view.
+ *
+ * The view shows Replication Controllers running in the cluster and allows to manage them.
  */
 export default angular
     .module(
-        'kubernetesDashboard.workloads',
+        'kubernetesDashboard.deploymentList',
         [
           'ngMaterial',
           'ngResource',
           'ui.router',
           filtersModule.name,
           componentsModule.name,
-          replicationControllerListModule.name,
-          replicaSetListModule.name,
-          deploymentListModule.name,
+          deploymentDetailModule.name,
         ])
-    .config(stateConfig);
+    .config(stateConfig)
+    .component('kdDeploymentCardList', deploymentCardListComponent)
+    .component('kdDeploymentCard', deploymentCardComponent);

--- a/src/app/frontend/deploymentlist/deploymentlist_state.js
+++ b/src/app/frontend/deploymentlist/deploymentlist_state.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'deployments';
+
+/** Absolute URL of the state. */
+export const stateUrl = '/deployments';

--- a/src/app/frontend/deploymentlist/deploymentlist_stateconfig.js
+++ b/src/app/frontend/deploymentlist/deploymentlist_stateconfig.js
@@ -1,0 +1,62 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {actionbarViewName} from 'chrome/chrome_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_component';
+import {DeploymentListController} from './deploymentlist_controller';
+import {stateName, stateUrl} from './deploymentlist_state';
+import {DeploymentListActionBarController} from './deploymentlistactionbar_controller';
+
+/**
+ * Configures states for the service view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    url: stateUrl,
+    resolve: {
+      'deployments': resolveDeployments,
+    },
+    data: {
+      [breadcrumbsConfig]: {
+        'label': 'Deployments',
+      },
+    },
+    views: {
+      '': {
+        controller: DeploymentListController,
+        controllerAs: '$ctrl',
+        templateUrl: 'deploymentlist/deploymentlist.html',
+      },
+      [actionbarViewName]: {
+        controller: DeploymentListActionBarController,
+        controllerAs: 'ctrl',
+        templateUrl: 'deploymentlist/deploymentlistactionbar.html',
+      },
+    },
+  });
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+export function resolveDeployments($resource) {
+  /** @type {!angular.Resource<!backendApi.DeploymentList>} */
+  let resource = $resource('api/v1/deployments');
+  return resource.get().$promise;
+}

--- a/src/app/frontend/deploymentlist/deploymentlistactionbar.html
+++ b/src/app/frontend/deploymentlist/deploymentlistactionbar.html
@@ -1,0 +1,20 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<md-button class="md-icon-button" ng-click="ctrl.redirectToDeployPage()">
+  <md-icon class="kd-actionbar-icon-button">add</md-icon>
+  <md-tooltip md-direction="left">Deploy a containerized app</md-tooltip>
+</md-button>

--- a/src/app/frontend/deploymentlist/deploymentlistactionbar_controller.js
+++ b/src/app/frontend/deploymentlist/deploymentlistactionbar_controller.js
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as deploy} from 'deploy/deploy_state';
+
+/**
+ * @final
+ */
+export class DeploymentListActionBarController {
+  /**
+   * @param {!ui.router.$state} $state
+   * @ngInject
+   */
+  constructor($state) {
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+  }
+
+  /**
+   * @export
+   */
+  redirectToDeployPage() { this.state_.go(deploy); }
+}

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -19,6 +19,7 @@
 import chromeModule from './chrome/chrome_module';
 import deployModule from './deploy/deploy_module';
 import deprecatedReplicationControllerListModule from './replicationcontrollerlistdeprecated/replicationcontrollerlist_module';
+import deploymentListModule from './deploymentlist/deploymentlist_module';
 import errorModule from './error/error_module';
 import indexConfig from './index_config';
 import logsModule from './logs/logs_module';
@@ -49,6 +50,7 @@ export default angular
           replicationControllerListModule.name,
           deprecatedReplicationControllerListModule.name,
           replicaSetListModule.name,
+          deploymentListModule.name,
           workloadsModule.name,
           serviceDetailModule.name,
           serviceListModule.name,

--- a/src/app/frontend/workloads/workloads.html
+++ b/src/app/frontend/workloads/workloads.html
@@ -14,6 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<kd-content-card ng-if=$ctrl.workloads.deploymentList.deployments>
+  <kd-title>
+    Deployments
+  </kd-title>
+  <kd-content>
+    <kd-deployment-card-list deployments="$ctrl.workloads.deploymentList.deployments">
+    </kd-deployment-card-list>
+  </kd-content>
+</kd-content-card>
+
 <kd-content-card>
   <kd-title>
     Replica Sets

--- a/src/test/frontend/deploymentlist/deploymentactionbar_component_test.js
+++ b/src/test/frontend/deploymentlist/deploymentactionbar_component_test.js
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DeploymentListActionBarController} from 'deploymentlist/deploymentlistactionbar_controller';
+import deploymentListModule from 'deploymentlist/deploymentlist_module';
+import {stateName as deploy} from 'deploy/deploy_state';
+
+describe('Replica Set List Action Bar controller', () => {
+  /** @type {!DeploymentListController} */
+  let ctrl;
+  /** @type {ui.router.$state} */
+  let state;
+
+  beforeEach(() => {
+    angular.mock.module(deploymentListModule.name);
+
+    angular.mock.inject(($controller, $state) => {
+      state = $state;
+      ctrl = $controller(DeploymentListActionBarController, {
+        $state: state,
+      });
+    });
+  });
+
+  it('should redirect to deploy page', () => {
+    // given
+    spyOn(state, 'go');
+
+    // when
+    ctrl.redirectToDeployPage();
+
+    // then
+    expect(state.go).toHaveBeenCalledWith(deploy);
+  });
+});

--- a/src/test/frontend/deploymentlist/deploymentcard_component_test.js
+++ b/src/test/frontend/deploymentlist/deploymentcard_component_test.js
@@ -1,0 +1,116 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import deploymentListModule from 'deploymentlist/deploymentlist_module';
+
+describe('Deployment card', () => {
+  /**
+   * @type
+   * {!deploymentlist/deploymentcard_component.DeploymentCardController}
+   */
+  let ctrl;
+
+  beforeEach(() => {
+    angular.mock.module(deploymentListModule.name);
+
+    angular.mock.inject(
+        ($componentController) => { ctrl = $componentController('kdDeploymentCard'); });
+  });
+
+  it('should construct details href', () => {
+    // given
+    ctrl.deployment = {
+      objectMeta: {
+        name: 'foo-name',
+        namespace: 'foo-namespace',
+      },
+    };
+
+    // then
+    expect(ctrl.getDeploymentDetailHref()).toEqual('#/deployments/foo-namespace/foo-name');
+  });
+
+  it('should return true when at least one replication controller pod has warning', () => {
+    // given
+    ctrl.deployment = {
+      pods: {
+        warnings: [{
+          message: 'test-error',
+          reason: 'test-reason',
+        }],
+      },
+    };
+
+    // then
+    expect(ctrl.hasWarnings()).toBeTruthy();
+  });
+
+  it('should return false when there are no errors related to replication controller pods', () => {
+    // given
+    ctrl.deployment = {
+      pods: {
+        warnings: [],
+      },
+    };
+
+    // then
+    expect(ctrl.hasWarnings()).toBe(false);
+    expect(ctrl.isSuccess()).toBe(true);
+  });
+
+  it('should return true when there are no warnings and at least one pod is in pending state',
+     () => {
+       // given
+       ctrl.deployment = {
+         pods: {
+           warnings: [],
+           pending: 1,
+         },
+       };
+
+       // then
+       expect(ctrl.isPending()).toBe(true);
+       expect(ctrl.isSuccess()).toBe(false);
+     });
+
+  it('should return false when there is warning related to replication controller pods', () => {
+    // given
+    ctrl.deployment = {
+      pods: {
+        warnings: [{
+          message: 'test-error',
+          reason: 'test-reason',
+        }],
+      },
+    };
+
+    // then
+    expect(ctrl.hasWarnings()).toBe(true);
+    expect(ctrl.isPending()).toBe(false);
+    expect(ctrl.isSuccess()).toBe(false);
+  });
+
+  it('should return false when there are no warnings and there is no pod in pending state', () => {
+    // given
+    ctrl.deployment = {
+      pods: {
+        warnings: [],
+        pending: 0,
+      },
+    };
+
+    // then
+    expect(ctrl.isPending()).toBe(false);
+    expect(ctrl.isSuccess()).toBe(true);
+  });
+});

--- a/src/test/frontend/deploymentlist/deploymentlist_controller_test.js
+++ b/src/test/frontend/deploymentlist/deploymentlist_controller_test.js
@@ -1,0 +1,29 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DeploymentListController} from 'deploymentlist/deploymentlist_controller';
+import deploymentListModule from 'deploymentlist/deploymentlist_module';
+
+describe('Replica Set list controller', () => {
+
+  beforeEach(() => { angular.mock.module(deploymentListModule.name); });
+
+  it('should initialize replication controllers', angular.mock.inject(($controller) => {
+    let ctrls = {};
+    /** @type {!DeploymentListController} */
+    let ctrl = $controller(DeploymentListController, {deployments: {deployments: ctrls}});
+
+    expect(ctrl.deployments).toBe(ctrls);
+  }));
+});

--- a/src/test/frontend/deploymentlist/deploymentlist_stateconfig_test.js
+++ b/src/test/frontend/deploymentlist/deploymentlist_stateconfig_test.js
@@ -1,0 +1,32 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import deploymentListModule from 'deploymentlist/deploymentlist_module';
+import {resolveDeployments} from 'deploymentlist/deploymentlist_stateconfig';
+
+describe('StateConfig for replication controller list', () => {
+  beforeEach(() => { angular.mock.module(deploymentListModule.name); });
+
+  it('should resolve replication controllers', angular.mock.inject(($q) => {
+    let promise = $q.defer().promise;
+
+    let resource = jasmine.createSpy('$resource');
+    resource.and.returnValue({get: function() { return {$promise: promise}; }});
+
+    let actual = resolveDeployments(resource);
+
+    expect(resource).toHaveBeenCalledWith('api/v1/deployments');
+    expect(actual).toBe(promise);
+  }));
+});


### PR DESCRIPTION
This looks much like a compy&paste (which is mostly true), but that's
the plan. I want to implement the list pages now and then extract common
patterns, if any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/717)
<!-- Reviewable:end -->
