### PR TITLE
Status icons fix

### DIFF
--- a/src/app/frontend/daemonsetlist/daemonsetcardlist.html
+++ b/src/app/frontend/daemonsetlist/daemonsetcardlist.html
@@ -38,7 +38,7 @@ limitations under the License.
         <md-tooltip md-direction="right">{{::$ctrl.i18n.MSG_PODS_ARE_PENDING_TOOLTIP}}</md-tooltip>
       </md-icon>
       <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess(daemonSet)">
-        beenhere
+        check_circle
       </md-icon>
     </kd-resource-card-status>
     <kd-resource-card-columns>

--- a/src/app/frontend/deploymentlist/deploymentcard.html
+++ b/src/app/frontend/deploymentlist/deploymentcard.html
@@ -25,7 +25,7 @@ limitations under the License.
       <md-tooltip md-direction="right">One or more pods are in pending state</md-tooltip>
     </md-icon>
     <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
-      beenhere
+      check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>

--- a/src/app/frontend/joblist/jobcard.html
+++ b/src/app/frontend/joblist/jobcard.html
@@ -29,7 +29,7 @@ limitations under the License.
 
     <md-icon class="material-icons" style="color: green";
              ng-if="::$ctrl.isSuccess()">
-      beenhere
+      check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>

--- a/src/app/frontend/petsetlist/petsetcard.html
+++ b/src/app/frontend/petsetlist/petsetcard.html
@@ -27,7 +27,7 @@ limitations under the License.
       </md-tooltip>
     </md-icon>
     <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
-      beenhere
+      check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>

--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -32,16 +32,16 @@ limitations under the License.
   <kd-resource-card ng-repeat="pod in $ctrl.podList.pods"
       type-meta="pod.typeMeta" object-meta="pod.objectMeta">
     <kd-resource-card-status layout="row">
-      <md-icon class="material-icons kd-error" ng-if="::pod.podPhase=='Failed'">
+      <md-icon class="material-icons kd-error" ng-if="$ctrl.isStatusFailed(pod)">
         error
         <md-tooltip md-direction="right">{{::$ctrl.i18n.MSG_POD_IS_FAILED_TOOLTIP}}</md-tooltip>
       </md-icon>
-      <md-icon class="material-icons" ng-if="::pod.podPhase=='Pending'">
+      <md-icon class="material-icons" ng-if="$ctrl.isStatusPending(pod)">
         timelapse
         <md-tooltip md-direction="right">{{::$ctrl.i18n.MSG_POD_IS_PENDING_TOOLTIP}}</md-tooltip>
       </md-icon>
-      <md-icon class="material-icons kd-success" ng-if="::pod.podPhase=='Running'">
-        beenhere
+      <md-icon class="material-icons kd-success" ng-if="$ctrl.isStatusSuccessful(pod)">
+        check_circle
       </md-icon>
     </kd-resource-card-status>
     <kd-resource-card-columns>

--- a/src/app/frontend/podlist/podcardlist_component.js
+++ b/src/app/frontend/podlist/podcardlist_component.js
@@ -61,6 +61,30 @@ export class PodCardListController {
     return this.state_.href(stateName,
                             new StateParams(pod.objectMeta.namespace, pod.objectMeta.name));
   }
+
+  /**
+   * Checks if pod status is successful, i.e. running or succeeded.
+   * @param pod
+   * @return {boolean}
+   * @export
+   */
+  isStatusSuccessful(pod) { return pod.podPhase === 'Running' || pod.podPhase === 'Succeeded'; }
+
+  /**
+   * Checks if pod status is pending.
+   * @param pod
+   * @return {boolean}
+   * @export
+   */
+  isStatusPending(pod) { return pod.podPhase === 'Pending'; }
+
+  /**
+   * Checks if pod status is failed.
+   * @param pod
+   * @return {boolean}
+   * @export
+   */
+  isStatusFailed(pod) { return pod.podPhase === 'Failed'; }
 }
 
 /**

--- a/src/app/frontend/replicasetlist/replicasetcard.html
+++ b/src/app/frontend/replicasetlist/replicasetcard.html
@@ -29,7 +29,7 @@ limitations under the License.
 
     <md-icon class="material-icons" style="color: green";
              ng-if="::$ctrl.isSuccess()">
-      beenhere
+      check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
@@ -26,7 +26,7 @@ limitations under the License.
       <md-tooltip md-direction="right">One or more pods are in pending state</md-tooltip>
     </md-icon>
     <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
-      beenhere
+      check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>

--- a/src/test/frontend/podlist/podcardlist_component_test.js
+++ b/src/test/frontend/podlist/podcardlist_component_test.js
@@ -52,4 +52,54 @@ describe('Pod card list controller', () => {
       },
     })).toBe('#/pod/foo-namespace/foo-pod');
   });
+
+  it('should check pod status correctly (succeeded is successful)', () => {
+    expect(ctrl.isStatusSuccessful({
+      name: 'test-pod',
+      podPhase: 'Succeeded',
+    })).toBeTruthy();
+  });
+
+  it('should check pod status correctly (running is successful)', () => {
+    expect(ctrl.isStatusSuccessful({
+      name: 'test-pod',
+      podPhase: 'Running',
+    })).toBeTruthy();
+  });
+
+  it('should check pod status correctly (failed isn\'t successful)', () => {
+    expect(ctrl.isStatusSuccessful({
+      name: 'test-pod',
+      podPhase: 'Failed',
+    })).toBeFalsy();
+  });
+
+  it('should check pod status correctly (pending is pending)', () => {
+    expect(ctrl.isStatusPending({
+      name: 'test-pod',
+      podPhase: 'Pending',
+    })).toBeTruthy();
+  });
+
+  it('should check pod status correctly (failed isn\'t pending)', () => {
+    expect(ctrl.isStatusPending({
+      name: 'test-pod',
+      podPhase: 'Failed',
+    })).toBeFalsy();
+  });
+
+  it('should check pod status correctly (failed is failed)', () => {
+    expect(ctrl.isStatusFailed({
+      name: 'test-pod',
+      podPhase: 'Failed',
+    })).toBeTruthy();
+  });
+
+  it('should check pod status correctly (running isn\'t failed)', () => {
+    expect(ctrl.isStatusFailed({
+      name: 'test-pod',
+      podPhase: 'Running',
+    })).toBeFalsy();
+  });
+
 });


### PR DESCRIPTION
Switched `beenhere` icon to `check_circle`.
Handled `succeeded` status.
Closes #831.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/844)
<!-- Reviewable:end -->
