### PR TITLE
Fix actionbar icons overflow resource name

### DIFF
--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs_component.js
@@ -207,7 +207,7 @@ export default class BreadcrumbsController {
  * @return {!angular.Component}
  */
 export const breadcrumbsComponent = {
-  binding: {
+  bindings: {
     'limit': '<',
   },
   controller: BreadcrumbsController,


### PR DESCRIPTION
Fixes #754

I've fixed limitation to display only direct parent in breadcrumb. This way it won't overflow.

![zrzut ekranu z 2016-05-20 11-02-23](https://cloud.githubusercontent.com/assets/2285385/15422769/5d2a1902-1e7a-11e6-8253-ba56ddfc71f5.png)
![zrzut ekranu z 2016-05-20 11-02-16](https://cloud.githubusercontent.com/assets/2285385/15422773/5f9e0f86-1e7a-11e6-80cb-8ba77840293f.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/755)
<!-- Reviewable:end -->
