### PR TITLE
Add related pods to service detail page

### DIFF
--- a/src/app/backend/client/heapsterclient.go
+++ b/src/app/backend/client/heapsterclient.go
@@ -26,8 +26,13 @@ type HeapsterClient interface {
 	// Creates a new GET HTTP request to heapster, specified by the path param, to the V1 API
 	// endpoint. The path param is without the API prefix, e.g.,
 	// /model/namespaces/default/pod-list/foo/metrics/memory-usage
+	Get(path string) RequestInterface
+}
 
-	Get(path string) *restclient.Request
+// RequestInterface is an interface that allows to make operations on pure request object.
+// Separation is done to allow testing.
+type RequestInterface interface {
+	DoRaw() ([]byte, error)
 }
 
 // InClusterHeapsterClient is an in-cluster implementation of a Heapster client. Talks with Heapster
@@ -37,7 +42,7 @@ type InClusterHeapsterClient struct {
 }
 
 // InClusterHeapsterClient.Get creates request to given path.
-func (c InClusterHeapsterClient) Get(path string) *restclient.Request {
+func (c InClusterHeapsterClient) Get(path string) RequestInterface {
 	return c.client.Get().Prefix("proxy").
 		Namespace("kube-system").
 		Resource("services").
@@ -52,7 +57,7 @@ type RemoteHeapsterClient struct {
 }
 
 // RemoteHeapsterClient.Get creates request to given path.
-func (c RemoteHeapsterClient) Get(path string) *restclient.Request {
+func (c RemoteHeapsterClient) Get(path string) RequestInterface {
 	return c.client.Get().Suffix(path)
 }
 

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -300,7 +300,8 @@ func (apiHandler *ApiHandler) handleGetServiceList(request *restful.Request, res
 func (apiHandler *ApiHandler) handleGetServiceDetail(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	service := request.PathParameter("service")
-	result, err := resourceService.GetServiceDetail(apiHandler.client, namespace, service)
+	result, err := resourceService.GetServiceDetail(apiHandler.client, apiHandler.heapsterClient,
+		namespace, service)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -284,7 +284,8 @@ backendApi.Pod;
  *  externalEndpoints: !Array<!backendApi.Endpoint>,
  *  selector: !Object<string, string>,
  *  type: string,
- *  clusterIP: string
+ *  clusterIP: string,
+ *  podList: !backendApi.PodList
  * }}
  */
 backendApi.ServiceDetail;

--- a/src/app/frontend/servicedetail/servicedetail.html
+++ b/src/app/frontend/servicedetail/servicedetail.html
@@ -15,3 +15,10 @@ limitations under the License.
 -->
 
 <kd-service-info service="ctrl.serviceDetail"></kd-service-info>
+
+<kd-content-card ng-if="ctrl.serviceDetail.podList.pods.length">
+  <kd-title>Pods</kd-title>
+  <kd-content>
+    <kd-pod-card-list pod-list="ctrl.serviceDetail.podList"></kd-pod-card-list>
+  </kd-content>
+</kd-content-card>

--- a/src/test/backend/resource/replicaset/replicasetdetail_test.go
+++ b/src/test/backend/resource/replicaset/replicasetdetail_test.go
@@ -19,21 +19,22 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 
+	"github.com/kubernetes/dashboard/client"
 	"github.com/kubernetes/dashboard/resource/common"
 	"github.com/kubernetes/dashboard/resource/pod"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
 type FakeHeapsterClient struct {
 	client k8sClient.Interface
 }
 
-func (c FakeHeapsterClient) Get(path string) *restclient.Request {
+func (c FakeHeapsterClient) Get(path string) client.RequestInterface {
 	return &restclient.Request{}
 }
 


### PR DESCRIPTION
I've also refactored heapster client to allow testing.

![zrzut ekranu z 2016-05-16 12-19-19](https://cloud.githubusercontent.com/assets/2285385/15287015/7117bb26-1b60-11e6-87c0-199615e4a6b7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/739)
<!-- Reviewable:end -->
