### PR TITLE
Refactor RC backend and prepare for pagination support

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -157,9 +157,17 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 		apiV1Ws.DELETE("/replicationcontroller/{namespace}/{replicationController}").
 			To(apiHandler.handleDeleteReplicationController))
 	apiV1Ws.Route(
-		apiV1Ws.GET("/replicationcontroller/pod/{namespace}/{replicationController}").
+		apiV1Ws.GET("/replicationcontroller/{namespace}/{replicationController}/pod").
 			To(apiHandler.handleGetReplicationControllerPods).
-			Writes(ReplicationControllerPods{}))
+			Writes(pod.PodList{}))
+	apiV1Ws.Route(
+		apiV1Ws.GET("/replicationcontroller/{namespace}/{replicationController}/event").
+			To(apiHandler.handleGetReplicationControllerEvents).
+			Writes(common.EventList{}))
+	apiV1Ws.Route(
+		apiV1Ws.GET("/replicationcontroller/{namespace}/{replicationController}/service").
+			To(apiHandler.handleGetReplicationControllerServices).
+			Writes(resourceService.ServiceList{}))
 
 	apiV1Ws.Route(
 		apiV1Ws.GET("/workload").
@@ -259,11 +267,6 @@ func CreateHttpApiHandler(client *client.Client, heapsterClient HeapsterClient,
 		apiV1Ws.GET("/namespace").
 			To(apiHandler.handleGetNamespaces).
 			Writes(NamespaceList{}))
-
-	apiV1Ws.Route(
-		apiV1Ws.GET("/event/{namespace}/{replicationController}").
-			To(apiHandler.handleEvents).
-			Writes(common.EventList{}))
 
 	apiV1Ws.Route(
 		apiV1Ws.GET("/secret/{namespace}").
@@ -505,7 +508,8 @@ func (apiHandler *ApiHandler) handleGetReplicationControllerList(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	result, err := GetReplicationControllerList(apiHandler.client, namespace)
+	pagination := parsePaginationPathParameter(request)
+	result, err := GetReplicationControllerList(apiHandler.client, namespace, pagination)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -732,11 +736,10 @@ func (apiHandler *ApiHandler) handleGetReplicationControllerPods(
 
 	namespace := request.PathParameter("namespace")
 	replicationController := request.PathParameter("replicationController")
-	limit, err := strconv.Atoi(request.QueryParameter("limit"))
-	if err != nil {
-		limit = 0
-	}
-	result, err := GetReplicationControllerPods(apiHandler.client, namespace, replicationController, limit)
+	pagination := parsePaginationPathParameter(request)
+
+	result, err := GetReplicationControllerPods(apiHandler.client, apiHandler.heapsterClient,
+		pagination, replicationController, namespace)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -848,11 +851,30 @@ func (apiHandler *ApiHandler) handleGetPodContainers(request *restful.Request, r
 	response.WriteHeaderAndEntity(http.StatusCreated, result)
 }
 
-// Handles event API call.
-func (apiHandler *ApiHandler) handleEvents(request *restful.Request, response *restful.Response) {
+// Handles get replication controller events API call.
+func (apiHandler *ApiHandler) handleGetReplicationControllerEvents(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	replicationController := request.PathParameter("replicationController")
-	result, err := GetReplicationControllerEvents(apiHandler.client, namespace, replicationController)
+	pagination := parsePaginationPathParameter(request)
+
+	result, err := GetReplicationControllerEvents(apiHandler.client, pagination, namespace,
+		replicationController)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
+// Handles get replication controller services API call.
+func (apiHandler *ApiHandler) handleGetReplicationControllerServices(request *restful.Request,
+	response *restful.Response) {
+	namespace := request.PathParameter("namespace")
+	replicationController := request.PathParameter("replicationController")
+	pagination := parsePaginationPathParameter(request)
+
+	result, err := GetReplicationControllerServices(apiHandler.client, pagination,
+		namespace, replicationController)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/handler/gziphandler.go
+++ b/src/app/backend/handler/gziphandler.go
@@ -15,10 +15,10 @@
 package handler
 
 import (
+	"compress/gzip"
 	"io"
 	"net/http"
 	"strings"
-	"compress/gzip"
 )
 
 type gzipResponseWriter struct {

--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
+// FilterNamespacedPodsBySelector returns pods targeted by given resource label selector in given
+// namespace.
 func FilterNamespacedPodsBySelector(pods []api.Pod, namespace string,
 	resourceSelector map[string]string) []api.Pod {
 
@@ -33,7 +35,7 @@ func FilterNamespacedPodsBySelector(pods []api.Pod, namespace string,
 	return matchingPods
 }
 
-// Returns pods targeted by given selector.
+// FilterPodsBySelector returns pods targeted by given resource selector.
 func FilterPodsBySelector(pods []api.Pod, resourceSelector map[string]string) []api.Pod {
 
 	var matchingPods []api.Pod
@@ -45,6 +47,8 @@ func FilterPodsBySelector(pods []api.Pod, resourceSelector map[string]string) []
 	return matchingPods
 }
 
+// FilterNamespacedPodsByLabelSelector returns pods targeted by given resource label selector in
+// given namespace.
 func FilterNamespacedPodsByLabelSelector(pods []api.Pod, namespace string,
 	labelSelector *unversioned.LabelSelector) []api.Pod {
 
@@ -58,6 +62,7 @@ func FilterNamespacedPodsByLabelSelector(pods []api.Pod, namespace string,
 	return matchingPods
 }
 
+// FilterPodsByLabelSelector returns pods targeted by given resource label selector.
 func FilterPodsByLabelSelector(pods []api.Pod, labelSelector *unversioned.LabelSelector) []api.Pod {
 
 	var matchingPods []api.Pod

--- a/src/app/backend/resource/common/service.go
+++ b/src/app/backend/resource/common/service.go
@@ -12,12 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package replicationcontroller
+package common
 
 import (
-	"testing"
+	"k8s.io/kubernetes/pkg/api"
 )
 
-func TestGetReplicationControllerPods(t *testing.T) {
-	// TODO add test
+// FilterNamespacedServicesBySelector returns services targeted by given resource selector in
+// given namespace.
+func FilterNamespacedServicesBySelector(services []api.Service, namespace string,
+	resourceSelector map[string]string) []api.Service {
+
+	var matchingServices []api.Service
+	for _, service := range services {
+		if service.ObjectMeta.Namespace == namespace &&
+			IsSelectorMatching(resourceSelector, service.Labels) {
+			matchingServices = append(matchingServices, service)
+		}
+	}
+
+	return matchingServices
 }

--- a/src/app/backend/resource/daemonset/daemonsetlist.go
+++ b/src/app/backend/resource/daemonset/daemonsetlist.go
@@ -91,7 +91,7 @@ func getDaemonSetList(daemonSets []extensions.DaemonSet, pods []api.Pod,
 
 	daemonSetList := &DaemonSetList{
 		DaemonSets: make([]DaemonSet, 0),
-		ListMeta: common.ListMeta{TotalItems: len(daemonSets)},
+		ListMeta:   common.ListMeta{TotalItems: len(daemonSets)},
 	}
 
 	for _, daemonSet := range daemonSets {

--- a/src/app/backend/resource/deployment/deploymentlist.go
+++ b/src/app/backend/resource/deployment/deploymentlist.go
@@ -98,7 +98,7 @@ func getDeploymentList(deployments []extensions.Deployment, pods []api.Pod,
 
 	deploymentList := &DeploymentList{
 		Deployments: make([]Deployment, 0),
-		ListMeta: common.ListMeta{TotalItems: len(deployments)},
+		ListMeta:    common.ListMeta{TotalItems: len(deployments)},
 	}
 
 	for _, deployment := range deployments {

--- a/src/app/backend/resource/job/jobdetail.go
+++ b/src/app/backend/resource/job/jobdetail.go
@@ -97,9 +97,9 @@ func getJobDetail(job *batch.Job, heapsterClient client.HeapsterClient,
 		ContainerImages: common.GetContainerImages(&job.Spec.Template.Spec),
 		PodInfo:         podInfo,
 		// TODO(floreks) Add pagination support
-		PodList:         pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
-		EventList:       *events,
-		Parallelism:     job.Spec.Parallelism,
-		Completions:     job.Spec.Completions,
+		PodList:     pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
+		EventList:   *events,
+		Parallelism: job.Spec.Parallelism,
+		Completions: job.Spec.Completions,
 	}
 }

--- a/src/app/backend/resource/job/joblist.go
+++ b/src/app/backend/resource/job/joblist.go
@@ -93,7 +93,7 @@ func GetJobListFromChannels(channels *common.ResourceChannels) (
 func ToJobList(jobs []batch.Job, pods []api.Pod, events []api.Event) *JobList {
 
 	jobList := &JobList{
-		Jobs: make([]Job, 0),
+		Jobs:     make([]Job, 0),
 		ListMeta: common.ListMeta{TotalItems: len(jobs)},
 	}
 

--- a/src/app/backend/resource/node/nodelist.go
+++ b/src/app/backend/resource/node/nodelist.go
@@ -57,7 +57,7 @@ func GetNodeList(client client.Interface) (*NodeList, error) {
 
 func toNodeList(nodes []api.Node) *NodeList {
 	nodeList := &NodeList{
-		Nodes: make([]Node, 0),
+		Nodes:    make([]Node, 0),
 		ListMeta: common.ListMeta{TotalItems: len(nodes)},
 	}
 

--- a/src/app/backend/resource/petset/petsetdetail.go
+++ b/src/app/backend/resource/petset/petsetdetail.go
@@ -91,7 +91,7 @@ func getPetSetDetail(petSet *apps.PetSet, heapsterClient client.HeapsterClient,
 		ContainerImages: common.GetContainerImages(&petSet.Spec.Template.Spec),
 		PodInfo:         podInfo,
 		// TODO(floreks): add pagination support
-		PodList:         pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
-		EventList:       *events,
+		PodList:   pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
+		EventList: *events,
 	}
 }

--- a/src/app/backend/resource/petset/petsetlist.go
+++ b/src/app/backend/resource/petset/petsetlist.go
@@ -96,7 +96,7 @@ func GetPetSetListFromChannels(channels *common.ResourceChannels) (
 func ToPetSetList(petSets []apps.PetSet, pods []api.Pod, events []api.Event) *PetSetList {
 
 	petSetList := &PetSetList{
-		PetSets: make([]PetSet, 0),
+		PetSets:  make([]PetSet, 0),
 		ListMeta: common.ListMeta{TotalItems: len(petSets)},
 	}
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -86,7 +86,7 @@ func CreatePodList(pods []api.Pod, pQuery *common.PaginationQuery,
 	}
 
 	podList := PodList{
-		Pods: make([]Pod, 0),
+		Pods:     make([]Pod, 0),
 		ListMeta: common.ListMeta{TotalItems: len(pods)},
 	}
 

--- a/src/app/backend/resource/replicaset/replicasetdetail.go
+++ b/src/app/backend/resource/replicaset/replicasetdetail.go
@@ -90,7 +90,7 @@ func getReplicaSetDetail(replicaSet *extensions.ReplicaSet, heapsterClient clien
 		ContainerImages: common.GetContainerImages(&replicaSet.Spec.Template.Spec),
 		PodInfo:         podInfo,
 		// TODO(floreks): add pagination support
-		PodList:         pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
-		EventList:       *events,
+		PodList:   pod.CreatePodList(matchingPods, common.NO_PAGINATION, heapsterClient),
+		EventList: *events,
 	}
 }

--- a/src/app/backend/resource/replicaset/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist.go
@@ -98,7 +98,7 @@ func ToReplicaSetList(replicaSets []extensions.ReplicaSet,
 
 	replicaSetList := &ReplicaSetList{
 		ReplicaSets: make([]ReplicaSet, 0),
-		ListMeta: common.ListMeta{TotalItems: len(replicaSets)},
+		ListMeta:    common.ListMeta{TotalItems: len(replicaSets)},
 	}
 
 	for _, replicaSet := range replicaSets {

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
@@ -25,8 +25,8 @@ import (
 )
 
 // GetEvents returns events for particular namespace and replication controller or error if occurred.
-func GetReplicationControllerEvents(client *client.Client, namespace, replicationControllerName string) (
-	*common.EventList, error) {
+func GetReplicationControllerEvents(client client.Interface, pQuery *common.PaginationQuery,
+	namespace, replicationControllerName string) (*common.EventList, error) {
 
 	log.Printf("Getting events related to %s replication controller in %s namespace", replicationControllerName,
 		namespace)
@@ -39,7 +39,7 @@ func GetReplicationControllerEvents(client *client.Client, namespace, replicatio
 	}
 
 	// Get events for pods in replication controller.
-	podEvents, err := GetReplicationControllerPodsEvents(client, namespace,
+	podEvents, err := getReplicationControllerPodsEvents(client, namespace,
 		replicationControllerName)
 
 	if err != nil {
@@ -52,6 +52,8 @@ func GetReplicationControllerEvents(client *client.Client, namespace, replicatio
 		apiEvents = resourceEvent.FillEventsType(apiEvents)
 	}
 
+	// TODO support pagination
+
 	events := resourceEvent.ToEventList(apiEvents, namespace)
 
 	log.Printf("Found %d events related to %s replication controller in %s namespace",
@@ -60,7 +62,7 @@ func GetReplicationControllerEvents(client *client.Client, namespace, replicatio
 	return &events, nil
 }
 
-func GetReplicationControllerPodsEvents(client client.Interface, namespace,
+func getReplicationControllerPodsEvents(client client.Interface, namespace,
 	replicationControllerName string) ([]api.Event, error) {
 
 	replicationController, err := client.ReplicationControllers(namespace).Get(replicationControllerName)

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
@@ -15,115 +15,77 @@
 package replicationcontroller
 
 import (
-	"log"
-	"sort"
+	"github.com/kubernetes/dashboard/src/app/backend/client"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
-// TotalRestartCountSorter sorts ReplicationControllerPodWithContainers by restarts number.
-type TotalRestartCountSorter []ReplicationControllerPodWithContainers
+// GetReplicationControllerPods return list of pods targeting replication controller associated
+// to given name.
+func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
+	pQuery *common.PaginationQuery, rcName, namespace string) (*pod.PodList, error) {
 
-func (a TotalRestartCountSorter) Len() int      { return len(a) }
-func (a TotalRestartCountSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a TotalRestartCountSorter) Less(i, j int) bool {
-	return a[i].TotalRestartCount > a[j].TotalRestartCount
-}
-
-// PodContainer is a representation of a Container that belongs to a Pod.
-type PodContainer struct {
-	// Name of a Container.
-	Name string `json:"name"`
-
-	// Number of restarts.
-	RestartCount int32 `json:"restartCount"`
-}
-
-// ReplicationControllerPods is a representation of pods list that belongs to a Replication
-// Controller.
-type ReplicationControllerPods struct {
-	// List of pods that belongs to a Replication Controller.
-	Pods []ReplicationControllerPodWithContainers `json:"pods"`
-}
-
-// ReplicationControllerPodWithContainers is a representation of a Pod that belongs to a Replication
-// Controller.
-type ReplicationControllerPodWithContainers struct {
-	// Name of the Pod.
-	Name string `json:"name"`
-
-	// Time the Pod has started. Empty if not started.
-	StartTime *unversioned.Time `json:"startTime"`
-
-	// Total number of restarts.
-	TotalRestartCount int32 `json:"totalRestartCount"`
-
-	// List of Containers that belongs to particular Pod.
-	PodContainers []PodContainer `json:"podContainers"`
-}
-
-// GetReplicationControllerPods returns list of pods with containers for the given replication
-// controller in the given namespace. Limit specify the number of records to return. There is no
-// limit when given value is zero.
-func GetReplicationControllerPods(client *client.Client, namespace, name string, limit int) (
-	*ReplicationControllerPods, error) {
-	log.Printf("Getting list of pods from %s replication controller in %s namespace with limit %d", name,
-		namespace, limit)
-
-	pods, err := getRawReplicationControllerPods(client, namespace, name)
+	pods, err := getRawReplicationControllerPods(client, rcName, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	return getReplicationControllerPods(pods.Items, limit), nil
+	// TODO support pagination
+
+	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	return &podList, nil
 }
 
-// Creates and return structure containing pods with containers for given replication controller.
-// Data is sorted by total number of restarts for replication controller pod.
-// Result set can be limited
-func getReplicationControllerPods(pods []api.Pod, limit int) *ReplicationControllerPods {
-	replicationControllerPods := &ReplicationControllerPods{
-		Pods: make([]ReplicationControllerPodWithContainers, 0),
-	}
-	for _, pod := range pods {
-		var totalRestartCount int32 = 0
-		replicationControllerPodWithContainers := ReplicationControllerPodWithContainers{
-			Name:          pod.Name,
-			StartTime:     pod.Status.StartTime,
-			PodContainers: make([]PodContainer, 0),
-		}
+// Returns array of api pods targeting replication controller associated to given name.
+func getRawReplicationControllerPods(client k8sClient.Interface, rcName, namespace string) (
+	[]api.Pod, error) {
 
-		podContainersByName := make(map[string]*PodContainer)
-
-		for _, container := range pod.Spec.Containers {
-			podContainer := PodContainer{Name: container.Name}
-			replicationControllerPodWithContainers.PodContainers =
-				append(replicationControllerPodWithContainers.PodContainers, podContainer)
-
-			podContainersByName[container.Name] = &(replicationControllerPodWithContainers.
-				PodContainers[len(replicationControllerPodWithContainers.PodContainers)-1])
-		}
-
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			podContainer, ok := podContainersByName[containerStatus.Name]
-			if ok {
-				podContainer.RestartCount = containerStatus.RestartCount
-				totalRestartCount += containerStatus.RestartCount
-			}
-		}
-		replicationControllerPodWithContainers.TotalRestartCount = totalRestartCount
-		replicationControllerPods.Pods = append(replicationControllerPods.Pods, replicationControllerPodWithContainers)
-	}
-	sort.Sort(TotalRestartCountSorter(replicationControllerPods.Pods))
-
-	if limit > 0 {
-		if limit > len(replicationControllerPods.Pods) {
-			limit = len(replicationControllerPods.Pods)
-		}
-		replicationControllerPods.Pods = replicationControllerPods.Pods[0:limit]
+	replicationController, err := client.ReplicationControllers(namespace).Get(rcName)
+	if err != nil {
+		return nil, err
 	}
 
-	return replicationControllerPods
+	labelSelector := labels.SelectorFromSet(replicationController.Spec.Selector)
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(namespace),
+			api.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fields.Everything(),
+			}, 1),
+	}
+
+	podList := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
+}
+
+// Returns simple info about pods(running, desired, failing, etc.) related to given replication
+// controller.
+func getReplicationControllerPodInfo(client k8sClient.Interface, rc *api.ReplicationController,
+	namespace string) (*common.PodInfo, error) {
+
+	labelSelector := labels.SelectorFromSet(rc.Spec.Selector)
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(namespace),
+			api.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fields.Everything(),
+			}, 1),
+	}
+
+	pods := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	podInfo := common.GetPodInfo(rc.Status.Replicas, rc.Spec.Replicas, pods.Items)
+	return &podInfo, nil
 }

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicationcontroller
+
+import (
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/service"
+)
+
+// GetReplicationControllerServices returns list of services that are related to replication
+// controller targeted by given name.
+func GetReplicationControllerServices(client client.Interface, pQuery *common.PaginationQuery,
+	namespace, rcName string) (*service.ServiceList, error) {
+
+	replicationController, err := client.ReplicationControllers(namespace).Get(rcName)
+	if err != nil {
+		return nil, err
+	}
+
+	channels := &common.ResourceChannels{
+		ServiceList: common.GetServiceListChannel(client, common.NewSameNamespaceQuery(namespace),
+			1),
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
+		replicationController.Spec.Selector)
+	serviceList := service.CreateServiceList(matchingServices, common.NO_PAGINATION)
+	return &serviceList, nil
+}

--- a/src/app/backend/resource/secret/secret.go
+++ b/src/app/backend/resource/secret/secret.go
@@ -15,11 +15,11 @@
 package secret
 
 import (
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 )
 
 // SecretSpec - common interface for the specification of different secrets.
@@ -74,7 +74,7 @@ type SecretsList struct {
 
 // GetSecrets - return all secrets in the given namespace.
 func GetSecrets(client *client.Client, namespace string) (*SecretsList,
-error) {
+	error) {
 	secretsList := &SecretsList{}
 	secrets, err := client.Secrets(namespace).List(api.ListOptions{
 		LabelSelector: labels.Everything(),
@@ -105,7 +105,7 @@ func CreateSecret(client *client.Client, spec SecretSpec) (*Secret, error) {
 }
 
 // NewSecret - creates a new instance of Secret struct based on K8s Secret.
-func NewSecret(secret *api.Secret) (*Secret) {
+func NewSecret(secret *api.Secret) *Secret {
 	return &Secret{common.NewObjectMeta(secret.ObjectMeta),
 		common.NewTypeMeta(common.ResourceKindSecret)}
 }

--- a/src/app/backend/resource/service/servicecommon.go
+++ b/src/app/backend/resource/service/servicecommon.go
@@ -45,3 +45,20 @@ func ToServiceDetail(service *api.Service) ServiceDetail {
 		Type:              service.Spec.Type,
 	}
 }
+
+// CreateServiceList returns paginated service list based on given service array
+// and pagination query.
+func CreateServiceList(services []api.Service, pQuery *common.PaginationQuery) ServiceList {
+	serviceList := ServiceList{
+		Services: make([]Service, 0),
+		ListMeta: common.ListMeta{TotalItems: len(services)},
+	}
+
+	// TODO support pagination
+
+	for _, service := range services {
+		serviceList.Services = append(serviceList.Services, ToService(&service))
+	}
+
+	return serviceList
+}

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -81,7 +81,8 @@ func GetWorkloadsFromChannels(channels *common.ResourceChannels,
 	errChan := make(chan error, 7)
 
 	go func() {
-		rcList, err := replicationcontroller.GetReplicationControllerListFromChannels(channels)
+		rcList, err := replicationcontroller.GetReplicationControllerListFromChannels(channels,
+			pQuery)
 		errChan <- err
 		rcChan <- rcList
 	}()

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -28,7 +28,8 @@ const backendApi = {};
  * @typedef {{
  *    itemsPerPage: number,
  *    page: number,
- *    namespace: string
+ *    namespace: string,
+ *    name: (string|undefined)
  * }}
  */
 backendApi.PaginationQuery;
@@ -367,6 +368,7 @@ backendApi.TypeMeta;
  *   podInfo: !backendApi.PodInfo,
  *   podList: !backendApi.PodList,
  *   serviceList: !backendApi.ServiceList,
+ *   eventList: !backendApi.EventList,
  *   hasMetrics: boolean
  * }}
  */

--- a/src/app/frontend/common/pagination/pagination_service.js
+++ b/src/app/frontend/common/pagination/pagination_service.js
@@ -112,9 +112,30 @@ export class PaginationService {
 
   /**
    * @param {string|undefined} namespace
-   * @returns {!backendApi.PaginationQuery}
+   * @return {!backendApi.PaginationQuery}
    */
   static getDefaultResourceQuery(namespace) {
     return {itemsPerPage: DEFAULT_ROWS_LIMIT, page: 1, namespace: namespace || ''};
+  }
+
+  /**
+   *
+   * @param {number} itemsPerPage
+   * @param {number} pageNr
+   * @param {string|undefined} namespace
+   * @param {string} name
+   * @return {!backendApi.PaginationQuery} pQuery
+   */
+  static getResourceDetailQuery(itemsPerPage, pageNr, namespace, name) {
+    return {itemsPerPage: itemsPerPage, page: pageNr, namespace: namespace || '', name: name};
+  }
+
+  /**
+   * @param {string|undefined} namespace
+   * @param {string} name
+   * @return {!backendApi.PaginationQuery} pQuery
+   */
+  static getDefaultResourceDetailQuery(namespace, name) {
+    return {itemsPerPage: DEFAULT_ROWS_LIMIT, page: 1, namespace: namespace || '', name: name};
   }
 }

--- a/src/app/frontend/podlist/podlist_stateconfig.js
+++ b/src/app/frontend/podlist/podlist_stateconfig.js
@@ -53,7 +53,7 @@ export default function stateConfig($stateProvider) {
 }
 
 /**
- * @param {!angular.$resource} kdPodListResource
+ * @param {!angular.Resource} kdPodListResource
  * @param {!./../chrome/chrome_state.StateParams} $stateParams
  * @return {!angular.$q.Promise}
  * @ngInject

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -39,7 +39,7 @@ limitations under the License.
         </kd-content-card>
       </md-tab>
       <md-tab label="{{::ctrl.i18n.MSG_RC_DETAIL_EVENTS_LABEL}}">
-        <kd-event-card-list event-list="::ctrl.eventList">
+        <kd-event-card-list event-list="::ctrl.replicationControllerDetail.eventList">
         </kd-event-card-list>
       </md-tab>
     </md-tabs>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -20,17 +20,13 @@
 export default class ReplicationControllerDetailController {
   /**
    * @param {!backendApi.ReplicationControllerDetail} replicationControllerDetail
-   * @param {!backendApi.EventList} replicationControllerEvents
    * @param {!ui.router.$state} $state
    * @param {!../common/resource/resourcedetail.StateParams} $stateParams
    * @ngInject
    */
-  constructor(replicationControllerDetail, replicationControllerEvents, $state, $stateParams) {
+  constructor(replicationControllerDetail, $state, $stateParams) {
     /** @export {!backendApi.ReplicationControllerDetail} */
     this.replicationControllerDetail = replicationControllerDetail;
-
-    /** @export {!backendApi.EventList} */
-    this.eventList = replicationControllerEvents;
 
     /** @private {!ui.router.$state} */
     this.state_ = $state;

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
@@ -47,4 +47,34 @@ export default angular
         ])
     .config(stateConfig)
     .component('kdReplicationControllerInfo', replicationControllerInfoComponent)
-    .service('kdReplicationControllerService', ReplicationControllerService);
+    .service('kdReplicationControllerService', ReplicationControllerService)
+    .factory('kdRCResource', replicationControllerResource)
+    .factory('kdRCPodsResource', replicationControllerPodsResource)
+    .factory('kdRCEventsResource', replicationControllerEventsResource);
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicationControllerResource($resource) {
+  return $resource('api/v1/replicationcontroller/:namespace/:name');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicationControllerPodsResource($resource) {
+  return $resource('api/v1/replicationcontroller/:namespace/:name/pod');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicationControllerEventsResource($resource) {
+  return $resource('api/v1/replicationcontroller/:namespace/:name/event');
+}

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
@@ -14,6 +14,7 @@
 
 import {actionbarViewName, stateName as chromeStateName} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+import {PaginationService} from 'common/pagination/pagination_service';
 import {stateName as replicationControllers} from 'replicationcontrollerlist/replicationcontrollerlist_state';
 
 import {ActionBarController} from './actionbar_controller';
@@ -34,9 +35,7 @@ export default function stateConfig($stateProvider) {
     parent: chromeStateName,
     resolve: {
       'replicationControllerSpecPodsResource': getReplicationControllerSpecPodsResource,
-      'replicationControllerDetailResource': getReplicationControllerDetailsResource,
       'replicationControllerDetail': resolveReplicationControllerDetails,
-      'replicationControllerEvents': resolveReplicationControllerEvents,
     },
     data: {
       [breadcrumbsConfig]: {
@@ -62,18 +61,6 @@ export default function stateConfig($stateProvider) {
 /**
  * @param {!./../common/resource/resourcedetail.StateParams} $stateParams
  * @param {!angular.$resource} $resource
- * @return {!angular.Resource<!backendApi.ReplicationControllerDetail>}
- * @ngInject
- */
-export function getReplicationControllerDetailsResource($stateParams, $resource) {
-  return $resource(
-      `api/v1/replicationcontroller/${$stateParams.objectNamespace}/` +
-      `${$stateParams.objectName}`);
-}
-
-/**
- * @param {!./../common/resource/resourcedetail.StateParams} $stateParams
- * @param {!angular.$resource} $resource
  * @return {!angular.Resource<!backendApi.ReplicationControllerSpec>}
  * @ngInject
  */
@@ -84,25 +71,13 @@ export function getReplicationControllerSpecPodsResource($stateParams, $resource
 }
 
 /**
- * @param {!angular.Resource<!backendApi.ReplicationControllerDetail>}
- * replicationControllerDetailResource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-function resolveReplicationControllerDetails(replicationControllerDetailResource) {
-  return replicationControllerDetailResource.get().$promise;
-}
-
-/**
+ * @param {!angular.Resource} kdRCResource
  * @param {!./../common/resource/resourcedetail.StateParams} $stateParams
- * @param {!angular.$resource} $resource
  * @return {!angular.$q.Promise}
  * @ngInject
  */
-function resolveReplicationControllerEvents($stateParams, $resource) {
-  /** @type {!angular.Resource<!backendApi.Events>} */
-  let resource =
-      $resource(`api/v1/event/${$stateParams.objectNamespace}/${$stateParams.objectName}`);
-
-  return resource.get().$promise;
+function resolveReplicationControllerDetails(kdRCResource, $stateParams) {
+  let query = PaginationService.getDefaultResourceDetailQuery(
+      $stateParams.objectNamespace, $stateParams.objectName);
+  return kdRCResource.get(query).$promise;
 }

--- a/src/test/backend/resource/common/pod_test.go
+++ b/src/test/backend/resource/common/pod_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/src/test/backend/resource/common/service_test.go
+++ b/src/test/backend/resource/common/service_test.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestFilterNamespacedServicesBySelector(t *testing.T) {
+	firstLabelSelectorMap := make(map[string]string)
+	firstLabelSelectorMap["name"] = "app-name-first"
+	secondLabelSelectorMap := make(map[string]string)
+	secondLabelSelectorMap["name"] = "app-name-second"
+
+	cases := []struct {
+		selector  map[string]string
+		namespace string
+		services  []api.Service
+		expected  []api.Service
+	}{
+		{
+			firstLabelSelectorMap, "test-ns-1",
+			[]api.Service{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:      "first-service-ok",
+						Labels:    firstLabelSelectorMap,
+						Namespace: "test-ns-1",
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:      "second-service-ok",
+						Labels:    firstLabelSelectorMap,
+						Namespace: "test-ns-2",
+					},
+				},
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:   "third-service-wrong",
+						Labels: secondLabelSelectorMap,
+					},
+				},
+			},
+			[]api.Service{
+				{
+					ObjectMeta: api.ObjectMeta{
+						Name:      "first-service-ok",
+						Labels:    firstLabelSelectorMap,
+						Namespace: "test-ns-1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := FilterNamespacedServicesBySelector(c.services, c.namespace, c.selector)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("FilterNamespacedServicesBySelector(%+v, %+v) == %+v, expected %+v",
+				c.services, c.selector, actual, c.expected)
+		}
+	}
+}

--- a/src/test/backend/resource/deployment/deploymentevents_test.go
+++ b/src/test/backend/resource/deployment/deploymentevents_test.go
@@ -32,7 +32,7 @@ func TestGetDeploymentEvents(t *testing.T) {
 					}}},
 			[]string{"list"},
 			&common.EventList{
-				ListMeta: common.ListMeta{TotalItems: 1},
+				ListMeta:  common.ListMeta{TotalItems: 1},
 				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},

--- a/src/test/backend/resource/event/eventcommon_test.go
+++ b/src/test/backend/resource/event/eventcommon_test.go
@@ -240,16 +240,16 @@ func TestToEventList(t *testing.T) {
 			},
 			"namespace-1",
 			common.EventList{
-				ListMeta: common.ListMeta{TotalItems: 2},
+				ListMeta:  common.ListMeta{TotalItems: 2},
 				Namespace: "namespace-1",
 				Events: []common.Event{
 					{
 						ObjectMeta: common.ObjectMeta{Name: "event-1"},
-						TypeMeta:        common.TypeMeta{common.ResourceKindEvent},
+						TypeMeta:   common.TypeMeta{common.ResourceKindEvent},
 					},
 					{
 						ObjectMeta: common.ObjectMeta{Name: "event-2"},
-						TypeMeta:        common.TypeMeta{common.ResourceKindEvent},
+						TypeMeta:   common.TypeMeta{common.ResourceKindEvent},
 					},
 				},
 			},

--- a/src/test/backend/resource/job/jobevents_test.go
+++ b/src/test/backend/resource/job/jobevents_test.go
@@ -48,7 +48,7 @@ func TestGetJobEvents(t *testing.T) {
 					}}},
 			[]string{"list", "get", "list", "list"},
 			&common.EventList{
-				ListMeta: common.ListMeta{TotalItems: 1},
+				ListMeta:  common.ListMeta{TotalItems: 1},
 				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},

--- a/src/test/backend/resource/replicaset/replicasetevents_test.go
+++ b/src/test/backend/resource/replicaset/replicasetevents_test.go
@@ -49,7 +49,7 @@ func TestGetReplicaSetEvents(t *testing.T) {
 					}}},
 			[]string{"list", "get", "list", "list"},
 			&common.EventList{
-				ListMeta: common.ListMeta{TotalItems: 1},
+				ListMeta:  common.ListMeta{TotalItems: 1},
 				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollercommon_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollercommon_test.go
@@ -23,50 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/labels"
 
-	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 )
-
-func TestGetReplicationPodInfo(t *testing.T) {
-	cases := []struct {
-		controller *api.ReplicationController
-		pods       []api.Pod
-		expected   common.PodInfo
-	}{
-		{
-			&api.ReplicationController{
-				Status: api.ReplicationControllerStatus{
-					Replicas: 5,
-				},
-				Spec: api.ReplicationControllerSpec{
-					Replicas: 4,
-				},
-			},
-			[]api.Pod{
-				{
-					Status: api.PodStatus{
-						Phase: api.PodRunning,
-					},
-				},
-			},
-			common.PodInfo{
-				Current:  5,
-				Desired:  4,
-				Running:  1,
-				Pending:  0,
-				Failed:   0,
-				Warnings: []common.Event{},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		actual := getReplicationPodInfo(c.controller, c.pods)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("getReplicaSetPodInfo(%#v, %#v) == \n%#v\nexpected \n%#v\n",
-				c.controller, c.pods, actual, c.expected)
-		}
-	}
-}
 
 func TestToLabelSelector(t *testing.T) {
 	selector, _ := unversioned.LabelSelectorAsSelector(

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
@@ -22,38 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func TestGetMatchingServices(t *testing.T) {
-	cases := []struct {
-		services              []api.Service
-		replicationController *api.ReplicationController
-		expected              []api.Service
-	}{
-		{nil, nil, nil},
-		{
-			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
-			&api.ReplicationController{
-				Spec: api.ReplicationControllerSpec{Selector: map[string]string{"app": "my-name"}}},
-			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
-		},
-		{
-			[]api.Service{
-				{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}},
-				{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name", "ver": "2"}}},
-			},
-			&api.ReplicationController{
-				Spec: api.ReplicationControllerSpec{Selector: map[string]string{"app": "my-name"}}},
-			[]api.Service{{Spec: api.ServiceSpec{Selector: map[string]string{"app": "my-name"}}}},
-		},
-	}
-	for _, c := range cases {
-		actual := getMatchingServices(c.services, c.replicationController)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("getMatchingServices(%+v, %+v) == %+v, expected %+v",
-				c.services, c.replicationController, actual, c.expected)
-		}
-	}
-}
-
 func TestGetReplicationControllerList(t *testing.T) {
 	events := []api.Event{}
 
@@ -217,7 +185,8 @@ func TestGetReplicationControllerList(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := getReplicationControllerList(c.replicationControllers, c.pods, events)
+		actual := CreateReplicationControllerList(c.replicationControllers, common.NO_PAGINATION,
+			c.pods, events)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getReplicationControllerList(%#v, %#v) == \n%#v\nexpected \n%#v\n",
 				c.replicationControllers, c.services, actual, c.expected)

--- a/src/test/backend/resource/service/servicedetail_test.go
+++ b/src/test/backend/resource/service/servicedetail_test.go
@@ -135,13 +135,13 @@ func TestGetServicePods(t *testing.T) {
 			&pod.PodList{
 				ListMeta: common.ListMeta{TotalItems: 1},
 				Pods: []pod.Pod{{
-				ObjectMeta: common.ObjectMeta{
-					Name:      "test-pod",
-					Labels:    firstSelector,
-					Namespace: "test-namespace-3",
-				},
-				TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
-			}}},
+					ObjectMeta: common.ObjectMeta{
+						Name:      "test-pod",
+						Labels:    firstSelector,
+						Namespace: "test-namespace-3",
+					},
+					TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
+				}}},
 		},
 	}
 

--- a/src/test/backend/resource/workload/workloads_test.go
+++ b/src/test/backend/resource/workload/workloads_test.go
@@ -162,32 +162,32 @@ func TestGetWorkloadsFromChannels(t *testing.T) {
 	for _, c := range cases {
 		expected := &Workloads{
 			ReplicationControllerList: replicationcontroller.ReplicationControllerList{
-				ListMeta: common.ListMeta{TotalItems: len(c.rcs)},
+				ListMeta:               common.ListMeta{TotalItems: len(c.rcs)},
 				ReplicationControllers: c.rcs,
 			},
 			ReplicaSetList: replicaset.ReplicaSetList{
-				ListMeta: common.ListMeta{TotalItems: len(c.rs)},
+				ListMeta:    common.ListMeta{TotalItems: len(c.rs)},
 				ReplicaSets: c.rs,
 			},
 			JobList: job.JobList{
 				ListMeta: common.ListMeta{TotalItems: len(c.jobs)},
-				Jobs: c.jobs,
+				Jobs:     c.jobs,
 			},
 			DaemonSetList: daemonset.DaemonSetList{
-				ListMeta: common.ListMeta{TotalItems: len(c.daemonset)},
+				ListMeta:   common.ListMeta{TotalItems: len(c.daemonset)},
 				DaemonSets: c.daemonset,
 			},
 			DeploymentList: deployment.DeploymentList{
-				ListMeta: common.ListMeta{TotalItems: len(c.deployment)},
+				ListMeta:    common.ListMeta{TotalItems: len(c.deployment)},
 				Deployments: c.deployment,
 			},
 			PodList: pod.PodList{
 				ListMeta: common.ListMeta{TotalItems: len(c.pod)},
-				Pods: c.pod,
+				Pods:     c.pod,
 			},
 			PetSetList: petset.PetSetList{
 				ListMeta: common.ListMeta{TotalItems: len(c.petSet)},
-				PetSets: c.petSet,
+				PetSets:  c.petSet,
 			},
 		}
 		var expectedErr error = nil


### PR DESCRIPTION
I've reafctored rc backend and a bit of frontend to match other resources coding style. Also I've added new endpoints in order to support pagination of related resources.

New style assumes that all related resources on detail pages will be exposed using following style:
`api/v1/<resource>/<namespace>/<resourceName>/<relatedResource>`

Newly exposed endpoints:
`api/v1/replicationcontroller/<namespace>/<resourceName>/pod`
`api/v1/replicationcontroller/<namespace>/<resourceName>/event`
`api/v1/replicationcontroller/<namespace>/<resourceName>/service`

Pagination support will be added in next PR.

#### TODO
- [x] Add tests
- [x] Add doc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1023)
<!-- Reviewable:end -->
