### PR TITLE
Add number of rows selector for pagination

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -439,4 +439,5 @@
 	<translation id="462429506979725356" key="MSG_NODE_DETAIL_CONDITION_LAST_TRANSITION_TIME_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Last transition time' for the condition table header on the node details page.">Last transition time</translation>
 	<translation id="210175108235822936" key="MSG_NODE_DETAIL_CONDITION_REASON_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Reason' for the condition table header on the node details page.">Reason</translation>
 	<translation id="9072625199342670630" key="MSG_NODE_DETAIL_CONDITION_MESSAGE_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Message' for the condition table header on the node details page.">Message</translation>
+	<translation id="5574079475783065419" key="MSG_RESOURCE_CARD_LIST_PAGINATION_ROW_SELECTOR_LABEL" source="/home/floreks/Projects/dashboard/.tmp/serve/app-dev.js" desc="Label for pagination rows selector visible on resource lists.">Rows per page</translation>
 </translationbundle>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -525,4 +525,5 @@
 	<translation id="462429506979725356" key="MSG_NODE_DETAIL_CONDITION_LAST_TRANSITION_TIME_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Last transition time' for the condition table header on the node details page.">最終遷移時間</translation>
 	<translation id="210175108235822936" key="MSG_NODE_DETAIL_CONDITION_REASON_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Reason' for the condition table header on the node details page.">理由</translation>
 	<translation id="9072625199342670630" key="MSG_NODE_DETAIL_CONDITION_MESSAGE_HEADER" source="/home/maciaszczykm/workspace/dashboard/.tmp/serve/app-dev.js" desc="Label 'Message' for the condition table header on the node details page.">メッセージ</translation>
+	<translation id="5574079475783065419" key="MSG_RESOURCE_CARD_LIST_PAGINATION_ROW_SELECTOR_LABEL" source="/home/floreks/Projects/dashboard/.tmp/serve/app-dev.js" desc="Label for pagination rows selector visible on resource lists.">Rows per page</translation>
 </translationbundle>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <div ng-class="{'kd-resource-card-list-footer': $ctrl.shouldShowFooter()}" layout="row">
-  <span ng-transclude="content" flex></span>
-  <span ng-transclude="pagination" flex></span>
+  <span ng-transclude="content" flex="nogrow"></span>
+  <span ng-transclude="pagination" flex layout="row" class="kd-list-pagination-slot"></span>
 </div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
@@ -16,4 +16,11 @@
 
 .kd-resource-card-list-footer {
   border-top: 1px solid $border;
+  white-space: nowrap;
+}
+
+.kd-list-pagination-slot {
+  kd-resource-card-list-pagination {
+    flex-grow: 1;
+  }
 }

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
@@ -45,14 +45,14 @@ export class ResourceCardListFooterController {
 
   /**
    * Returns true if pagination slot has been filled and number of items on the list is bigger
-   * then max available limit, false otherwise.
+   * then min available rows limit, false otherwise.
    *
    * @return {boolean}
    * @private
    */
   shouldShowPagination_() {
     return this.listPagination_ &&
-        this.listPagination_.totalItems > this.paginationService_.getRowsLimit();
+        this.listPagination_.totalItems > this.paginationService_.getMinRowsLimit();
   }
 
   /**

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
@@ -14,6 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<dir-pagination-controls class="kd-list-pagination" boundary-links="true"
-                         pagination-id="$ctrl.paginationId" template-url="common/pagination/pagination.html">
-</dir-pagination-controls>
+<div ng-if="$ctrl.shouldShowPagination()" flex layout="row" class="kd-list-pagination">
+  <div class="kd-rows-selector-label">
+    {{$ctrl.i18n.MSG_RESOURCE_CARD_LIST_PAGINATION_ROW_SELECTOR_LABEL}}:
+  </div>
+  <md-select ng-model="$ctrl.rowsLimit" class="kd-list-pagination-row-selector"
+             md-selected-text="$ctrl.rowsLimit" ng-change="$ctrl.onRowsLimitUpdate()"
+             aria-label="Rows per page">
+    <md-option ng-repeat="rows in $ctrl.rowsLimitOptions" ng-value="{{rows}}">
+      {{rows}}
+    </md-option>
+  </md-select>
+
+  <dir-pagination-controls pagination-id="$ctrl.paginationId" class="kd-list-pagination-controls"
+                           boundary-links="true" template-url="common/pagination/pagination.html">
+  </dir-pagination-controls>
+</div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.scss
@@ -16,12 +16,29 @@
 
 .kd-list-pagination {
   align-items: center;
-  color: $foreground-2;
-  display: flex;
   justify-content: flex-end;
+}
 
+.kd-list-pagination-controls {
   > * {
     align-items: center;
     display: flex;
+  }
+}
+
+.kd-rows-selector-label {
+  line-height: 6 * $baseline-grid;
+  margin-right: $baseline-grid;
+  vertical-align: middle;
+}
+
+md-select {
+  &.kd-list-pagination-row-selector {
+    margin: 0 ($baseline-grid * 2) ($baseline-grid / 2) 0;
+
+    .md-select-value {
+      min-width: 6 * $baseline-grid;
+      width: 100%;
+    }
   }
 }

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination_component.js
@@ -19,7 +19,7 @@ export class ResourceCardListPaginationController {
   /**
    * @ngInject
    */
-  constructor() {
+  constructor(kdPaginationService) {
     /** @export {!./resourcecardlistfooter_component.ResourceCardListFooterController} -
      * Initialized from require just before $onInit is called. */
     this.resourceCardListFooterCtrl;
@@ -28,12 +28,45 @@ export class ResourceCardListPaginationController {
     /** @export {string} - Unique pagination id. Used together with id on <dir-paginate>
      *  directive */
     this.paginationId;
+    /** @private {!../../pagination/pagination_service.PaginationService} */
+    this.paginationService_ = kdPaginationService;
+    /** @export {number} */
+    this.rowsLimit = this.paginationService_.getRowsLimit(this.paginationId);
+    /** @export {!Array<number>} */
+    this.rowsLimitOptions = this.paginationService_.getRowsLimitOptions();
+    /** @export */
+    this.i18n = i18n;
   }
 
   /**
    * @export
    */
-  $onInit() { this.resourceCardListFooterCtrl.setListPagination(this); }
+  $onInit() {
+    if (this.paginationId === undefined || this.paginationId.length === 0) {
+      throw new Error('Pagination id has to be set.');
+    }
+
+    if (!this.paginationService_.isRegistered(this.paginationId)) {
+      this.paginationService_.registerInstance(this.paginationId);
+    }
+
+    this.resourceCardListFooterCtrl.setListPagination(this);
+  }
+
+  /**
+   * Updates number of rows to display on associated resource list.
+   * @export
+   */
+  onRowsLimitUpdate() { this.paginationService_.setRowsLimit(this.rowsLimit, this.paginationId); }
+
+  /**
+   * Returns true if number of items on the list is bigger
+   * then min available rows limit, false otherwise.
+   *
+   * @return {boolean}
+   * @export
+   */
+  shouldShowPagination() { return this.totalItems > this.paginationService_.getMinRowsLimit(); }
 }
 
 /**
@@ -56,4 +89,9 @@ export const resourceCardListPaginationComponent = {
     'paginationId': '@',
     'totalItems': '<',
   },
+};
+
+const i18n = {
+  /** @export {string} @desc Label for pagination rows selector visible on resource lists. */
+  MSG_RESOURCE_CARD_LIST_PAGINATION_ROW_SELECTOR_LABEL: goog.getMsg('Rows per page'),
 };

--- a/src/app/frontend/common/filters/itemsperpage_filter.js
+++ b/src/app/frontend/common/filters/itemsperpage_filter.js
@@ -33,7 +33,11 @@ export default function itemsPerPageFilter($delegate, kdPaginationService) {
    */
   let filterItems = function(collection, itemsPerPage, paginationId) {
     if (itemsPerPage === undefined) {
-      return sourceFilter(collection, kdPaginationService.getRowsLimit(), paginationId);
+      if (!kdPaginationService.isRegistered(paginationId)) {
+        kdPaginationService.registerInstance(paginationId);
+      }
+
+      return sourceFilter(collection, kdPaginationService.getRowsLimit(paginationId), paginationId);
     }
 
     return sourceFilter(collection, itemsPerPage, paginationId);

--- a/src/app/frontend/common/pagination/pagination.html
+++ b/src/app/frontend/common/pagination/pagination.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div ng-if="pages.length > 1 || !autoHide">
+<div>
   <div class="kd-list-pagination-label">
     {{ range.lower }} - {{ range.upper }} of {{ range.total}}
   </div>

--- a/src/app/frontend/common/pagination/pagination.scss
+++ b/src/app/frontend/common/pagination/pagination.scss
@@ -20,7 +20,6 @@
   > .md-button {
     &.md-icon-button {
       margin: 0;
-      padding-top: $baseline-grid / 2;
     }
   }
 }

--- a/src/app/frontend/common/pagination/pagination_service.js
+++ b/src/app/frontend/common/pagination/pagination_service.js
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** Available numbers of rows that can be shown on resource list. */
+export const ROWS_LIMIT_OPTIONS = [10, 25, 50, 100];
 /** Defines max number of rows that will be displayed on the list before applying pagination. */
-export const ROWS_LIMIT = 20;
+export const DEFAULT_ROWS_LIMIT = 10;
 
 /**
  * @final
@@ -21,16 +23,72 @@ export const ROWS_LIMIT = 20;
 export class PaginationService {
   /** @ngInject */
   constructor() {
-    /**
-     * @const
-     * @private {number} - Defines max number of rows that will be displayed on the list before
-     * applying pagination.
-     */
-    this.rowsLimit_ = ROWS_LIMIT;
+    this.rowsLimitOptions_ = ROWS_LIMIT_OPTIONS;
+    /** @private {Map<string, number>} */
+    this.instances_ = new Map();
   }
 
   /**
+   * Returns true if given pagination id is registered, false otherwise.
+   *
+   * @param {string} paginationId
+   * @return {boolean}
+   */
+  isRegistered(paginationId) { return this.instances_.has(paginationId); }
+
+  /**
+   * Registers pagination instance for given pagination id.
+   *
+   * @param {string} paginationId
+   */
+  registerInstance(paginationId) { this.instances_.set(paginationId, DEFAULT_ROWS_LIMIT); }
+
+  /**
+   * Returns number of rows that should be displayed on the list based on given pagination id.
+   * If given id is not registered an error is thrown.
+   *
    * @return {number}
    */
-  getRowsLimit() { return this.rowsLimit_; }
+  getRowsLimit(paginationId) {
+    let rowsLimit = this.instances_.get(paginationId);
+
+    if (!rowsLimit) {
+      throw new Error(`Pagination limit for given pagination id ${paginationId} does not exist`);
+    }
+
+    return rowsLimit;
+  }
+
+  /**
+   *
+   * @param limit
+   * @param paginationId
+   */
+  setRowsLimit(limit, paginationId) {
+    let rowsLimit = this.instances_.get(paginationId);
+
+    if (!rowsLimit) {
+      throw new Error(`Pagination limit for given pagination id ${paginationId} does not exist`);
+    }
+
+    if (this.rowsLimitOptions_.indexOf(limit) < 0) {
+      throw new Error(`Limit has to be in range ${ROWS_LIMIT_OPTIONS}`);
+    }
+
+    this.instances_.set(paginationId, limit);
+  }
+
+  /**
+   * Returns minimum available number of rows that can be displayed.
+   *
+   * @return {number}
+   */
+  getMinRowsLimit() { return Math.min.apply(Math, this.rowsLimitOptions_); }
+
+  /**
+   * Returns numbers of rows that can be shown on resource list.
+   *
+   * @return {!Array<number>}
+   */
+  getRowsLimitOptions() { return this.rowsLimitOptions_; }
 }

--- a/src/test/frontend/common/components/resourcecard/resourcecardlistfooter_component_test.js
+++ b/src/test/frontend/common/components/resourcecard/resourcecardlistfooter_component_test.js
@@ -14,6 +14,7 @@
 
 import resourceCardModule from 'common/components/resourcecard/resourcecard_module';
 import paginationModule from 'common/pagination/pagination_module';
+import {DEFAULT_ROWS_LIMIT} from 'common/pagination/pagination_service';
 
 describe('Resource card list footer', () => {
   /** @type
@@ -63,7 +64,7 @@ describe('Resource card list footer', () => {
 
   it('should show pagination', () => {
     // given
-    let listPaginationCtrl = {totalItems: 100};
+    let listPaginationCtrl = {totalItems: DEFAULT_ROWS_LIMIT + 1};
 
     // when
     ctrl.setListPagination(listPaginationCtrl);
@@ -75,7 +76,7 @@ describe('Resource card list footer', () => {
 
   it('should hide pagination', () => {
     // given
-    let listPaginationCtrl = {totalItems: 20};
+    let listPaginationCtrl = {totalItems: DEFAULT_ROWS_LIMIT};
 
     // when
     ctrl.setListPagination(listPaginationCtrl);

--- a/src/test/frontend/common/components/resourcecard/resourcecardlistpagination_component_test.js
+++ b/src/test/frontend/common/components/resourcecard/resourcecardlistpagination_component_test.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import resourceCardModule from 'common/components/resourcecard/resourcecard_module';
+import paginationModule from 'common/pagination/pagination_module';
 
 describe('Resource card list pagination', () => {
   /** @type
@@ -23,21 +24,69 @@ describe('Resource card list pagination', () => {
    *  {!common/components/resourcecard/resourcecardlistfooter_component.ResourceCardListFooterController}
    */
   let resourceCardListFooterCtrl;
+  /** @type {string} */
+  let paginationId = 'test-id';
+  /** @type {!common/pagination/pagination_service.PaginationService} */
+  let paginationService;
 
   beforeEach(() => {
+    angular.mock.module(paginationModule.name);
     angular.mock.module(resourceCardModule.name);
 
-    angular.mock.inject(($componentController) => {
+    angular.mock.inject(($componentController, _kdPaginationService_) => {
       resourceCardListFooterCtrl = {setListPagination: () => {}};
-      ctrl = $componentController(
-          'kdResourceCardListPagination', {},
-          {resourceCardListFooterCtrl: resourceCardListFooterCtrl});
+      paginationService = _kdPaginationService_;
+      paginationService.registerInstance(paginationId);
+      ctrl = $componentController('kdResourceCardListPagination', {}, {
+        paginationId: paginationId,
+        kdPaginationService: paginationService,
+        resourceCardListFooterCtrl: resourceCardListFooterCtrl,
+      });
     });
   });
 
   it('should set pagination controller on resource card list footer ctrl', () => {
+    // given
     spyOn(resourceCardListFooterCtrl, 'setListPagination');
+
+    // when
     ctrl.$onInit();
+
+    // then
     expect(resourceCardListFooterCtrl.setListPagination).toHaveBeenCalledWith(ctrl);
+  });
+
+  it('should show pagination', () => {
+    // given
+    ctrl.totalItems = 50;
+
+    // when
+    let result = ctrl.shouldShowPagination();
+
+    // then
+    expect(result).toBeTruthy();
+  });
+
+  it('should hide pagination', () => {
+    // given
+    ctrl.totalItems = 10;
+
+    // when
+    let result = ctrl.shouldShowPagination();
+
+    // then
+    expect(result).toBeFalsy();
+  });
+
+  it('should update rows limit', () => {
+    // given
+    ctrl.rowsLimit = 100;
+    spyOn(paginationService, 'setRowsLimit');
+
+    // when
+    ctrl.onRowsLimitUpdate();
+
+    // then
+    expect(paginationService.setRowsLimit).toHaveBeenCalledWith(100, paginationId);
   });
 });

--- a/src/test/frontend/common/filters/itemsperpage_filter_test.js
+++ b/src/test/frontend/common/filters/itemsperpage_filter_test.js
@@ -14,7 +14,7 @@
 
 import filtersModule from 'common/filters/filters_module';
 import paginationModule from 'common/pagination/pagination_module';
-import {ROWS_LIMIT} from 'common/pagination/pagination_service';
+import {DEFAULT_ROWS_LIMIT} from 'common/pagination/pagination_service';
 
 describe('Items per page filter', () => {
   /** @type {function(!Array<Object>, number, string): !Array<Object>} */
@@ -41,13 +41,13 @@ describe('Items per page filter', () => {
     // then
     expect(itemsPerPageFilter(new Array(20), 5, paginationId).length).toEqual(5);
     expect(itemsPerPageFilter(new Array(100), 0, paginationId).length).toEqual(100);
-    expect(itemsPerPageFilter(new Array(ROWS_LIMIT + 10), undefined, paginationId).length)
-        .toEqual(ROWS_LIMIT);
-    expect(itemsPerPageFilter(new Array(ROWS_LIMIT + 1), undefined, paginationId).length)
-        .toEqual(ROWS_LIMIT);
-    expect(itemsPerPageFilter(new Array(ROWS_LIMIT), undefined, paginationId).length)
-        .toEqual(ROWS_LIMIT);
-    expect(itemsPerPageFilter(new Array(ROWS_LIMIT - 1), undefined, paginationId).length)
-        .toEqual(ROWS_LIMIT - 1);
+    expect(itemsPerPageFilter(new Array(DEFAULT_ROWS_LIMIT + 10), undefined, paginationId).length)
+        .toEqual(DEFAULT_ROWS_LIMIT);
+    expect(itemsPerPageFilter(new Array(DEFAULT_ROWS_LIMIT + 1), undefined, paginationId).length)
+        .toEqual(DEFAULT_ROWS_LIMIT);
+    expect(itemsPerPageFilter(new Array(DEFAULT_ROWS_LIMIT), undefined, paginationId).length)
+        .toEqual(DEFAULT_ROWS_LIMIT);
+    expect(itemsPerPageFilter(new Array(DEFAULT_ROWS_LIMIT - 1), undefined, paginationId).length)
+        .toEqual(DEFAULT_ROWS_LIMIT - 1);
   });
 });


### PR DESCRIPTION
Logic changed a bit and pagination will be displayed if number of resources on the list is bigger than minimal rows limit option. Needs some work in the future to style it better (specially mobile version).

Todo:
- [x] add tests

![zrzut ekranu z 2016-06-13 15-48-51](https://cloud.githubusercontent.com/assets/2285385/16009750/5c343d2c-317e-11e6-8892-5eb024dd46f9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/893)
<!-- Reviewable:end -->
