### PR TITLE
Give logs view sane line spacing

### DIFF
--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -35,7 +35,8 @@ $logs-color-white: #fff;
   font-size: $body-font-size-base;
 }
 
-.kd-logs-element, .kd-logs-element-compact {
+.kd-logs-element,
+.kd-logs-element-compact {
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
 

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -27,7 +27,8 @@ $logs-color-white: #fff;
   color: $logs-color-black;
 }
 
-@mixin kd-logs-element-mixin {
+.kd-logs-element {
+  font-size: $body-font-size-base;
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
 
@@ -37,11 +38,7 @@ $logs-color-white: #fff;
 }
 
 .kd-logs-element-compact {
-  @include kd-logs-element-mixin;
-  font-size: $caption-font-size-base;
-}
+  @extend .kd-logs-element;
 
-.kd-logs-element {
-  @include kd-logs-element-mixin;
-  font-size: $body-font-size-base;
+  font-size: $caption-font-size-base;
 }

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -27,20 +27,21 @@ $logs-color-white: #fff;
   color: $logs-color-black;
 }
 
-.kd-logs-element-compact {
-  font-size: $caption-font-size-base;
-}
-
-.kd-logs-element {
-  font-size: $body-font-size-base;
-}
-
-.kd-logs-element,
-.kd-logs-element-compact {
+@mixin kd-logs-element-mixin {
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
 
   pre {
     margin: 0;
   }
+}
+
+.kd-logs-element-compact {
+  font-size: $caption-font-size-base;
+  @include kd-logs-element-mixin;
+}
+
+.kd-logs-element {
+  font-size: $body-font-size-base;
+  @include kd-logs-element-mixin;
 }

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -37,8 +37,8 @@ $logs-color-white: #fff;
   font-size: $body-font-size-base;
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
-  
-  pre: {
+
+  pre {
     margin: 0;
   }
 }

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -29,12 +29,13 @@ $logs-color-white: #fff;
 
 .kd-logs-element-compact {
   font-size: $caption-font-size-base;
-  padding: 0 (2 * $baseline-grid);
-  word-wrap: break-word;
 }
 
 .kd-logs-element {
   font-size: $body-font-size-base;
+}
+
+.kd-logs-element, .kd-logs-element-compact {
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
 

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -37,11 +37,11 @@ $logs-color-white: #fff;
 }
 
 .kd-logs-element-compact {
-  font-size: $caption-font-size-base;
   @include kd-logs-element-mixin;
+  font-size: $caption-font-size-base;
 }
 
 .kd-logs-element {
-  font-size: $body-font-size-base;
   @include kd-logs-element-mixin;
+  font-size: $body-font-size-base;
 }

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -37,4 +37,8 @@ $logs-color-white: #fff;
   font-size: $body-font-size-base;
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
+  
+  pre: {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
This is what logs look like now: 

![screenshot 2016-07-27 20 52 59](https://cloud.githubusercontent.com/assets/613320/17200687/4f6ef77c-543c-11e6-82ae-e7abd9524148.png)

This is what they look like after this change: 

![screenshot 2016-07-27 20 53 22](https://cloud.githubusercontent.com/assets/613320/17200699/6241a750-543c-11e6-8409-a28273437ac6.png)

but honestly having a `<pre>` element for each line of log output seems pretty nonideal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1077)
<!-- Reviewable:end -->
