### PR TITLE
Added graph backend

### DIFF
--- a/src/app/backend/resource/graph/aggregation.go
+++ b/src/app/backend/resource/graph/aggregation.go
@@ -1,0 +1,120 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"sort"
+)
+
+// Aggregate modes which should be used for data aggregation. Eg. [sum, min, max].
+type Aggregate []string
+
+var AggregatingFunctions = map[string]func([]int64) (int64){
+	"sum": SumAggregate,
+	"max": MaxAggregate,
+	"min": MinAggregate,
+	"default": SumAggregate,
+}
+
+// SortableInt64 implements sort.Interface for []int64. This allows to use built in sort with int64.
+type SortableInt64 []int64
+func (a SortableInt64) Len() int {return len(a)}
+func (a SortableInt64) Swap(i, j int) {a[i], a[j] = a[j], a[i]}
+func (a SortableInt64) Less(i, j int) bool {return a[i] < a[j]}
+
+
+// AggregateData aggregates all the data from dataList using AggregatingFunction with name aggregateName.
+// Standard data aggregation function.
+func AggregateData(dataList DataList, metrics Metrics, aggregateName string, drill *Drill) (DataList) {
+	_, isAggregateAvailable := AggregatingFunctions[aggregateName]
+	if !isAggregateAvailable {
+		aggregateName = "default"
+	}
+	newDataList := DataList{}
+	for _, metric := range metrics {
+		aggrMap := AggregatingMapFromDataList(dataList, metric)
+		Xs := SortableInt64{}
+		for k, _ := range aggrMap {
+			Xs = append(Xs, k)
+		}
+		newDataPoints := []DataPoint{}
+		sort.Sort(Xs) // ensure X data points are sorted
+		for _, x := range Xs {
+			y := AggregatingFunctions[aggregateName](aggrMap[x])
+			newDataPoints = append(newDataPoints, DataPoint{x, y})
+		}
+
+		// Create new data cell
+		newData := Data{
+			Metric: metric,
+			Drill: *drill,
+			DataPoints: newDataPoints,
+			Aggregate: aggregateName,
+		}
+		newDataList = append(newDataList, newData)
+	}
+	return newDataList
+}
+
+// AggregatingMapFromDataList for all Data entries of given metric generates a cumulative map X -> [List of all Ys at this X].
+// Afterwards this list of Ys can be easily aggregated.
+func AggregatingMapFromDataList(dataList DataList, metric string) (map[int64][]int64){
+	aggrMap := make(map[int64][]int64, 0)
+	for _, data := range dataList {
+		if data.Metric != metric {
+			continue
+		}
+		for _, dataPoint := range data.DataPoints {
+			_, isXPresent := aggrMap[dataPoint.X]
+			if !isXPresent {
+				aggrMap[dataPoint.X] = []int64{}
+			}
+			aggrMap[dataPoint.X] = append(aggrMap[dataPoint.X], dataPoint.Y)
+		}
+
+	}
+	return aggrMap
+}
+
+
+// Implement aggregating functions:
+
+func SumAggregate(values []int64) int64 {
+	result := int64(0)
+	for _, e := range values {
+		result += e
+	}
+	return result
+}
+
+func MaxAggregate(values []int64) int64 {
+	result := values[0]
+	for _, e := range values {
+		if e > result {
+			result = e
+		}
+	}
+	return result
+}
+
+func MinAggregate(values []int64) int64 {
+	result := values[0]
+	for _, e := range values {
+		if e < result {
+			result = e
+		}
+	}
+	return result
+}

--- a/src/app/backend/resource/graph/downloader.go
+++ b/src/app/backend/resource/graph/downloader.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"github.com/kubernetes/dashboard/src/app/backend/client"
+)
+
+// CollectHeapsterData is a downloader function that can talk and download data from heapster.
+// Heapster understands only few resources - pods, nodes, namespaces, containers - so you can only download these resources
+// (I call them native resources). This is quite limiting because,  we also want to download data for other resources.
+// In case you want to download data for resources not present in heapster (derived resources) you can use
+// ExecuteDataQueries function which accepts accepts more complex queries and supports download of derived resources by
+// simply translating derived resources to native resources.
+func CollectHeapsterData(heapsterClient client.HeapsterClient, nativeSelection NativeSelection, metrics Metrics) (DataList, error) {
+        // Depending on the query there is a specific order in which resources should be requested from heapster
+	// determine this order here
+	resolutionOrder := FakeDrillFromSelection(nativeSelection).GetResourceResolutionOrder()
+	drill := Drill{}
+	depth := 0
+
+	extractedDataPromiseList, err := extractAll(heapsterClient, nativeSelection, resolutionOrder, drill, depth, metrics)
+	if err != nil {
+		return nil, err
+	}
+	// extract the data from DataPromise channels.
+	extractedDataList := DataList{}
+	for _, dataPromise := range extractedDataPromiseList {
+		err := <- dataPromise.Error
+		if err != nil {
+			return nil, err
+		}
+		extractedDataList = append(extractedDataList, *(<- dataPromise.Data))
+	}
+	return extractedDataList, nil
+}
+
+// Helper function for CollectHeapsterData. Downloads all the data and returns a DataPromise list (download is done in parallel).
+func extractAll(heapsterClient client.HeapsterClient, nativeSelection NativeSelection, resolutionOrder []string, drill Drill, depth int, m Metrics) ([]DataPromise, error) {
+	if len(resolutionOrder) == depth {
+		// download metrics and return
+		return drill.DownloadMetrics(heapsterClient, m), nil
+	} else {
+		// we have to go deeper to reach requested resource download type.
+		resourceName := resolutionOrder[depth]
+		var toExtract []string
+		var err error
+		if len(nativeSelection[resourceName]) == 0 {
+			// if no resourceName provided then just select all available resources
+			toExtract, err = drill.GetAvailableResources(heapsterClient, resourceName)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			toExtract = nativeSelection[resourceName]
+			err = nil
+		}
+		result := []DataPromise{}
+		// collect and aggregate data for all the resources from toExtract.
+		for _, resourceValue := range toExtract {
+			deeperdrill := drill.Copy()
+			deeperdrill[resourceName] = resourceValue
+			extracted, err := extractAll(heapsterClient, nativeSelection, resolutionOrder, deeperdrill, depth + 1, m)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, extracted...)
+		}
+		return result, nil
+	}
+}

--- a/src/app/backend/resource/graph/drill.go
+++ b/src/app/backend/resource/graph/drill.go
@@ -1,0 +1,276 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"time"
+	"github.com/kubernetes/dashboard/src/app/backend/client"
+	"errors"
+	"encoding/json"
+	"strings"
+)
+
+type DataList []Data
+
+// Data is a format of data used in this module. This is also the format of data that is being sent by backend API.
+type Data struct {
+	DataPoints    `json:"dataPoints"`
+	Metric    string `json:"metric"`
+	// Drill used to download the data
+	Drill     `json:"drill"`
+	// aggregating function used (if any)
+	Aggregate string `json:"aggregate,omitempty"`
+}
+
+// DataPromise is used for parallel data extraction. Contains len 1 channels for Data and Error.
+type DataPromise struct {
+	Data chan *Data
+	Error chan error
+}
+
+type Metrics []string
+
+type DataPoints []DataPoint
+
+type DataPoint struct {
+	X int64 `json:"x"`
+	Y int64    `json:"y"`
+}
+
+// NativeSelection containing resources natively supported by heapster
+// for example {"pods": ["pod1", "pod2", ...], namespaces: ["kube-system"]}
+// Check NativeResourceDependencies map to get a full list of supported native resources.
+type NativeSelection map[string][]string
+
+func (s *NativeSelection) Copy() (NativeSelection) {
+	copy := NativeSelection{}
+	for k, v := range *s {
+		if v == nil {
+			copy[k] = v
+			continue
+		}
+		nv := []string{}
+		for _, e := range v {
+			nv = append(nv, e)
+		}
+		copy[k] = nv
+	}
+	return copy
+}
+
+// DerivedSelection containing resources not natively supported by heapster
+// for example {"deployments": ["deployment1", "deployment2", ...]}
+// Check DerivedResources map to get a full list of supported derived resources.
+type DerivedSelection map[string][]string
+
+// NativeResourceDependencies represents heapster data model.
+var NativeResourceDependencies = map[string]string{
+//	"nodes": "",  // removed nodes as main resource! Now metrics for them will be provided as a sum of metrics from their pods
+	"namespaces": "",
+	"pods": "namespaces",
+	"containers": "pods",
+}
+
+
+// HeapsterJSONFormat represents format of JSON provided by heapster.
+type HeapsterJSONFormat struct {
+	RawDataPoints []RawDataPoint `json:"metrics"`
+}
+
+type RawDataPoint struct {
+	Timestamp string `json:"timestamp"`
+	Value     int64 `json:"value"`
+}
+
+
+// Drill contains the map of resourceType, resourceName pairs that define the resource for which we should perform heapster operations
+// like for example data download, listing all metrics etc. ResourceTypes MUST be in NativeResourceDependencies, otherwise heapster will not understand.
+type Drill map[string]string
+
+// ResolveDependency is a general dependency resolution algorithm.
+func ResolveDependency(dep string, resolved []string, unresolved []string, depMap map[string]string) ([]string, []string, error) {
+	if isInsideArray(dep, resolved) {
+		return resolved, unresolved, nil
+	}
+	// check for circular dep
+	if isInsideArray(dep, unresolved) {
+		return nil, nil, errors.New("Intrernal Error: circular resource dependency detected")
+	}
+	if NativeResourceDependencies[dep] != "" {
+		unresolved = append(unresolved, dep)
+		var err error
+		resolved, unresolved, err = ResolveDependency(NativeResourceDependencies[dep], resolved, unresolved, depMap)
+		unresolved = unresolved[:len(unresolved) - 1]
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	resolved = append(resolved, dep)
+	return resolved, unresolved, nil
+
+}
+
+//
+// GetResourceResolutionOrder determines resource download order from heapster.
+// For example namespace must be selected before pods and pods have to be selected before containers.
+// This makes my design very general so in case heapster adds new resources, we will just need to add the dependencies to the
+// NativeResourceDependencies map.
+func (ds *Drill) GetResourceResolutionOrder() ([]string) {
+	resolved := []string{}
+	unresolved := []string{}
+	for dependency, _ := range *ds {
+		var err error
+		resolved, unresolved, err = ResolveDependency(dependency, resolved, unresolved, NativeResourceDependencies)
+		if err != nil {
+			return nil
+		}
+	}
+	return resolved
+}
+
+// GetTerminalPath converts this drill to its heapster path.
+func (ds *Drill) GetTerminalPath() (string) {
+	path := "/model/"
+	order := ds.GetResourceResolutionOrder()
+	for _, e := range order {
+		path += e + "/" + (*ds)[e] + "/"
+	}
+	return path
+}
+
+// GetAvailableMetrics lists all the metrics available for this drill.
+func (ds *Drill) GetAvailableMetrics(client client.HeapsterClient) ([]string, error) {
+	return heapsterUnmarshalStringList(client, ds.GetTerminalPath() + "metrics/")
+}
+
+// GetAvailableResources lists all the resource names available for this drill.
+func (ds *Drill) GetAvailableResources(client client.HeapsterClient, resourceName string) ([]string, error) {
+	return heapsterUnmarshalStringList(client, ds.GetTerminalPath() + resourceName + "/")
+}
+
+// DownloadMetric downloads one metric for this drill from heapster and returns it as a DataPromise (returns instantly).
+func (ds *Drill) DownloadMetric(client client.HeapsterClient, metric string) (DataPromise) {
+        dataPromise := DataPromise{
+		Data: make(chan *Data, 1),
+		Error: make(chan error, 1),
+	}
+	go func() {
+		currentRawResult := HeapsterJSONFormat{}
+		err := heapsterUnmarshalType(client, ds.GetTerminalPath() + "metrics/" + metric, &currentRawResult)
+		if err != nil {
+			dataPromise.Data <- nil
+			dataPromise.Error <- err
+			return
+		}
+		dataPoints, err := DataPointsFromMetricJSONFormat(currentRawResult)
+		if err != nil {
+			dataPromise.Data <- nil
+			dataPromise.Error <- err
+			return
+		}
+		// now put all inside data
+		data := Data{}
+		data.DataPoints = dataPoints
+		data.Drill = ds.Copy()
+		data.Metric = metric
+		dataPromise.Data <- &data
+		dataPromise.Error <- nil
+		return
+
+	}()
+	return dataPromise
+}
+
+// DownloadMetrics downloads the metrics provided in parallel and returns DataPromise list.
+func (ds *Drill) DownloadMetrics(client client.HeapsterClient, metrics Metrics) ([]DataPromise) {
+	result := []DataPromise{}
+	for _, metric := range metrics {
+		result = append(result, ds.DownloadMetric(client, metric))
+	}
+	return result
+}
+
+// Copy the drill.
+func (ds *Drill) Copy() (Drill) {
+	copy := Drill{}
+	for k, v := range *ds {
+		copy[k] = v
+	}
+	return copy
+}
+
+// FakeDrillFromSelection converts selection to drill. Useful if you want to determine resource download order (because Drill
+// provides appropriate method) or if you want to add label to the downloaded data.
+func FakeDrillFromSelection(s NativeSelection) *Drill {
+	result := Drill{}
+	for k, v := range s {
+		result[k] = strings.Join(v, ",")
+	}
+	return &result
+}
+
+
+
+// DataPointsFromMetricJSONFormat converts all the data points from format used by heapster to our format.
+func DataPointsFromMetricJSONFormat(raw HeapsterJSONFormat) (DataPoints, error) {
+	dp := DataPoints{}
+	for _, raw := range raw.RawDataPoints {
+		parsed, err := DataPointFromRawDataPoint(raw)
+		if err != nil {
+			return nil, err
+		}
+		dp = append(dp, parsed)
+	}
+	return dp, nil
+}
+
+// DataPointFromRawDataPoint converts raw data point supplied by heapster to our internal format.
+func DataPointFromRawDataPoint(r RawDataPoint) (DataPoint, error) {
+	d := DataPoint{}
+	t, err := time.Parse(time.RFC3339, r.Timestamp)
+	if err != nil {
+		return d, err
+	}
+	d.X = t.Unix()
+	d.Y = r.Value
+	return d, nil
+}
+
+// Performs heapster GET request to the specifies path and transfers the data to the interface provided.
+func heapsterUnmarshalType(client client.HeapsterClient, path string, v interface{}) error {
+	rawData, err := client.Get(path).DoRaw()
+	if err != nil {
+		return err
+	}
+	json.Unmarshal(rawData, v)
+	return nil
+}
+
+// Performs heapster GET request to the specifies path and returns the data it as a string list.
+func heapsterUnmarshalStringList(client client.HeapsterClient, path string) ([]string, error) {
+	result := make([]string, 0)
+	err := heapsterUnmarshalType(client, path, &result)
+	return result, err
+}
+
+// checks whether string value is present in the array.
+func isInsideArray(value string, array []string) (bool) {
+	for _, e := range array {
+		if (value == e) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/app/backend/resource/graph/labelgetters.go
+++ b/src/app/backend/resource/graph/labelgetters.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// ResourceLabelGetters map contains label getters for selected resources.
+// Label getter has a standard interface:
+// func(client k8sClient.Interface, namespace string, resourceNameInNamespace string)(labels.Set, error)
+// Labels returned by these getters can then be used to for example select all pods belonging to that resource.
+var ResourceLabelGetters = map[string]func(k8sClient.Interface, string, string)(labels.Set, error){
+	"deployments": getDeploymentLabel,
+	"deamonsets": getDeamonSetLabel,
+	"replicasets": getReplicaSetLabel,
+	"replicationcontrollers": getReplicationControllerLabel,
+}
+
+
+// Implementation of label getters:
+
+func getDeploymentLabel(client k8sClient.Interface, namespace string, name string) (labels.Set, error) {
+	replicationController, err := client.Extensions().Deployments(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return replicationController.Spec.Selector.MatchLabels, nil
+}
+
+func getDeamonSetLabel(client k8sClient.Interface, namespace string, name string) (labels.Set, error) {
+	replicationController, err := client.Extensions().DaemonSets(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return replicationController.Spec.Selector.MatchLabels, nil
+}
+
+func getReplicaSetLabel(client k8sClient.Interface, namespace string, name string) (labels.Set, error) {
+	replicationController, err := client.Extensions().ReplicaSets(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return replicationController.Spec.Selector.MatchLabels, nil
+}
+
+func getReplicationControllerLabel(client k8sClient.Interface, namespace string, name string) (labels.Set, error) {
+	replicationController, err := client.ReplicationControllers(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return replicationController.Spec.Selector, nil
+}

--- a/src/app/backend/resource/graph/query.go
+++ b/src/app/backend/resource/graph/query.go
@@ -1,0 +1,208 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"github.com/kubernetes/dashboard/src/app/backend/client"
+	"strings"
+	"errors"
+	"fmt"
+)
+
+// DataQuery contains data download and processing instructions.
+type DataQuery struct {
+	Namespace        string
+	SummingResource  string
+	NativeSelection  NativeSelection
+	DerivedSelection DerivedSelection
+	Aggregate        Aggregate
+	Metrics          Metrics
+	RawDrill         *Drill
+}
+
+// DataListPromise is a structure holding DataList and error channels.
+type DataListPromise struct {
+	List chan DataList
+	Error chan error
+}
+
+// Resource names are not unique across different namespaces so we have to convert selector with
+// multiple namespaces into selectors with one namespace each.
+func expandNamespaces(query DataQuery) ([]DataQuery, error) {
+	namespaces, isNamespacesPresent := query.NativeSelection["namespaces"]
+	if !isNamespacesPresent {
+		return nil, errors.New(`namespaces must be specified in graph query, if you want all user namespaces just leave the field empty ie. namespaces=`)
+	} else if len(namespaces) == 0 {
+		return nil, errors.New(`Sorry, all user namespaces option is not supported yet, please specify the namespaces manually!`)
+	}
+	queries := []DataQuery{}
+	for _, namespace := range namespaces {
+		newQuery := DataQuery{
+			Namespace:         query.Namespace,
+			SummingResource:   query.SummingResource,
+			NativeSelection:   query.NativeSelection.Copy(),
+			DerivedSelection:  query.DerivedSelection,
+			Aggregate:         query.Aggregate,
+			Metrics:           query.Metrics,
+			RawDrill:          query.RawDrill,
+		}
+
+		newQuery.NativeSelection["namespaces"] = []string{namespace}
+		newQuery.Namespace = namespace
+
+		queries = append(queries, newQuery)
+	}
+	return queries, nil
+}
+
+// Executes single data query and returns a data promise list (done in parallel).
+// NOTE: does not process the data - only downloads.
+func executeDataQuery(heapsterClient client.HeapsterClient, client k8sClient.Interface, dataQuery DataQuery) (DataListPromise) {
+	dataListPromise := DataListPromise{
+		List:  make(chan DataList, 1),
+		Error: make(chan error, 1),
+	}
+	go func() {
+		translatedSelection, err := getFullNativeSelection(client, dataQuery)
+		if err != nil {
+			dataListPromise.List <- nil
+			dataListPromise.Error <- err
+			return
+		}
+		dataList, err := CollectHeapsterData(heapsterClient, translatedSelection, dataQuery.Metrics)
+		dataListPromise.List <- dataList
+		dataListPromise.Error <- err
+	}()
+	return dataListPromise
+}
+
+
+// ExecuteDataQueries downloads all the required data in parallel and processes resulting data as instructed in data query.
+func ExecuteDataQueries(heapsterClient client.HeapsterClient, client k8sClient.Interface, dataQueries []DataQuery) (DataList, error) {
+	if dataQueries == nil || len(dataQueries) == 0 {
+		return nil, nil
+	}
+	dataListPromiseList := []DataListPromise{}
+	for _, dataQuery := range dataQueries {
+		dataListPromiseList = append(dataListPromiseList, executeDataQuery(heapsterClient, client, dataQuery))
+	}
+	dataList := DataList{}
+	for _, dataListPromise := range dataListPromiseList {
+		err := <- dataListPromise.Error
+		if err != nil {
+			return nil, err
+		}
+		dataList = append(dataList, (<- dataListPromise.List)...)
+	}
+	aggregate := dataQueries[0].Aggregate
+	if len(aggregate) == 0 {
+		return dataList, nil
+	}
+	// Aggregate everything
+	aggregatedDataList := DataList{}
+	for _, aggregateName := range aggregate {
+		aggregatedDataList = append(aggregatedDataList, AggregateData(dataList, dataQueries[0].Metrics,
+			aggregateName, dataQueries[0].RawDrill)...)
+	}
+	return aggregatedDataList, nil
+}
+
+// ExecuteRawQuery executes raw query from the GET request and returns resulting data list.
+func ExecuteRawQuery(heapsterClient client.HeapsterClient, client k8sClient.Interface, raw_query map[string][]string) (DataList, error) {
+	dataQueries, err := ParseQuery(client, raw_query)
+	if err != nil {
+		return nil, err
+	}
+	return ExecuteDataQueries(heapsterClient, client, dataQueries)
+}
+
+// ParseQuery parses query from the GET request and returns DataQuery list which is accepted by downloader function.
+func ParseQuery(client k8sClient.Interface, q map[string][]string) ([]DataQuery, error) {
+	baseDataQuery := DataQuery{}
+
+	// Native resources
+	native := NativeSelection{}
+	for k, v := range q {
+		_, isResourceName := NativeResourceDependencies[k]
+		if isResourceName {
+			if v == nil || len(v) == 0 || v[0] == "" {
+				native[k] = []string{}
+			} else {
+				native[k] = strings.Split(v[0], ",")
+			}
+		}
+	}
+	baseDataQuery.NativeSelection = native
+	baseDataQuery.RawDrill = FakeDrillFromSelection(native)
+
+	// Metrics
+	metrics, metricsPresent := q["metrics"]
+	if !metricsPresent || len(metrics) == 0 {
+		metrics = []string{}
+	} else {
+		metrics = strings.Split(metrics[0], ",")
+	}
+	baseDataQuery.Metrics = metrics
+
+	// Aggregate
+	aggregate, aggregatePresent := q["aggregate"]
+	if !aggregatePresent || len(aggregate) == 0 {
+		aggregate = []string{}
+	} else {
+		aggregate = strings.Split(aggregate[0], ",")
+	}
+	baseDataQuery.Aggregate = aggregate
+
+	// Derived resources
+	derived := DerivedSelection{}
+	summingResource := ""
+	for k, v := range q {
+		_, isDerivedResourceName := DerivedResources[k]
+		if isDerivedResourceName {
+			if summingResource == "" {
+				summingResource = DerivedResources[k]
+			} else if DerivedResources[k] != summingResource {
+				// cannot sum incompatible resources
+				return nil, fmt.Errorf(`Some of chosen derived resources use conflicting summing resources: "%s" and "%s"`, k, summingResource)
+			}
+			if v == nil || len(v) == 0 || v[0] == "" {
+				return nil, fmt.Errorf(`Getting all resources by specifying empty derived resource "%s" is not yet supported!`, k)
+			} else {
+				derived[k] = strings.Split(v[0], ",")
+			}
+		}
+	}
+	if summingResource == "" {  // no derived resources, simple query
+		baseDataQuery.DerivedSelection = derived
+	} else {  // query uses derived resources that have to be translated to native resources later
+		// validate NativeResources selection...
+		summingDependencies, _, err := ResolveDependency(summingResource, []string{}, []string{}, NativeResourceDependencies)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range baseDataQuery.NativeSelection {
+			if !isInsideArray(k, summingDependencies) {
+				return nil, fmt.Errorf(`Resource "%s" is conflicting with summing resource "%s"`, k, summingResource)
+			} else if k == summingResource && len(v) != 0 {
+				return nil, fmt.Errorf(`Forbidden to specify resources for summing resource "%s"`, summingResource)
+			}
+		}
+		baseDataQuery.DerivedSelection = derived
+		baseDataQuery.SummingResource = summingResource
+	}
+	return expandNamespaces(baseDataQuery)
+}

--- a/src/app/backend/resource/graph/resourcenamegetters.go
+++ b/src/app/backend/resource/graph/resourcenamegetters.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/api"
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"fmt"
+)
+
+
+// ResourceNameGetters is a map holding name getters for different resource types
+// For example getFullXYZNameList - returns full list of names of XYZ resources belonging to another resource.
+var ResourceNameGetters = map[string]func(k8sClient.Interface, string, string, string)([]string, error){
+	"pods": getFullPodNameList,
+}
+
+// Gets full list of pod names for given resourceType (eg "deployments") and resourceName under some namespace( eg name of deployment)
+// Supported resourceTypes are those defined in ResourceLabelGetters.
+func getFullPodNameList(client k8sClient.Interface, resourceName string, namespace string, resourceValue string) ([]string, error) {
+	podList, err := getFullPodList(client, resourceName, namespace, resourceValue)
+	if err != nil {
+		return nil, err
+	}
+	return podListToNameList(podList), nil
+}
+
+// Converts list of pods to the list of pod names.
+func podListToNameList(podList []api.Pod) ([]string) {
+	result := []string{}
+	for _, pod := range podList {
+		result = append(result, pod.ObjectMeta.Name)
+	}
+	return result
+}
+
+// Gets full list of pods for given resourceType (eg "deployments") and resourceName under some namespace( eg name of deployment)
+// Supported resourceTypes are those defined in ResourceLabelGetters.
+func getFullPodList(client k8sClient.Interface, resourceType string, namespace string, resourceName string) ([]api.Pod, error) {
+	// choose the appropriate labelGetter for this resourceType
+	labelGetter, isLabelGetterPresent :=  ResourceLabelGetters[resourceType]
+	if !isLabelGetterPresent {
+		return nil, fmt.Errorf(`Label getter is not present for resourse "%s"`, resourceType)
+	}
+	// Use the labelGetter to get label of this resource
+	label, err := labelGetter(client, namespace, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	// Use the label to select all pods belonging to this resource.
+	labelSelector := labels.SelectorFromSet(label)
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(namespace),
+			api.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: fields.Everything(),
+			}, 1),
+	}
+	podList := <-channels.PodList.List
+	if err := <-channels.PodList.Error; err != nil {
+		return nil, err
+	}
+	return podList.Items, nil
+}

--- a/src/app/backend/resource/graph/resourcetranslation.go
+++ b/src/app/backend/resource/graph/resourcetranslation.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	k8sClient "k8s.io/kubernetes/pkg/client/unversioned"
+	"fmt"
+)
+
+
+// DerivedResources do not exist in heapster. Calculate metrics for them as a sum of metrics of contained resources.
+var DerivedResources = map[string]string{
+	"deployments": "pods",
+	"deamonsets": "pods",
+	"replicasets": "pods",
+	"replicationcontrollers": "pods",
+}
+
+
+// Converts dataQuery which contains derived resources (it is resources that
+// are not available in heapster eg. deployments) to resources supported by heapster - to native heapster resources.
+// The process is rather simple. If the user chose certain deployment for example deploymentXYZ then we will just download
+// metrics for all pods belonging to that deployment and aggregate them to get the metrics for deploymentXYZ.
+func getFullNativeSelection(client k8sClient.Interface, dataQuery DataQuery) (NativeSelection, error) {
+	// Check if query contains any derived resources. If not then no conversion is required and just return
+	// its native selection.
+	if dataQuery.SummingResource == "" {
+		return dataQuery.NativeSelection.Copy(), nil
+	}
+	// List containing a list of names of summingResource that should be downloaded
+	var finalResourceList []string
+	initialisedFinalResourceList := false
+	// resource name getter that translates derived resource to the list of contained native resources
+	resourceNameListGetter, isGetterPresent := ResourceNameGetters[dataQuery.SummingResource]
+	if !isGetterPresent {
+		return nil, fmt.Errorf(`Resource name list getter is not available for summing resource "%s"`, dataQuery.SummingResource)
+	}
+	for resourceName, resourceValueList := range dataQuery.DerivedSelection {
+		if len(resourceValueList) == 0 {
+			// maybe todo(@pdabkowski) - download all available resources here and remove error from query parse in case of empty derived resource list
+			return nil, fmt.Errorf("how did you get here?")
+		}
+		resourceList := []string{}
+		for _, derivedResourceValue := range resourceValueList {
+			matchedResourceNames, err  := resourceNameListGetter(client, resourceName, dataQuery.Namespace, derivedResourceValue)
+			if err != nil { // todo(@pdabkowski) - maybe just ignore the error if a resource could not be found?...
+				return nil, err
+			}
+			resourceList = append(resourceList, matchedResourceNames...)
+		}
+		// continuously calculate intersection between resource names
+		if !initialisedFinalResourceList {
+			finalResourceList = resourceList
+		} else {
+			temp := []string{}
+			for _, resource := range resourceList {
+				if isInsideArray(resource, finalResourceList) {
+					temp = append(temp, resource)
+				}
+			}
+			finalResourceList = temp
+		}
+	}
+	// Check if any resource satisfies the query. If no resources satisfied the query then dont download anything.
+	// Unfortunately if we return empty list then data downloader will download all the resources so we have
+	// to use trick to not download anything - just return invalid name
+	if finalResourceList == nil || len(finalResourceList) == 0 {
+		finalResourceList = []string{"No/Resources/Matched/Just/Download/Nothing"}
+	}
+
+	// Instruct data downloader to download matched native resources.
+	fullNativeSelection := dataQuery.NativeSelection.Copy()
+	fullNativeSelection[dataQuery.SummingResource] = finalResourceList
+	return fullNativeSelection, nil
+}


### PR DESCRIPTION
Backend allows to download any metrics available in heapster for specified resources.
Supports most resources, new resources easy to add. Can perform
automatic aggregation of the data.

### Usage Example 

To get memory and cpu usage from all pods in kube-system and default namespaces you can use:
http://0.0.0.0:9090/api/v1/graph?metrics=cpu/usage_rate,memory/usage&namespaces=kube-system,default&pods=

And to aggregate this data:
http://0.0.0.0:9090/api/v1/graph?metrics=cpu/usage_rate,memory/usage&namespaces=kube-system,default&pods=&aggregate=sum

Similarly, to get and aggregate all memory and cpu consumption of few deployments (ie. all their pods):
http://0.0.0.0:9090/api/v1/graph?metrics=cpu/usage_rate,memory/usage&namespaces=some_namespace&deployments=deployment1,deployment2&aggregate=sum

Note: you have to comment out both `--heapster-host=` lines inside build/serve.js  to enable heapster metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1090)
<!-- Reviewable:end -->
