### PR TITLE
moving from rc to deployment

### DIFF
--- a/src/deploy/kubernetes-dashboard.yaml
+++ b/src/deploy/kubernetes-dashboard.yaml
@@ -16,55 +16,54 @@
 #
 # Example usage: kubectl create -f <this_file>
 
-kind: List
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    app: kubernetes-dashboard
+    version: v1.1.0
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        app: kubernetes-dashboard
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        args:
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+---
+kind: Service
 apiVersion: v1
-items:
-- kind: ReplicationController
-  apiVersion: v1
-  metadata:
-    labels:
-      app: kubernetes-dashboard
-      version: v1.1.0
-    name: kubernetes-dashboard
-    namespace: kube-system
-  spec:
-    replicas: 1
-    selector:
-      app: kubernetes-dashboard
-    template:
-      metadata:
-        labels:
-          app: kubernetes-dashboard
-      spec:
-        containers:
-        - name: kubernetes-dashboard
-          image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0
-          imagePullPolicy: Always
-          ports:
-          - containerPort: 9090
-            protocol: TCP
-          args:
-            # Uncomment the following line to manually specify Kubernetes API server Host
-            # If not specified, Dashboard will attempt to auto discover the API server and connect
-            # to it. Uncomment only if the default does not work.
-            # - --apiserver-host=http://my-address:port
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 9090
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
-- kind: Service
-  apiVersion: v1
-  metadata:
-    labels:
-      app: kubernetes-dashboard
-    name: kubernetes-dashboard
-    namespace: kube-system
-  spec:
-    type: NodePort
-    ports:
-    - port: 80
-      targetPort: 9090
-    selector:
-      app: kubernetes-dashboard
+metadata:
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 9090
+  selector:
+    app: kubernetes-dashboard


### PR DESCRIPTION
As deployments (and replica sets) are replacing the rc primitive, I thought of moving this manifest to deployments, too.

The `kind: list` thingy doesn't work here, as it has problems with using `extensions/v1beta1` so I used `---` to make a valid YAML list.

Other than that nothing has changed. The selector had to be slightly modified to include `matchLabels:`.

I've tested this already, and it works for me.