### PR TITLE
Fix installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ If you find that you’re not able to access the Dashboard you can install and o
 stable release by running the following commands:
 ```bash
 kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
-kubectl proxy --port=9090
 ```
-And then navigate to `http://localhost:9090/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard`
+And then navigate to `https://<kubernetes-master>/ui`
 
 If it asks password, use `$ kubectl config view` to find it.
 

--- a/src/deploy/kubernetes-dashboard-canary.yaml
+++ b/src/deploy/kubernetes-dashboard-canary.yaml
@@ -61,7 +61,6 @@ items:
   metadata:
     labels:
       app: kubernetes-dashboard-canary
-      kubernetes.io/cluster-service: "true"
     name: dashboard-canary
     namespace: kube-system
   spec:

--- a/src/deploy/kubernetes-dashboard.yaml
+++ b/src/deploy/kubernetes-dashboard.yaml
@@ -59,7 +59,6 @@ items:
   metadata:
     labels:
       app: kubernetes-dashboard
-      kubernetes.io/cluster-service: "true"
     name: kubernetes-dashboard
     namespace: kube-system
   spec:


### PR DESCRIPTION
fixes #665 and some clean up. I assumed the following use cases:



Use Case 1:
Dashboard is part of add-on manager      => fine nothing to do

Use Case 2:
Dashboard is not part of add-on. User wants to add Dashboard.  

=> removed label kubernetes.io/cluster-servservice to prevent add-on manager to remove dashboard again. However, `kubectl cluster-info` will not list dashboard service

=> update readme to better fit to use case



Use Case 3.
Dashboard is part of add-on manager. Howerver, user wants to deploy latest (canary) version of Dashboard
=> prevent add-on manager to remove canary version. 

@batikanu can you review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/774)
<!-- Reviewable:end -->
