### PR TITLE
Add missing filters for node details view

### DIFF
--- a/src/app/frontend/nodedetail/nodeallocatedresources.html
+++ b/src/app/frontend/nodedetail/nodeallocatedresources.html
@@ -47,7 +47,7 @@ limitations under the License.
         <div>{{$ctrl.allocatedResources.cpuRequestsFraction | number: 2}}</div>
       </kd-resource-card-column>
     <kd-resource-card-column>
-      <div>{{$ctrl.allocatedResources.cpuLimits}} /
+      <div>{{$ctrl.allocatedResources.cpuLimits | kdCores}} /
         {{$ctrl.allocatedResources.cpuCapacity | kdCores}}</div>
     </kd-resource-card-column>
     <kd-resource-card-column>
@@ -61,7 +61,7 @@ limitations under the License.
       <div>{{$ctrl.allocatedResources.memoryRequestsFraction | number: 2}}</div>
     </kd-resource-card-column>
       <kd-resource-card-column>
-        <div>{{$ctrl.allocatedResources.memoryLimits}} /
+        <div>{{$ctrl.allocatedResources.memoryLimits | kdMemory}} /
           {{$ctrl.allocatedResources.memoryCapacity | kdMemory}}</div>
       </kd-resource-card-column>
       <kd-resource-card-column>


### PR DESCRIPTION
Added missing filters for node details view:

![image](https://cloud.githubusercontent.com/assets/2823399/16583481/17cec42e-42b6-11e6-96b9-7d8a69db75cc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/988)
<!-- Reviewable:end -->
