### PR TITLE
Fix generic delete: make it work with extension resources

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -85,7 +85,7 @@ func FormatResponseLog(resp *restful.Response, req *restful.Request) string {
 func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 	clientConfig clientcmd.ClientConfig) http.Handler {
 
-	verber := common.NewResourceVerber(client.RESTClient)
+	verber := common.NewResourceVerber(client.RESTClient, client.ExtensionsClient.RESTClient)
 	apiHandler := ApiHandler{client, heapsterClient, clientConfig, verber}
 	wsContainer := restful.NewContainer()
 
@@ -194,8 +194,8 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 			Writes(pod.PodList{}))
 	podsWs.Route(
 		podsWs.GET("/{namespace}/{pod}").
-		To(apiHandler.handleGetPodDetail).
-		Writes(pod.PodDetail{}))
+			To(apiHandler.handleGetPodDetail).
+			Writes(pod.PodDetail{}))
 	wsContainer.Add(podsWs)
 
 	deploymentsWs := new(restful.WebService)

--- a/src/app/backend/resource/common/types.go
+++ b/src/app/backend/resource/common/types.go
@@ -100,14 +100,19 @@ const (
 // Mapping from resource kind to K8s apiserver API path. This is mostly pluralization, because
 // K8s apiserver uses plural paths and this project singular.
 // Must be kept in sync with the list of supported kinds.
-var kindToAPIPathMapping = map[string]string{
-	ResourceKindService:               "services",
-	ResourceKindPod:                   "pods",
-	ResourceKindEvent:                 "events",
-	ResourceKindReplicationController: "replicationcontrollers",
-	ResourceKindDeployment:            "deployments",
-	ResourceKindReplicaSet:            "replicasets",
-	ResourceKindDaemonSet:             "daemonsets",
+var kindToAPIMapping = map[string]struct {
+	// K8s resource name
+	Resource string
+	// Whether extensions client should be used. True for extensions client, false for normal.
+	Extension bool
+}{
+	ResourceKindService:               {"services", false},
+	ResourceKindPod:                   {"pods", false},
+	ResourceKindEvent:                 {"events", false},
+	ResourceKindReplicationController: {"replicationcontrollers", false},
+	ResourceKindDeployment:            {"deployments", true},
+	ResourceKindReplicaSet:            {"replicasets", true},
+	ResourceKindDaemonSet:             {"daemonsets", false},
 }
 
 // IsSelectorMatching returns true when an object with the given

--- a/src/test/backend/resource/common/verber_test.go
+++ b/src/test/backend/resource/common/verber_test.go
@@ -26,10 +26,19 @@ func (c *FakeRESTClient) Delete() *restclient.Request {
 	}), "DELETE", nil, "/api/v1", restclient.ContentConfig{}, nil, nil)
 }
 
-func TestDeleteShouldPropagateErrors(t *testing.T) {
-	verber := ResourceVerber{client: &FakeRESTClient{err: errors.New("err")}}
+func TestDeleteShouldPropagateErrorsAndChoseClient(t *testing.T) {
+	verber := ResourceVerber{
+		client:           &FakeRESTClient{err: errors.New("err")},
+		extensionsClient: &FakeRESTClient{err: errors.New("err from extensions")},
+	}
 
 	err := verber.Delete("replicaset", "bar", "baz")
+
+	if !reflect.DeepEqual(err, errors.New("err from extensions")) {
+		t.Fatalf("Expected error on verber delete but got %#v", err)
+	}
+
+	err = verber.Delete("service", "bar", "baz")
 
 	if !reflect.DeepEqual(err, errors.New("err")) {
 		t.Fatalf("Expected error on verber delete but got %#v", err)


### PR DESCRIPTION
Previously it couldn't delete, e.g., a replica set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/756)
<!-- Reviewable:end -->
