### PR TITLE
Add .tools dir to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ cache:
   directories:
     - node_modules
     - bower_components
+    - .tools
 # Use Node.js as primary language because Gulp is the build system used in the project.
 language: node_js
 node_js:


### PR DESCRIPTION
This should cut a minute from our build

Travis cache has been reenabled recently for our project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/851)
<!-- Reviewable:end -->
