### PR TITLE
Fix external endpoints and add node port information to service details

### DIFF
--- a/src/app/backend/resource/common/serviceport.go
+++ b/src/app/backend/resource/common/serviceport.go
@@ -25,13 +25,16 @@ type ServicePort struct {
 
 	// Protocol name, e.g., TCP or UDP.
 	Protocol api.Protocol `json:"protocol"`
+
+	// The port on each node on which service is exposed.
+	NodePort int32 `json:"nodePort"`
 }
 
 // GetServicePorts returns human readable name for the given service ports list.
 func GetServicePorts(apiPorts []api.ServicePort) []ServicePort {
 	var ports []ServicePort
 	for _, port := range apiPorts {
-		ports = append(ports, ServicePort{port.Port, port.Protocol})
+		ports = append(ports, ServicePort{port.Port, port.Protocol, port.NodePort})
 	}
 	return ports
 }

--- a/src/app/frontend/common/components/endpoint/endpoint.scss
+++ b/src/app/frontend/common/components/endpoint/endpoint.scss
@@ -12,15 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * Returns directive definition object for the component that displays the service
- * endpoint (type {backendApi.Endpoint}) which is accessible from the outside of the cluster
- * @return {!angular.Directive}
- */
-export const externalEndpointComponent = {
-  templateUrl: 'common/components/endpoint/externalendpoint.html',
-  bindings: {
-    /** {!Array<!backendApi.Endpoint>} */
-    'endpoints': '<',
-  },
-};
+.kd-endpoint-icon {
+  font-size: inherit;
+  height: inherit;
+  margin: 0;
+  vertical-align: middle;
+}

--- a/src/app/frontend/common/components/endpoint/externalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/externalendpoint.html
@@ -20,13 +20,26 @@ limitations under the License.
    Link is always shown independent of the endpoint capabilities to support HTTP.
 -->
 <div>
-  <div ng-repeat="port in ::$ctrl.endpoint.ports">
-      <a href="http://{{::$ctrl.endpoint.host}}:{{::port.port}}" target="_blank"
-         layout layout-align="start center">
-        <kd-middle-ellipsis display-string="{{::$ctrl.endpoint.host}}:{{::port.port}}">
-        </kd-middle-ellipsis>
-        &nbsp;
-        <i class="material-icons kd-text-icon">open_in_new</i>
-      </a>
+  <div ng-repeat="endpoint in ::$ctrl.endpoints">
+    <div ng-repeat="port in ::endpoint.ports">
+      <div>
+        <a href="http://{{::endpoint.host}}:{{::port.port}}" target="_blank"
+           layout layout-align="start center">
+          <kd-middle-ellipsis display-string="{{::endpoint.host}}:{{::port.port}}">
+          </kd-middle-ellipsis>
+          &nbsp;
+          <md-icon class="kd-endpoint-icon">open_in_new</md-icon>
+        </a>
+      </div>
+      <div>
+        <a href="http://{{::endpoint.host}}:{{::port.nodePort}}" target="_blank"
+           layout layout-align="start center">
+          <kd-middle-ellipsis display-string="{{::endpoint.host}}:{{::port.nodePort}}">
+          </kd-middle-ellipsis>
+          &nbsp;
+          <md-icon class="kd-endpoint-icon">open_in_new</md-icon>
+        </a>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/frontend/common/components/endpoint/internalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/internalendpoint.html
@@ -21,5 +21,10 @@ limitations under the License.
               display-string="{{::$ctrl.endpoint.host}}:{{::port.port}} {{::port.protocol}}">
       </kd-middle-ellipsis>
     </div>
+    <div>
+      <kd-middle-ellipsis
+              display-string="{{::$ctrl.endpoint.host}}:{{::port.nodePort}} {{::port.protocol}}">
+      </kd-middle-ellipsis>
+    </div>
   </div>
 </div>

--- a/src/app/frontend/servicedetail/servicedetailinfo.html
+++ b/src/app/frontend/servicedetail/servicedetailinfo.html
@@ -51,8 +51,9 @@ limitations under the License.
     <kd-info-card-entry title="{{::$ctrl.i18n.MSG_SERVICE_DETAIL_INTERNAL_ENDPOINTS_LABEL}}" ng-if="::$ctrl.service.internalEndpoint">
       <kd-internal-endpoint endpoint="::$ctrl.service.internalEndpoint"></kd-internal-endpoint>
     </kd-info-card-entry>
-    <kd-info-card-entry title="{{::$ctrl.i18n.MSG_SERVICE_DETAIL_EXTERNAL_ENDPOINTS_LABEL}}" ng-if="::$ctrl.detail.externalEndpoints">
-      <kd-external-endpoint endpoint="::$ctrl.service.internalEndpoint"></kd-external-endpoint>
+    <kd-info-card-entry title="{{::$ctrl.i18n.MSG_SERVICE_DETAIL_EXTERNAL_ENDPOINTS_LABEL}}"
+                        ng-if="::$ctrl.service.externalEndpoints">
+      <kd-external-endpoint endpoints="::$ctrl.service.externalEndpoints"></kd-external-endpoint>
     </kd-info-card-entry>
   </kd-info-card-section>
 </kd-info-card>


### PR DESCRIPTION
Closes #919

Fixed issue where external endpoints were not displayed on service details page. Added new external/internal endpoints paired with auto-allocated node port.

![zrzut ekranu z 2016-06-22 13-35-23](https://cloud.githubusercontent.com/assets/2285385/16265185/34612af6-387e-11e6-9011-ebb86cc81262.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/940)
<!-- Reviewable:end -->
