### PR TITLE
Add related Services to Replica Set Details page

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -543,4 +543,5 @@
 	<translation id="7091154364335994224" key="MSG_DAEMON_SET_LIST_NAMESPACE_LABEL" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Label 'Namespace' which appears as a column label in the table of daemon sets (daemon set list view).">Namespace</translation>
 	<translation id="4677646778972512564" key="MSG_RC_LIST_NAMESPACE_LABEL" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Label 'Namespace' which appears as a column label in the table of replication controllers (RC list view).">Namespace</translation>
 	<translation id="6106340570580081121" key="MSG_DAEMON_SET_DETAIL_SERVICES_TITLE" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Title 'Services' for the services information section on the daemon set detail page.">Services</translation>
+	<translation id="4440799155040620024" key="MSG_REPLICA_SET_DETAIL_SERVICES_TITLE" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Title 'Services' for the services information section on the replica set detail page.">Services</translation>
 </translationbundle>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -732,4 +732,5 @@
 	<translation id="910153156225182799" key="MSG_CONFIG_MAP_LIST_NAMESPACE_LABEL" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Config map list header: namespace.">Namespace</translation>
 	<translation id="6106340570580081121" key="MSG_DAEMON_SET_DETAIL_SERVICES_TITLE" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Title 'Services' for the services information section on the daemon set detail page.">Services</translation>
 	<translation id="6106340570580081121" key="MSG_DAEMON_SET_DETAIL_SERVICES_TITLE" source="/home/floreks/Projects/dashboard/.tmp/serve/app-dev.js" desc="Title 'Services' for the services information section on the daemon set detail page.">Services</translation>
+	<translation id="4440799155040620024" key="MSG_REPLICA_SET_DETAIL_SERVICES_TITLE" source="/home/denis/Projects/dashboard/.tmp/serve/app-dev.js" desc="Title 'Services' for the services information section on the replica set detail page.">Services</translation>
 </translationbundle>

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -652,6 +652,23 @@ func (apiHandler *APIHandler) handleGetReplicaSetPods(
 	response.WriteHeaderAndEntity(http.StatusCreated, result)
 }
 
+// Handles get Replica Set services API call.
+func (apiHandler *APIHandler) handleGetReplicaSetServices(
+	request *restful.Request, response *restful.Response) {
+
+	namespace := request.PathParameter("namespace")
+	replicaSet := request.PathParameter("replicaSet")
+	pagination := parsePaginationPathParameter(request)
+	result, err := replicaset.GetReplicaSetServices(apiHandler.client, pagination, namespace,
+		replicaSet)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+
+	response.WriteHeaderAndEntity(http.StatusCreated, result)
+}
+
 // Handles get Deployment list API call.
 func (apiHandler *APIHandler) handleGetDeployments(
 	request *restful.Request, response *restful.Response) {

--- a/src/app/backend/resource/replicaset/replicasetcommon.go
+++ b/src/app/backend/resource/replicaset/replicasetcommon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/service"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -60,7 +61,7 @@ func ToReplicaSet(replicaSet *extensions.ReplicaSet, podInfo *common.PodInfo) Re
 
 // ToReplicaSetDetail converts replica set api object to replica set detail model object.
 func ToReplicaSetDetail(replicaSet *extensions.ReplicaSet, eventList common.EventList,
-	podList pod.PodList, podInfo common.PodInfo) ReplicaSetDetail {
+	podList pod.PodList, podInfo common.PodInfo, serviceList service.ServiceList) ReplicaSetDetail {
 
 	return ReplicaSetDetail{
 		ObjectMeta:      common.NewObjectMeta(replicaSet.ObjectMeta),
@@ -68,8 +69,9 @@ func ToReplicaSetDetail(replicaSet *extensions.ReplicaSet, eventList common.Even
 		ContainerImages: common.GetContainerImages(&replicaSet.Spec.Template.Spec),
 		PodInfo:         podInfo,
 		// TODO(floreks): add pagination support
-		PodList:   podList,
-		EventList: eventList,
+		PodList:     podList,
+		ServiceList: serviceList,
+		EventList:   eventList,
 	}
 }
 

--- a/src/app/backend/resource/replicaset/replicasetdetail.go
+++ b/src/app/backend/resource/replicaset/replicasetdetail.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
+	resourceService "github.com/kubernetes/dashboard/src/app/backend/resource/service"
 )
 
 // ReplicaSetDetail is a presentation layer view of Kubernetes Replica Set resource. This means
@@ -36,6 +37,9 @@ type ReplicaSetDetail struct {
 
 	// Detailed information about Pods belonging to this Replica Set.
 	PodList pod.PodList `json:"podList"`
+
+	// Detailed information about service related to Replica Set.
+	ServiceList resourceService.ServiceList `json:"serviceList"`
 
 	// Container images of the Replica Set.
 	ContainerImages []string `json:"containerImages"`
@@ -70,6 +74,11 @@ func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.Heaps
 		return nil, err
 	}
 
-	replicaSet := ToReplicaSetDetail(replicaSetData, *eventList, *podList, *podInfo)
+	serviceList, err := GetReplicaSetServices(client, pQuery, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	replicaSet := ToReplicaSetDetail(replicaSetData, *eventList, *podList, *podInfo, *serviceList)
 	return &replicaSet, nil
 }

--- a/src/app/backend/resource/replicaset/replicasetservices.go
+++ b/src/app/backend/resource/replicaset/replicasetservices.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicaset
+
+import (
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/service"
+)
+
+// GetReplicaSetServices returns list of services that are related to replica set targeted by given
+// name.
+func GetReplicaSetServices(client client.Interface, pQuery *common.PaginationQuery,
+	namespace, name string) (*service.ServiceList, error) {
+
+	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	channels := &common.ResourceChannels{
+		ServiceList: common.GetServiceListChannel(client, common.NewSameNamespaceQuery(namespace),
+			1),
+	}
+
+	services := <-channels.ServiceList.List
+	if err := <-channels.ServiceList.Error; err != nil {
+		return nil, err
+	}
+
+	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
+		replicaSet.Spec.Selector.MatchLabels)
+	return service.CreateServiceList(matchingServices, pQuery), nil
+}

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -20,6 +20,14 @@ limitations under the License.
       <md-tab label="{{::ctrl.i18n.MSG_REPLICA_SET_DETAIL_OVERVIEW_LABEL}}">
         <kd-replica-set-info replica-set="::ctrl.replicaSetDetail"></kd-replica-set-info>
 
+        <kd-content-card ng-if="::ctrl.replicaSetDetail.serviceList.services.length">
+          <kd-title>{{::ctrl.i18n.MSG_REPLICA_SET_DETAIL_SERVICES_TITLE}}</kd-title>
+          <kd-content>
+            <kd-service-card-list service-list="::ctrl.replicaSetDetail.serviceList"
+                                  service-list-resource="::ctrl.replicaSetServicesResource">
+            </kd-service-card-list>
+          </kd-content>
+        </kd-content-card>
         <kd-content-card ng-if="::ctrl.replicaSetDetail.podList.pods.length">
           <kd-title>{{::ctrl.i18n.MSG_REPLICA_SET_DETAIL_PODS_TITLE}}</kd-title>
           <kd-content>

--- a/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_controller.js
@@ -18,14 +18,19 @@
 export class ReplicaSetDetailController {
   /**
    * @param {!backendApi.ReplicaSetDetail} replicaSetDetail
+   * @param {!angular.Resource} kdReplicaSetPodsResource
+   * @param {!angular.Resource} kdReplicaSetServicesResource
    * @ngInject
    */
-  constructor(replicaSetDetail, kdReplicaSetPodsResource) {
+  constructor(replicaSetDetail, kdReplicaSetPodsResource, kdReplicaSetServicesResource) {
     /** @export {!backendApi.ReplicaSetDetail} */
     this.replicaSetDetail = replicaSetDetail;
 
     /** @export {!angular.Resource} */
     this.replicaSetPodsResource = kdReplicaSetPodsResource;
+
+    /** @export {!angular.Resource} */
+    this.replicaSetServicesResource = kdReplicaSetServicesResource;
 
     /** @export */
     this.i18n = i18n;
@@ -36,6 +41,9 @@ const i18n = {
   /** @export {string} @desc Title 'Pods', which appears at the top of the pods list on the
       replica set details view. */
   MSG_REPLICA_SET_DETAIL_PODS_TITLE: goog.getMsg('Pods'),
+  /** @export {string} @desc Title 'Services' for the services information section on the replica set
+   *  detail page. */
+  MSG_REPLICA_SET_DETAIL_SERVICES_TITLE: goog.getMsg('Services'),
   /** @export {string} @desc Label 'Overview' for the left navigation tab on the replica
       set details page. */
   MSG_REPLICA_SET_DETAIL_OVERVIEW_LABEL: goog.getMsg('Overview'),

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -39,7 +39,8 @@ export default angular
     .config(stateConfig)
     .component('kdReplicaSetInfo', replicaSetInfoComponent)
     .factory('kdReplicaSetDetailResource', replicaSetDetailResource)
-    .factory('kdReplicaSetPodsResource', replicaSetPodsResource);
+    .factory('kdReplicaSetPodsResource', replicaSetPodsResource)
+    .factory('kdReplicaSetServicesResource', replicaSetServicesResource);
 
 /**
  * @param {!angular.$resource} $resource
@@ -57,4 +58,13 @@ function replicaSetDetailResource($resource) {
  */
 function replicaSetPodsResource($resource) {
   return $resource('api/v1/replicaset/:namespace/:name/pod');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
+function replicaSetServicesResource($resource) {
+  return $resource('api/v1/replicaset/:namespace/:name/service');
 }

--- a/src/test/backend/resource/replicaset/replicasetcommon_test.go
+++ b/src/test/backend/resource/replicaset/replicasetcommon_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/service"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -96,23 +97,26 @@ func TestToReplicaSet(t *testing.T) {
 
 func TestToReplicaSetDetail(t *testing.T) {
 	cases := []struct {
-		replicaSet *extensions.ReplicaSet
-		eventList  common.EventList
-		podList    pod.PodList
-		podInfo    common.PodInfo
-		expected   ReplicaSetDetail
+		replicaSet  *extensions.ReplicaSet
+		eventList   common.EventList
+		podList     pod.PodList
+		podInfo     common.PodInfo
+		serviceList service.ServiceList
+		expected    ReplicaSetDetail
 	}{
 		{
 			&extensions.ReplicaSet{},
 			common.EventList{},
 			pod.PodList{},
 			common.PodInfo{},
+			service.ServiceList{},
 			ReplicaSetDetail{TypeMeta: common.TypeMeta{Kind: common.ResourceKindReplicaSet}},
 		}, {
 			&extensions.ReplicaSet{ObjectMeta: api.ObjectMeta{Name: "replica-set"}},
 			common.EventList{Events: []common.Event{{Message: "event-msg"}}},
 			pod.PodList{Pods: []pod.Pod{{ObjectMeta: common.ObjectMeta{Name: "pod-1"}}}},
 			common.PodInfo{},
+			service.ServiceList{Services: []service.Service{{ObjectMeta: common.ObjectMeta{Name: "service-1"}}}},
 			ReplicaSetDetail{
 				ObjectMeta: common.ObjectMeta{Name: "replica-set"},
 				TypeMeta:   common.TypeMeta{Kind: common.ResourceKindReplicaSet},
@@ -122,16 +126,21 @@ func TestToReplicaSetDetail(t *testing.T) {
 						ObjectMeta: common.ObjectMeta{Name: "pod-1"},
 					}},
 				},
+				ServiceList: service.ServiceList{
+					Services: []service.Service{{
+						ObjectMeta: common.ObjectMeta{Name: "service-1"},
+					}},
+				},
 			},
 		},
 	}
 
 	for _, c := range cases {
-		actual := ToReplicaSetDetail(c.replicaSet, c.eventList, c.podList, c.podInfo)
+		actual := ToReplicaSetDetail(c.replicaSet, c.eventList, c.podList, c.podInfo, c.serviceList)
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("ToReplicaSetDetail(%#v, %#v, %#v, %#v) == \ngot %#v, \nexpected %#v",
-				c.replicaSet, c.eventList, c.podList, c.podInfo, actual, c.expected)
+				c.replicaSet, c.eventList, c.podList, c.podInfo, c.serviceList, actual, c.expected)
 		}
 	}
 }

--- a/src/test/backend/resource/replicaset/replicasetdetail_test.go
+++ b/src/test/backend/resource/replicaset/replicasetdetail_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/service"
 )
 
 type FakeHeapsterClient struct {
@@ -41,6 +42,7 @@ func (c FakeHeapsterClient) Get(path string) client.RequestInterface {
 func TestGetReplicaSetDetail(t *testing.T) {
 	eventList := &api.EventList{}
 	podList := &api.PodList{}
+	serviceList := &api.ServiceList{}
 
 	cases := []struct {
 		namespace, name string
@@ -50,7 +52,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 	}{
 		{
 			"test-namespace", "test-name",
-			[]string{"get", "list", "get", "list", "list", "get", "list", "list"},
+			[]string{"get", "list", "get", "list", "list", "get", "list", "list", "get", "list"},
 			&extensions.ReplicaSet{
 				ObjectMeta: api.ObjectMeta{Name: "test-replicaset"},
 				Spec: extensions.ReplicaSetSpec{
@@ -59,18 +61,19 @@ func TestGetReplicaSetDetail(t *testing.T) {
 					}},
 			},
 			&ReplicaSetDetail{
-				ObjectMeta: common.ObjectMeta{Name: "test-replicaset"},
-				TypeMeta:   common.TypeMeta{Kind: common.ResourceKindReplicaSet},
-				PodInfo:    common.PodInfo{Warnings: []common.Event{}},
-				PodList:    pod.PodList{Pods: []pod.Pod{}},
-				EventList:  common.EventList{Events: []common.Event{}},
+				ObjectMeta:  common.ObjectMeta{Name: "test-replicaset"},
+				TypeMeta:    common.TypeMeta{Kind: common.ResourceKindReplicaSet},
+				PodInfo:     common.PodInfo{Warnings: []common.Event{}},
+				PodList:     pod.PodList{Pods: []pod.Pod{}},
+				ServiceList: service.ServiceList{Services: []service.Service{}},
+				EventList:   common.EventList{Events: []common.Event{}},
 			},
 		},
 	}
 
 	for _, c := range cases {
-		fakeClient := testclient.NewSimpleFake(c.replicaSet, podList, eventList, c.replicaSet,
-			podList, eventList)
+		fakeClient := testclient.NewSimpleFake(c.replicaSet, podList, serviceList, eventList, c.replicaSet,
+			podList, serviceList, eventList)
 		fakeHeapsterClient := FakeHeapsterClient{client: testclient.NewSimpleFake()}
 
 		actual, _ := GetReplicaSetDetail(fakeClient, fakeHeapsterClient, common.NoPagination,


### PR DESCRIPTION
Replica Set Details now includes a section with related Services
#1087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1088)
<!-- Reviewable:end -->
