### PR TITLE
Pod list backend

### DIFF
--- a/src/app/backend/resource/common/podinfo.go
+++ b/src/app/backend/resource/common/podinfo.go
@@ -27,7 +27,7 @@ type PodInfo struct {
 	// Number of pods that are created.
 	Current int `json:"current"`
 
-	// Number of pods that are desired in this Replication Controller.
+	// Number of pods that are desired.
 	Desired int `json:"desired"`
 
 	// Number of pods that are currently running.
@@ -39,11 +39,11 @@ type PodInfo struct {
 	// Number of pods that are failed.
 	Failed int `json:"failed"`
 
-	// Unique warning messages related to pods in this Replication Controller.
+	// Unique warning messages related to pods in this resource.
 	Warnings []event.Event `json:"warnings"`
 }
 
-// GetPodInfo returns aggregate information about replication controller pods.
+// GetPodInfo returns aggregate information about a group of pods.
 func GetPodInfo(current int, desired int, pods []api.Pod) PodInfo {
 	result := PodInfo{
 		Current:  current,
@@ -65,9 +65,9 @@ func GetPodInfo(current int, desired int, pods []api.Pod) PodInfo {
 	return result
 }
 
-// IsLabelSelectorMatching returns true when a Service with the given
+// IsLabelSelectorMatching returns true when an object with the given
 // selector targets the same Pods (or subset) that
-// a Replication Controller with the given selector.
+// the tested object with the given selector.
 func IsLabelSelectorMatching(labelSelector map[string]string,
 	testedObjectLabels map[string]string) bool {
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -1,0 +1,129 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/client"
+	"github.com/kubernetes/dashboard/resource/common"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// ReplicationSetList contains a list of Pods in the cluster.
+type PodList struct {
+	// Unordered list of Pods.
+	Pods []Pod `json:"pods"`
+}
+
+// Pod is a presentation layer view of Kubernetes Pod resource. This means
+// it is Pod plus additional augumented data we can get from other sources
+// (like services that target it).
+type Pod struct {
+	// Name of the Pod.
+	Name string `json:"name"`
+
+	// Namespace this Pod is in.
+	Namespace string `json:"namespace"`
+
+	// Label of this Pod.
+	Labels map[string]string `json:"labels"`
+
+	// Container images of the Pod.
+	ContainerImages []string `json:"containerImages"`
+
+	// Time the replication controller was created.
+	CreationTime unversioned.Time `json:"creationTime"`
+
+	// Status of the Pod. See Kubernetes API for reference.
+	PodPhase api.PodPhase `json:"podPhase"`
+
+	// IP address of the Pod.
+	PodIP string `json:"podIP"`
+
+	// Name of the Node this Pod runs on.
+	NodeName string `json:"nodeName"`
+
+	// Count of containers restarts.
+	RestartCount int `json:"restartCount"`
+
+	// Pod metrics.
+	Metrics *PodMetrics `json:"metrics"`
+}
+
+// GetPodList returns a list of all Pods in the cluster.
+func GetPodList(client k8sClient.Interface, heapsterClient client.HeapsterClient) (*PodList, error) {
+	log.Printf("Getting list of all pods in the cluster")
+
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannel(client, 1),
+	}
+
+	return GetPodListFromChannels(channels, heapsterClient)
+}
+
+// GetPodList returns a list of all Pods in the cluster
+// reading required resource list once from the channels.
+func GetPodListFromChannels(channels *common.ResourceChannels, heapsterClient client.HeapsterClient) (
+	*PodList, error) {
+
+	pods := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	podList := CreatePodList(pods.Items, heapsterClient)
+	return &podList, nil
+}
+
+func CreatePodList(pods []api.Pod, heapsterClient client.HeapsterClient) PodList {
+	metrics, err := getPodMetrics(pods, heapsterClient)
+	if err != nil {
+		log.Printf("Skipping Heapster metrics because of error: %s\n", err)
+	}
+
+	podList := PodList{
+		Pods: make([]Pod, 0),
+	}
+
+	for _, pod := range pods {
+		podDetail := Pod{
+			Name:         pod.Name,
+			PodPhase:     pod.Status.Phase,
+			CreationTime: pod.ObjectMeta.CreationTimestamp,
+			PodIP:        pod.Status.PodIP,
+			NodeName:     pod.Spec.NodeName,
+			RestartCount: getRestartCount(pod),
+		}
+		if metrics != nil && metrics.MetricsMap[pod.Namespace] != nil {
+			metric := metrics.MetricsMap[pod.Namespace][pod.Name]
+			podDetail.Metrics = &metric
+		}
+		podList.Pods = append(podList.Pods, podDetail)
+	}
+
+	return podList
+}
+
+// Gets restart count of given pod (total number of its containers restarts).
+func getRestartCount(pod api.Pod) int {
+	restartCount := 0
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		restartCount += containerStatus.RestartCount
+	}
+	return restartCount
+}

--- a/src/app/backend/resource/pod/podmetrics.go
+++ b/src/app/backend/resource/pod/podmetrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package replicationcontroller
+package pod
 
 import (
 	"log"
@@ -22,8 +22,7 @@ import (
 	"strings"
 	"time"
 
-	// TODO(maciaszczykm): Avoid using dot-imports.
-	. "github.com/kubernetes/dashboard/client"
+	"github.com/kubernetes/dashboard/client"
 	heapster "k8s.io/heapster/api/v1/types"
 	"k8s.io/kubernetes/pkg/api"
 )
@@ -33,10 +32,10 @@ const (
 	memoryUsage = "memory-usage"
 )
 
-// ReplicationControllerMetricsByPod is a metrics map by pod name.
-type ReplicationControllerMetricsByPod struct {
-	// Metrics map by pod name
-	MetricsMap map[string]PodMetrics `json:"metricsMap"`
+// MetricsByPod is a metrics map by pod name.
+type MetricsByPod struct {
+	// Metrics by namespace and name of a pod.
+	MetricsMap map[string]map[string]PodMetrics `json:"metricsMap"`
 }
 
 // MetricResult is a some sample measurement of a non-negative, integer quantity
@@ -59,39 +58,58 @@ type PodMetrics struct {
 	MemoryUsageHistory []MetricResult `json:"memoryUsageHistory"`
 }
 
-// Return Pods metrics for Replication Controller or error when occurred.
-func getReplicationControllerPodsMetrics(podList *api.PodList, heapsterClient HeapsterClient,
-	namespace string, replicationController string) (*ReplicationControllerMetricsByPod, error) {
-	log.Printf("Getting Pods metrics for Replication Controller %s in %s namespace", replicationController, namespace)
-	podNames := make([]string, 0)
+// Return Pods metrics for the given list of pods. Returns error in case of errors when talking
+// with heapster.
+func getPodMetrics(pods []api.Pod,
+	heapsterClient client.HeapsterClient) (*MetricsByPod, error) {
+	log.Printf("Getting pod metrics")
 
-	pods := podList.Items
+	podsByNamespace := make(map[string][]api.Pod)
+
 	for _, pod := range pods {
-		podNames = append(podNames, pod.Name)
+		podsByNamespace[pod.ObjectMeta.Namespace] = append(podsByNamespace[pod.ObjectMeta.Namespace], pod)
 	}
 
-	metricCpuUsagePath := createMetricPath(namespace, podNames, cpuUsage)
-	metricMemUsagePath := createMetricPath(namespace, podNames, memoryUsage)
+	result := &MetricsByPod{MetricsMap: make(map[string]map[string]PodMetrics)}
 
-	resultCpuUsageRaw, err := getRawMetrics(heapsterClient, metricCpuUsagePath)
-	if err != nil {
-		return nil, err
+	for namespace, pods := range podsByNamespace {
+		podNames := make([]string, 0)
+
+		for _, pod := range pods {
+			podNames = append(podNames, pod.Name)
+		}
+
+		metricCpuUsagePath := createMetricPath(namespace, podNames, cpuUsage)
+		metricMemUsagePath := createMetricPath(namespace, podNames, memoryUsage)
+
+		resultCpuUsageRaw, err := getRawMetrics(heapsterClient, metricCpuUsagePath)
+		if err != nil {
+			return nil, err
+		}
+
+		resultMemUsageRaw, err := getRawMetrics(heapsterClient, metricMemUsagePath)
+		if err != nil {
+			return nil, err
+		}
+
+		cpuMetricResult, err := unmarshalMetrics(resultCpuUsageRaw)
+		if err != nil {
+			return nil, err
+		}
+		memMetricResult, err := unmarshalMetrics(resultMemUsageRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		if result.MetricsMap[namespace] == nil {
+			result.MetricsMap[namespace] = make(map[string]PodMetrics)
+		}
+
+		fillPodMetrics(cpuMetricResult, memMetricResult, podNames,
+			result.MetricsMap[namespace])
 	}
 
-	resultMemUsageRaw, err := getRawMetrics(heapsterClient, metricMemUsagePath)
-	if err != nil {
-		return nil, err
-	}
-
-	cpuMetricResult, err := unmarshalMetrics(resultCpuUsageRaw)
-	if err != nil {
-		return nil, err
-	}
-	memMetricResult, err := unmarshalMetrics(resultMemUsageRaw)
-	if err != nil {
-		return nil, err
-	}
-	return createResponse(cpuMetricResult, memMetricResult, podNames), nil
+	return result, nil
 }
 
 // Create URL path for metrics.
@@ -103,7 +121,7 @@ func createMetricPath(namespace string, podNames []string, metricName string) st
 }
 
 // Retrieves raw metrics from Heapster.
-func getRawMetrics(heapsterClient HeapsterClient, metricPath string) ([]byte, error) {
+func getRawMetrics(heapsterClient client.HeapsterClient, metricPath string) ([]byte, error) {
 	resultRaw, err := heapsterClient.Get(metricPath).DoRaw()
 
 	if err != nil {
@@ -123,10 +141,8 @@ func unmarshalMetrics(rawData []byte) ([]heapster.MetricResult, error) {
 }
 
 // Create response structure for API call.
-func createResponse(cpuMetrics []heapster.MetricResult, memMetrics []heapster.MetricResult,
-	podNames []string) *ReplicationControllerMetricsByPod {
-	replicationControllerPodsResources := make(map[string]PodMetrics)
-
+func fillPodMetrics(cpuMetrics []heapster.MetricResult, memMetrics []heapster.MetricResult,
+	podNames []string, result map[string]PodMetrics) {
 	if len(cpuMetrics) == len(podNames) && len(memMetrics) == len(podNames) {
 		for iterator, podName := range podNames {
 			var memValue *uint64
@@ -161,10 +177,7 @@ func createResponse(cpuMetrics []heapster.MetricResult, memMetrics []heapster.Me
 				CpuUsageHistory:    cpuHistory,
 				MemoryUsageHistory: memHistory,
 			}
-			replicationControllerPodsResources[podName] = podResources
+			result[podName] = podResources
 		}
-	}
-	return &ReplicationControllerMetricsByPod{
-		MetricsMap: replicationControllerPodsResources,
 	}
 }

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -188,6 +188,13 @@ backendApi.ReplicaSetList;
 
 /**
  * @typedef {{
+ *   pods: !Array<!backendApi.Pod>
+ * }}
+ */
+backendApi.PodList;
+
+/**
+ * @typedef {{
  *   name: string,
  *   namespace: string,
  *   type: string
@@ -203,7 +210,7 @@ backendApi.ResourceMetadata;
  *   labelSelector: !Object<string, string>,
  *   containerImages: !Array<string>,
  *   podInfo: !backendApi.PodInfo,
- *   pods: !Array<!backendApi.Pod>,
+ *   pods: !backendApi.PodList,
  *   services: !Array<!backendApi.ServiceDetail>,
  *   hasMetrics: boolean
  * }}
@@ -223,19 +230,6 @@ backendApi.ReplicationControllerSpec;
  * }}
  */
 backendApi.DeleteReplicationControllerSpec;
-
-/**
- * @typedef {{
- *   name: string,
- *   startTime: ?string,
- *   status: string,
- *   podIP: string,
- *   nodeName: string,
- *   restartCount: number,
- *   metrics: backendApi.PodMetrics
- * }}
- */
-backendApi.ReplicationControllerPod;
 
 /**
  * @typedef {{

--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-content-card ng-if="::$ctrl.pods">
+<kd-content-card ng-if="::$ctrl.podList.pods">
   <kd-title>Pods</kd-title>
   <kd-content>
     <kd-resource-card-list selectable="false" with-statuses="false">
@@ -29,7 +29,7 @@ limitations under the License.
         <kd-resource-card-header-column>Logs</kd-resource-card-header-column>
       </kd-resource-card-header-columns>
 
-      <kd-resource-card ng-repeat="pod in $ctrl.pods">
+      <kd-resource-card ng-repeat="pod in $ctrl.podList.pods">
         <kd-resource-card-columns>
           <kd-resource-card-column>
             <div>

--- a/src/app/frontend/podlist/podcardlist_component.js
+++ b/src/app/frontend/podlist/podcardlist_component.js
@@ -22,9 +22,9 @@ export class PodCardListController {
   constructor() {
     /**
      * List of pods. Initialized from the scope.
-     * @export {!Array<!backendApi.Pod>}
+     * @export {!backendApi.PodList}
      */
-    this.pods;
+    this.podList;
 
     /**
      * Callback function that returns link to pod logs. Initialized from the scope.
@@ -50,8 +50,8 @@ export const podCardListComponent = {
   templateUrl: 'podlist/podcardlist.html',
   controller: PodCardListController,
   bindings: {
-    /** {!Array<!backendApi.Pod>} */
-    'pods': '<',
+    /** {!backendApi.PodList} */
+    'podList': '<',
     /** {!function({pod: !backendApi.Pod}): string} */
     'logsHrefFn': '&',
   },

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -24,7 +24,7 @@ limitations under the License.
         <kd-replication-controller-services services="::ctrl.replicationControllerDetail.services">
         </kd-replication-controller-services>
 
-        <kd-pod-card-list pods="::ctrl.replicationControllerDetail.pods"
+        <kd-pod-card-list pod-list="::ctrl.replicationControllerDetail.pods"
                       logs-href-fn="::ctrl.getPodLogsHref(pod)">
         </kd-pod-card-list>
       </md-tab>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -48,7 +48,7 @@ export default class ReplicationControllerDetailController {
   }
 
   /**
-   * @param {!backendApi.ReplicationControllerPod} pod
+   * @param {!backendApi.Pod} pod
    * @return {boolean}
    * @export
    */
@@ -57,7 +57,7 @@ export default class ReplicationControllerDetailController {
   }
 
   /**
-   * @param {!backendApi.ReplicationControllerPod} pod
+   * @param {!backendApi.Pod} pod
    * @return {boolean}
    * @export
    */
@@ -67,7 +67,7 @@ export default class ReplicationControllerDetailController {
   }
 
   /**
-   * @param {!backendApi.ReplicationControllerPod} pod
+   * @param {!backendApi.Pod} pod
    * @return {string}
    * @export
    */

--- a/src/test/backend/resource/pod/podlist_test.go
+++ b/src/test/backend/resource/pod/podlist_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestGetRestartCount(t *testing.T) {
+	cases := []struct {
+		pod      api.Pod
+		expected int
+	}{
+		{
+			api.Pod{}, 0,
+		},
+		{
+			api.Pod{
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-1",
+							RestartCount: 1,
+						},
+					},
+				},
+			},
+			1,
+		},
+		{
+			api.Pod{
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Name:         "container-1",
+							RestartCount: 3,
+						},
+						{
+							Name:         "container-2",
+							RestartCount: 2,
+						},
+					},
+				},
+			},
+			5,
+		},
+	}
+	for _, c := range cases {
+		actual := getRestartCount(c.pod)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("AppendEvents(%#v) == %#v, expected %#v", c.pod, actual, c.expected)
+		}
+	}
+}

--- a/src/test/backend/resource/pod/podmetrics_test.go
+++ b/src/test/backend/resource/pod/podmetrics_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package replicationcontroller
+package pod
 
 import (
 	"reflect"
@@ -66,12 +66,10 @@ func TestCreateResponse(t *testing.T) {
 		cpuMetrics []heapster.MetricResult
 		memMetrics []heapster.MetricResult
 		podNames   []string
-		expected   *ReplicationControllerMetricsByPod
+		expected   map[string]PodMetrics
 	}{
 		{make([]heapster.MetricResult, 0), make([]heapster.MetricResult, 0), make([]string, 0),
-			&ReplicationControllerMetricsByPod{
-				MetricsMap: map[string]PodMetrics{},
-			}},
+			map[string]PodMetrics{}},
 		{[]heapster.MetricResult{
 			{Metrics: []heapster.MetricPoint{
 				{Value: 0},
@@ -83,9 +81,7 @@ func TestCreateResponse(t *testing.T) {
 				}},
 			},
 			[]string{"a", "b"},
-			&ReplicationControllerMetricsByPod{
-				MetricsMap: map[string]PodMetrics{},
-			},
+			map[string]PodMetrics{},
 		},
 		{[]heapster.MetricResult{
 			{Metrics: []heapster.MetricPoint{
@@ -104,33 +100,32 @@ func TestCreateResponse(t *testing.T) {
 				}},
 			},
 			[]string{"a", "b"},
-			&ReplicationControllerMetricsByPod{
-				MetricsMap: map[string]PodMetrics{
-					"a": {
-						CpuUsage: &cpuUsage1,
-						CpuUsageHistory: []MetricResult{
-							{Value: cpuUsage1},
-						},
-						MemoryUsage: &memoryUsage,
-						MemoryUsageHistory: []MetricResult{
-							{Value: memoryUsage},
-						},
-					}, "b": {
-						CpuUsage: &cpuUsage2,
-						CpuUsageHistory: []MetricResult{
-							{Value: cpuUsage2},
-						},
-						MemoryUsage: &memoryUsage,
-						MemoryUsageHistory: []MetricResult{
-							{Value: memoryUsage},
-						},
+			map[string]PodMetrics{
+				"a": {
+					CpuUsage: &cpuUsage1,
+					CpuUsageHistory: []MetricResult{
+						{Value: cpuUsage1},
+					},
+					MemoryUsage: &memoryUsage,
+					MemoryUsageHistory: []MetricResult{
+						{Value: memoryUsage},
+					},
+				}, "b": {
+					CpuUsage: &cpuUsage2,
+					CpuUsageHistory: []MetricResult{
+						{Value: cpuUsage2},
+					},
+					MemoryUsage: &memoryUsage,
+					MemoryUsageHistory: []MetricResult{
+						{Value: memoryUsage},
 					},
 				},
 			},
 		},
 	}
 	for _, c := range cases {
-		actual := createResponse(c.cpuMetrics, c.memMetrics, c.podNames)
+		actual := make(map[string]PodMetrics)
+		fillPodMetrics(c.cpuMetrics, c.memMetrics, c.podNames, actual)
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("createResponse(%#v, %#v, %#v) == %#v, expected %#v",

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerdetail_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerdetail_test.go
@@ -148,53 +148,6 @@ func TestUpdateReplicasCount(t *testing.T) {
 	}
 }
 
-func TestGetRestartCount(t *testing.T) {
-	cases := []struct {
-		pod      api.Pod
-		expected int
-	}{
-		{
-			api.Pod{}, 0,
-		},
-		{
-			api.Pod{
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:         "container-1",
-							RestartCount: 1,
-						},
-					},
-				},
-			},
-			1,
-		},
-		{
-			api.Pod{
-				Status: api.PodStatus{
-					ContainerStatuses: []api.ContainerStatus{
-						{
-							Name:         "container-1",
-							RestartCount: 3,
-						},
-						{
-							Name:         "container-2",
-							RestartCount: 2,
-						},
-					},
-				},
-			},
-			5,
-		},
-	}
-	for _, c := range cases {
-		actual := getRestartCount(c.pod)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("AppendEvents(%#v) == %#v, expected %#v", c.pod, actual, c.expected)
-		}
-	}
-}
-
 func TestGetServicePortsName(t *testing.T) {
 	cases := []struct {
 		ports    []api.ServicePort


### PR DESCRIPTION
This includes a huge refactor to extract pod list common code from RC
deatails to a separate directory. With this, though, it can be reused in
lots of places (e.g., in Daemon Sets).

Check api/v1/pods endpoint to verify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/723)
<!-- Reviewable:end -->
