### PR TITLE
Backend for namespace selection

### DIFF
--- a/src/app/backend/resource/common/namespace.go
+++ b/src/app/backend/resource/common/namespace.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "k8s.io/kubernetes/pkg/api"
+
+// NamespaceQuery is a query for namespaces of a list of objects.
+// There's three cases:
+// 1. No namespace selected: this means "user namespaces" query, i.e., all except kube-system
+// 2. Single namespace selected: this allows for optimizations when querying backends
+// 3. More than one namespace selected: resources from all namespaces are queried and then
+//    filtered here.
+type NamespaceQuery struct {
+	namespaces []string
+}
+
+// NewSameNamespaceQuery creates new namespace query that queries single namespace.
+func NewSameNamespaceQuery(namespace string) *NamespaceQuery {
+	return &NamespaceQuery{[]string{namespace}}
+}
+
+// NewNamespaceQuery creates new query for given namespaces.
+func NewNamespaceQuery(namespaces []string) *NamespaceQuery {
+	return &NamespaceQuery{namespaces}
+}
+
+// ToRequestParam returns K8s API namespace query for list of objects from this namespaces.
+// This is an optimization to query for single namespace if one was selected and for all
+// namespaces otherwise.
+func (n *NamespaceQuery) ToRequestParam() string {
+	if len(n.namespaces) == 1 {
+		return n.namespaces[0]
+	}
+	return api.NamespaceAll
+}
+
+// Matches returns true when the given namespace matches this query.
+func (n *NamespaceQuery) Matches(namespace string) bool {
+	if len(n.namespaces) == 0 {
+		return namespace != api.NamespaceSystem
+	}
+
+	for _, queryNamespace := range n.namespaces {
+		if namespace == queryNamespace {
+			return true
+		}
+	}
+	return false
+}

--- a/src/app/backend/resource/common/resourcechannels.go
+++ b/src/app/backend/resource/common/resourcechannels.go
@@ -59,29 +59,32 @@ type ResourceChannels struct {
 	NodeList NodeListChannel
 }
 
-// List and error channels to Services.
+// ServiceListChannel is a list and error channels to Services.
 type ServiceListChannel struct {
 	List  chan *api.ServiceList
 	Error chan error
 }
 
-var listEverything api.ListOptions = api.ListOptions{
-	LabelSelector: labels.Everything(),
-	FieldSelector: fields.Everything(),
-}
+// GetServiceListChannel returns a pair of channels to a Service list and errors that both
+// must be read numReads times.
+func GetServiceListChannel(client client.ServicesNamespacer,
+	nsQuery *NamespaceQuery, numReads int) ServiceListChannel {
 
-// Returns a pair of channels to a Service list and errors that both must be read
-// numReads times.
-func GetServiceListChannel(client client.ServicesNamespacer, numReads int) ServiceListChannel {
 	channel := ServiceListChannel{
 		List:  make(chan *api.ServiceList, numReads),
 		Error: make(chan error, numReads),
 	}
 	go func() {
-		services, err := client.Services(api.NamespaceAll).List(listEverything)
-
+		list, err := client.Services(nsQuery.ToRequestParam()).List(listEverything)
+		var filteredItems []api.Service
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- services
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -89,25 +92,32 @@ func GetServiceListChannel(client client.ServicesNamespacer, numReads int) Servi
 	return channel
 }
 
-// List and error channels to Nodes.
+// NodeListChannel is a list and error channels to Nodes.
 type NodeListChannel struct {
 	List  chan *api.NodeList
 	Error chan error
 }
 
-// Returns a pair of channels to a Node list and errors that both must be read
+// GetNodeListChannel returns a pair of channels to a Node list and errors that both must be read
 // numReads times.
-func GetNodeListChannel(client client.NodesInterface, numReads int) NodeListChannel {
+func GetNodeListChannel(client client.NodesInterface,
+	nsQuery *NamespaceQuery, numReads int) NodeListChannel {
 	channel := NodeListChannel{
 		List:  make(chan *api.NodeList, numReads),
 		Error: make(chan error, numReads),
 	}
 
 	go func() {
-		nodes, err := client.Nodes().List(listEverything)
-
+		list, err := client.Nodes().List(listEverything)
+		var filteredItems []api.Node
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- nodes
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -115,25 +125,38 @@ func GetNodeListChannel(client client.NodesInterface, numReads int) NodeListChan
 	return channel
 }
 
-// List and error channels to Nodes.
+// EventListChannel is a list and error channels to Nodes.
 type EventListChannel struct {
 	List  chan *api.EventList
 	Error chan error
 }
 
-// Returns a pair of channels to an Event list and errors that both must be read
+// GetEventListChannel returns a pair of channels to an Event list and errors that both must be read
 // numReads times.
-func GetEventListChannel(client client.EventNamespacer, numReads int) EventListChannel {
+func GetEventListChannel(client client.EventNamespacer,
+	nsQuery *NamespaceQuery, numReads int) EventListChannel {
+	return GetEventListChannelWithOptions(client, nsQuery, listEverything, numReads)
+}
+
+// GetEventListChannelWithOptions is GetEventListChannel plus list options.
+func GetEventListChannelWithOptions(client client.EventNamespacer,
+	nsQuery *NamespaceQuery, options api.ListOptions, numReads int) EventListChannel {
 	channel := EventListChannel{
 		List:  make(chan *api.EventList, numReads),
 		Error: make(chan error, numReads),
 	}
 
 	go func() {
-		events, err := client.Events(api.NamespaceAll).List(listEverything)
-
+		list, err := client.Events(nsQuery.ToRequestParam()).List(options)
+		var filteredItems []api.Event
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- events
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -141,54 +164,22 @@ func GetEventListChannel(client client.EventNamespacer, numReads int) EventListC
 	return channel
 }
 
-func GetNamespacedEventListChannel(client client.EventNamespacer, numReads int,
-	namespace string, options api.ListOptions) EventListChannel {
-
-	channel := EventListChannel{
-		List:  make(chan *api.EventList, numReads),
-		Error: make(chan error, numReads),
-	}
-
-	go func() {
-		events, err := client.Events(namespace).List(options)
-
-		for i := 0; i < numReads; i++ {
-			channel.List <- events
-			channel.Error <- err
-		}
-	}()
-
-	return channel
-}
-
-// List and error channels to Nodes.
+// PodListChannel is a list and error channels to Nodes.
 type PodListChannel struct {
 	List  chan *api.PodList
 	Error chan error
 }
 
-// Returns a pair of channels to a Pod list and errors that both must be read
+// GetPodListChannel returns a pair of channels to a Pod list and errors that both must be read
 // numReads times.
-func GetPodListChannel(client client.PodsNamespacer, numReads int) PodListChannel {
-	channel := PodListChannel{
-		List:  make(chan *api.PodList, numReads),
-		Error: make(chan error, numReads),
-	}
-
-	go func() {
-		pods, err := client.Pods(api.NamespaceAll).List(listEverything)
-
-		for i := 0; i < numReads; i++ {
-			channel.List <- pods
-			channel.Error <- err
-		}
-	}()
-
-	return channel
+func GetPodListChannel(client client.PodsNamespacer,
+	nsQuery *NamespaceQuery, numReads int) PodListChannel {
+	return GetPodListChannelWithOptions(client, nsQuery, listEverything, numReads)
 }
 
-func GetNamespacedPodListChannel(client client.PodsNamespacer, numReads int,
-	namespace string, options api.ListOptions) PodListChannel {
+// GetPodListChannelWithOptions is GetPodListChannel plus listing options.
+func GetPodListChannelWithOptions(client client.PodsNamespacer,
+	nsQuery *NamespaceQuery, options api.ListOptions, numReads int) PodListChannel {
 
 	channel := PodListChannel{
 		List:  make(chan *api.PodList, numReads),
@@ -196,10 +187,16 @@ func GetNamespacedPodListChannel(client client.PodsNamespacer, numReads int,
 	}
 
 	go func() {
-		pods, err := client.Pods(namespace).List(options)
-
+		list, err := client.Pods(nsQuery.ToRequestParam()).List(options)
+		var filteredItems []api.Pod
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- pods
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -207,16 +204,17 @@ func GetNamespacedPodListChannel(client client.PodsNamespacer, numReads int,
 	return channel
 }
 
-// List and error channels to Nodes.
+// ReplicationControllerListChannel is a list and error channels to Nodes.
 type ReplicationControllerListChannel struct {
 	List  chan *api.ReplicationControllerList
 	Error chan error
 }
 
-// Returns a pair of channels to a Replication Controller list and errors that both must be read
+// GetReplicationControllerListChannel Returns a pair of channels to a
+// Replication Controller list and errors that both must be read
 // numReads times.
 func GetReplicationControllerListChannel(client client.ReplicationControllersNamespacer,
-	numReads int) ReplicationControllerListChannel {
+	nsQuery *NamespaceQuery, numReads int) ReplicationControllerListChannel {
 
 	channel := ReplicationControllerListChannel{
 		List:  make(chan *api.ReplicationControllerList, numReads),
@@ -224,9 +222,16 @@ func GetReplicationControllerListChannel(client client.ReplicationControllersNam
 	}
 
 	go func() {
-		rcs, err := client.ReplicationControllers(api.NamespaceAll).List(listEverything)
+		list, err := client.ReplicationControllers(nsQuery.ToRequestParam()).List(listEverything)
+		var filteredItems []api.ReplicationController
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- rcs
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -234,24 +239,33 @@ func GetReplicationControllerListChannel(client client.ReplicationControllersNam
 	return channel
 }
 
-// List and error channels to Deployments.
+// DeploymentListChannel is a list and error channels to Deployments.
 type DeploymentListChannel struct {
 	List  chan *extensions.DeploymentList
 	Error chan error
 }
 
-// Returns a pair of channels to a Deployment list and errors that both must be read
-// numReads times.
-func GetDeploymentListChannel(client client.DeploymentsNamespacer, numReads int) DeploymentListChannel {
+// GetDeploymentListChannel returns a pair of channels to a Deployment list and errors
+// that both must be read numReads times.
+func GetDeploymentListChannel(client client.DeploymentsNamespacer,
+	nsQuery *NamespaceQuery, numReads int) DeploymentListChannel {
+
 	channel := DeploymentListChannel{
 		List:  make(chan *extensions.DeploymentList, numReads),
 		Error: make(chan error, numReads),
 	}
 
 	go func() {
-		rcs, err := client.Deployments(api.NamespaceAll).List(listEverything)
+		list, err := client.Deployments(nsQuery.ToRequestParam()).List(listEverything)
+		var filteredItems []extensions.Deployment
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		list.Items = filteredItems
 		for i := 0; i < numReads; i++ {
-			channel.List <- rcs
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -259,24 +273,31 @@ func GetDeploymentListChannel(client client.DeploymentsNamespacer, numReads int)
 	return channel
 }
 
-// List and error channels to Replica Sets.
+// ReplicaSetListChannel is a list and error channels to Replica Sets.
 type ReplicaSetListChannel struct {
 	List  chan *extensions.ReplicaSetList
 	Error chan error
 }
 
-// Returns a pair of channels to a ReplicaSet list and errors that both must be read
-// numReads times.
-func GetReplicaSetListChannel(client client.ReplicaSetsNamespacer, numReads int) ReplicaSetListChannel {
+// GetReplicaSetListChannel returns a pair of channels to a ReplicaSet list and
+// errors that both must be read numReads times.
+func GetReplicaSetListChannel(client client.ReplicaSetsNamespacer,
+	nsQuery *NamespaceQuery, numReads int) ReplicaSetListChannel {
 	channel := ReplicaSetListChannel{
 		List:  make(chan *extensions.ReplicaSetList, numReads),
 		Error: make(chan error, numReads),
 	}
 
 	go func() {
-		rcs, err := client.ReplicaSets(api.NamespaceAll).List(listEverything)
+		list, err := client.ReplicaSets(nsQuery.ToRequestParam()).List(listEverything)
+		var filteredItems []extensions.ReplicaSet
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
 		for i := 0; i < numReads; i++ {
-			channel.List <- rcs
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
@@ -284,27 +305,39 @@ func GetReplicaSetListChannel(client client.ReplicaSetsNamespacer, numReads int)
 	return channel
 }
 
-// List and error channels to Nodes.
+// DaemonSetListChannel is a list and error channels to Nodes.
 type DaemonSetListChannel struct {
 	List  chan *extensions.DaemonSetList
 	Error chan error
 }
 
-// Returns a pair of channels to a DaemonSet list and errors that both must be read
-// numReads times.
-func GetDaemonSetListChannel(client client.DaemonSetsNamespacer, numReads int) DaemonSetListChannel {
+// GetDaemonSetListChannel returns a pair of channels to a DaemonSet list and errors that
+// both must be read numReads times.
+func GetDaemonSetListChannel(client client.DaemonSetsNamespacer,
+	nsQuery *NamespaceQuery, numReads int) DaemonSetListChannel {
 	channel := DaemonSetListChannel{
 		List:  make(chan *extensions.DaemonSetList, numReads),
 		Error: make(chan error, numReads),
 	}
 
 	go func() {
-		rcs, err := client.DaemonSets(api.NamespaceAll).List(listEverything)
+		list, err := client.DaemonSets(nsQuery.ToRequestParam()).List(listEverything)
+		var filteredItems []extensions.DaemonSet
+		for _, item := range list.Items {
+			if nsQuery.Matches(item.ObjectMeta.Namespace) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
 		for i := 0; i < numReads; i++ {
-			channel.List <- rcs
+			channel.List <- list
 			channel.Error <- err
 		}
 	}()
 
 	return channel
+}
+
+var listEverything api.ListOptions = api.ListOptions{
+	LabelSelector: labels.Everything(),
+	FieldSelector: fields.Everything(),
 }

--- a/src/app/backend/resource/daemonset/daemonsetlist.go
+++ b/src/app/backend/resource/daemonset/daemonsetlist.go
@@ -50,14 +50,14 @@ type DaemonSet struct {
 }
 
 // GetDaemonSetList returns a list of all Daemon Set in the cluster.
-func GetDaemonSetList(client *client.Client, namespace string) (*DaemonSetList, error) {
+func GetDaemonSetList(client *client.Client, nsQuery *common.NamespaceQuery) (*DaemonSetList, error) {
 	log.Printf("Getting list of all daemon sets in the cluster")
 	channels := &common.ResourceChannels{
-		DaemonSetList: common.GetDaemonSetListChannel(client, 1),
-		ServiceList:   common.GetServiceListChannel(client, 1),
-		PodList:       common.GetPodListChannel(client, 1),
-		EventList:     common.GetEventListChannel(client, 1),
-		NodeList:      common.GetNodeListChannel(client, 1),
+		DaemonSetList: common.GetDaemonSetListChannel(client, nsQuery, 1),
+		ServiceList:   common.GetServiceListChannel(client, nsQuery, 1),
+		PodList:       common.GetPodListChannel(client, nsQuery, 1),
+		EventList:     common.GetEventListChannel(client, nsQuery, 1),
+		NodeList:      common.GetNodeListChannel(client, nsQuery, 1),
 	}
 
 	return GetDaemonSetListFromChannels(channels)

--- a/src/app/backend/resource/deployment/deploymentdetail.go
+++ b/src/app/backend/resource/deployment/deploymentdetail.go
@@ -11,6 +11,7 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/util/deployment"
 )
 
+// RollingUpdateStrategy is behavior of a rolling update. See RollingUpdateDeployment K8s object.
 type RollingUpdateStrategy struct {
 	MaxSurge       int `json:"maxSurge"`
 	MaxUnavailable int `json:"maxUnavailable"`
@@ -31,7 +32,7 @@ type StatusInfo struct {
 	Unavailable int `json:"unavailable"`
 }
 
-// ReplicaSetDetail is a presentation layer view of Kubernetes Replica Set resource. This means
+// DeploymentDetail is a presentation layer view of Kubernetes Deployment resource.
 type DeploymentDetail struct {
 	ObjectMeta common.ObjectMeta `json:"objectMeta"`
 	TypeMeta   common.TypeMeta   `json:"typeMeta"`
@@ -62,6 +63,7 @@ type DeploymentDetail struct {
 	EventList common.EventList `json:"eventList"`
 }
 
+// GetDeploymentDetail returns model object of deployment and error, if any.
 func GetDeploymentDetail(client client.Interface, namespace string,
 	name string) (*DeploymentDetail, error) {
 
@@ -73,8 +75,9 @@ func GetDeploymentDetail(client client.Interface, namespace string,
 	}
 
 	channels := &common.ResourceChannels{
-		ReplicaSetList: common.GetReplicaSetListChannel(client.Extensions(), 1),
-		PodList:        common.GetPodListChannel(client, 1),
+		ReplicaSetList: common.GetReplicaSetListChannel(client.Extensions(),
+			common.NewSameNamespaceQuery(namespace), 1),
+		PodList: common.GetPodListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
 	}
 
 	replicaSetList := <-channels.ReplicaSetList.List

--- a/src/app/backend/resource/deployment/deploymentlist.go
+++ b/src/app/backend/resource/deployment/deploymentlist.go
@@ -46,15 +46,15 @@ type Deployment struct {
 }
 
 // GetDeploymentList returns a list of all Deployments in the cluster.
-func GetDeploymentList(client client.Interface) (*DeploymentList, error) {
+func GetDeploymentList(client client.Interface, nsQuery *common.NamespaceQuery) (*DeploymentList, error) {
 	log.Printf("Getting list of all deployments in the cluster")
 
 	channels := &common.ResourceChannels{
-		DeploymentList: common.GetDeploymentListChannel(client.Extensions(), 1),
-		ServiceList:    common.GetServiceListChannel(client, 1),
-		PodList:        common.GetPodListChannel(client, 1),
-		EventList:      common.GetEventListChannel(client, 1),
-		NodeList:       common.GetNodeListChannel(client, 1),
+		DeploymentList: common.GetDeploymentListChannel(client.Extensions(), nsQuery, 1),
+		ServiceList:    common.GetServiceListChannel(client, nsQuery, 1),
+		PodList:        common.GetPodListChannel(client, nsQuery, 1),
+		EventList:      common.GetEventListChannel(client, nsQuery, 1),
+		NodeList:       common.GetNodeListChannel(client, nsQuery, 1),
 	}
 
 	return GetDeploymentListFromChannels(channels)

--- a/src/app/backend/resource/event/eventcommon.go
+++ b/src/app/backend/resource/event/eventcommon.go
@@ -33,11 +33,14 @@ func GetEvents(client client.EventNamespacer, namespace, resourceName string) ([
 	}
 
 	channels := &common.ResourceChannels{
-		EventList: common.GetNamespacedEventListChannel(client, 1, namespace,
+		EventList: common.GetEventListChannelWithOptions(
+			client,
+			common.NewSameNamespaceQuery(namespace),
 			api.ListOptions{
 				LabelSelector: labels.Everything(),
 				FieldSelector: fieldSelector,
-			}),
+			},
+			1),
 	}
 
 	eventList := <-channels.EventList.List
@@ -53,11 +56,15 @@ func GetPodsEvents(client client.Interface, namespace string, resourceSelector m
 	[]api.Event, error) {
 
 	channels := &common.ResourceChannels{
-		PodList: common.GetNamespacedPodListChannel(client, 1, namespace, api.ListOptions{
-			LabelSelector: labels.SelectorFromSet(resourceSelector),
-			FieldSelector: fields.Everything(),
-		}),
-		EventList: common.GetEventListChannel(client, 1),
+		PodList: common.GetPodListChannelWithOptions(
+			client,
+			common.NewSameNamespaceQuery(namespace),
+			api.ListOptions{
+				LabelSelector: labels.SelectorFromSet(resourceSelector),
+				FieldSelector: fields.Everything(),
+			},
+			1),
+		EventList: common.GetEventListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
 	}
 
 	podList := <-channels.PodList.List

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -51,11 +51,12 @@ type Pod struct {
 }
 
 // GetPodList returns a list of all Pods in the cluster.
-func GetPodList(client k8sClient.Interface, heapsterClient client.HeapsterClient) (*PodList, error) {
+func GetPodList(client k8sClient.Interface, heapsterClient client.HeapsterClient,
+	nsQuery *common.NamespaceQuery) (*PodList, error) {
 	log.Printf("Getting list of all pods in the cluster")
 
 	channels := &common.ResourceChannels{
-		PodList: common.GetPodListChannel(client, 1),
+		PodList: common.GetPodListChannel(client, nsQuery, 1),
 	}
 
 	return GetPodListFromChannels(channels, heapsterClient)

--- a/src/app/backend/resource/replicaset/replicasetdetail.go
+++ b/src/app/backend/resource/replicaset/replicasetdetail.go
@@ -59,7 +59,7 @@ func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.Heaps
 	}
 
 	channels := &common.ResourceChannels{
-		PodList: common.GetPodListChannel(client, 1),
+		PodList: common.GetPodListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
 	}
 
 	pods := <-channels.PodList.List

--- a/src/app/backend/resource/replicaset/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist.go
@@ -46,15 +46,15 @@ type ReplicaSet struct {
 }
 
 // GetReplicaSetList returns a list of all Replica Sets in the cluster.
-func GetReplicaSetList(client client.Interface) (*ReplicaSetList, error) {
+func GetReplicaSetList(client client.Interface, nsQuery *common.NamespaceQuery) (*ReplicaSetList, error) {
 	log.Printf("Getting list of all replica sets in the cluster")
 
 	channels := &common.ResourceChannels{
-		ReplicaSetList: common.GetReplicaSetListChannel(client.Extensions(), 1),
-		ServiceList:    common.GetServiceListChannel(client, 1),
-		PodList:        common.GetPodListChannel(client, 1),
-		EventList:      common.GetEventListChannel(client, 1),
-		NodeList:       common.GetNodeListChannel(client, 1),
+		ReplicaSetList: common.GetReplicaSetListChannel(client.Extensions(), nsQuery, 1),
+		ServiceList:    common.GetServiceListChannel(client, nsQuery, 1),
+		PodList:        common.GetPodListChannel(client, nsQuery, 1),
+		EventList:      common.GetEventListChannel(client, nsQuery, 1),
+		NodeList:       common.GetNodeListChannel(client, nsQuery, 1),
 	}
 
 	return GetReplicaSetListFromChannels(channels)

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
@@ -50,15 +50,15 @@ type ReplicationController struct {
 }
 
 // GetReplicationControllerList returns a list of all Replication Controllers in the cluster.
-func GetReplicationControllerList(client *client.Client) (*ReplicationControllerList, error) {
+func GetReplicationControllerList(client *client.Client, nsQuery *common.NamespaceQuery) (*ReplicationControllerList, error) {
 	log.Printf("Getting list of all replication controllers in the cluster")
 
 	channels := &common.ResourceChannels{
-		ReplicationControllerList: common.GetReplicationControllerListChannel(client, 1),
-		ServiceList:               common.GetServiceListChannel(client, 1),
-		PodList:                   common.GetPodListChannel(client, 1),
-		EventList:                 common.GetEventListChannel(client, 1),
-		NodeList:                  common.GetNodeListChannel(client, 1),
+		ReplicationControllerList: common.GetReplicationControllerListChannel(client, nsQuery, 1),
+		ServiceList:               common.GetServiceListChannel(client, nsQuery, 1),
+		PodList:                   common.GetPodListChannel(client, nsQuery, 1),
+		EventList:                 common.GetEventListChannel(client, nsQuery, 1),
+		NodeList:                  common.GetNodeListChannel(client, nsQuery, 1),
 	}
 
 	return GetReplicationControllerListFromChannels(channels)

--- a/src/app/backend/resource/service/servicedetail.go
+++ b/src/app/backend/resource/service/servicedetail.go
@@ -80,7 +80,7 @@ func GetServicePods(client k8sClient.Interface, heapsterClient client.HeapsterCl
 	namespace string, serviceSelector map[string]string) (*pod.PodList, error) {
 
 	channels := &common.ResourceChannels{
-		PodList: common.GetPodListChannel(client, 1),
+		PodList: common.GetPodListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
 	}
 
 	apiPodList := <-channels.PodList.List

--- a/src/app/backend/resource/service/servicelist.go
+++ b/src/app/backend/resource/service/servicelist.go
@@ -50,11 +50,11 @@ type ServiceList struct {
 }
 
 // GetServiceList returns a list of all services in the cluster.
-func GetServiceList(client client.Interface) (*ServiceList, error) {
+func GetServiceList(client client.Interface, nsQuery *common.NamespaceQuery) (*ServiceList, error) {
 	log.Printf("Getting list of all services in the cluster")
 
 	channels := &common.ResourceChannels{
-		ServiceList: common.GetServiceListChannel(client, 1),
+		ServiceList: common.GetServiceListChannel(client, nsQuery, 1),
 	}
 
 	services := <-channels.ServiceList.List

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -39,17 +39,17 @@ type Workloads struct {
 
 // GetWorkloads returns a list of all workloads in the cluster.
 func GetWorkloads(client k8sClient.Interface,
-	heapsterClient client.HeapsterClient) (*Workloads, error) {
+	heapsterClient client.HeapsterClient, nsQuery *common.NamespaceQuery) (*Workloads, error) {
 
 	log.Printf("Getting lists of all workloads")
 	channels := &common.ResourceChannels{
-		ReplicationControllerList: common.GetReplicationControllerListChannel(client, 1),
-		ReplicaSetList:            common.GetReplicaSetListChannel(client.Extensions(), 1),
-		DeploymentList:            common.GetDeploymentListChannel(client.Extensions(), 1),
-		ServiceList:               common.GetServiceListChannel(client, 3),
-		PodList:                   common.GetPodListChannel(client, 4),
-		EventList:                 common.GetEventListChannel(client, 3),
-		NodeList:                  common.GetNodeListChannel(client, 3),
+		ReplicationControllerList: common.GetReplicationControllerListChannel(client, nsQuery, 1),
+		ReplicaSetList:            common.GetReplicaSetListChannel(client.Extensions(), nsQuery, 1),
+		DeploymentList:            common.GetDeploymentListChannel(client.Extensions(), nsQuery, 1),
+		ServiceList:               common.GetServiceListChannel(client, nsQuery, 3),
+		PodList:                   common.GetPodListChannel(client, nsQuery, 4),
+		EventList:                 common.GetEventListChannel(client, nsQuery, 3),
+		NodeList:                  common.GetNodeListChannel(client, nsQuery, 3),
 	}
 
 	return GetWorkloadsFromChannels(channels, heapsterClient)

--- a/src/test/backend/resource/common/namespace_test.go
+++ b/src/test/backend/resource/common/namespace_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestToRequestParam(t *testing.T) {
+	nsQ := NewSameNamespaceQuery("foo")
+	if nsQ.ToRequestParam() != "foo" {
+		t.Errorf("Expected %s to be foo", nsQ.ToRequestParam())
+	}
+
+	nsQ = NewNamespaceQuery([]string{"foo", "bar"})
+	if nsQ.ToRequestParam() != "" {
+		t.Errorf("Expected %s to be ''", nsQ.ToRequestParam())
+	}
+
+	nsQ = NewNamespaceQuery([]string{})
+	if nsQ.ToRequestParam() != "" {
+		t.Errorf("Expected %s to be ''", nsQ.ToRequestParam())
+	}
+
+	nsQ = NewNamespaceQuery(nil)
+	if nsQ.ToRequestParam() != "" {
+		t.Errorf("Expected %s to be ''", nsQ.ToRequestParam())
+	}
+}
+
+func TestMatches(t *testing.T) {
+	nsQ := NewSameNamespaceQuery("foo")
+	if !nsQ.Matches("foo") {
+		t.Errorf("Expected foo to match")
+	}
+	if nsQ.Matches("foo-bar") {
+		t.Errorf("Expected foo-bar not to match")
+	}
+
+	nsQ = NewNamespaceQuery(nil)
+	if !nsQ.Matches("foo") {
+		t.Errorf("Expected foo to match")
+	}
+	if nsQ.Matches("kube-system") {
+		t.Errorf("Expected kube-system not to match")
+	}
+
+	nsQ = NewNamespaceQuery([]string{"foo", "bar"})
+	if !nsQ.Matches("foo") {
+		t.Errorf("Expected foo to match")
+	}
+	if !nsQ.Matches("bar") {
+		t.Errorf("Expected bar to match")
+	}
+	if nsQ.Matches("baz") {
+		t.Errorf("Expected baz not to match")
+	}
+	if nsQ.Matches("kube-system") {
+		t.Errorf("Expected kube-system not to match")
+	}
+}

--- a/src/test/backend/resource/deployment/deploymentevents_test.go
+++ b/src/test/backend/resource/deployment/deploymentevents_test.go
@@ -22,7 +22,9 @@ func TestGetDeploymentEvents(t *testing.T) {
 	}{
 		{
 			"test-namespace", "test-name",
-			&api.EventList{Items: []api.Event{{Message: "test-message"}}},
+			&api.EventList{Items: []api.Event{
+				{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			}},
 			&extensions.Deployment{
 				ObjectMeta: api.ObjectMeta{Name: "test-replicaset"},
 				Spec: extensions.DeploymentSpec{
@@ -33,9 +35,10 @@ func TestGetDeploymentEvents(t *testing.T) {
 			&common.EventList{
 				Namespace: "test-namespace",
 				Events: []common.Event{{
-					TypeMeta: common.TypeMeta{common.ResourceKindEvent},
-					Message:  "test-message",
-					Type:     api.EventTypeNormal,
+					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
+					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},
+					Message:    "test-message",
+					Type:       api.EventTypeNormal,
 				}}},
 		},
 	}

--- a/src/test/backend/resource/event/eventcommon_test.go
+++ b/src/test/backend/resource/event/eventcommon_test.go
@@ -37,10 +37,14 @@ func TestGetEvents(t *testing.T) {
 		{
 			"test-namespace", "test-name",
 			&api.EventList{
-				Items: []api.Event{{Message: "test-event-msg"}},
+				Items: []api.Event{
+					{Message: "test-event-msg", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+				},
 			},
 			[]string{"list"},
-			[]api.Event{{Message: "test-event-msg"}},
+			[]api.Event{
+				{Message: "test-event-msg", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			},
 		},
 	}
 
@@ -83,23 +87,27 @@ func TestGetPodsEvents(t *testing.T) {
 			"test-namespace", map[string]string{"app": "test"},
 			&api.PodList{Items: []api.Pod{{
 				ObjectMeta: api.ObjectMeta{
-					Name:   "test-pod",
-					UID:    "test-uid",
-					Labels: map[string]string{"app": "test"},
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+					Labels:    map[string]string{"app": "test"},
 				}}, {
 				ObjectMeta: api.ObjectMeta{
-					Name:   "test-pod",
-					UID:    "test-uid",
-					Labels: map[string]string{"app": "test-app"},
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+					Labels:    map[string]string{"app": "test-app"},
 				}},
 			}},
 			&api.EventList{Items: []api.Event{{
 				Message:        "event-test-msg",
+				ObjectMeta:     api.ObjectMeta{Namespace: "test-namespace"},
 				InvolvedObject: api.ObjectReference{UID: "test-uid"},
 			}}},
 			[]string{"list", "list"},
 			[]api.Event{{
 				Message:        "event-test-msg",
+				ObjectMeta:     api.ObjectMeta{Namespace: "test-namespace"},
 				InvolvedObject: api.ObjectReference{UID: "test-uid"},
 			}},
 		},

--- a/src/test/backend/resource/replicaset/replicasetevents_test.go
+++ b/src/test/backend/resource/replicaset/replicasetevents_test.go
@@ -37,7 +37,9 @@ func TestGetReplicaSetEvents(t *testing.T) {
 	}{
 		{
 			"test-namespace", "test-name",
-			&api.EventList{Items: []api.Event{{Message: "test-message"}}},
+			&api.EventList{Items: []api.Event{
+				{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			}},
 			&api.PodList{Items: []api.Pod{{ObjectMeta: api.ObjectMeta{Name: "test-pod"}}}},
 			&extensions.ReplicaSet{
 				ObjectMeta: api.ObjectMeta{Name: "test-replicaset"},
@@ -49,9 +51,10 @@ func TestGetReplicaSetEvents(t *testing.T) {
 			&common.EventList{
 				Namespace: "test-namespace",
 				Events: []common.Event{{
-					TypeMeta: common.TypeMeta{common.ResourceKindEvent},
-					Message:  "test-message",
-					Type:     api.EventTypeNormal,
+					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
+					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},
+					Message:    "test-message",
+					Type:       api.EventTypeNormal,
 				}}},
 		},
 	}
@@ -94,16 +97,18 @@ func TestGetReplicaSetPodsEvents(t *testing.T) {
 	}{
 		{
 			"test-namespace", "test-name",
-			&api.EventList{Items: []api.Event{{Message: "test-message"}}},
-			&api.PodList{Items: []api.Pod{{ObjectMeta: api.ObjectMeta{Name: "test-pod"}}}},
+			&api.EventList{Items: []api.Event{
+				{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			}},
+			&api.PodList{Items: []api.Pod{{ObjectMeta: api.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"}}}},
 			&extensions.ReplicaSet{
-				ObjectMeta: api.ObjectMeta{Name: "test-replicaset"},
+				ObjectMeta: api.ObjectMeta{Name: "test-replicaset", Namespace: "test-namespace"},
 				Spec: extensions.ReplicaSetSpec{
 					Selector: &unversioned.LabelSelector{
 						MatchLabels: map[string]string{},
 					}}},
 			[]string{"get", "list", "list"},
-			[]api.Event{{Message: "test-message"}},
+			[]api.Event{{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}}},
 		},
 	}
 

--- a/src/test/backend/resource/service/servicelist_test.go
+++ b/src/test/backend/resource/service/servicelist_test.go
@@ -59,7 +59,7 @@ func TestGetServiceList(t *testing.T) {
 	for _, c := range cases {
 		fakeClient := testclient.NewSimpleFake(c.serviceList)
 
-		actual, _ := GetServiceList(fakeClient)
+		actual, _ := GetServiceList(fakeClient, common.NewNamespaceQuery(nil))
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {


### PR DESCRIPTION
Now default behavior is to omit kube-system namespace when listing all.
In a future PR I'll add namespace selector.

Now all list pages can be optionally filtered by (multiple) namespaces.

Try it, e.g.,: http://localhost:9090/api/v1/workload/default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/768)
<!-- Reviewable:end -->
