### PR TITLE
Add: flag.CommandLine.Parse at start for glog initialization

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -41,6 +41,7 @@ var (
 func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+	flag.CommandLine.Parse(make([]string,0))  // Init for glog calls in kubernetes packages
 
 	log.Printf("Starting HTTP server on port %d", *argPort)
 


### PR DESCRIPTION
Hi,

This pull request is a small fix to remove the following warning message in dashboard logs : 
 

```
ERROR: logging before flag.Parse: I0512 18:03:01.134758       1FILE:LINENO] Message
```

The errors comes when glog is called without being initialized. As the dashboard uses kubernetes, which uses glog, we have to add the flag.CommandLine.Parse(make([] string, 0)) line to initialize glog.

In our case the log line will just become : 
```
I0512 18:03:01.134758       1FILE:LINENO] Message
```


Source : https://github.com/golang/glog/blob/master/glog.go#L40

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/737)
<!-- Reviewable:end -->
