### PR TITLE
Enable gzip HTTP compression

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	// TODO(maciaszczykm): Avoid using dot-imports.
 	. "github.com/kubernetes/dashboard/client"
 	. "github.com/kubernetes/dashboard/handler"
 	"github.com/spf13/pflag"
-	"os"
 )
 
 var (
@@ -67,7 +67,7 @@ func main() {
 
 	// Run a HTTP server that serves static public files from './public' and handles API calls.
 	// TODO(bryk): Disable directory listing.
-	http.Handle("/", CreateLocaleHandler())
+	http.Handle("/", MakeGzipHandler(CreateLocaleHandler()))
 	http.Handle("/api/", CreateHttpApiHandler(apiserverClient, heapsterRESTClient, config))
 	// TODO(maciaszczykm): Move to /appConfig.json as it was discussed in #640.
 	http.Handle("/api/appConfig.json", AppHandler(ConfigHandler))

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -94,6 +94,7 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 		client.AppsClient.RESTClient, client.BatchClient.RESTClient)
 	apiHandler := ApiHandler{client, heapsterClient, clientConfig, verber}
 	wsContainer := restful.NewContainer()
+	wsContainer.EnableContentEncoding(true)
 
 	apiV1Ws := new(restful.WebService)
 	apiV1Ws.Filter(wsLogger)

--- a/src/app/backend/handler/gziphandler.go
+++ b/src/app/backend/handler/gziphandler.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"compress/gzip"
+)
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+// Use the Writer part of gzipResponseWriter to write the output.
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// MakeGzipHandler adds support for gzip compression for given handler
+func MakeGzipHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if the client can accept the gzip encoding.
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// Set the HTTP header indicating encoding.
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		gzw := gzipResponseWriter{Writer: gz, ResponseWriter: w}
+		handler.ServeHTTP(gzw, r)
+	})
+}


### PR DESCRIPTION
Closes #967

I've tested it with curl by setting `Accept-Encoding` header to `gzip`.

![zrzut ekranu z 2016-06-28 11-22-53](https://cloud.githubusercontent.com/assets/2285385/16410414/b208c876-3d22-11e6-98da-37ddc77ed423.png)

Endpoint: **assets/images/kubernetes-logo.svg**
Down from **11785** bytes to **5456** bytes (~53% decrease)

Endpoint: **api/v1/workload/kube-system**
Down from **6249** bytes to **958** bytes (~85% decrease)

Endpoint: **static/vendor.js**
Down from **1047549** bytes to **301127** bytes (~71% decrease)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/968)
<!-- Reviewable:end -->
