### PR TITLE
Add backend pagination on details page to resources related to replica set

### DIFF
--- a/src/app/backend/resource/deployment/deploymentdetail.go
+++ b/src/app/backend/resource/deployment/deploymentdetail.go
@@ -154,7 +154,8 @@ func getDeploymentDetail(deployment *extensions.Deployment,
 	for i, replicaSet := range oldRs {
 		oldReplicaSets[i] = *replicaSet
 	}
-	oldReplicaSetList := replicaset.ToReplicaSetList(oldReplicaSets, pods, rawEvents)
+	oldReplicaSetList := replicaset.CreateReplicaSetList(oldReplicaSets, pods, rawEvents,
+		common.NO_PAGINATION)
 
 	var rollingUpdateStrategy *RollingUpdateStrategy
 	if deployment.Spec.Strategy.RollingUpdate != nil {

--- a/src/app/backend/resource/replicaset/replicasetpods.go
+++ b/src/app/backend/resource/replicaset/replicasetpods.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicaset
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/src/app/backend/client"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// GetReplicaSetPods return list of pods targeting replica set.
+func GetReplicaSetPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
+	pQuery *common.PaginationQuery, petSetName, namespace string) (*pod.PodList, error) {
+	log.Printf("Getting replication controller %s pods in namespace %s", petSetName, namespace)
+
+	pods, err := getRawReplicaSetPods(client, petSetName, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	return &podList, nil
+}
+
+// Returns array of api pods targeting replica set with given name.
+func getRawReplicaSetPods(client k8sClient.Interface, petSetName, namespace string) (
+	[]api.Pod, error) {
+
+	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(petSetName)
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := labels.SelectorFromSet(replicaSet.Spec.Selector.MatchLabels)
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(namespace),
+			api.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fields.Everything(),
+			}, 1),
+	}
+
+	podList := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
+}
+
+// Returns simple info about pods(running, desired, failing, etc.) related to given replica set.
+func getReplicaSetPodInfo(client k8sClient.Interface, replicaSet *extensions.ReplicaSet) (
+	*common.PodInfo, error) {
+
+	labelSelector := labels.SelectorFromSet(replicaSet.Spec.Selector.MatchLabels)
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(
+			replicaSet.Namespace),
+			api.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fields.Everything(),
+			}, 1),
+	}
+
+	pods := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+
+	podInfo := common.GetPodInfo(replicaSet.Status.Replicas, replicaSet.Spec.Replicas, pods.Items)
+	return &podInfo, nil
+}

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -88,7 +88,7 @@ func GetWorkloadsFromChannels(channels *common.ResourceChannels,
 	}()
 
 	go func() {
-		rsList, err := replicaset.GetReplicaSetListFromChannels(channels)
+		rsList, err := replicaset.GetReplicaSetListFromChannels(channels, pQuery)
 		errChan <- err
 		rsChan <- rsList
 	}()

--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -39,9 +39,9 @@ limitations under the License.
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
 
-  <kd-resource-card ng-if="$ctrl.podListResource" object-meta="pod.objectMeta" pagination-id="pods"
-                    dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default"
-                    total-items="::$ctrl.podList.listMeta.totalItems" type-meta="pod.typeMeta">
+  <kd-resource-card ng-if="::$ctrl.podListResource" total-items="::$ctrl.podList.listMeta.totalItems"
+                    pagination-id="pods" object-meta="pod.objectMeta" type-meta="pod.typeMeta"
+                    dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default">
     <kd-resource-card-status layout="row">
       <md-icon class="material-icons kd-error" ng-if="$ctrl.isStatusFailed(pod)">
         error
@@ -111,7 +111,7 @@ limitations under the License.
     </kd-resource-card-columns>
   </kd-resource-card>
 
-  <kd-resource-card ng-if="!$ctrl.podListResource" object-meta="pod.objectMeta"
+  <kd-resource-card ng-if="::!$ctrl.podListResource" object-meta="pod.objectMeta"
                     pagination-id="pods" type-meta="pod.typeMeta"
                     dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default">
     <kd-resource-card-status layout="row">

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -23,7 +23,8 @@ limitations under the License.
         <kd-content-card ng-if="::ctrl.replicaSetDetail.podList.pods.length">
           <kd-title>{{::ctrl.i18n.MSG_REPLICA_SET_DETAIL_PODS_TITLE}}</kd-title>
           <kd-content>
-            <kd-pod-card-list pod-list="::ctrl.replicaSetDetail.podList" with-statuses="true">
+            <kd-pod-card-list pod-list="::ctrl.replicaSetDetail.podList" with-statuses="true"
+                              pod-list-resource="::ctrl.replicaSetPodsResource">
             </kd-pod-card-list>
           </kd-content>
         </kd-content-card>

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -20,9 +20,12 @@ export class ReplicaSetDetailController {
    * @param {!backendApi.ReplicaSetDetail} replicaSetDetail
    * @ngInject
    */
-  constructor(replicaSetDetail) {
+  constructor(replicaSetDetail, kdReplicaSetPodsResource) {
     /** @export {!backendApi.ReplicaSetDetail} */
     this.replicaSetDetail = replicaSetDetail;
+
+    /** @export {!angular.Resource} */
+    this.replicaSetPodsResource = kdReplicaSetPodsResource;
 
     /** @export */
     this.i18n = i18n;

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -37,4 +37,24 @@ export default angular
           eventsModule.name,
         ])
     .config(stateConfig)
-    .component('kdReplicaSetInfo', replicaSetInfoComponent);
+    .component('kdReplicaSetInfo', replicaSetInfoComponent)
+    .factory('kdReplicaSetDetailResource', replicaSetDetailResource)
+    .factory('kdReplicaSetPodsResource', replicaSetPodsResource);
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicaSetDetailResource($resource) {
+  return $resource('api/v1/replicaset/:namespace/:name');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicaSetPodsResource($resource) {
+  return $resource('api/v1/replicaset/:namespace/:name/pod');
+}

--- a/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_stateconfig.js
@@ -14,6 +14,7 @@
 
 import {actionbarViewName, stateName as chromeStateName} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+import {PaginationService} from 'common/pagination/pagination_service';
 import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
 import {stateName as replicaSetList, stateUrl} from 'replicasetlist/replicasetlist_state';
 
@@ -32,8 +33,7 @@ export default function stateConfig($stateProvider) {
     url: appendDetailParamsToUrl(stateUrl),
     parent: chromeStateName,
     resolve: {
-      'replicaSetDetailResource': getReplicaSetDetailResource,
-      'replicaSetDetail': getReplicaSetDetail,
+      'replicaSetDetail': resolveReplicaSetDetailResource,
     },
     data: {
       [breadcrumbsConfig]: {
@@ -57,20 +57,13 @@ export default function stateConfig($stateProvider) {
 }
 
 /**
+ * @param {!angular.Resource} kdReplicaSetDetailResource
  * @param {!./../common/resource/resourcedetail.StateParams} $stateParams
- * @param {!angular.$resource} $resource
  * @return {!angular.Resource<!backendApi.ReplicaSetDetail>}
  * @ngInject
  */
-export function getReplicaSetDetailResource($resource, $stateParams) {
-  return $resource(`api/v1/replicaset/${$stateParams.objectNamespace}/${$stateParams.objectName}`);
-}
-
-/**
- * @param {!angular.Resource<!backendApi.ReplicaSetDetail>} replicaSetDetailResource
- * @return {!angular.$q.Promise}
- * @ngInject
- */
-export function getReplicaSetDetail(replicaSetDetailResource) {
-  return replicaSetDetailResource.get().$promise;
+export function resolveReplicaSetDetailResource(kdReplicaSetDetailResource, $stateParams) {
+  let query = PaginationService.getDefaultResourceQuery(
+      $stateParams.objectNamespace, $stateParams.objectName);
+  return kdReplicaSetDetailResource.get(query).$promise;
 }

--- a/src/app/frontend/replicasetlist/replicasetcardlist.html
+++ b/src/app/frontend/replicasetlist/replicasetcardlist.html
@@ -34,11 +34,18 @@ limitations under the License.
     <kd-resource-card-header-column size="small" grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-replica-set-card dir-paginate="rc in $ctrl.replicaSetList.replicaSets | itemsPerPage: default"
-                       pagination-id="replicasets" replica-set="rc">
+  <kd-replica-set-card ng-if="::$ctrl.replicaSetListResource"
+                       dir-paginate="rs in $ctrl.replicaSetList.replicaSets | itemsPerPage: default"
+                       pagination-id="replicasets" replica-set="rs"
+                       total-items="::$ctrl.replicaSetList.listMeta.totalItems">
+  </kd-replica-set-card>
+  <kd-replica-set-card ng-if="::!$ctrl.replicaSetListResource"
+                       dir-paginate="rs in $ctrl.replicaSetList.replicaSets | itemsPerPage: default"
+                       pagination-id="replicasets" replica-set="rs">
   </kd-replica-set-card>
   <kd-resource-card-list-footer>
-    <kd-resource-card-list-pagination pagination-id="replicasets" list="$ctrl.replicaSetList">
+    <kd-resource-card-list-pagination pagination-id="replicasets" list="$ctrl.replicaSetList"
+                                      list-resource="$ctrl.replicaSetListResource">
     </kd-resource-card-list-pagination>
   </kd-resource-card-list-footer>
 </kd-resource-card-list>

--- a/src/app/frontend/replicasetlist/replicasetcardlist_component.js
+++ b/src/app/frontend/replicasetlist/replicasetcardlist_component.js
@@ -34,6 +34,7 @@ export const replicaSetCardListComponent = {
   transclude: true,
   bindings: {
     'replicaSetList': '<',
+    'replicaSetListResource': '<',
   },
   templateUrl: 'replicasetlist/replicasetcardlist.html',
   controller: ReplicaSetCardListController,

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -16,7 +16,8 @@ limitations under the License.
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
-    <kd-replica-set-card-list replica-set-list="$ctrl.replicaSetList">
+    <kd-replica-set-card-list replica-set-list="$ctrl.replicaSetList"
+                              replica-set-list-resource="$ctrl.replicaSetListResource">
     </kd-replica-set-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/replicasetlist/replicasetlist_controller.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_controller.js
@@ -20,11 +20,15 @@
 export class ReplicaSetListController {
   /**
    * @param {!backendApi.ReplicaSetList} replicaSetList
+   * @param {!angular.Resource} kdReplicaSetListResource
    * @ngInject
    */
-  constructor(replicaSetList) {
+  constructor(replicaSetList, kdReplicaSetListResource) {
     /** @export {!backendApi.ReplicaSetList} */
     this.replicaSetList = replicaSetList;
+
+    /** @export {!angular.Resource} */
+    this.replicaSetListResource = kdReplicaSetListResource;
   }
 
   /**

--- a/src/app/frontend/replicasetlist/replicasetlist_module.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_module.js
@@ -39,4 +39,14 @@ export default angular
         ])
     .config(stateConfig)
     .component('kdReplicaSetCardList', replicaSetCardListComponent)
-    .component('kdReplicaSetCard', replicaSetCardComponent);
+    .component('kdReplicaSetCard', replicaSetCardComponent)
+    .factory('kdReplicaSetListResource', replicaSetListResource);
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicaSetListResource($resource) {
+  return $resource('api/v1/replicaset/:namespace');
+}

--- a/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_stateconfig.js
@@ -14,6 +14,7 @@
 
 import {actionbarViewName, stateName as chromeStateName} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+import {PaginationService} from 'common/pagination/pagination_service';
 import {stateName as workloadsState} from 'workloads/workloads_state';
 
 import {ReplicaSetListController} from './replicasetlist_controller';
@@ -52,15 +53,15 @@ export default function stateConfig($stateProvider) {
 }
 
 /**
- * @param {!angular.$resource} $resource
+ * @param {!angular.Resource} kdReplicaSetListResource
  * @param {!./../chrome/chrome_state.StateParams} $stateParams
  * @return {!angular.$q.Promise}
  * @ngInject
  */
-export function resolveReplicaSetList($resource, $stateParams) {
-  /** @type {!angular.Resource<!backendApi.ReplicaSetList>} */
-  let resource = $resource(`api/v1/replicaset/${$stateParams.namespace || ''}`);
-  return resource.get().$promise;
+export function resolveReplicaSetList(kdReplicaSetListResource, $stateParams) {
+  /** @type {!backendApi.PaginationQuery} */
+  let query = PaginationService.getDefaultResourceQuery($stateParams.namespace);
+  return kdReplicaSetListResource.get(query).$promise;
 }
 
 const i18n = {

--- a/src/app/frontend/workloads/workloads.html
+++ b/src/app/frontend/workloads/workloads.html
@@ -58,7 +58,8 @@ limitations under the License.
       </a>
     </kd-title>
     <kd-content>
-      <kd-replica-set-card-list replica-set-list="$ctrl.workloads.replicaSetList">
+      <kd-replica-set-card-list replica-set-list="$ctrl.workloads.replicaSetList"
+                                replica-set-list-resource="$ctrl.replicaSetListResource">
       </kd-replica-set-card-list>
     </kd-content>
   </kd-content-card>

--- a/src/app/frontend/workloads/workloads_controller.js
+++ b/src/app/frontend/workloads/workloads_controller.js
@@ -18,15 +18,19 @@
 export class WorkloadsController {
   /**
    * @param {!backendApi.Workloads} workloads
-   * @param {!angular.$resource} kdPodListResource
+   * @param {!angular.Resource} kdPodListResource
+   * @param {!angular.Resource} kdReplicaSetListResource
    * @ngInject
    */
-  constructor(workloads, kdPodListResource) {
+  constructor(workloads, kdPodListResource, kdReplicaSetListResource) {
     /** @export {!backendApi.Workloads} */
     this.workloads = workloads;
 
-    /** @export {!angular.$resource} */
+    /** @export {!angular.Resource} */
     this.podListResource = kdPodListResource;
+
+    /** @export {!angular.Resource} */
+    this.replicaSetListResource = kdReplicaSetListResource;
 
     /** @export */
     this.i18n = i18n;

--- a/src/test/backend/resource/replicaset/replicasetdetail_test.go
+++ b/src/test/backend/resource/replicaset/replicasetdetail_test.go
@@ -50,7 +50,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 	}{
 		{
 			"test-namespace", "test-name",
-			[]string{"get", "list", "list", "get", "list", "list"},
+			[]string{"get", "list", "get", "list", "list", "get", "list", "list"},
 			&extensions.ReplicaSet{
 				ObjectMeta: api.ObjectMeta{Name: "test-replicaset"},
 				Spec: extensions.ReplicaSetSpec{
@@ -73,7 +73,8 @@ func TestGetReplicaSetDetail(t *testing.T) {
 			podList, eventList)
 		fakeHeapsterClient := FakeHeapsterClient{client: testclient.NewSimpleFake()}
 
-		actual, _ := GetReplicaSetDetail(fakeClient, fakeHeapsterClient, c.namespace, c.name)
+		actual, _ := GetReplicaSetDetail(fakeClient, fakeHeapsterClient, common.NO_PAGINATION,
+			c.namespace, c.name)
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {

--- a/src/test/backend/resource/replicaset/replicasetlist_test.go
+++ b/src/test/backend/resource/replicaset/replicasetlist_test.go
@@ -177,7 +177,7 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetReplicaSetListFromChannels(channels)
+		actual, err := GetReplicaSetListFromChannels(channels, common.NO_PAGINATION)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetReplicaSetListChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/frontend/replicasetlist/replicasetlist_stateconfig_test.js
+++ b/src/test/frontend/replicasetlist/replicasetlist_stateconfig_test.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {PaginationService} from 'common/pagination/pagination_service';
+
 import replicaSetListModule from 'replicasetlist/replicasetlist_module';
 import {resolveReplicaSetList} from 'replicasetlist/replicasetlist_stateconfig';
 
@@ -21,24 +23,24 @@ describe('StateConfig for replica set list', () => {
   it('should resolve replica sets', angular.mock.inject(($q) => {
     let promise = $q.defer().promise;
 
-    let resource = jasmine.createSpy('$resource');
-    resource.and.returnValue({get: function() { return {$promise: promise}; }});
+    let resource = jasmine.createSpyObj('$resource', ['get']);
+    resource.get.and.callFake(function() { return {$promise: promise}; });
 
     let actual = resolveReplicaSetList(resource, {namespace: 'foo'});
 
-    expect(resource).toHaveBeenCalledWith('api/v1/replicaset/foo');
+    expect(resource.get).toHaveBeenCalledWith(PaginationService.getDefaultResourceQuery('foo'));
     expect(actual).toBe(promise);
   }));
 
   it('should resolve replica sets with no namespace', angular.mock.inject(($q) => {
     let promise = $q.defer().promise;
 
-    let resource = jasmine.createSpy('$resource');
-    resource.and.returnValue({get: function() { return {$promise: promise}; }});
+    let resource = jasmine.createSpyObj('$resource', ['get']);
+    resource.get.and.callFake(function() { return {$promise: promise}; });
 
     let actual = resolveReplicaSetList(resource, {});
 
-    expect(resource).toHaveBeenCalledWith('api/v1/replicaset/');
+    expect(resource.get).toHaveBeenCalledWith(PaginationService.getDefaultResourceQuery(''));
     expect(actual).toBe(promise);
   }));
 });


### PR DESCRIPTION
Added backend pagination support to:
- replica set list page
- replica set list on workloads page
- pod list on replica set details page

New endpoint:
`/api/v1/replicaset/:namespace/:name/pod`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1047)
<!-- Reviewable:end -->
