### PR TITLE
Clean packaged backend source before each build

### DIFF
--- a/build/backend.js
+++ b/build/backend.js
@@ -15,6 +15,7 @@
 /**
  * @fileoverview Gulp tasks for compiling backend application.
  */
+import del from 'del';
 import gulp from 'gulp';
 import lodash from 'lodash';
 import path from 'path';
@@ -74,11 +75,16 @@ gulp.task('package-backend', ['package-backend-source', 'link-vendor']);
  * Moves all backend source files (app and tests) to a temporary package directory where it can be
  * applied go commands.
  */
-gulp.task('package-backend-source', function() {
+gulp.task('package-backend-source', ['clean-packaged-backend-source'], function() {
   return gulp
       .src([path.join(conf.paths.backendSrc, '**/*'), path.join(conf.paths.backendTest, '**/*')])
       .pipe(gulp.dest(conf.paths.backendTmpSrc));
 });
+
+/**
+ * Cleans packaged backend source to remove any leftovers from there.
+ */
+gulp.task('clean-packaged-backend-source', function() { return del([conf.paths.backendTmpSrc]); });
 
 /**
  * Links vendor folder to the packaged backend source.


### PR DESCRIPTION
This is to avoid running `gulp clean && gulp build`. Now just `gulp
build` should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1013)
<!-- Reviewable:end -->
