### PR TITLE
Prevent gulp from crashing during serve

### DIFF
--- a/build/serve.js
+++ b/build/serve.js
@@ -204,6 +204,6 @@ gulp.task('watch', ['index'], function() {
         }
       });
 
-  gulp.watch(path.join(conf.paths.frontendSrc, '**/*.js'), ['scripts']);
+  gulp.watch(path.join(conf.paths.frontendSrc, '**/*.js'), ['scripts-watch']);
   gulp.watch(path.join(conf.paths.backendSrc, '**/*.go'), ['spawn-backend']);
 });


### PR DESCRIPTION
In case of JS syntax error detected during watch task gulp will just
show the error message and retry on next file change instead of crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1049)
<!-- Reviewable:end -->
