### PR TITLE
Increase performance of middle ellipsis formatting

### DIFF
--- a/src/app/frontend/common/components/middleellipsis/middleellipsis_directive.js
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis_directive.js
@@ -19,11 +19,12 @@ import computeTextLength from './middleellipsis';
  * Returns directive definition for middle ellipsis.
  *
  * @param {!function(string, number): string} middleEllipsisFilter
+ * @param {!angular.$window} $window
  *
  * @return {!angular.Directive}
  * @ngInject
  */
-export default function middleEllipsisDirective(middleEllipsisFilter) {
+export default function middleEllipsisDirective(middleEllipsisFilter, $window) {
   return {
     controller: MiddleEllipsisController,
     controllerAs: 'ellipsisCtrl',
@@ -54,12 +55,20 @@ export default function middleEllipsisDirective(middleEllipsisFilter) {
 
       let nonNullElement = ellipsisElem;
 
-      scope.$watch(
-          () => [container.offsetWidth, ctrl.displayString], ([containerWidth, displayString]) => {
-            let newLength = computeTextLength(
-                containerWidth, nonNullElement, element, middleEllipsisFilter, displayString);
-            ctrl.maxLength = newLength;
-          }, true);
+      angular.element($window).ready(recalculateTextLength);
+
+      angular.element($window).bind('resize', recalculateTextLength);
+
+      function recalculateTextLength() {
+        ctrl.maxLength = computeTextLength(
+            container.offsetWidth, nonNullElement, element, middleEllipsisFilter,
+            ctrl.displayString);
+      }
+
+      scope.$on('$destroy', () => {
+        angular.element($window).unbind('ready', recalculateTextLength);
+        angular.element($window).unbind('resize', recalculateTextLength);
+      });
     },
   };
 }

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_directive_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_directive_test.js
@@ -19,12 +19,15 @@ describe('Middle ellipsis directive', () => {
   let scope;
   /** @type {function(!angular.Scope):!angular.JQLite} */
   let compileFn;
+  /** @type {!angular.$window} */
+  let window;
 
   beforeEach(() => {
     angular.mock.module(componentsModule.name);
 
-    angular.mock.inject(($rootScope, $compile) => {
+    angular.mock.inject(($rootScope, $compile, $window) => {
       scope = $rootScope.$new();
+      window = $window;
       compileFn = $compile(`<div><kd-middle-ellipsis display-string="{{displayString}}"
           max-length="{{maxLength}}"></kd-middle-ellipsis></div>`);
     });
@@ -39,6 +42,7 @@ describe('Middle ellipsis directive', () => {
 
     // when
     element[0].style.width = '500px';
+    window.dispatchEvent(new Event('resize'));
     scope.$digest();
 
     // then
@@ -46,6 +50,7 @@ describe('Middle ellipsis directive', () => {
 
     // when
     element[0].style.width = '1px';
+    window.dispatchEvent(new Event('resize'));
     scope.$digest();
 
     // then
@@ -53,6 +58,7 @@ describe('Middle ellipsis directive', () => {
 
     // when
     element[0].style.width = '50px';
+    window.dispatchEvent(new Event('resize'));
     scope.$digest();
 
     // then


### PR DESCRIPTION
#### Performance
With this small change performance has increased about 3 times. I've used CPU profiling on chrome and JS profiling on firefox 47/40.

 - On chrome `computeTextLength` function usage decreased from ~6.2% to ~1.8%
 - On firefox 47 loading time of my workload page decreased from ~17s to ~8s. Other pages are loading instantly. On firefox 40 performance increase is similar, but it takes ~4.5s to load the page. It seems that newer the version of FF is, longer it takes to render the page. Unfortunately...

#### About changes
It will recalculate middle ellipsis only on first page load and on resize. This way it won't be fired on every digest loop. Dashboard seems to be more responsive now. Please test it also. It is only half measure, but for now should be sufficient.

Also thanks to registering it on `resize` event, I've fixed #691.
Partially fixes also #899

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/913)
<!-- Reviewable:end -->
