### PR TITLE
Add backend pagination on rc detail page for related resource

### DIFF
--- a/src/app/backend/resource/common/event.go
+++ b/src/app/backend/resource/common/event.go
@@ -22,9 +22,6 @@ import (
 type EventList struct {
 	ListMeta ListMeta `json:"listMeta"`
 
-	// Namespace.
-	Namespace string `json:"namespace"`
-
 	// List of events from given namespace.
 	Events []Event `json:"events"`
 }

--- a/src/app/backend/resource/daemonset/daemonsetevents.go
+++ b/src/app/backend/resource/daemonset/daemonsetevents.go
@@ -51,7 +51,7 @@ func GetDaemonSetEvents(client client.Interface, namespace, daemonSetName string
 		apiEvents = event.FillEventsType(apiEvents)
 	}
 
-	events := event.ToEventList(apiEvents, namespace)
+	events := event.CreateEventList(apiEvents, common.NO_PAGINATION)
 
 	log.Printf("Found %d events related to %s daemon set in %s namespace",
 		len(events.Events), daemonSetName, namespace)

--- a/src/app/backend/resource/deployment/deploymentevents.go
+++ b/src/app/backend/resource/deployment/deploymentevents.go
@@ -25,8 +25,8 @@ import (
 
 // GetDeploymentEvents returns model events for a deployment with the given name in the given
 // namespace
-func GetDeploymentEvents(dpEvents []api.Event, namespace string,
-	deploymentName string) (*common.EventList, error) {
+func GetDeploymentEvents(dpEvents []api.Event, namespace string, deploymentName string) (
+	*common.EventList, error) {
 
 	log.Printf("Getting events related to %s deployment in %s namespace", deploymentName,
 		namespace)
@@ -35,7 +35,8 @@ func GetDeploymentEvents(dpEvents []api.Event, namespace string,
 		dpEvents = event.FillEventsType(dpEvents)
 	}
 
-	events := event.ToEventList(dpEvents, namespace)
+	// TODO support pagination
+	events := event.CreateEventList(dpEvents, common.NO_PAGINATION)
 
 	log.Printf("Found %d events related to %s deployment in %s namespace",
 		len(events.Events), deploymentName, namespace)

--- a/src/app/backend/resource/job/jobevents.go
+++ b/src/app/backend/resource/job/jobevents.go
@@ -51,7 +51,8 @@ func GetJobEvents(client client.Interface, namespace, jobName string) (
 		apiEvents = event.FillEventsType(apiEvents)
 	}
 
-	events := event.ToEventList(apiEvents, namespace)
+	// TODO support pagination
+	events := event.CreateEventList(apiEvents, common.NO_PAGINATION)
 
 	log.Printf("Found %d events related to %s job in %s namespace",
 		len(events.Events), jobName, namespace)

--- a/src/app/backend/resource/petset/petsetevents.go
+++ b/src/app/backend/resource/petset/petsetevents.go
@@ -51,7 +51,8 @@ func GetPetSetEvents(client *client.Client, namespace, petSetName string) (
 		apiEvents = event.FillEventsType(apiEvents)
 	}
 
-	events := event.ToEventList(apiEvents, namespace)
+	// TODO support pagination
+	events := event.CreateEventList(apiEvents, common.NO_PAGINATION)
 
 	log.Printf("Found %d events related to %s pet set in %s namespace",
 		len(events.Events), petSetName, namespace)

--- a/src/app/backend/resource/replicaset/replicasetevents.go
+++ b/src/app/backend/resource/replicaset/replicasetevents.go
@@ -51,7 +51,8 @@ func GetReplicaSetEvents(client client.Interface, namespace, replicaSetName stri
 		apiEvents = event.FillEventsType(apiEvents)
 	}
 
-	events := event.ToEventList(apiEvents, namespace)
+	// TODO support pagination
+	events := event.CreateEventList(apiEvents, common.NO_PAGINATION)
 
 	log.Printf("Found %d events related to %s replica set in %s namespace",
 		len(events.Events), replicaSetName, namespace)

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
@@ -52,9 +52,7 @@ func GetReplicationControllerEvents(client client.Interface, pQuery *common.Pagi
 		apiEvents = resourceEvent.FillEventsType(apiEvents)
 	}
 
-	// TODO support pagination
-
-	events := resourceEvent.ToEventList(apiEvents, namespace)
+	events := resourceEvent.CreateEventList(apiEvents, pQuery)
 
 	log.Printf("Found %d events related to %s replication controller in %s namespace",
 		len(events.Events), replicationControllerName, namespace)

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
@@ -23,19 +23,19 @@ import (
 	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
+	"log"
 )
 
 // GetReplicationControllerPods return list of pods targeting replication controller associated
 // to given name.
 func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
 	pQuery *common.PaginationQuery, rcName, namespace string) (*pod.PodList, error) {
+	log.Printf("Getting replication controller %s pods in namespace %s", rcName, namespace)
 
 	pods, err := getRawReplicationControllerPods(client, rcName, namespace)
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO support pagination
 
 	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
 	return &podList, nil

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
@@ -43,6 +43,6 @@ func GetReplicationControllerServices(client client.Interface, pQuery *common.Pa
 
 	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
 		replicationController.Spec.Selector)
-	serviceList := service.CreateServiceList(matchingServices, common.NO_PAGINATION)
+	serviceList := service.CreateServiceList(matchingServices, pQuery)
 	return &serviceList, nil
 }

--- a/src/app/backend/resource/service/servicecommon.go
+++ b/src/app/backend/resource/service/servicecommon.go
@@ -54,11 +54,22 @@ func CreateServiceList(services []api.Service, pQuery *common.PaginationQuery) S
 		ListMeta: common.ListMeta{TotalItems: len(services)},
 	}
 
-	// TODO support pagination
+	services = paginate(services, pQuery)
 
 	for _, service := range services {
 		serviceList.Services = append(serviceList.Services, ToService(&service))
 	}
 
 	return serviceList
+}
+
+func paginate(services []api.Service, pQuery *common.PaginationQuery) []api.Service {
+	startIndex, endIndex := pQuery.GetPaginationSettings(len(services))
+
+	// Return all items if provided settings do not meet requirements
+	if !pQuery.CanPaginate(len(services), startIndex) {
+		return services
+	}
+
+	return services[startIndex:endIndex]
 }

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -95,7 +95,6 @@ backendApi.AppDeploymentFromFileSpec;
 
 /**
  * @typedef {{
- *   namespace: string,
  *   events: !Array<!backendApi.Event>,
  *   listMeta: !backendApi.ListMeta
  * }}

--- a/src/app/frontend/chrome/chrome_state.js
+++ b/src/app/frontend/chrome/chrome_state.js
@@ -34,7 +34,6 @@ export const namespaceParam = 'namespace';
 
 /**
  * All properties are @exported and in sync with URL param names.
- * @final
  */
 export class StateParams {
   /**

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination_component.js
@@ -21,7 +21,7 @@ export class ResourceCardListPaginationController {
   /**
    * @ngInject
    * @param {!../../pagination/pagination_service.PaginationService} kdPaginationService
-   * @param {!../../../chrome/chrome_state.StateParams} $stateParams
+   * @param {!../../resource/resourcedetail.StateParams} $stateParams
    * @param {!../../errorhandling/errordialog_service.ErrorDialog} errorDialog
    * @param {!angular.Scope} $scope
    */
@@ -38,7 +38,7 @@ export class ResourceCardListPaginationController {
     this.list;
     /** @private {!../../pagination/pagination_service.PaginationService} */
     this.paginationService_ = kdPaginationService;
-    /** @private {!./../../../chrome/chrome_state.StateParams} */
+    /** @private {!./../../resource/resourcedetail.StateParams} */
     this.stateParams_ = $stateParams;
     /** @export {number} */
     this.rowsLimit;
@@ -106,9 +106,10 @@ export class ResourceCardListPaginationController {
    * @export
    */
   pageChanged(newPageNumber) {
+    let namespace = this.stateParams_.namespace || this.stateParams_.objectNamespace;
     let query = PaginationService.getResourceQuery(
-        this.paginationService_.getRowsLimit(this.paginationId), newPageNumber,
-        this.stateParams_.namespace);
+        this.paginationService_.getRowsLimit(this.paginationId), newPageNumber, namespace,
+        this.stateParams_.objectName);
 
     this.listResource.get(
         query, (list) => { this.list = list; },

--- a/src/app/frontend/common/pagination/pagination_service.js
+++ b/src/app/frontend/common/pagination/pagination_service.js
@@ -104,38 +104,19 @@ export class PaginationService {
    * @param {number} itemsPerPage
    * @param {number} pageNr
    * @param {string|undefined} namespace
+   * @param {string|undefined} [name]
    * @return {!backendApi.PaginationQuery}
    */
-  static getResourceQuery(itemsPerPage, pageNr, namespace) {
-    return {itemsPerPage: itemsPerPage, page: pageNr, namespace: namespace || ''};
-  }
-
-  /**
-   * @param {string|undefined} namespace
-   * @return {!backendApi.PaginationQuery}
-   */
-  static getDefaultResourceQuery(namespace) {
-    return {itemsPerPage: DEFAULT_ROWS_LIMIT, page: 1, namespace: namespace || ''};
-  }
-
-  /**
-   *
-   * @param {number} itemsPerPage
-   * @param {number} pageNr
-   * @param {string|undefined} namespace
-   * @param {string} name
-   * @return {!backendApi.PaginationQuery} pQuery
-   */
-  static getResourceDetailQuery(itemsPerPage, pageNr, namespace, name) {
+  static getResourceQuery(itemsPerPage, pageNr, namespace, name) {
     return {itemsPerPage: itemsPerPage, page: pageNr, namespace: namespace || '', name: name};
   }
 
   /**
    * @param {string|undefined} namespace
-   * @param {string} name
-   * @return {!backendApi.PaginationQuery} pQuery
+   * @param {string|undefined} [name]
+   * @return {!backendApi.PaginationQuery}
    */
-  static getDefaultResourceDetailQuery(namespace, name) {
+  static getDefaultResourceQuery(namespace, name) {
     return {itemsPerPage: DEFAULT_ROWS_LIMIT, page: 1, namespace: namespace || '', name: name};
   }
 }

--- a/src/app/frontend/common/resource/globalresourcedetail.js
+++ b/src/app/frontend/common/resource/globalresourcedetail.js
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {StateParams} from 'chrome/chrome_state';
+
 /**
  * Parameters for this state.
  *
  * All properties are @exported and in sync with URL param names.
  */
-export class GlobalStateParams {
+export class GlobalStateParams extends StateParams {
   /**
    * @param {string} objectName
   */
   constructor(objectName) {
+    // Base StateParams are inherited from chrome parent state. GlobalStateParams are used on
+    // detail pages for non-namespaced objects, which do not require namespace to be set.
+    super(undefined);
+
     /** @export {string} Name of this object. */
     this.objectName = objectName;
   }

--- a/src/app/frontend/events/eventcardlist_component.js
+++ b/src/app/frontend/events/eventcardlist_component.js
@@ -27,7 +27,7 @@ export class EventCardListController {
     this.eventList;
 
     /** @export {!backendApi.EventList} */
-    this.filteredEventList = this.eventList;
+    this.filteredEventList = {events: [], listMeta: {totalItems: 0}};
 
     /** @const @export {!Array<string>} */
     this.eventTypeFilter = [EVENT_ALL, EVENT_TYPE_WARNING];
@@ -37,6 +37,14 @@ export class EventCardListController {
 
     /** @export */
     this.i18n = i18n;
+  }
+
+  /**
+   * @export
+   */
+  $onInit() {
+    this.filteredEventList.listMeta = this.eventList.listMeta;
+    this.filteredEventList.events = this.eventList.events;
   }
 
   /**
@@ -54,7 +62,7 @@ export class EventCardListController {
    * @export
    */
   hasEvents() {
-    return this.filteredEventList !== undefined && this.filteredEventList.events.length > 0;
+    return this.filteredEventList !== undefined && this.filteredEventList.listMeta.totalItems > 0;
   }
 
   /**
@@ -62,23 +70,22 @@ export class EventCardListController {
    * @export
    */
   handleEventFiltering() {
-    this.filteredEventList = this.filterByType(this.eventList, this.eventType);
+    this.filteredEventList.events = this.filterByType_(this.eventList.events, this.eventType);
   }
 
   /**
    * Filters events by their type.
-   * @param {!backendApi.EventList} eventList
+   * @param {!Array<!backendApi.Event>} events
    * @param {string} type
-   * @return {!backendApi.EventList}
-   * @export
+   * @return {!Array<!backendApi.Event>}
+   * @private
    */
-  filterByType(eventList, type) {
+  filterByType_(events, type) {
     if (type === EVENT_TYPE_WARNING) {
-      eventList.events = eventList.events.filter((event) => event.type === EVENT_TYPE_WARNING);
-      return eventList;
+      return events.filter((event) => event.type === EVENT_TYPE_WARNING);
     } else {
       // In case of selected 'All' option.
-      return eventList;
+      return events;
     }
   }
 }
@@ -93,7 +100,7 @@ export const eventCardListComponent = {
   controller: EventCardListController,
   bindings: {
     /** {!backendApi.EventList} */
-    'eventList': '=',
+    'eventList': '<',
   },
 };
 

--- a/src/app/frontend/nodedetail/nodeconditions.html
+++ b/src/app/frontend/nodedetail/nodeconditions.html
@@ -35,8 +35,7 @@ limitations under the License.
       {{::$ctrl.i18n.MSG_NODE_DETAIL_CONDITION_MESSAGE_HEADER}}
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-resource-card dir-paginate="condition in $ctrl.conditions | itemsPerPage: default"
-                    pagination-id="conditions" omit-meta="true">
+  <kd-resource-card ng-repeat="condition in $ctrl.conditions" omit-meta="true">
     <kd-resource-card-columns>
       <kd-resource-card-column>
         <div>{{condition.type}}</div>
@@ -58,9 +57,4 @@ limitations under the License.
     </kd-resource-card-column>
     </kd-resource-card-columns>
   </kd-resource-card>
-  <kd-resource-card-list-footer>
-    <kd-resource-card-list-pagination pagination-id="conditions"
-                                      total-items="$ctrl.conditions.length">
-    </kd-resource-card-list-pagination>
-  </kd-resource-card-list-footer>
 </kd-resource-card-list>

--- a/src/app/frontend/nodedetail/nodedetail.html
+++ b/src/app/frontend/nodedetail/nodedetail.html
@@ -21,7 +21,7 @@ limitations under the License.
         <kd-node-info node="::ctrl.nodeDetail"></kd-node-info>
       </md-tab>
       <md-tab label="{{::ctrl.i18n.MSG_NODE_DETAIL_EVENTS_LABEL}}">
-        <kd-event-card-list events="::ctrl.nodeDetail.eventList.events"></kd-event-card-list>
+        <kd-event-card-list event-list="::ctrl.nodeDetail.eventList"></kd-event-card-list>
       </md-tab>
     </md-tabs>
   </md-content>

--- a/src/app/frontend/nodedetail/nodeinfo.html
+++ b/src/app/frontend/nodedetail/nodeinfo.html
@@ -109,8 +109,7 @@ limitations under the License.
 <kd-content-card>
   <kd-title>{{::$ctrl.i18n.MSG_NODE_DETAIL_PODS_LABEL}}</kd-title>
   <kd-content>
-    <kd-pod-card-list pod-list="::$ctrl.node.podList" with-statuses="true"
-                      logs-href-fn="::$ctrl.getPodLogsHref(pod)">
+    <kd-pod-card-list pod-list="$ctrl.node.podList" with-statuses="true">
     </kd-pod-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/podlist/podcardlist_component.js
+++ b/src/app/frontend/podlist/podcardlist_component.js
@@ -32,7 +32,7 @@ export class PodCardListController {
      */
     this.podList;
 
-    /** @export {!angular.$resource} Initialized from binding. */
+    /** @export {!angular.Resource} Initialized from binding. */
     this.podListResource;
 
     /** @private {!ui.router.$state} */
@@ -149,7 +149,7 @@ export const podCardListComponent = {
   bindings: {
     /** {!backendApi.PodList} */
     'podList': '<',
-    /** {!angular.$resource} */
+    /** {!angular.Resource} */
     'podListResource': '<',
     /** {boolean} */
     'selectable': '<',

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -24,7 +24,8 @@ limitations under the License.
         <kd-content-card ng-if="::ctrl.replicationControllerDetail.serviceList.services.length">
           <kd-title>{{::ctrl.i18n.MSG_RC_DETAIL_SERVICES_TITLE}}</kd-title>
           <kd-content>
-            <kd-service-card-list service-list="::ctrl.replicationControllerDetail.serviceList">
+            <kd-service-card-list service-list="::ctrl.replicationControllerDetail.serviceList"
+                                  service-list-resource="::ctrl.serviceListResource">
             </kd-service-card-list>
           </kd-content>
         </kd-content-card>
@@ -32,7 +33,8 @@ limitations under the License.
         <kd-content-card ng-if="::ctrl.replicationControllerDetail.podList.pods.length">
           <kd-title>{{::ctrl.i18n.MSG_RC_DETAIL_PODS_TITLE}}</kd-title>
           <kd-content>
-            <kd-pod-card-list pod-list="ctrl.replicationControllerDetail.podList"
+            <kd-pod-card-list pod-list="::ctrl.replicationControllerDetail.podList"
+                              pod-list-resource="::ctrl.podListResource"
                               with-statuses="true">
             </kd-pod-card-list>
           </kd-content>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_controller.js
@@ -22,11 +22,20 @@ export default class ReplicationControllerDetailController {
    * @param {!backendApi.ReplicationControllerDetail} replicationControllerDetail
    * @param {!ui.router.$state} $state
    * @param {!../common/resource/resourcedetail.StateParams} $stateParams
+   * @param {!angular.Resource} kdRCPodsResource
+   * @param {!angular.Resource} kdRCServicesResource
    * @ngInject
    */
-  constructor(replicationControllerDetail, $state, $stateParams) {
+  constructor(
+      replicationControllerDetail, $state, $stateParams, kdRCPodsResource, kdRCServicesResource) {
     /** @export {!backendApi.ReplicationControllerDetail} */
     this.replicationControllerDetail = replicationControllerDetail;
+
+    /** @export {!angular.Resource} */
+    this.podListResource = kdRCPodsResource;
+
+    /** @export {!angular.Resource} */
+    this.serviceListResource = kdRCServicesResource;
 
     /** @private {!ui.router.$state} */
     this.state_ = $state;

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
@@ -50,7 +50,8 @@ export default angular
     .service('kdReplicationControllerService', ReplicationControllerService)
     .factory('kdRCResource', replicationControllerResource)
     .factory('kdRCPodsResource', replicationControllerPodsResource)
-    .factory('kdRCEventsResource', replicationControllerEventsResource);
+    .factory('kdRCEventsResource', replicationControllerEventsResource)
+    .factory('kdRCServicesResource', replicationControllerServicesResource);
 
 /**
  * @param {!angular.$resource} $resource
@@ -77,4 +78,13 @@ function replicationControllerPodsResource($resource) {
  */
 function replicationControllerEventsResource($resource) {
   return $resource('api/v1/replicationcontroller/:namespace/:name/event');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicationControllerServicesResource($resource) {
+  return $resource('api/v1/replicationcontroller/:namespace/:name/service');
 }

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
@@ -77,7 +77,7 @@ export function getReplicationControllerSpecPodsResource($stateParams, $resource
  * @ngInject
  */
 function resolveReplicationControllerDetails(kdRCResource, $stateParams) {
-  let query = PaginationService.getDefaultResourceDetailQuery(
+  let query = PaginationService.getDefaultResourceQuery(
       $stateParams.objectNamespace, $stateParams.objectName);
   return kdRCResource.get(query).$promise;
 }

--- a/src/app/frontend/servicelist/servicecardlist.html
+++ b/src/app/frontend/servicelist/servicecardlist.html
@@ -36,6 +36,7 @@ limitations under the License.
   </kd-resource-card-header-columns>
 
   <kd-resource-card dir-paginate="service in $ctrl.serviceList.services | itemsPerPage: default"
+                    total-items="$ctrl.serviceList.listMeta.totalItems"
                     pagination-id="services" object-meta="service.objectMeta"
                     type-meta="service.typeMeta">
     <kd-resource-card-status layout="row">
@@ -84,7 +85,8 @@ limitations under the License.
     </kd-resource-card-columns>
   </kd-resource-card>
   <kd-resource-card-list-footer>
-    <kd-resource-card-list-pagination pagination-id="services" list="$ctrl.serviceList">
+    <kd-resource-card-list-pagination pagination-id="services" list="$ctrl.serviceList"
+                                      list-resource="$ctrl.serviceListResource">
     </kd-resource-card-list-pagination>
   </kd-resource-card-list-footer>
 </kd-resource-card-list>

--- a/src/app/frontend/servicelist/servicecardlist_component.js
+++ b/src/app/frontend/servicelist/servicecardlist_component.js
@@ -83,6 +83,8 @@ export const serviceCardListComponent = {
   bindings: {
     /** {!backendApi.ServiceList} */
     'serviceList': '<',
+    /** {angular.Resource} */
+    'serviceListResource': '<',
     /** {boolean} */
     'selectable': '<',
   },

--- a/src/test/backend/resource/daemonset/daemonsetevents_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetevents_test.go
@@ -50,7 +50,6 @@ func TestGetDaemonSetEvents(t *testing.T) {
 			[]string{"list", "get", "list", "list"},
 			&common.EventList{
 				ListMeta:  common.ListMeta{TotalItems: 1},
-				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
 					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},

--- a/src/test/backend/resource/deployment/deploymentdetail_test.go
+++ b/src/test/backend/resource/deployment/deploymentdetail_test.go
@@ -110,7 +110,6 @@ func TestGetDeploymentDetail(t *testing.T) {
 					Pods:       common.PodInfo{Warnings: []common.Event{}},
 				},
 				EventList: common.EventList{
-					Namespace: "test-namespace",
 					Events:    []common.Event{},
 				},
 			},

--- a/src/test/backend/resource/deployment/deploymentevents_test.go
+++ b/src/test/backend/resource/deployment/deploymentevents_test.go
@@ -33,7 +33,6 @@ func TestGetDeploymentEvents(t *testing.T) {
 			[]string{"list"},
 			&common.EventList{
 				ListMeta:  common.ListMeta{TotalItems: 1},
-				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
 					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},

--- a/src/test/backend/resource/job/jobevents_test.go
+++ b/src/test/backend/resource/job/jobevents_test.go
@@ -49,7 +49,6 @@ func TestGetJobEvents(t *testing.T) {
 			[]string{"list", "get", "list", "list"},
 			&common.EventList{
 				ListMeta:  common.ListMeta{TotalItems: 1},
-				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
 					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},

--- a/src/test/backend/resource/node/nodedetail_test.go
+++ b/src/test/backend/resource/node/nodedetail_test.go
@@ -66,7 +66,6 @@ func TestGetNodeDetail(t *testing.T) {
 					Pods: []pod.Pod{},
 				},
 				EventList: common.EventList{
-					Namespace: api.NamespaceAll,
 					Events:    nil,
 				},
 				AllocatedResources: NodeAllocatedResources{

--- a/src/test/backend/resource/replicaset/replicasetevents_test.go
+++ b/src/test/backend/resource/replicaset/replicasetevents_test.go
@@ -50,7 +50,6 @@ func TestGetReplicaSetEvents(t *testing.T) {
 			[]string{"list", "get", "list", "list"},
 			&common.EventList{
 				ListMeta:  common.ListMeta{TotalItems: 1},
-				Namespace: "test-namespace",
 				Events: []common.Event{{
 					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindEvent},
 					ObjectMeta: common.ObjectMeta{Namespace: "test-namespace"},

--- a/src/test/frontend/common/pagination/pagination_service_test.js
+++ b/src/test/frontend/common/pagination/pagination_service_test.js
@@ -119,8 +119,8 @@ describe('Pagination service', () => {
 
   it('should return pagination query object', () => {
     let cases = [
-      [10, 1, 'ns-1', {itemsPerPage: 10, page: 1, namespace: 'ns-1'}],
-      [10, 2, undefined, {itemsPerPage: 10, page: 2, namespace: ''}],
+      [10, 1, 'ns-1', {itemsPerPage: 10, page: 1, namespace: 'ns-1', name: undefined}],
+      [10, 2, undefined, {itemsPerPage: 10, page: 2, namespace: '', name: undefined}],
     ];
 
     cases.forEach((testData) => {
@@ -137,8 +137,8 @@ describe('Pagination service', () => {
 
   it('should return default pagination query object', () => {
     let cases = [
-      ['ns-1', {itemsPerPage: 10, page: 1, namespace: 'ns-1'}],
-      [undefined, {itemsPerPage: 10, page: 1, namespace: ''}],
+      ['ns-1', {itemsPerPage: 10, page: 1, namespace: 'ns-1', name: undefined}],
+      [undefined, {itemsPerPage: 10, page: 1, namespace: '', name: undefined}],
     ];
 
     cases.forEach((testData) => {

--- a/src/test/frontend/events/eventcardlist_component_test.js
+++ b/src/test/frontend/events/eventcardlist_component_test.js
@@ -46,10 +46,10 @@ describe('Event Card List controller', () => {
     };
 
     // when
-    let result = ctrl.filterByType(eventList, eventType);
+    let result = ctrl.filterByType_(eventList.events, eventType);
 
     // then
-    expect(result.events.length).toEqual(2);
+    expect(result.length).toEqual(2);
   });
 
   it('should filter all non-warning events if warning option is selected', () => {
@@ -73,15 +73,15 @@ describe('Event Card List controller', () => {
     };
 
     // when
-    let result = ctrl.filterByType(eventList, eventType);
+    let result = ctrl.filterByType_(eventList.events, eventType);
 
     // then
-    expect(result.events.length).toEqual(1);
+    expect(result.length).toEqual(1);
   });
 
   it('should return true when there are events to display', () => {
     // given
-    ctrl.filteredEventList = {events: ['Some event']};
+    ctrl.filteredEventList = {events: ['Some event'], listMeta: {totalItems: 1}};
 
     // when
     let result = ctrl.hasEvents();
@@ -92,7 +92,7 @@ describe('Event Card List controller', () => {
 
   it('should return false if there are no events to display', () => {
     // given
-    ctrl.filteredEventList = {events: []};
+    ctrl.filteredEventList = {events: [], listMeta: {totalItems: 0}};
 
     // when
     let result = ctrl.hasEvents();
@@ -131,26 +131,28 @@ describe('Event Card List controller', () => {
   it('should not filter any events and show all', () => {
     // given
     ctrl.eventType = 'All';
-    ctrl.eventList = [
-      {
-        type: 'Warning',
-        message: 'event-1',
-      },
-      {
-        type: 'Normal',
-        message: 'event-2',
-      },
-      {
-        type: 'Normal',
-        message: 'event-3',
-      },
-    ];
+    ctrl.eventList = {
+      events: [
+        {
+          type: 'Warning',
+          message: 'event-1',
+        },
+        {
+          type: 'Normal',
+          message: 'event-2',
+        },
+        {
+          type: 'Normal',
+          message: 'event-3',
+        },
+      ],
+    };
 
     // when
     ctrl.handleEventFiltering();
 
     // then
-    expect(ctrl.filteredEventList.length).toEqual(3);
+    expect(ctrl.filteredEventList.events.length).toEqual(3);
   });
 
   it('should return true when warning event', () => {


### PR DESCRIPTION
- Added backend paginaton support for related services/pods
- Fixed issue with events list where after filtering warning events, all events switch did not work.

Events backend pagination will be added later as frontend filtering and backend pagination do not work well together. I have to think about a way to resolve that. Probably backend filtering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1032)
<!-- Reviewable:end -->
