### PR TITLE
Fix IE layout issues

### DIFF
--- a/src/app/frontend/common/components/actionbar/actionbar.html
+++ b/src/app/frontend/common/components/actionbar/actionbar.html
@@ -16,8 +16,8 @@ limitations under the License.
 
 <md-toolbar class="kd-toolbar kd-actionbar">
   <div class="md-toolbar-tools" layout="row">
-    <kd-breadcrumbs class="kd-actionbar-breadcrumbs" limit="2" flex></kd-breadcrumbs>
-    <span flex></span>
+    <kd-breadcrumbs class="kd-actionbar-breadcrumbs" limit="2" flex="auto"></kd-breadcrumbs>
+    <span flex="auto"></span>
     <ng-transclude ui-view="actionbar"></ng-transclude>
   </div>
 </md-toolbar>

--- a/src/app/frontend/common/components/infocard/infocardsection.html
+++ b/src/app/frontend/common/components/infocard/infocardsection.html
@@ -16,5 +16,5 @@ limitations under the License.
 
 <div layout="column" class="kd-info-card-section-container">
   <div class="kd-info-card-section-name">{{$ctrl.name}}</div>
-  <div flex ng-transclude="entry"></div>
+  <div flex="auto" ng-transclude="entry"></div>
 </div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
@@ -16,5 +16,5 @@ limitations under the License.
 
 <div ng-class="{'kd-resource-card-list-footer': $ctrl.shouldShowFooter()}" layout="row">
   <span ng-transclude="content" flex="nogrow"></span>
-  <span ng-transclude="pagination" flex layout="row" class="kd-list-pagination-slot"></span>
+  <span ng-transclude="pagination" flex="auto" layout="row" class="kd-list-pagination-slot"></span>
 </div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div ng-if="$ctrl.shouldShowPagination()" flex layout="row" class="kd-list-pagination">
+<div ng-if="$ctrl.shouldShowPagination()" flex="auto" layout="row" class="kd-list-pagination">
   <div class="kd-rows-selector-label">
     {{$ctrl.i18n.MSG_RESOURCE_CARD_LIST_PAGINATION_ROW_SELECTOR_LABEL}}:
   </div>


### PR DESCRIPTION
All `flex` attrs should be converted into `fles="auto"` for IE.
Otherwise columns are merged togheder.

Please test whether this breaks something on chrome or firefox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/939)
<!-- Reviewable:end -->
