### PR TITLE
Bugfix #762 - nullpointer dereference at RS / Deployments lists

### DIFF
--- a/src/app/backend/resource/deployment/deploymentlist.go
+++ b/src/app/backend/resource/deployment/deploymentlist.go
@@ -71,7 +71,10 @@ func GetDeploymentListFromChannels(channels *common.ResourceChannels) (
 		if ok && statusErr.ErrStatus.Reason == "NotFound" {
 			// NotFound - this means that the server does not support Deployment objects, which
 			// is fine.
-			return nil, nil
+			emptyList := &DeploymentList{
+				Deployments: make([]Deployment, 0),
+			}
+			return emptyList, nil
 		}
 		return nil, err
 	}

--- a/src/app/backend/resource/replicaset/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist.go
@@ -71,7 +71,10 @@ func GetReplicaSetListFromChannels(channels *common.ResourceChannels) (
 		if ok && statusErr.ErrStatus.Reason == "NotFound" {
 			// NotFound - this means that the server does not support Replica Set objects, which
 			// is fine.
-			return nil, nil
+			emptyList := &ReplicaSetList{
+				ReplicaSets: make([]ReplicaSet, 0),
+			}
+			return emptyList, nil
 		}
 		return nil, err
 	}

--- a/src/test/backend/resource/deployment/deploymentlist_test.go
+++ b/src/test/backend/resource/deployment/deploymentlist_test.go
@@ -74,7 +74,9 @@ func TestGetDeploymentListFromChannels(t *testing.T) {
 			extensions.DeploymentList{},
 			&k8serrors.StatusError{ErrStatus: unversioned.Status{Reason: "NotFound"}},
 			&api.PodList{},
-			nil,
+			&DeploymentList{
+				Deployments: make([]Deployment, 0),
+			},
 			nil,
 		},
 		{

--- a/src/test/backend/resource/replicaset/replicasetlist_test.go
+++ b/src/test/backend/resource/replicaset/replicasetlist_test.go
@@ -74,7 +74,9 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 			extensions.ReplicaSetList{},
 			&k8serrors.StatusError{ErrStatus: unversioned.Status{Reason: "NotFound"}},
 			&api.PodList{},
-			nil,
+			&ReplicaSetList{
+				ReplicaSets: make([]ReplicaSet, 0),
+			},
 			nil,
 		},
 		{


### PR DESCRIPTION
see https://github.com/kubernetes/dashboard/issues/762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/764)
<!-- Reviewable:end -->
