### PR TITLE
Removing redundant first/last seen labels from events log

### DIFF
--- a/src/app/frontend/events/eventcardlist.html
+++ b/src/app/frontend/events/eventcardlist.html
@@ -65,10 +65,10 @@ limitations under the License.
           </kd-resource-card-column>
           <kd-resource-card-column>{{event.count}}</kd-resource-card-column>
           <kd-resource-card-column>
-            First seen at {{event.firstSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
+            {{event.firstSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
           </kd-resource-card-column>
           <kd-resource-card-column>
-            Last seen at {{event.lastSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
+            {{event.lastSeen | date:'d/M/yy HH:mm':'UTC'}} UTC
           </kd-resource-card-column>
         </kd-resource-card-columns>
       </kd-resource-card>


### PR DESCRIPTION
The events log shows redundant `First seen` and `Last seen` labels for every row, which adds visual noise and can lead to line breaks, depending on viewport width.

## Before

![image](https://cloud.githubusercontent.com/assets/273727/16019607/0c43ec5a-31aa-11e6-9a64-7a41a8f0e08d.png)

## After

![image](https://cloud.githubusercontent.com/assets/273727/16020696/7c9df07c-31af-11e6-807b-0f8aaf52ba91.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/896)
<!-- Reviewable:end -->
