### PR TITLE
implement events for DaemonSets on back end

### DIFF
--- a/src/app/backend/resource/daemonset/daemonsetdetail.go
+++ b/src/app/backend/resource/daemonset/daemonsetdetail.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	resourceService "github.com/kubernetes/dashboard/src/app/backend/resource/service"
 	"k8s.io/kubernetes/pkg/api"
@@ -77,12 +76,18 @@ func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.Heapst
 		return nil, err
 	}
 
+	events, err := GetDaemonSetEvents(client, daemonSet.Namespace, daemonSet.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	daemonSetDetail := &DaemonSetDetail{
 		ObjectMeta:    common.NewObjectMeta(daemonSet.ObjectMeta),
 		TypeMeta:      common.NewTypeMeta(common.ResourceKindDaemonSet),
 		LabelSelector: daemonSet.Spec.Selector,
 		PodInfo:       getDaemonSetPodInfo(daemonSet, pods.Items),
 		ServiceList:   resourceService.ServiceList{Services: make([]resourceService.Service, 0)},
+		EventList:     *events,
 	}
 
 	matchingServices := getMatchingServicesforDS(services.Items, daemonSet)
@@ -98,9 +103,6 @@ func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.Heapst
 	}
 
 	daemonSetDetail.PodList = pod.CreatePodList(pods.Items, common.NO_PAGINATION, heapsterClient)
-
-	// TODO related issue #991
-	daemonSetDetail.EventList = event.ToEventList([]api.Event{}, namespace)
 
 	return daemonSetDetail, nil
 }

--- a/src/app/backend/resource/daemonset/daemonsetevents.go
+++ b/src/app/backend/resource/daemonset/daemonsetevents.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// GetDaemonSetEvents gets events associated to daemon set.
+func GetDaemonSetEvents(client client.Interface, namespace, daemonSetName string) (
+	*common.EventList, error) {
+
+	log.Printf("Getting events related to %s daemon set in %s namespace", daemonSetName,
+		namespace)
+
+	// Get events for daemon set.
+	dsEvents, err := event.GetEvents(client, namespace, daemonSetName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Get events for pods in daemon set.
+	podEvents, err := GetDaemonSetPodsEvents(client, namespace, daemonSetName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	apiEvents := append(dsEvents, podEvents...)
+
+	if !event.IsTypeFilled(apiEvents) {
+		apiEvents = event.FillEventsType(apiEvents)
+	}
+
+	events := event.ToEventList(apiEvents, namespace)
+
+	log.Printf("Found %d events related to %s daemon set in %s namespace",
+		len(events.Events), daemonSetName, namespace)
+
+	return &events, nil
+}
+
+// GetDaemonSetPodsEvents gets events associated to pods in daemon set.
+func GetDaemonSetPodsEvents(client client.Interface, namespace, daemonSetName string) (
+	[]api.Event, error) {
+
+	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(daemonSetName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	podEvents, err := event.GetPodsEvents(client, namespace, daemonSet.Spec.Selector.MatchLabels)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return podEvents, nil
+}

--- a/src/test/backend/resource/daemonset/daemonsetevents_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetevents_test.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemonset
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+func TestGetDaemonSetEvents(t *testing.T) {
+	cases := []struct {
+		namespace, name string
+		eventList       *api.EventList
+		podList         *api.PodList
+		daemonSet       *extensions.DaemonSet
+		expectedActions []string
+		expected        *common.EventList
+	}{
+		{
+			"test-namespace", "test-name",
+			&api.EventList{Items: []api.Event{
+				{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			}},
+			&api.PodList{Items: []api.Pod{{ObjectMeta: api.ObjectMeta{Name: "test-pod"}}}},
+			&extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "test-daemonset"},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{},
+					}}},
+			[]string{"list", "get", "list", "list"},
+			&common.EventList{
+				ListMeta:  common.ListMeta{TotalItems: 1},
+				Namespace: "test-namespace",
+				Events: []common.Event{{
+					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
+					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},
+					Message:    "test-message",
+					Type:       api.EventTypeNormal,
+				}}},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.eventList, c.daemonSet, c.podList,
+			&api.EventList{})
+
+		actual, _ := GetDaemonSetEvents(fakeClient, c.namespace, c.name)
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetDaemonSetEvents(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
+				c.namespace, c.name, actual, c.expected)
+		}
+	}
+}
+
+func TestGetDaemonSetPodsEvents(t *testing.T) {
+	cases := []struct {
+		namespace, name string
+		eventList       *api.EventList
+		podList         *api.PodList
+		daemonSet       *extensions.DaemonSet
+		expectedActions []string
+		expected        []api.Event
+	}{
+		{
+			"test-namespace", "test-name",
+			&api.EventList{Items: []api.Event{
+				{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}},
+			}},
+			&api.PodList{Items: []api.Pod{{ObjectMeta: api.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"}}}},
+			&extensions.DaemonSet{
+				ObjectMeta: api.ObjectMeta{Name: "test-daemonset", Namespace: "test-namespace"},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &unversioned.LabelSelector{
+						MatchLabels: map[string]string{},
+					}}},
+			[]string{"get", "list", "list"},
+			[]api.Event{{Message: "test-message", ObjectMeta: api.ObjectMeta{Namespace: "test-namespace"}}},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := testclient.NewSimpleFake(c.daemonSet, c.podList, c.eventList)
+
+		actual, _ := GetDaemonSetPodsEvents(fakeClient, c.namespace, c.name)
+
+		actions := fakeClient.Actions()
+		if len(actions) != len(c.expectedActions) {
+			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
+				len(c.expectedActions), len(actions))
+			continue
+		}
+
+		for i, verb := range c.expectedActions {
+			if actions[i].GetVerb() != verb {
+				t.Errorf("Unexpected action: %+v, expected %s",
+					actions[i], verb)
+			}
+		}
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetDaemonSetPodsEvents(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
+				c.namespace, c.name, actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
Added daemonsetevents.go which handles events on the backend for daemonsets. Events now show properly for daemonsets in the Events tab. #991

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1031)
<!-- Reviewable:end -->