### PR TITLE
fix lint issue

### DIFF
--- a/src/app/frontend/events/eventcardlist.scss
+++ b/src/app/frontend/events/eventcardlist.scss
@@ -19,7 +19,7 @@
 }
 
 .kd-replicationcontrollerevents-no-events {
-  padding: (4 * $baseline-grid) 0 (4 * $baseline-grid);
+  padding: (4 * $baseline-grid) 0;
   text-align: center;
 }
 


### PR DESCRIPTION
After a fresh/clean build I get the following lint error:

src/app/frontend/events/eventcardlist.scss
  22:12  error  Property `padding` should be written more concisely as `(4 * $baseline-grid) 0` instead of `(4 * $baseline-grid) 0 (4 * $baseline-grid)`  shorthand-values

I fixed as suggested.

Travis and other have not got into issues because of caching node_modules