### PR TITLE
Removing dead link in empty events log

### DIFF
--- a/src/app/frontend/events/eventcardlist.html
+++ b/src/app/frontend/events/eventcardlist.html
@@ -81,7 +81,6 @@ limitations under the License.
       <div class="kd-replicationcontrollerevents-no-events-text">No events were found</div>
       <div class="kd-replicationcontrollerevents-no-events-info">
         There are no events to display. It's possible that all of them have expired.
-        <a href="">Learn more</a>
       </div>
     </div>
   </kd-content>


### PR DESCRIPTION
When the events log is empty, a message is shown with a "Learn more" link underneath, which had no link target.

I tried finding a good target to link to in the documentation, but it seems as if the link had no target for a good reason: there is no content describing the event log or expiry of events, currently.

To avoid a dysfunctional link in the Dashboard I suggest removing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/897)
<!-- Reviewable:end -->
