### PR TITLE
Fix a bug where deployment details page crashed

### DIFF
--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -297,7 +297,7 @@ backendApi.DeploymentInfo;
  *   objectMeta: !backendApi.ObjectMeta,
  *   typeMeta: !backendApi.TypeMeta,
  *   selector: !Array<backendApi.Label>,
- *   status: !backendApi.DeploymentInfo,
+ *   statusInfo: !backendApi.DeploymentInfo,
  *   strategy: !string,
  *   minReadySeconds: !number,
  *   rollingUpdateStrategy: !backendApi.RollingUpdateStrategy,

--- a/src/app/frontend/deploymentdetail/deploymentinfo_component.js
+++ b/src/app/frontend/deploymentdetail/deploymentinfo_component.js
@@ -74,19 +74,19 @@ function i18n(deployment) {
     /** @export {string} @desc The message says that that many replicas were updated in the deployment
         (deployment details page). */
     MSG_DEPLOYMENT_DETAIL_REPLICAS_UPDATED_LABEL:
-        goog.getMsg('{$replicas} updated', {'replicas': deployment.status.updated}),
+        goog.getMsg('{$replicas} updated', {'replicas': deployment.statusInfo.updated}),
     /** @export {string} @desc The message says that that many replicas (in total) are in the deployment
         (deployment details page). */
     MSG_DEPLOYMENT_DETAIL_REPLICAS_TOTAL_LABEL:
-        goog.getMsg('{$replicas} total', {'replicas': deployment.status.replicas}),
+        goog.getMsg('{$replicas} total', {'replicas': deployment.statusInfo.replicas}),
     /** @export {string} @desc The message says that that many replicas are available in the deployment
         (deployment details page). */
     MSG_DEPLOYMENT_DETAIL_REPLICAS_AVAILABLE_LABEL:
-        goog.getMsg('{$replicas} available', {'replicas': deployment.status.available}),
+        goog.getMsg('{$replicas} available', {'replicas': deployment.statusInfo.available}),
     /** @export {string} @desc The message says that that many replicas are unavailable in the deployment
         (deployment details page). */
     MSG_DEPLOYMENT_DETAIL_REPLICAS_UNAVAILABLE_LABEL:
-        goog.getMsg('{$replicas} unavailable', {'replicas': deployment.status.unavailable}),
+        goog.getMsg('{$replicas} unavailable', {'replicas': deployment.statusInfo.unavailable}),
     /** @export {string} @desc The message says how many replicas are allowed to be unavailable during an
         update in the deployment (deployment details page). */
     MSG_DEPLOYMENT_DETAIL_MAX_UNAVAILABLE_LABEL: goog.getMsg(

--- a/src/test/frontend/deploymentdetail/deploymentinfo_component_test.js
+++ b/src/test/frontend/deploymentdetail/deploymentinfo_component_test.js
@@ -13,7 +13,7 @@ describe('Deployment Info controller', () => {
     angular.mock.inject(($componentController, $rootScope) => {
       ctrl = $componentController('kdDeploymentInfo', {$scope: $rootScope}, {
         deployment: {
-          status: {
+          statusInfo: {
             updated: 0,
             replicas: 0,
             available: 0,


### PR DESCRIPTION
We used status instead of statusInfo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/867)
<!-- Reviewable:end -->
