### PR TITLE
Added backend sort support to all resources

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -1231,5 +1231,5 @@ func parseSortPathParameter(request *restful.Request) *common.SortQuery {
 func parseDataSelectPathParameter(request *restful.Request) *common.DataSelectQuery {
 	paginationQuery := parsePaginationPathParameter(request)
 	sortQuery := parseSortPathParameter(request)
-	return common.NewDataSelect(paginationQuery, sortQuery)
+	return common.NewDataSelectQuery(paginationQuery, sortQuery)
 }

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -387,8 +387,8 @@ func CreateHTTPAPIHandler(client *clientK8s.Client, heapsterClient client.Heapst
 func (apiHandler *APIHandler) handleGetPetSetList(request *restful.Request,
 	response *restful.Response) {
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := petset.GetPetSetList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := petset.GetPetSetList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -402,9 +402,9 @@ func (apiHandler *APIHandler) handleGetPetSetDetail(request *restful.Request,
 	response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	name := request.PathParameter("petset")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := petset.GetPetSetDetail(apiHandler.client, apiHandler.heapsterClient,
-		namespace, name, pagination)
+		namespace, name, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -417,9 +417,9 @@ func (apiHandler *APIHandler) handleGetPetSetPods(request *restful.Request,
 	response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	name := request.PathParameter("petset")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := petset.GetPetSetPods(apiHandler.client, apiHandler.heapsterClient,
-		pagination, name, namespace)
+		dataSelect, name, namespace)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -430,8 +430,8 @@ func (apiHandler *APIHandler) handleGetPetSetPods(request *restful.Request,
 // Handles get service list API call.
 func (apiHandler *APIHandler) handleGetServiceList(request *restful.Request, response *restful.Response) {
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := resourceService.GetServiceList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := resourceService.GetServiceList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -444,9 +444,9 @@ func (apiHandler *APIHandler) handleGetServiceList(request *restful.Request, res
 func (apiHandler *APIHandler) handleGetServiceDetail(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	service := request.PathParameter("service")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := resourceService.GetServiceDetail(apiHandler.client, apiHandler.heapsterClient,
-		namespace, service, pagination)
+		namespace, service, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -460,9 +460,9 @@ func (apiHandler *APIHandler) handleGetServicePods(request *restful.Request,
 
 	namespace := request.PathParameter("namespace")
 	service := request.PathParameter("service")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := resourceService.GetServicePods(apiHandler.client, apiHandler.heapsterClient,
-		namespace, service, pagination)
+		namespace, service, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -472,8 +472,8 @@ func (apiHandler *APIHandler) handleGetServicePods(request *restful.Request,
 
 // Handles get node list API call.
 func (apiHandler *APIHandler) handleGetNodeList(request *restful.Request, response *restful.Response) {
-	pagination := parsePaginationPathParameter(request)
-	result, err := node.GetNodeList(apiHandler.client, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := node.GetNodeList(apiHandler.client, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -589,8 +589,8 @@ func (apiHandler *APIHandler) handleGetReplicationControllerList(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := replicationcontroller.GetReplicationControllerList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := replicationcontroller.GetReplicationControllerList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -604,9 +604,9 @@ func (apiHandler *APIHandler) handleGetWorkloads(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := workload.GetWorkloads(apiHandler.client, apiHandler.heapsterClient, namespace,
-		pagination)
+		dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -620,8 +620,8 @@ func (apiHandler *APIHandler) handleGetReplicaSets(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := replicaset.GetReplicaSetList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := replicaset.GetReplicaSetList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -636,9 +636,9 @@ func (apiHandler *APIHandler) handleGetReplicaSetDetail(
 
 	namespace := request.PathParameter("namespace")
 	replicaSet := request.PathParameter("replicaSet")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := replicaset.GetReplicaSetDetail(apiHandler.client, apiHandler.heapsterClient,
-		pagination, namespace, replicaSet)
+		dataSelect, namespace, replicaSet)
 
 	if err != nil {
 		handleInternalError(response, err)
@@ -654,9 +654,9 @@ func (apiHandler *APIHandler) handleGetReplicaSetPods(
 
 	namespace := request.PathParameter("namespace")
 	replicaSet := request.PathParameter("replicaSet")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := replicaset.GetReplicaSetPods(apiHandler.client, apiHandler.heapsterClient,
-		pagination, replicaSet, namespace)
+		dataSelect, replicaSet, namespace)
 
 	if err != nil {
 		handleInternalError(response, err)
@@ -672,8 +672,8 @@ func (apiHandler *APIHandler) handleGetReplicaSetServices(
 
 	namespace := request.PathParameter("namespace")
 	replicaSet := request.PathParameter("replicaSet")
-	pagination := parsePaginationPathParameter(request)
-	result, err := replicaset.GetReplicaSetServices(apiHandler.client, pagination, namespace,
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := replicaset.GetReplicaSetServices(apiHandler.client, dataSelect, namespace,
 		replicaSet)
 	if err != nil {
 		handleInternalError(response, err)
@@ -688,8 +688,8 @@ func (apiHandler *APIHandler) handleGetDeployments(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := deployment.GetDeploymentList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := deployment.GetDeploymentList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -719,8 +719,8 @@ func (apiHandler *APIHandler) handleGetPods(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := pod.GetPodList(apiHandler.client, apiHandler.heapsterClient, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := pod.GetPodList(apiHandler.client, apiHandler.heapsterClient, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -857,10 +857,10 @@ func (apiHandler *APIHandler) handleGetReplicationControllerPods(
 
 	namespace := request.PathParameter("namespace")
 	replicationController := request.PathParameter("replicationController")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
 	result, err := replicationcontroller.GetReplicationControllerPods(apiHandler.client, apiHandler.heapsterClient,
-		pagination, replicationController, namespace)
+		dataSelect, replicationController, namespace)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -889,8 +889,8 @@ func (apiHandler *APIHandler) handleCreateNamespace(request *restful.Request,
 func (apiHandler *APIHandler) handleGetNamespaces(
 	request *restful.Request, response *restful.Response) {
 
-	pagination := parsePaginationPathParameter(request)
-	result, err := namespace.GetNamespaceList(apiHandler.client, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := namespace.GetNamespaceList(apiHandler.client, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -951,8 +951,8 @@ func (apiHandler *APIHandler) handleGetSecretList(request *restful.Request, resp
 
 func (apiHandler *APIHandler) handleGetConfigMapList(request *restful.Request, response *restful.Response) {
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := configmap.GetConfigMapList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := configmap.GetConfigMapList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1021,9 +1021,9 @@ func (apiHandler *APIHandler) handleGetPodContainers(request *restful.Request, r
 func (apiHandler *APIHandler) handleGetReplicationControllerEvents(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	replicationController := request.PathParameter("replicationController")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
-	result, err := replicationcontroller.GetReplicationControllerEvents(apiHandler.client, pagination, namespace,
+	result, err := replicationcontroller.GetReplicationControllerEvents(apiHandler.client, dataSelect, namespace,
 		replicationController)
 	if err != nil {
 		handleInternalError(response, err)
@@ -1037,9 +1037,9 @@ func (apiHandler *APIHandler) handleGetReplicationControllerServices(request *re
 	response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	replicationController := request.PathParameter("replicationController")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
-	result, err := replicationcontroller.GetReplicationControllerServices(apiHandler.client, pagination,
+	result, err := replicationcontroller.GetReplicationControllerServices(apiHandler.client, dataSelect,
 		namespace, replicationController)
 	if err != nil {
 		handleInternalError(response, err)
@@ -1060,8 +1060,8 @@ func (apiHandler *APIHandler) handleGetDaemonSetList(
 	request *restful.Request, response *restful.Response) {
 
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := daemonset.GetDaemonSetList(apiHandler.client, namespace, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := daemonset.GetDaemonSetList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1076,9 +1076,9 @@ func (apiHandler *APIHandler) handleGetDaemonSetDetail(
 
 	namespace := request.PathParameter("namespace")
 	daemonSet := request.PathParameter("daemonSet")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := daemonset.GetDaemonSetDetail(apiHandler.client, apiHandler.heapsterClient,
-		pagination, namespace, daemonSet)
+		dataSelect, namespace, daemonSet)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1093,9 +1093,9 @@ func (apiHandler *APIHandler) handleGetDaemonSetPods(
 
 	namespace := request.PathParameter("namespace")
 	daemonSet := request.PathParameter("daemonSet")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 	result, err := daemonset.GetDaemonSetPods(apiHandler.client, apiHandler.heapsterClient,
-		pagination, daemonSet, namespace)
+		dataSelect, daemonSet, namespace)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1110,8 +1110,8 @@ func (apiHandler *APIHandler) handleGetDaemonSetServices(
 
 	namespace := request.PathParameter("namespace")
 	daemonSet := request.PathParameter("daemonSet")
-	pagination := parsePaginationPathParameter(request)
-	result, err := daemonset.GetDaemonSetServices(apiHandler.client, pagination, namespace,
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := daemonset.GetDaemonSetServices(apiHandler.client, dataSelect, namespace,
 		daemonSet)
 	if err != nil {
 		handleInternalError(response, err)
@@ -1146,9 +1146,9 @@ func (apiHandler *APIHandler) handleDeleteDaemonSet(
 func (apiHandler *APIHandler) handleGetJobList(request *restful.Request,
 	response *restful.Response) {
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
-	result, err := job.GetJobList(apiHandler.client, namespace, pagination)
+	result, err := job.GetJobList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1160,10 +1160,10 @@ func (apiHandler *APIHandler) handleGetJobList(request *restful.Request,
 func (apiHandler *APIHandler) handleGetJobDetail(request *restful.Request, response *restful.Response) {
 	namespace := request.PathParameter("namespace")
 	jobParam := request.PathParameter("job")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
 	result, err := job.GetJobDetail(apiHandler.client, apiHandler.heapsterClient, namespace,
-		jobParam, pagination)
+		jobParam, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1178,9 +1178,9 @@ func (apiHandler *APIHandler) handleGetJobPods(request *restful.Request,
 
 	namespace := request.PathParameter("namespace")
 	jobParam := request.PathParameter("job")
-	pagination := parsePaginationPathParameter(request)
+	dataSelect := parseDataSelectPathParameter(request)
 
-	result, err := job.GetJobPods(apiHandler.client, apiHandler.heapsterClient, pagination,
+	result, err := job.GetJobPods(apiHandler.client, apiHandler.heapsterClient, dataSelect,
 		jobParam, namespace)
 	if err != nil {
 		handleInternalError(response, err)
@@ -1221,12 +1221,13 @@ func parsePaginationPathParameter(request *restful.Request) *common.PaginationQu
 	return common.NewPaginationQuery(int(itemsPerPage), int(page-1))
 }
 
-
+// Parses query parameters of the request and returns a SortQuery object
 func parseSortPathParameter(request *restful.Request) *common.SortQuery {
 	return common.NewSortQuery(strings.Split(request.QueryParameter("sortby"), ","))
 
 }
 
+// Parses query parameters of the request and returns a DataSelectQuery object
 func parseDataSelectPathParameter(request *restful.Request) *common.DataSelectQuery {
 	paginationQuery := parsePaginationPathParameter(request)
 	sortQuery := parseSortPathParameter(request)

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -972,8 +972,8 @@ func (apiHandler *APIHandler) handleGetConfigMapDetail(request *restful.Request,
 }
 
 func (apiHandler *APIHandler) handleGetPersistentVolumeList(request *restful.Request, response *restful.Response) {
-	pagination := parsePaginationPathParameter(request)
-	result, err := persistentvolume.GetPersistentVolumeList(apiHandler.client, pagination)
+	dataSelect := parseDataSelectPathParameter(request)
+	result, err := persistentvolume.GetPersistentVolumeList(apiHandler.client, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -939,9 +939,9 @@ func (apiHandler *APIHandler) handleGetSecretDetail(request *restful.Request, re
 
 // Handles get secrets list API call.
 func (apiHandler *APIHandler) handleGetSecretList(request *restful.Request, response *restful.Response) {
+	dataSelect := parseDataSelectPathParameter(request)
 	namespace := parseNamespacePathParameter(request)
-	pagination := parsePaginationPathParameter(request)
-	result, err := secret.GetSecretList(apiHandler.client, namespace, pagination)
+	result, err := secret.GetSecretList(apiHandler.client, namespace, dataSelect)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -1219,4 +1219,16 @@ func parsePaginationPathParameter(request *restful.Request) *common.PaginationQu
 
 	// Frontend pages start from 1 and backend starts from 0
 	return common.NewPaginationQuery(int(itemsPerPage), int(page-1))
+}
+
+
+func parseSortPathParameter(request *restful.Request) *common.SortQuery {
+	return common.NewSortQuery(strings.Split(request.QueryParameter("sortby"), ","))
+
+}
+
+func parseDataSelectPathParameter(request *restful.Request) *common.DataSelectQuery {
+	paginationQuery := parsePaginationPathParameter(request)
+	sortQuery := parseSortPathParameter(request)
+	return common.NewDataSelect(paginationQuery, sortQuery)
 }

--- a/src/app/backend/resource/common/dataselect.go
+++ b/src/app/backend/resource/common/dataselect.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
@@ -6,10 +20,12 @@ import (
 	"sort"
 )
 
-
-
+// Interface of the generic data cell.
+// GenericDataSelect takes a list of these interfaces and performs selection operation.
+// As long as the list is composed of GenericDataCells you can perform any data selection!
 type GenericDataCell interface {
-	// GetPropertyAtIndex returns the property of this data cell
+	// GetPropertyAtIndex returns the property of this data cell.
+	// Value returned has to have Compare method which is required by Sort functionality of DataSelect.
 	GetProperty(string) ComparableValue
 }
 
@@ -17,21 +33,23 @@ type ComparableValue interface {
 	Compare(ComparableValue) int
 }
 
-
+// Object containing all the required data to perform data selection.
+// It implements sort.Interface so its sortable under sort.Sort
+// You can use its Select method to get selected GenericDataCell list
 type SelectableDataList struct {
 	GenericDataList []GenericDataCell
 	DataSelectQuery *DataSelectQuery
 }
 
-// here I am using a trick to be able to use built in sort function (sort.Sort) for sorting
+// here I am using a trick to be able to use built in sort function (sort.Sort) for sorting SelectableDataList
 // The aim is to implement sort.Interface - it is to define 3 methods:
 // Len, Swap and Less
 
-// 2 easy functions, just wrap
+// Implementation of sort.Interface
 func (self SelectableDataList) Len() int {return len(self.GenericDataList)}
+
 func (self SelectableDataList) Swap(i, j int) {self.GenericDataList[i], self.GenericDataList[j] = self.GenericDataList[j], self.GenericDataList[i]}
 
-// Now more complicated one, implement less! Here we have to be careful because value of less depends on SortQuery
 func (self SelectableDataList) Less(i, j int) bool {
 	for _, sortBy := range (*self.DataSelectQuery.SortQuery).SortByList {
 		a := self.GenericDataList[i].GetProperty(sortBy.Property)
@@ -46,11 +64,16 @@ func (self SelectableDataList) Less(i, j int) bool {
 	return false
 }
 
+// Implementation of convenience Select method. Returns selected generic data cell list.
 func (self SelectableDataList) Select() []GenericDataCell {
+	// Simple pipeline:
+	// First sort,
 	sort.Sort(self)
+	// later paginate and return
 	return GenericPaginate(self.GenericDataList, self.DataSelectQuery.PaginationQuery)
 }
 
+// Selects slice of the data as required by PaginationQuery
 func GenericPaginate(dataList []GenericDataCell, pQuery *PaginationQuery) ([]GenericDataCell) {
 	startIndex, endIndex := pQuery.GetPaginationSettings(len(dataList))
 
@@ -61,6 +84,7 @@ func GenericPaginate(dataList []GenericDataCell, pQuery *PaginationQuery) ([]Gen
 	return dataList[startIndex:endIndex]
 }
 
+// Takes list of GenericDataCells and DataSelectQuery and returns selected data
 func GenericDataSelect(dataList []GenericDataCell, dsQuery *DataSelectQuery) ([]GenericDataCell){
 	selectableDataList := SelectableDataList{
 		GenericDataList: dataList,
@@ -70,7 +94,7 @@ func GenericDataSelect(dataList []GenericDataCell, dsQuery *DataSelectQuery) ([]
 }
 
 
-
+// Int comparison functions. Similar to strings.Compare
 func intsCompare(a, b int) int {
 	if a > b {
 		return 1
@@ -94,7 +118,6 @@ func ints64Compare(a, b int64) int {
 // You can convert basic types to these types to supprt auto sorting etc.
 // If you cant find your type compare here you will have to implement it yourself :)
 
-
 type StdComparableInt int
 
 func (self StdComparableInt) Compare(otherV ComparableValue) int {
@@ -110,7 +133,7 @@ func (self StdComparableString) Compare(otherV ComparableValue) int {
 	return strings.Compare(string(self), string(other))
 }
 
-
+// Takes RFC3339 Timestamp strings and compares them as TIMES. In case of time parsing error compares values as strings.
 type StdComparableRFC3339Timestamp string
 
 func (self StdComparableRFC3339Timestamp) Compare(otherV ComparableValue) int {

--- a/src/app/backend/resource/common/dataselect.go
+++ b/src/app/backend/resource/common/dataselect.go
@@ -1,0 +1,203 @@
+package common
+
+import (
+	"time"
+	"strings"
+	"sort"
+	"log"
+)
+
+type DataSelectQuery struct {
+	PaginationQuery *PaginationQuery
+	SortQuery       *SortQuery
+//	Filter     *FilterQuery
+}
+
+type SelectableInterface interface {
+	// Returns length of the collection
+	Len() int
+	// Returns slice of the collection (just like slice in go with start, end indexes)
+	Slice(int, int) SelectableInterface
+
+	// swaps 2 elements of the collection
+	Swap(int, int)
+	// GetPropertyAtIndex returns the value of the property at this index.
+	// value has a Compare method which allows to compare it to other property
+	GetPropertyAtIndex(string, int) ComparableValueInterface
+
+}
+
+type ComparableValueInterface interface {
+	Compare(ComparableValueInterface) int
+}
+
+// here I am using a trick to be able to use built in sort function (sort.Sort) for sorting
+// The aim is to implement sort.Interface - it is to define 3 methods:
+// Len, Swap and Less
+type SortableSelectableInterface struct {
+	SelectableInterface SelectableInterface
+	SortQuery *SortQuery
+}
+// 2 easy functions, just wrap
+func (self SortableSelectableInterface) Len() int {return self.SelectableInterface.Len()}
+func (self SortableSelectableInterface) Swap(i, j int) {self.SelectableInterface.Swap(i, j)}
+
+// Now more complicated one, implement less! Here we have to be careful because value of less depends on SortQuery
+func (self SortableSelectableInterface) Less(i, j int) bool {
+	for _, sortBy := range (*self.SortQuery).SortByList {
+		a := self.SelectableInterface.GetPropertyAtIndex(sortBy.Property, i)
+		b := self.SelectableInterface.GetPropertyAtIndex(sortBy.Property, j)
+		cmp := a.Compare(b)
+		if cmp == 0 { // values are the same. Just continue to next sortBy
+			continue
+		} else {  // values different
+			return (cmp==-1 && sortBy.Ascending) || (cmp==1 && !sortBy.Ascending)
+		}
+	}
+	return false
+}
+
+
+// sort qury will be in format - a,name,d,age,...   which means sort ascending name, later descending age, ...
+type SortQuery struct {
+      SortByList []SortBy
+
+}
+
+type SortBy struct {
+	Property  string
+	Ascending bool
+}
+
+
+func NewSortQuery(sortByListRaw []string) (*SortQuery) {
+	if sortByListRaw == nil || len(sortByListRaw)%2 == 1{
+		return NoSort
+	}
+	sortByList := []SortBy{}
+	for i:=0; i+1 < len(sortByListRaw); i+=2 {
+		// parse order option
+		var ascending bool
+		orderOption := sortByListRaw[i]
+		if sortByListRaw[i] == "a" {
+			ascending = true
+		} else if sortByListRaw[i] == "d" {
+			ascending = false
+		} else {
+			log.Print(`Invalid order option. Only ascending (a), descending (d) options are supported. Found "%s".`, orderOption)
+			return NoSort
+		}
+
+		// parse variable name. sortByListRaw cant be odd so following index will never fail.
+		variableName := sortByListRaw[i+1]
+		sortBy := SortBy{
+			Property: variableName,
+			Ascending: ascending,
+		}
+		sortByList = append(sortByList, sortBy)
+	}
+	return &SortQuery{
+		SortByList: sortByList,
+	}
+}
+
+
+func NewDataSelect(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*DataSelectQuery) {
+	return &DataSelectQuery{
+		PaginationQuery: paginationQuery,
+		SortQuery:       sortQuery,
+	}
+}
+var NoSort = &SortQuery{
+	SortByList: []SortBy{},
+}
+
+
+
+func GenericDataSelect(dataList SelectableInterface, dsQuery *DataSelectQuery) (SelectableInterface){
+	log.Print("Welcome to the generics!")
+	// Simple pipeline:
+	// First sort
+	dataList = GenericSort(dataList, dsQuery.SortQuery)
+	// Afterwards paginate
+	return GenericPaginate(dataList, dsQuery.PaginationQuery)
+}
+
+
+func GenericSort(dataList SelectableInterface, sQuery *SortQuery) (SelectableInterface) {
+	sort.Sort(SortableSelectableInterface{SelectableInterface: dataList, SortQuery: sQuery})
+	return dataList
+}
+
+func GenericPaginate(dataList SelectableInterface, pQuery *PaginationQuery) (SelectableInterface) {
+	startIndex, endIndex := pQuery.GetPaginationSettings(dataList.Len())
+
+	// Return all items if provided settings do not meet requirements
+	if !pQuery.CanPaginate(dataList.Len(), startIndex) {
+		return dataList
+	}
+	return dataList.Slice(startIndex, endIndex)
+}
+
+func intsCompare(a, b int) int {
+	if a > b {
+		return 1
+	} else if a == b {
+		return 0
+	}
+	return -1
+}
+
+func ints64Compare(a, b int64) int {
+	if a > b {
+		return 1
+	} else if a == b {
+		return 0
+	}
+	return -1
+}
+// ----------------------- Standard Comparable Types ------------------------
+// These types specify how given value should be compared
+// They all implement ComparableValueInterface
+// You can convert basic types to these types to supprt auto sorting etc.
+// If you cant find your type compare here you will have to implement it yourself :)
+
+
+type StdComparableInt int
+
+func (self StdComparableInt) Compare(otherV ComparableValueInterface) int {
+	other := otherV.(StdComparableInt)
+	return intsCompare(int(self), int(other))
+}
+
+
+type StdComparableString string
+
+func (self StdComparableString) Compare(otherV ComparableValueInterface) int {
+	other := otherV.(StdComparableString)
+	return strings.Compare(string(self), string(other))
+}
+
+
+type StdComparableRFC3339Timestamp string
+
+func (self StdComparableRFC3339Timestamp) Compare(otherV ComparableValueInterface) int {
+	other := otherV.(StdComparableRFC3339Timestamp)
+	// try to compare as timestamp (earlier = smaller)
+	selfTime, err1 := time.Parse(time.RFC3339, string(self))
+        otherTime, err2 := time.Parse(time.RFC3339, string(other))
+
+	if err1!=nil || err2!=nil {
+		// in case of timestamp parsing failure just compare as strings
+		return strings.Compare(string(self), string(other))
+	} else {
+		return ints64Compare(selfTime.Unix(), otherTime.Unix())
+	}
+}
+
+type StdComparableTime time.Time
+
+func (self StdComparableTime) Compare(otherV ComparableValueInterface) int {
+	other := otherV.(StdComparableTime)
+	return ints64Compare(time.Time(self).Unix(), time.Time(other).Unix())
+}

--- a/src/app/backend/resource/common/dataselect.go
+++ b/src/app/backend/resource/common/dataselect.go
@@ -84,9 +84,15 @@ func (self *SelectableData) Paginate() (*SelectableData) {
 	startIndex, endIndex := pQuery.GetPaginationSettings(len(dataList))
 
 	// Return all items if provided settings do not meet requirements
-	if !pQuery.CanPaginate(len(self.GenericDataList), startIndex) {
+	if !pQuery.IsValidPagination() {
 		return self
 	}
+	// Return no items if requested page does not exist
+	if !pQuery.IsPageAvailable(len(self.GenericDataList), startIndex) {
+		self.GenericDataList = []DataCell{}
+		return self
+	}
+
 	self.GenericDataList = dataList[startIndex:endIndex]
 	return self
 }

--- a/src/app/backend/resource/common/dataselectquery.go
+++ b/src/app/backend/resource/common/dataselectquery.go
@@ -1,0 +1,63 @@
+package common
+
+import "log"
+
+type DataSelectQuery struct {
+	PaginationQuery *PaginationQuery
+	SortQuery       *SortQuery
+	//	Filter     *FilterQuery
+}
+// sort query will be in format - a,name,d,age,...   which means sort ascending name, later descending age, ...
+type SortQuery struct {
+	SortByList []SortBy
+
+}
+
+type SortBy struct {
+	Property  string
+	Ascending bool
+}
+
+
+func NewSortQuery(sortByListRaw []string) (*SortQuery) {
+	if sortByListRaw == nil || len(sortByListRaw)%2 == 1{
+		return NoSort
+	}
+	sortByList := []SortBy{}
+	for i:=0; i+1 < len(sortByListRaw); i+=2 {
+		// parse order option
+		var ascending bool
+		orderOption := sortByListRaw[i]
+		if sortByListRaw[i] == "a" {
+			ascending = true
+		} else if sortByListRaw[i] == "d" {
+			ascending = false
+		} else {
+			log.Print(`Invalid order option. Only ascending (a), descending (d) options are supported. Found "%s".`, orderOption)
+			return NoSort
+		}
+
+		// parse variable name. sortByListRaw cant be odd so following index will never fail.
+		variableName := sortByListRaw[i+1]
+		sortBy := SortBy{
+			Property: variableName,
+			Ascending: ascending,
+		}
+		sortByList = append(sortByList, sortBy)
+	}
+	return &SortQuery{
+		SortByList: sortByList,
+	}
+}
+
+
+func NewDataSelect(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*DataSelectQuery) {
+	return &DataSelectQuery{
+		PaginationQuery: paginationQuery,
+		SortQuery:       sortQuery,
+	}
+}
+var NoSort = &SortQuery{
+	SortByList: []SortBy{},
+}
+

--- a/src/app/backend/resource/common/dataselectquery.go
+++ b/src/app/backend/resource/common/dataselectquery.go
@@ -1,7 +1,22 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
-import "log"
-
+// Options for GenericDataSelect which takes []GenericDataCell and returns selected data.
+// Can be extended to include any kind of selection - for example filtering.
+// Currently included only Pagination and Sort options.
 type DataSelectQuery struct {
 	PaginationQuery *PaginationQuery
 	SortQuery       *SortQuery
@@ -13,42 +28,17 @@ type SortQuery struct {
 
 }
 
+// Option for Sort. Property which should be sorted and whether should use ascending order.
 type SortBy struct {
 	Property  string
 	Ascending bool
 }
 
-
-func NewSortQuery(sortByListRaw []string) (*SortQuery) {
-	if sortByListRaw == nil || len(sortByListRaw)%2 == 1{
-		return NoSort
-	}
-	sortByList := []SortBy{}
-	for i:=0; i+1 < len(sortByListRaw); i+=2 {
-		// parse order option
-		var ascending bool
-		orderOption := sortByListRaw[i]
-		if sortByListRaw[i] == "a" {
-			ascending = true
-		} else if sortByListRaw[i] == "d" {
-			ascending = false
-		} else {
-			log.Print(`Invalid order option. Only ascending (a), descending (d) options are supported. Found "%s".`, orderOption)
-			return NoSort
-		}
-
-		// parse variable name. sortByListRaw cant be odd so following index will never fail.
-		variableName := sortByListRaw[i+1]
-		sortBy := SortBy{
-			Property: variableName,
-			Ascending: ascending,
-		}
-		sortByList = append(sortByList, sortBy)
-	}
-	return &SortQuery{
-		SortByList: sortByList,
-	}
+var NoSort = &SortQuery{
+	SortByList: []SortBy{},
 }
+
+var NoDataSelect = NewDataSelect(NoPagination, NoSort)
 
 
 func NewDataSelect(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*DataSelectQuery) {
@@ -57,7 +47,39 @@ func NewDataSelect(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*Dat
 		SortQuery:       sortQuery,
 	}
 }
-var NoSort = &SortQuery{
-	SortByList: []SortBy{},
-}
 
+// Takes raw sort options list and returns SortQuery object. For example:
+// ["a", "parameter1", "d", "parameter2"] - means that the data should be sorted by
+// parameter1 (ascending) and later - for results that return equal under parameter 1 sort - by parameter2 (descending)
+func NewSortQuery(sortByListRaw []string) (*SortQuery) {
+	if sortByListRaw == nil || len(sortByListRaw)%2 == 1{
+		// Empty sort list or invalid (odd) length
+		return NoSort
+	}
+	sortByList := []SortBy{}
+	for i:=0; i+1 < len(sortByListRaw); i+=2 {
+		// parse order option
+		var ascending bool
+		orderOption := sortByListRaw[i]
+		if orderOption == "a" {
+			ascending = true
+		} else if orderOption == "d" {
+			ascending = false
+		} else {
+			//  Invalid order option. Only ascending (a), descending (d) options are supported
+			return NoSort
+		}
+
+		// parse property name
+		propertyName := sortByListRaw[i+1]
+		sortBy := SortBy{
+			Property: propertyName,
+			Ascending: ascending,
+		}
+		// Add to the sort options.
+		sortByList = append(sortByList, sortBy)
+	}
+	return &SortQuery{
+		SortByList: sortByList,
+	}
+}

--- a/src/app/backend/resource/common/dataselectquery.go
+++ b/src/app/backend/resource/common/dataselectquery.go
@@ -22,33 +22,36 @@ type DataSelectQuery struct {
 	SortQuery       *SortQuery
 	//	Filter     *FilterQuery
 }
-// sort query will be in format - a,name,d,age,...   which means sort ascending name, later descending age, ...
+// SortQuery holds options for sort functionality of data select.
 type SortQuery struct {
 	SortByList []SortBy
 
 }
 
-// Option for Sort. Property which should be sorted and whether should use ascending order.
+// SortBy holds the name of the property that should be sorted and whether order should be ascending or descending.
 type SortBy struct {
-	Property  string
+	Property  PropertyName
 	Ascending bool
 }
 
+// NoSort is as option for no sort.
 var NoSort = &SortQuery{
 	SortByList: []SortBy{},
 }
 
-var NoDataSelect = NewDataSelect(NoPagination, NoSort)
+// NoDataSelect is an option for no data select (same data will be returned).
+var NoDataSelect = NewDataSelectQuery(NoPagination, NoSort)
 
 
-func NewDataSelect(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*DataSelectQuery) {
+// NewDataSelectQuery creates DataSelectQuery object from simpler data select queries.
+func NewDataSelectQuery(paginationQuery *PaginationQuery, sortQuery *SortQuery) (*DataSelectQuery) {
 	return &DataSelectQuery{
 		PaginationQuery: paginationQuery,
 		SortQuery:       sortQuery,
 	}
 }
 
-// Takes raw sort options list and returns SortQuery object. For example:
+// NewSortQuery takes raw sort options list and returns SortQuery object. For example:
 // ["a", "parameter1", "d", "parameter2"] - means that the data should be sorted by
 // parameter1 (ascending) and later - for results that return equal under parameter 1 sort - by parameter2 (descending)
 func NewSortQuery(sortByListRaw []string) (*SortQuery) {
@@ -73,7 +76,7 @@ func NewSortQuery(sortByListRaw []string) (*SortQuery) {
 		// parse property name
 		propertyName := sortByListRaw[i+1]
 		sortBy := SortBy{
-			Property: propertyName,
+			Property: PropertyName(propertyName),
 			Ascending: ascending,
 		}
 		// Add to the sort options.

--- a/src/app/backend/resource/common/pagination.go
+++ b/src/app/backend/resource/common/pagination.go
@@ -17,6 +17,9 @@ package common
 // By default backend pagination will not be applied.
 var NoPagination = NewPaginationQuery(-1, -1)
 
+// No items will be returned
+var EmptyPagination = NewPaginationQuery(0, 0)
+
 // PaginationQuery structure represents pagination settings
 type PaginationQuery struct {
 	// How many items per page should be returned
@@ -30,10 +33,16 @@ func NewPaginationQuery(itemsPerPage, page int) *PaginationQuery {
 	return &PaginationQuery{itemsPerPage, page}
 }
 
-// CanPaginate returns true if pagination can be applied to the list, false otherwise
-func (p *PaginationQuery) CanPaginate(itemsCount, startingIndex int) bool {
-	return p.ItemsPerPage > 0 && p.Page >= 0 && itemsCount > startingIndex
+// IsValidPagination returns true if pagination has non negative parameters
+func (p *PaginationQuery) IsValidPagination() bool {
+	return p.ItemsPerPage >= 0 && p.Page >= 0
 }
+
+// IsPageAvailable returns true if at least one element can be placed on page. False otherwise
+func (p *PaginationQuery) IsPageAvailable(itemsCount, startingIndex int) bool {
+	return itemsCount > startingIndex && p.ItemsPerPage > 0
+}
+
 
 // GetPaginationSettings based on number of items and pagination query parameters returns start
 // and end index that can be used to return paginated list of items.

--- a/src/app/backend/resource/common/propertyname.go
+++ b/src/app/backend/resource/common/propertyname.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// PropertyName is used to get the value of certain property of data cell.
+// For example if we want to get the namespace of certain Deployment we can use DeploymentCell.GetProperty(NamespaceProperty)
+type PropertyName string
+
+// List of all property names supported by the UI.
+const (
+	NameProperty = "name"
+	CreationTimestampProperty = "creationTimestamp"
+	NamespaceProperty = "namespace"
+)

--- a/src/app/backend/resource/common/stdcomparabletypes.go
+++ b/src/app/backend/resource/common/stdcomparabletypes.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"time"
+	"strings"
+)
+
+// ----------------------- Standard Comparable Types ------------------------
+// These types specify how given value should be compared
+// They all implement ComparableValueInterface
+// You can convert basic types to these types to supprt auto sorting etc.
+// If you cant find your type compare here you will have to implement it yourself :)
+
+type StdComparableInt int
+
+func (self StdComparableInt) Compare(otherV ComparableValue) int {
+	other := otherV.(StdComparableInt)
+	return intsCompare(int(self), int(other))
+}
+
+
+type StdComparableString string
+
+func (self StdComparableString) Compare(otherV ComparableValue) int {
+	other := otherV.(StdComparableString)
+	return strings.Compare(string(self), string(other))
+}
+
+// StdComparableRFC3339Timestamp takes RFC3339 Timestamp strings and compares them as TIMES. In case of time parsing error compares values as strings.
+type StdComparableRFC3339Timestamp string
+
+func (self StdComparableRFC3339Timestamp) Compare(otherV ComparableValue) int {
+	other := otherV.(StdComparableRFC3339Timestamp)
+	// try to compare as timestamp (earlier = smaller)
+	selfTime, err1 := time.Parse(time.RFC3339, string(self))
+	otherTime, err2 := time.Parse(time.RFC3339, string(other))
+
+	if err1!=nil || err2!=nil {
+		// in case of timestamp parsing failure just compare as strings
+		return strings.Compare(string(self), string(other))
+	} else {
+		return ints64Compare(selfTime.Unix(), otherTime.Unix())
+	}
+}
+
+type StdComparableTime time.Time
+
+func (self StdComparableTime) Compare(otherV ComparableValue) int {
+	other := otherV.(StdComparableTime)
+	return ints64Compare(time.Time(self).Unix(), time.Time(other).Unix())
+}
+
+// Int comparison functions. Similar to strings.Compare.
+func intsCompare(a, b int) int {
+	if a > b {
+		return 1
+	} else if a == b {
+		return 0
+	}
+	return -1
+}
+
+func ints64Compare(a, b int64) int {
+	if a > b {
+		return 1
+	} else if a == b {
+		return 0
+	}
+	return -1
+}

--- a/src/app/backend/resource/configmap/configmapcommon.go
+++ b/src/app/backend/resource/configmap/configmapcommon.go
@@ -30,13 +30,18 @@ var propertyGetters = map[string]func(ConfigMapCell)(common.ComparableValue){
 
 type ConfigMapCell api.ConfigMap
 
-func (self ConfigMapCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self ConfigMapCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/configmap/configmapcommon.go
+++ b/src/app/backend/resource/configmap/configmapcommon.go
@@ -19,13 +19,39 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func paginate(configMaps []api.ConfigMap, pQuery *common.PaginationQuery) []api.ConfigMap {
-	startIndex, endIndex := pQuery.GetPaginationSettings(len(configMaps))
+// The code below allows to perform complex data section on []api.ConfigMap
 
-	// Return all items if provided settings do not meet requirements
-	if !pQuery.CanPaginate(len(configMaps), startIndex) {
-		return configMaps
+var propertyGetters = map[string]func(ConfigMapCell)(common.ComparableValue){
+	"name": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
+	"creationTimestamp": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
+	"namespace": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
+}
+
+
+type ConfigMapCell api.ConfigMap
+
+func (self ConfigMapCell) GetProperty(name string) common.ComparableValue {
+	getter, isGetterPresent := propertyGetters[name]
+	if !isGetterPresent {
+		// if getter not present then just return a constant dummy value, sort will have no effect.
+		return common.StdComparableInt(0)
 	}
+	return getter(self)
+}
 
-	return configMaps[startIndex:endIndex]
+
+func toCells(std []api.ConfigMap) []common.GenericDataCell {
+	cells := make([]common.GenericDataCell, len(std))
+	for i := range std {
+		cells[i] = ConfigMapCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []common.GenericDataCell) []api.ConfigMap {
+	std := make([]api.ConfigMap, len(cells))
+	for i := range std {
+		std[i] = api.ConfigMap(cells[i].(ConfigMapCell))
+	}
+	return std
 }

--- a/src/app/backend/resource/configmap/configmapcommon.go
+++ b/src/app/backend/resource/configmap/configmapcommon.go
@@ -21,13 +21,6 @@ import (
 
 // The code below allows to perform complex data section on []api.ConfigMap
 
-var propertyGetters = map[string]func(ConfigMapCell)(common.ComparableValue){
-	"name": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self ConfigMapCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type ConfigMapCell api.ConfigMap
 
 func (self ConfigMapCell) GetProperty(name common.PropertyName) common.ComparableValue {
@@ -45,15 +38,15 @@ func (self ConfigMapCell) GetProperty(name common.PropertyName) common.Comparabl
 }
 
 
-func toCells(std []api.ConfigMap) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.ConfigMap) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = ConfigMapCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.ConfigMap {
+func fromCells(cells []common.DataCell) []api.ConfigMap {
 	std := make([]api.ConfigMap, len(cells))
 	for i := range std {
 		std[i] = api.ConfigMap(cells[i].(ConfigMapCell))

--- a/src/app/backend/resource/configmap/configmaplist.go
+++ b/src/app/backend/resource/configmap/configmaplist.go
@@ -41,18 +41,18 @@ type ConfigMap struct {
 
 // GetConfigMapList returns a list of all ConfigMaps in the cluster.
 func GetConfigMapList(client *client.Client, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*ConfigMapList, error) {
+	dsQuery *common.DataSelectQuery) (*ConfigMapList, error) {
 	log.Printf("Getting list config maps in the namespace %s", nsQuery.ToRequestParam())
 	channels := &common.ResourceChannels{
 		ConfigMapList: common.GetConfigMapListChannel(client, nsQuery, 1),
 	}
 
-	return GetConfigMapListFromChannels(channels, pQuery)
+	return GetConfigMapListFromChannels(channels, dsQuery)
 }
 
 // GetConfigMapListFromChannels returns a list of all Config Maps in the cluster
 // reading required resource list once from the channels.
-func GetConfigMapListFromChannels(channels *common.ResourceChannels, pQuery *common.PaginationQuery) (
+func GetConfigMapListFromChannels(channels *common.ResourceChannels, dsQuery *common.DataSelectQuery) (
 	*ConfigMapList, error) {
 
 	configMaps := <-channels.ConfigMapList.List
@@ -60,19 +60,19 @@ func GetConfigMapListFromChannels(channels *common.ResourceChannels, pQuery *com
 		return nil, err
 	}
 
-	result := getConfigMapList(configMaps.Items, pQuery)
+	result := getConfigMapList(configMaps.Items, dsQuery)
 
 	return result, nil
 }
 
-func getConfigMapList(configMaps []api.ConfigMap, pQuery *common.PaginationQuery) *ConfigMapList {
+func getConfigMapList(configMaps []api.ConfigMap, dsQuery *common.DataSelectQuery) *ConfigMapList {
 
 	result := &ConfigMapList{
 		Items:    make([]ConfigMap, 0),
 		ListMeta: common.ListMeta{TotalItems: len(configMaps)},
 	}
 
-	configMaps = paginate(configMaps, pQuery)
+	configMaps = fromCells(common.GenericDataSelect(toCells(configMaps), dsQuery))
 
 	for _, item := range configMaps {
 		result.Items = append(result.Items,

--- a/src/app/backend/resource/daemonset/daemonsetcommon.go
+++ b/src/app/backend/resource/daemonset/daemonsetcommon.go
@@ -57,13 +57,6 @@ func getServicesForDSDeletion(client client.Interface, labelSelector labels.Sele
 
 // The code below allows to perform complex data section on []extensions.DaemonSet
 
-var propertyGetters = map[string]func(DaemonSetCell)(common.ComparableValue){
-	"name": func(self DaemonSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self DaemonSetCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self DaemonSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type DaemonSetCell extensions.DaemonSet
 
 func (self DaemonSetCell) GetProperty(name common.PropertyName) common.ComparableValue {
@@ -81,15 +74,15 @@ func (self DaemonSetCell) GetProperty(name common.PropertyName) common.Comparabl
 }
 
 
-func toCells(std []extensions.DaemonSet) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []extensions.DaemonSet) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = DaemonSetCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []extensions.DaemonSet {
+func fromCells(cells []common.DataCell) []extensions.DaemonSet {
 	std := make([]extensions.DaemonSet, len(cells))
 	for i := range std {
 		std[i] = extensions.DaemonSet(cells[i].(DaemonSetCell))

--- a/src/app/backend/resource/daemonset/daemonsetcommon.go
+++ b/src/app/backend/resource/daemonset/daemonsetcommon.go
@@ -66,13 +66,18 @@ var propertyGetters = map[string]func(DaemonSetCell)(common.ComparableValue){
 
 type DaemonSetCell extensions.DaemonSet
 
-func (self DaemonSetCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self DaemonSetCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/daemonset/daemonsetdetail.go
+++ b/src/app/backend/resource/daemonset/daemonsetdetail.go
@@ -55,7 +55,7 @@ type DaemonSetDetail struct {
 
 // Returns detailed information about the given daemon set in the given namespace.
 func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, namespace, name string) (*DaemonSetDetail, error) {
+	dsQuery *common.DataSelectQuery, namespace, name string) (*DaemonSetDetail, error) {
 	log.Printf("Getting details of %s daemon set in %s namespace", name, namespace)
 
 	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name)
@@ -63,7 +63,7 @@ func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.Heapst
 		return nil, err
 	}
 
-	podList, err := GetDaemonSetPods(client, heapsterClient, pQuery, name, namespace)
+	podList, err := GetDaemonSetPods(client, heapsterClient, dsQuery, name, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.Heapst
 		return nil, err
 	}
 
-	serviceList, err := GetDaemonSetServices(client, pQuery, namespace, name)
+	serviceList, err := GetDaemonSetServices(client, dsQuery, namespace, name)
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/daemonset/daemonsetevents.go
+++ b/src/app/backend/resource/daemonset/daemonsetevents.go
@@ -51,7 +51,7 @@ func GetDaemonSetEvents(client client.Interface, namespace, daemonSetName string
 		apiEvents = event.FillEventsType(apiEvents)
 	}
 
-	events := event.CreateEventList(apiEvents, common.NoPagination)
+	events := event.CreateEventList(apiEvents, common.NoDataSelect)
 
 	log.Printf("Found %d events related to %s daemon set in %s namespace",
 		len(events.Events), daemonSetName, namespace)

--- a/src/app/backend/resource/daemonset/daemonsetpods.go
+++ b/src/app/backend/resource/daemonset/daemonsetpods.go
@@ -28,7 +28,7 @@ import (
 
 // GetDaemonSetPods return list of pods targeting daemon set.
 func GetDaemonSetPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, daemonSetName, namespace string) (*pod.PodList, error) {
+	dsQuery *common.DataSelectQuery, daemonSetName, namespace string) (*pod.PodList, error) {
 	log.Printf("Getting replication controller %s pods in namespace %s", daemonSetName, namespace)
 
 	pods, err := getRawDaemonSetPods(client, daemonSetName, namespace)
@@ -36,7 +36,7 @@ func GetDaemonSetPods(client k8sClient.Interface, heapsterClient client.Heapster
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/daemonset/daemonsetservices.go
+++ b/src/app/backend/resource/daemonset/daemonsetservices.go
@@ -23,7 +23,7 @@ import (
 
 // GetDaemonSetServices returns list of services that are related to daemon set targeted by given
 // name.
-func GetDaemonSetServices(client client.Interface, pQuery *common.PaginationQuery,
+func GetDaemonSetServices(client client.Interface, dsQuery *common.DataSelectQuery,
 	namespace, name string) (*service.ServiceList, error) {
 
 	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name)
@@ -43,5 +43,5 @@ func GetDaemonSetServices(client client.Interface, pQuery *common.PaginationQuer
 
 	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
 		daemonSet.Spec.Selector.MatchLabels)
-	return service.CreateServiceList(matchingServices, pQuery), nil
+	return service.CreateServiceList(matchingServices, dsQuery), nil
 }

--- a/src/app/backend/resource/deployment/deploymentcommon.go
+++ b/src/app/backend/resource/deployment/deploymentcommon.go
@@ -22,22 +22,20 @@ import (
 
 // The code below allows to perform complex data section on []extensions.Deployment
 
-var propertyGetters = map[string]func(DeploymentCell)(common.ComparableValue){
-	"name": func(self DeploymentCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self DeploymentCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self DeploymentCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type DeploymentCell extensions.Deployment
 
-func (self DeploymentCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self DeploymentCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/deployment/deploymentcommon.go
+++ b/src/app/backend/resource/deployment/deploymentcommon.go
@@ -39,15 +39,15 @@ func (self DeploymentCell) GetProperty(name common.PropertyName) common.Comparab
 }
 
 
-func toCells(std []extensions.Deployment) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []extensions.Deployment) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = DeploymentCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []extensions.Deployment {
+func fromCells(cells []common.DataCell) []extensions.Deployment {
 	std := make([]extensions.Deployment, len(cells))
 	for i := range std {
 		std[i] = extensions.Deployment(cells[i].(DeploymentCell))

--- a/src/app/backend/resource/deployment/deploymentdetail.go
+++ b/src/app/backend/resource/deployment/deploymentdetail.go
@@ -155,7 +155,7 @@ func getDeploymentDetail(deployment *extensions.Deployment,
 		oldReplicaSets[i] = *replicaSet
 	}
 	oldReplicaSetList := replicaset.CreateReplicaSetList(oldReplicaSets, pods, rawEvents,
-		common.NoPagination)
+		common.NoDataSelect)
 
 	var rollingUpdateStrategy *RollingUpdateStrategy
 	if deployment.Spec.Strategy.RollingUpdate != nil {

--- a/src/app/backend/resource/deployment/deploymentevents.go
+++ b/src/app/backend/resource/deployment/deploymentevents.go
@@ -36,7 +36,7 @@ func GetDeploymentEvents(dpEvents []api.Event, namespace string, deploymentName 
 	}
 
 	// TODO support pagination
-	events := event.CreateEventList(dpEvents, common.NoPagination)
+	events := event.CreateEventList(dpEvents, common.NoDataSelect)
 
 	log.Printf("Found %d events related to %s deployment in %s namespace",
 		len(events.Events), deploymentName, namespace)

--- a/src/app/backend/resource/deployment/deploymentlist.go
+++ b/src/app/backend/resource/deployment/deploymentlist.go
@@ -50,7 +50,7 @@ type Deployment struct {
 
 // GetDeploymentList returns a list of all Deployments in the cluster.
 func GetDeploymentList(client client.Interface, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*DeploymentList, error) {
+	dsQuery *common.DataSelectQuery) (*DeploymentList, error) {
 	log.Printf("Getting list of all deployments in the cluster")
 
 	channels := &common.ResourceChannels{
@@ -59,13 +59,13 @@ func GetDeploymentList(client client.Interface, nsQuery *common.NamespaceQuery,
 		EventList:      common.GetEventListChannel(client, nsQuery, 1),
 	}
 
-	return GetDeploymentListFromChannels(channels, pQuery)
+	return GetDeploymentListFromChannels(channels, dsQuery)
 }
 
 // GetDeploymentList returns a list of all Deployments in the cluster
 // reading required resource list once from the channels.
 func GetDeploymentListFromChannels(channels *common.ResourceChannels,
-	pQuery *common.PaginationQuery) (*DeploymentList, error) {
+	dsQuery *common.DataSelectQuery) (*DeploymentList, error) {
 
 	deployments := <-channels.DeploymentList.List
 	if err := <-channels.DeploymentList.Error; err != nil {
@@ -91,20 +91,20 @@ func GetDeploymentListFromChannels(channels *common.ResourceChannels,
 		return nil, err
 	}
 
-	return CreateDeploymentList(deployments.Items, pods.Items, events.Items, pQuery), nil
+	return CreateDeploymentList(deployments.Items, pods.Items, events.Items, dsQuery), nil
 }
 
 // CreateDeploymentList returns a list of all Deployment model objects in the cluster, based on all
 // Kubernetes Deployment API objects.
 func CreateDeploymentList(deployments []extensions.Deployment, pods []api.Pod,
-	events []api.Event, pQuery *common.PaginationQuery) *DeploymentList {
+	events []api.Event, dsQuery *common.DataSelectQuery) *DeploymentList {
 
 	deploymentList := &DeploymentList{
 		Deployments: make([]Deployment, 0),
 		ListMeta:    common.ListMeta{TotalItems: len(deployments)},
 	}
 
-	deployments = paginate(deployments, pQuery)
+	deployments = fromCells(common.GenericDataSelect(toCells(deployments), dsQuery))
 
 	for _, deployment := range deployments {
 

--- a/src/app/backend/resource/event/eventcommon.go
+++ b/src/app/backend/resource/event/eventcommon.go
@@ -196,15 +196,15 @@ func (self EventCell) GetProperty(name common.PropertyName) common.ComparableVal
 }
 
 
-func toCells(std []api.Event) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Event) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = EventCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Event {
+func fromCells(cells []common.DataCell) []api.Event {
 	std := make([]api.Event, len(cells))
 	for i := range std {
 		std[i] = api.Event(cells[i].(EventCell))

--- a/src/app/backend/resource/event/eventcommon.go
+++ b/src/app/backend/resource/event/eventcommon.go
@@ -179,22 +179,20 @@ func CreateEventList(events []api.Event, dsQuery *common.DataSelectQuery) common
 
 // The code below allows to perform complex data section on []api.Event
 
-var propertyGetters = map[string]func(EventCell)(common.ComparableValue){
-	"name": func(self EventCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self EventCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self EventCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type EventCell api.Event
 
-func (self EventCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self EventCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/job/jobcommon.go
+++ b/src/app/backend/resource/job/jobcommon.go
@@ -21,22 +21,20 @@ import (
 
 // The code below allows to perform complex data section on []batch.Job
 
-var propertyGetters = map[string]func(JobCell)(common.ComparableValue){
-	"name": func(self JobCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self JobCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self JobCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type JobCell batch.Job
 
-func (self JobCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self JobCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/job/jobcommon.go
+++ b/src/app/backend/resource/job/jobcommon.go
@@ -38,15 +38,15 @@ func (self JobCell) GetProperty(name common.PropertyName) common.ComparableValue
 }
 
 
-func toCells(std []batch.Job) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []batch.Job) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = JobCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []batch.Job {
+func fromCells(cells []common.DataCell) []batch.Job {
 	std := make([]batch.Job, len(cells))
 	for i := range std {
 		std[i] = batch.Job(cells[i].(JobCell))

--- a/src/app/backend/resource/job/jobdetail.go
+++ b/src/app/backend/resource/job/jobdetail.go
@@ -54,7 +54,7 @@ type JobDetail struct {
 
 // GetJobDetail gets job details.
 func GetJobDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	namespace, name string, pQuery *common.PaginationQuery) (*JobDetail, error) {
+	namespace, name string, dsQuery *common.DataSelectQuery) (*JobDetail, error) {
 
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
@@ -64,7 +64,7 @@ func GetJobDetail(client k8sClient.Interface, heapsterClient client.HeapsterClie
 		return nil, err
 	}
 
-	podList, err := GetJobPods(client, heapsterClient, pQuery, name, namespace)
+	podList, err := GetJobPods(client, heapsterClient, dsQuery, name, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/job/jobevents.go
+++ b/src/app/backend/resource/job/jobevents.go
@@ -52,7 +52,7 @@ func GetJobEvents(client client.Interface, namespace, jobName string) (
 	}
 
 	// TODO support pagination
-	events := event.CreateEventList(apiEvents, common.NoPagination)
+	events := event.CreateEventList(apiEvents, common.NoDataSelect)
 
 	log.Printf("Found %d events related to %s job in %s namespace",
 		len(events.Events), jobName, namespace)

--- a/src/app/backend/resource/job/joblist.go
+++ b/src/app/backend/resource/job/joblist.go
@@ -49,7 +49,7 @@ type Job struct {
 
 // GetJobList returns a list of all Jobs in the cluster.
 func GetJobList(client client.Interface, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*JobList, error) {
+	dsQuery *common.DataSelectQuery) (*JobList, error) {
 	log.Printf("Getting list of all jobs in the cluster")
 
 	channels := &common.ResourceChannels{
@@ -58,12 +58,12 @@ func GetJobList(client client.Interface, nsQuery *common.NamespaceQuery,
 		EventList: common.GetEventListChannel(client, nsQuery, 1),
 	}
 
-	return GetJobListFromChannels(channels, pQuery)
+	return GetJobListFromChannels(channels, dsQuery)
 }
 
 // GetJobList returns a list of all Jobs in the cluster
 // reading required resource list once from the channels.
-func GetJobListFromChannels(channels *common.ResourceChannels, pQuery *common.PaginationQuery) (
+func GetJobListFromChannels(channels *common.ResourceChannels, dsQuery *common.DataSelectQuery) (
 	*JobList, error) {
 
 	jobs := <-channels.JobList.List
@@ -90,20 +90,20 @@ func GetJobListFromChannels(channels *common.ResourceChannels, pQuery *common.Pa
 		return nil, err
 	}
 
-	return CreateJobList(jobs.Items, pods.Items, events.Items, pQuery), nil
+	return CreateJobList(jobs.Items, pods.Items, events.Items, dsQuery), nil
 }
 
 // CreateJobList returns a list of all Job model objects in the cluster, based on all
 // Kubernetes Job API objects.
 func CreateJobList(jobs []batch.Job, pods []api.Pod, events []api.Event,
-	pQuery *common.PaginationQuery) *JobList {
+	dsQuery *common.DataSelectQuery) *JobList {
 
 	jobList := &JobList{
 		Jobs:     make([]Job, 0),
 		ListMeta: common.ListMeta{TotalItems: len(jobs)},
 	}
 
-	jobs = paginate(jobs, pQuery)
+	jobs = fromCells(common.GenericDataSelect(toCells(jobs), dsQuery))
 
 	for _, job := range jobs {
 		var completions int32

--- a/src/app/backend/resource/job/jobpods.go
+++ b/src/app/backend/resource/job/jobpods.go
@@ -30,7 +30,7 @@ import (
 
 // GetJobPods return list of pods targeting job.
 func GetJobPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, jobName, namespace string) (*pod.PodList, error) {
+	dsQuery *common.DataSelectQuery, jobName, namespace string) (*pod.PodList, error) {
 	log.Printf("Getting replication controller %s pods in namespace %s", jobName, namespace)
 
 	pods, err := getRawJobPods(client, jobName, namespace)
@@ -38,7 +38,7 @@ func GetJobPods(client k8sClient.Interface, heapsterClient client.HeapsterClient
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/namespace/namespacecommon.go
+++ b/src/app/backend/resource/namespace/namespacecommon.go
@@ -44,22 +44,20 @@ func CreateNamespace(spec *NamespaceSpec, client *client.Client) error {
 
 // The code below allows to perform complex data section on []api.Namespace
 
-var propertyGetters = map[string]func(NamespaceCell)(common.ComparableValue){
-	"name": func(self NamespaceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self NamespaceCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self NamespaceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type NamespaceCell api.Namespace
 
-func (self NamespaceCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self NamespaceCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/namespace/namespacecommon.go
+++ b/src/app/backend/resource/namespace/namespacecommon.go
@@ -61,15 +61,15 @@ func (self NamespaceCell) GetProperty(name common.PropertyName) common.Comparabl
 }
 
 
-func toCells(std []api.Namespace) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Namespace) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = NamespaceCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Namespace {
+func fromCells(cells []common.DataCell) []api.Namespace {
 	std := make([]api.Namespace, len(cells))
 	for i := range std {
 		std[i] = api.Namespace(cells[i].(NamespaceCell))

--- a/src/app/backend/resource/namespace/namespacelist.go
+++ b/src/app/backend/resource/namespace/namespacelist.go
@@ -43,7 +43,7 @@ type Namespace struct {
 }
 
 // GetNamespaceList returns a list of all namespaces in the cluster.
-func GetNamespaceList(client *client.Client, pQuery *common.PaginationQuery) (*NamespaceList,
+func GetNamespaceList(client *client.Client, dsQuery *common.DataSelectQuery) (*NamespaceList,
 	error) {
 	log.Printf("Getting namespace list")
 
@@ -56,16 +56,16 @@ func GetNamespaceList(client *client.Client, pQuery *common.PaginationQuery) (*N
 		return nil, err
 	}
 
-	return toNamespaceList(namespaces.Items, pQuery), nil
+	return toNamespaceList(namespaces.Items, dsQuery), nil
 }
 
-func toNamespaceList(namespaces []api.Namespace, pQuery *common.PaginationQuery) *NamespaceList {
+func toNamespaceList(namespaces []api.Namespace, dsQuery *common.DataSelectQuery) *NamespaceList {
 	namespaceList := &NamespaceList{
 		Namespaces: make([]Namespace, 0),
 		ListMeta:   common.ListMeta{TotalItems: len(namespaces)},
 	}
 
-	namespaces = paginate(namespaces, pQuery)
+	namespaces = fromCells(common.GenericDataSelect(toCells(namespaces), dsQuery))
 
 	for _, namespace := range namespaces {
 		namespaceList.Namespaces = append(namespaceList.Namespaces, toNamespace(namespace))

--- a/src/app/backend/resource/node/nodecommon.go
+++ b/src/app/backend/resource/node/nodecommon.go
@@ -50,15 +50,15 @@ func (self NodeCell) GetProperty(name common.PropertyName) common.ComparableValu
 }
 
 
-func toCells(std []api.Node) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Node) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = NodeCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Node {
+func fromCells(cells []common.DataCell) []api.Node {
 	std := make([]api.Node, len(cells))
 	for i := range std {
 		std[i] = api.Node(cells[i].(NodeCell))

--- a/src/app/backend/resource/node/nodecommon.go
+++ b/src/app/backend/resource/node/nodecommon.go
@@ -33,22 +33,20 @@ func getContainerImages(node api.Node) []string {
 
 // The code below allows to perform complex data section on []api.Node
 
-var propertyGetters = map[string]func(NodeCell)(common.ComparableValue){
-	"name": func(self NodeCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self NodeCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self NodeCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type NodeCell api.Node
 
-func (self NodeCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self NodeCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/node/nodedetail.go
+++ b/src/app/backend/resource/node/nodedetail.go
@@ -124,7 +124,7 @@ func GetNodeDetail(client k8sClient.Interface, heapsterClient client.HeapsterCli
 	}
 
 	// TODO(floreks) add pagination support
-	podList := pod.CreatePodList(pods.Items, common.NoPagination, heapsterClient)
+	podList := pod.CreatePodList(pods.Items, common.NoDataSelect, heapsterClient)
 
 	events, err := event.GetNodeEvents(client, node.Name)
 	if err != nil {

--- a/src/app/backend/resource/node/nodelist.go
+++ b/src/app/backend/resource/node/nodelist.go
@@ -43,7 +43,7 @@ type Node struct {
 }
 
 // GetNodeList returns a list of all Nodes in the cluster.
-func GetNodeList(client client.Interface, pQuery *common.PaginationQuery) (*NodeList, error) {
+func GetNodeList(client client.Interface, dsQuery *common.DataSelectQuery) (*NodeList, error) {
 	log.Printf("Getting list of all nodes in the cluster")
 
 	nodes, err := client.Nodes().List(api.ListOptions{
@@ -55,16 +55,16 @@ func GetNodeList(client client.Interface, pQuery *common.PaginationQuery) (*Node
 		return nil, err
 	}
 
-	return toNodeList(nodes.Items, pQuery), nil
+	return toNodeList(nodes.Items, dsQuery), nil
 }
 
-func toNodeList(nodes []api.Node, pQuery *common.PaginationQuery) *NodeList {
+func toNodeList(nodes []api.Node, dsQuery *common.DataSelectQuery) *NodeList {
 	nodeList := &NodeList{
 		Nodes:    make([]Node, 0),
 		ListMeta: common.ListMeta{TotalItems: len(nodes)},
 	}
 
-	nodes = paginate(nodes, pQuery)
+	nodes = fromCells(common.GenericDataSelect(toCells(nodes), dsQuery))
 
 	for _, node := range nodes {
 		nodeList.Nodes = append(nodeList.Nodes, toNode(node))

--- a/src/app/backend/resource/petset/petsetcommon.go
+++ b/src/app/backend/resource/petset/petsetcommon.go
@@ -22,13 +22,6 @@ import (
 
 // The code below allows to perform complex data section on []apps.PetSet
 
-var propertyGetters = map[string]func(PetSetCell)(common.ComparableValue){
-	"name": func(self PetSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self PetSetCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self PetSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type PetSetCell apps.PetSet
 
 func (self PetSetCell) GetProperty(name common.PropertyName) common.ComparableValue {
@@ -46,15 +39,15 @@ func (self PetSetCell) GetProperty(name common.PropertyName) common.ComparableVa
 }
 
 
-func toCells(std []apps.PetSet) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []apps.PetSet) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = PetSetCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []apps.PetSet {
+func fromCells(cells []common.DataCell) []apps.PetSet {
 	std := make([]apps.PetSet, len(cells))
 	for i := range std {
 		std[i] = apps.PetSet(cells[i].(PetSetCell))

--- a/src/app/backend/resource/petset/petsetcommon.go
+++ b/src/app/backend/resource/petset/petsetcommon.go
@@ -31,13 +31,18 @@ var propertyGetters = map[string]func(PetSetCell)(common.ComparableValue){
 
 type PetSetCell apps.PetSet
 
-func (self PetSetCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self PetSetCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/petset/petsetdetail.go
+++ b/src/app/backend/resource/petset/petsetdetail.go
@@ -47,7 +47,7 @@ type PetSetDetail struct {
 
 // GetPetSetDetail gets pet set details.
 func GetPetSetDetail(client *k8sClient.Client, heapsterClient client.HeapsterClient,
-	namespace, name string, pQuery *common.PaginationQuery) (*PetSetDetail, error) {
+	namespace, name string, dsQuery *common.DataSelectQuery) (*PetSetDetail, error) {
 
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
@@ -57,7 +57,7 @@ func GetPetSetDetail(client *k8sClient.Client, heapsterClient client.HeapsterCli
 		return nil, err
 	}
 
-	podList, err := GetPetSetPods(client, heapsterClient, pQuery, name, namespace)
+	podList, err := GetPetSetPods(client, heapsterClient, dsQuery, name, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/petset/petsetevents.go
+++ b/src/app/backend/resource/petset/petsetevents.go
@@ -52,7 +52,7 @@ func GetPetSetEvents(client *client.Client, namespace, petSetName string) (
 	}
 
 	// TODO support pagination
-	events := event.CreateEventList(apiEvents, common.NoPagination)
+	events := event.CreateEventList(apiEvents, common.NoDataSelect)
 
 	log.Printf("Found %d events related to %s pet set in %s namespace",
 		len(events.Events), petSetName, namespace)

--- a/src/app/backend/resource/petset/petsetpods.go
+++ b/src/app/backend/resource/petset/petsetpods.go
@@ -28,7 +28,7 @@ import (
 
 // GetPetSetPods return list of pods targeting pet set.
 func GetPetSetPods(client *k8sClient.Client, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, petSetName, namespace string) (*pod.PodList, error) {
+	dsQuery *common.DataSelectQuery, petSetName, namespace string) (*pod.PodList, error) {
 	log.Printf("Getting replication controller %s pods in namespace %s", petSetName, namespace)
 
 	pods, err := getRawPetSetPods(client, petSetName, namespace)
@@ -36,7 +36,7 @@ func GetPetSetPods(client *k8sClient.Client, heapsterClient client.HeapsterClien
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -57,22 +57,20 @@ func GetContainerImages(podTemplate *api.PodSpec) []string {
 
 // The code below allows to perform complex data section on []api.Pod
 
-var propertyGetters = map[string]func(PodCell)(common.ComparableValue){
-	"name": func(self PodCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self PodCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self PodCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type PodCell api.Pod
 
-func (self PodCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self PodCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -74,15 +74,15 @@ func (self PodCell) GetProperty(name common.PropertyName) common.ComparableValue
 }
 
 
-func toCells(std []api.Pod) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Pod) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = PodCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Pod {
+func fromCells(cells []common.DataCell) []api.Pod {
 	std := make([]api.Pod, len(cells))
 	for i := range std {
 		std[i] = api.Pod(cells[i].(PodCell))

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -55,25 +55,13 @@ func GetContainerImages(podTemplate *api.PodSpec) []string {
 	return containerImages
 }
 
-//
-type SelectablePodList []api.Pod
+func paginate(pods []api.Pod, pQuery *common.PaginationQuery) []api.Pod {
+	startIndex, endIndex := pQuery.GetPaginationSettings(len(pods))
 
-var propertyGetters = map[string]func(SelectablePodList, int)(common.ComparableValueInterface){
-	"name": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Name)},
-	"creationTimestamp": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableTime(self[i].ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Namespace)},
-}
-
-// its a bit pain to define these, just copy and paste...
-func (self SelectablePodList) Len() int {return len(self)}
-func (self SelectablePodList) Slice(start, end int) common.SelectableInterface {return self[start:end]}
-
-func (self SelectablePodList) Swap(i int, j int) {self[i], self[j] = self[j], self[i]}
-func (self SelectablePodList) GetPropertyAtIndex(name string, i int) common.ComparableValueInterface {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+	// Return all items if provided settings do not meet requirements
+	if !pQuery.CanPaginate(len(pods), startIndex) {
+		return pods
 	}
-	return getter(self, i)
+
+	return pods[startIndex:endIndex]
 }

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -55,13 +55,25 @@ func GetContainerImages(podTemplate *api.PodSpec) []string {
 	return containerImages
 }
 
-func paginate(pods []api.Pod, pQuery *common.PaginationQuery) []api.Pod {
-	startIndex, endIndex := pQuery.GetPaginationSettings(len(pods))
+//
+type SelectablePodList []api.Pod
 
-	// Return all items if provided settings do not meet requirements
-	if !pQuery.CanPaginate(len(pods), startIndex) {
-		return pods
+var propertyGetters = map[string]func(SelectablePodList, int)(common.ComparableValueInterface){
+	"name": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Name)},
+	"creationTimestamp": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableTime(self[i].ObjectMeta.CreationTimestamp.Time)},
+	"namespace": func(self SelectablePodList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Namespace)},
+}
+
+// its a bit pain to define these, just copy and paste...
+func (self SelectablePodList) Len() int {return len(self)}
+func (self SelectablePodList) Slice(start, end int) common.SelectableInterface {return self[start:end]}
+
+func (self SelectablePodList) Swap(i int, j int) {self[i], self[j] = self[j], self[i]}
+func (self SelectablePodList) GetPropertyAtIndex(name string, i int) common.ComparableValueInterface {
+	getter, isGetterPresent := propertyGetters[name]
+	if !isGetterPresent {
+		// if getter not present then just return a constant dummy value, sort will have no effect.
+		return common.StdComparableInt(0)
 	}
-
-	return pods[startIndex:endIndex]
+	return getter(self, i)
 }

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -54,19 +54,19 @@ type Pod struct {
 
 // GetPodList returns a list of all Pods in the cluster.
 func GetPodList(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	nsQuery *common.NamespaceQuery, pQuery *common.PaginationQuery) (*PodList, error) {
+	nsQuery *common.NamespaceQuery, dsQuery *common.DataSelectQuery) (*PodList, error) {
 	log.Printf("Getting list of all pods in the cluster")
 
 	channels := &common.ResourceChannels{
 		PodList: common.GetPodListChannelWithOptions(client, nsQuery, api.ListOptions{}, 1),
 	}
 
-	return GetPodListFromChannels(channels, pQuery, heapsterClient)
+	return GetPodListFromChannels(channels, dsQuery, heapsterClient)
 }
 
 // GetPodList returns a list of all Pods in the cluster
 // reading required resource list once from the channels.
-func GetPodListFromChannels(channels *common.ResourceChannels, pQuery *common.PaginationQuery,
+func GetPodListFromChannels(channels *common.ResourceChannels, dsQuery *common.DataSelectQuery,
 	heapsterClient client.HeapsterClient) (*PodList, error) {
 
 	pods := <-channels.PodList.List
@@ -74,11 +74,11 @@ func GetPodListFromChannels(channels *common.ResourceChannels, pQuery *common.Pa
 		return nil, err
 	}
 
-	podList := CreatePodList(pods.Items, pQuery, heapsterClient)
+	podList := CreatePodList(pods.Items, dsQuery, heapsterClient)
 	return &podList, nil
 }
 
-func CreatePodList(pods []api.Pod, pQuery *common.PaginationQuery,
+func CreatePodList(pods []api.Pod, dsQuery *common.DataSelectQuery,
 	heapsterClient client.HeapsterClient) PodList {
 
 	channels := &common.ResourceChannels{
@@ -95,7 +95,7 @@ func CreatePodList(pods []api.Pod, pQuery *common.PaginationQuery,
 		ListMeta: common.ListMeta{TotalItems: len(pods)},
 	}
 
-	pods = paginate(pods, pQuery)
+	pods = fromCells(common.GenericDataSelect(toCells(pods), dsQuery))
 
 	for _, pod := range pods {
 		podDetail := ToPod(&pod, metrics)

--- a/src/app/backend/resource/replicaset/replicasetcommon.go
+++ b/src/app/backend/resource/replicaset/replicasetcommon.go
@@ -77,22 +77,20 @@ func ToReplicaSetDetail(replicaSet *extensions.ReplicaSet, eventList common.Even
 
 // The code below allows to perform complex data section on []extensions.ReplicaSet
 
-var propertyGetters = map[string]func(ReplicaSetCell)(common.ComparableValue){
-	"name": func(self ReplicaSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self ReplicaSetCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self ReplicaSetCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type ReplicaSetCell extensions.ReplicaSet
 
-func (self ReplicaSetCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self ReplicaSetCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/replicaset/replicasetcommon.go
+++ b/src/app/backend/resource/replicaset/replicasetcommon.go
@@ -94,15 +94,15 @@ func (self ReplicaSetCell) GetProperty(name common.PropertyName) common.Comparab
 }
 
 
-func toCells(std []extensions.ReplicaSet) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []extensions.ReplicaSet) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = ReplicaSetCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []extensions.ReplicaSet {
+func fromCells(cells []common.DataCell) []extensions.ReplicaSet {
 	std := make([]extensions.ReplicaSet, len(cells))
 	for i := range std {
 		std[i] = extensions.ReplicaSet(cells[i].(ReplicaSetCell))

--- a/src/app/backend/resource/replicaset/replicasetdetail.go
+++ b/src/app/backend/resource/replicaset/replicasetdetail.go
@@ -50,7 +50,7 @@ type ReplicaSetDetail struct {
 
 // GetReplicaSetDetail gets replica set details.
 func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, namespace, name string) (*ReplicaSetDetail, error) {
+	dsQuery *common.DataSelectQuery, namespace, name string) (*ReplicaSetDetail, error) {
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
 	// TODO(floreks): Use channels.
@@ -64,7 +64,7 @@ func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.Heaps
 		return nil, err
 	}
 
-	podList, err := GetReplicaSetPods(client, heapsterClient, pQuery, name, namespace)
+	podList, err := GetReplicaSetPods(client, heapsterClient, dsQuery, name, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.Heaps
 		return nil, err
 	}
 
-	serviceList, err := GetReplicaSetServices(client, pQuery, namespace, name)
+	serviceList, err := GetReplicaSetServices(client, dsQuery, namespace, name)
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/replicaset/replicasetevents.go
+++ b/src/app/backend/resource/replicaset/replicasetevents.go
@@ -52,7 +52,7 @@ func GetReplicaSetEvents(client client.Interface, namespace, replicaSetName stri
 	}
 
 	// TODO support pagination
-	events := event.CreateEventList(apiEvents, common.NoPagination)
+	events := event.CreateEventList(apiEvents, common.NoDataSelect)
 
 	log.Printf("Found %d events related to %s replica set in %s namespace",
 		len(events.Events), replicaSetName, namespace)

--- a/src/app/backend/resource/replicaset/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist.go
@@ -47,7 +47,7 @@ type ReplicaSet struct {
 
 // GetReplicaSetList returns a list of all Replica Sets in the cluster.
 func GetReplicaSetList(client client.Interface, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*ReplicaSetList, error) {
+	dsQuery *common.DataSelectQuery) (*ReplicaSetList, error) {
 	log.Printf("Getting list of all replica sets in the cluster")
 
 	channels := &common.ResourceChannels{
@@ -56,13 +56,13 @@ func GetReplicaSetList(client client.Interface, nsQuery *common.NamespaceQuery,
 		EventList:      common.GetEventListChannel(client, nsQuery, 1),
 	}
 
-	return GetReplicaSetListFromChannels(channels, pQuery)
+	return GetReplicaSetListFromChannels(channels, dsQuery)
 }
 
 // GetReplicaSetList returns a list of all Replica Sets in the cluster
 // reading required resource list once from the channels.
 func GetReplicaSetListFromChannels(channels *common.ResourceChannels,
-	pQuery *common.PaginationQuery) (*ReplicaSetList, error) {
+	dsQuery *common.DataSelectQuery) (*ReplicaSetList, error) {
 
 	replicaSets := <-channels.ReplicaSetList.List
 	if err := <-channels.ReplicaSetList.Error; err != nil {
@@ -88,5 +88,5 @@ func GetReplicaSetListFromChannels(channels *common.ResourceChannels,
 		return nil, err
 	}
 
-	return CreateReplicaSetList(replicaSets.Items, pods.Items, events.Items, pQuery), nil
+	return CreateReplicaSetList(replicaSets.Items, pods.Items, events.Items, dsQuery), nil
 }

--- a/src/app/backend/resource/replicaset/replicasetpods.go
+++ b/src/app/backend/resource/replicaset/replicasetpods.go
@@ -30,7 +30,7 @@ import (
 
 // GetReplicaSetPods return list of pods targeting replica set.
 func GetReplicaSetPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, petSetName, namespace string) (*pod.PodList, error) {
+	dsQuery *common.DataSelectQuery, petSetName, namespace string) (*pod.PodList, error) {
 	log.Printf("Getting replication controller %s pods in namespace %s", petSetName, namespace)
 
 	pods, err := getRawReplicaSetPods(client, petSetName, namespace)
@@ -38,7 +38,7 @@ func GetReplicaSetPods(client k8sClient.Interface, heapsterClient client.Heapste
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/replicaset/replicasetservices.go
+++ b/src/app/backend/resource/replicaset/replicasetservices.go
@@ -23,7 +23,7 @@ import (
 
 // GetReplicaSetServices returns list of services that are related to replica set targeted by given
 // name.
-func GetReplicaSetServices(client client.Interface, pQuery *common.PaginationQuery,
+func GetReplicaSetServices(client client.Interface, dsQuery *common.DataSelectQuery,
 	namespace, name string) (*service.ServiceList, error) {
 
 	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(name)
@@ -43,5 +43,5 @@ func GetReplicaSetServices(client client.Interface, pQuery *common.PaginationQue
 
 	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
 		replicaSet.Spec.Selector.MatchLabels)
-	return service.CreateServiceList(matchingServices, pQuery), nil
+	return service.CreateServiceList(matchingServices, dsQuery), nil
 }

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
@@ -132,22 +132,20 @@ func CreateReplicationControllerList(replicationControllers []api.ReplicationCon
 
 // The code below allows to perform complex data section on []api.ReplicationController
 
-var propertyGetters = map[string]func(ReplicationControllerCell)(common.ComparableValue){
-	"name": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type ReplicationControllerCell api.ReplicationController
 
-func (self ReplicationControllerCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self ReplicationControllerCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
@@ -149,15 +149,15 @@ func (self ReplicationControllerCell) GetProperty(name common.PropertyName) comm
 }
 
 
-func toCells(std []api.ReplicationController) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.ReplicationController) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = ReplicationControllerCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.ReplicationController {
+func fromCells(cells []common.DataCell) []api.ReplicationController {
 	std := make([]api.ReplicationController, len(cells))
 	for i := range std {
 		std[i] = api.ReplicationController(cells[i].(ReplicationControllerCell))

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollercommon.go
@@ -107,15 +107,15 @@ func ToReplicationControllerDetail(replicationController *api.ReplicationControl
 // CreateReplicationControllerList creates paginated list of Replication Controller model
 // objects based on Kubernetes Replication Controller objects array and related resources arrays.
 func CreateReplicationControllerList(replicationControllers []api.ReplicationController,
-	pQuery *common.PaginationQuery, pods []api.Pod, events []api.Event) *ReplicationControllerList {
+	dsQuery *common.DataSelectQuery, pods []api.Pod, events []api.Event) *ReplicationControllerList {
 
 	rcList := &ReplicationControllerList{
 		ReplicationControllers: make([]ReplicationController, 0),
 		ListMeta:               common.ListMeta{TotalItems: len(replicationControllers)},
 	}
 
-	replicationControllers = paginate(replicationControllers, pQuery)
-
+	replicationControllers = fromCells(common.GenericDataSelect(toCells(replicationControllers), dsQuery))
+ 
 	for _, rc := range replicationControllers {
 		matchingPods := common.FilterNamespacedPodsBySelector(pods, rc.ObjectMeta.Namespace,
 			rc.Spec.Selector)
@@ -129,15 +129,40 @@ func CreateReplicationControllerList(replicationControllers []api.ReplicationCon
 	return rcList
 }
 
-func paginate(replicationControllers []api.ReplicationController,
-	pQuery *common.PaginationQuery) []api.ReplicationController {
 
-	startIndex, endIndex := pQuery.GetPaginationSettings(len(replicationControllers))
+// The code below allows to perform complex data section on []api.ReplicationController
 
-	// Return all items if provided settings do not meet requirements
-	if !pQuery.CanPaginate(len(replicationControllers), startIndex) {
-		return replicationControllers
+var propertyGetters = map[string]func(ReplicationControllerCell)(common.ComparableValue){
+	"name": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
+	"creationTimestamp": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
+	"namespace": func(self ReplicationControllerCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
+}
+
+
+type ReplicationControllerCell api.ReplicationController
+
+func (self ReplicationControllerCell) GetProperty(name string) common.ComparableValue {
+	getter, isGetterPresent := propertyGetters[name]
+	if !isGetterPresent {
+		// if getter not present then just return a constant dummy value, sort will have no effect.
+		return common.StdComparableInt(0)
 	}
+	return getter(self)
+}
 
-	return replicationControllers[startIndex:endIndex]
+
+func toCells(std []api.ReplicationController) []common.GenericDataCell {
+	cells := make([]common.GenericDataCell, len(std))
+	for i := range std {
+		cells[i] = ReplicationControllerCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []common.GenericDataCell) []api.ReplicationController {
+	std := make([]api.ReplicationController, len(cells))
+	for i := range std {
+		std[i] = api.ReplicationController(cells[i].(ReplicationControllerCell))
+	}
+	return std
 }

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail.go
@@ -76,20 +76,20 @@ func GetReplicationControllerDetail(client k8sClient.Interface, heapsterClient c
 	}
 
 	// TODO support pagination
-	podList, err := GetReplicationControllerPods(client, heapsterClient, common.NoPagination,
+	podList, err := GetReplicationControllerPods(client, heapsterClient, common.NoDataSelect,
 		name, namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO support pagination
-	eventList, err := GetReplicationControllerEvents(client, common.NoPagination, namespace, name)
+	eventList, err := GetReplicationControllerEvents(client, common.NoDataSelect, namespace, name)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO support pagination
-	serviceList, err := GetReplicationControllerServices(client, common.NoPagination, namespace,
+	serviceList, err := GetReplicationControllerServices(client, common.NoDataSelect, namespace,
 		name)
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerevents.go
@@ -26,7 +26,7 @@ import (
 
 // GetReplicationControllerEvents returns events for particular namespace and replication
 // controller or error if occurred.
-func GetReplicationControllerEvents(client client.Interface, pQuery *common.PaginationQuery,
+func GetReplicationControllerEvents(client client.Interface, dsQuery *common.DataSelectQuery,
 	namespace, replicationControllerName string) (*common.EventList, error) {
 
 	log.Printf("Getting events related to %s replication controller in %s namespace", replicationControllerName,
@@ -53,7 +53,7 @@ func GetReplicationControllerEvents(client client.Interface, pQuery *common.Pagi
 		apiEvents = resourceEvent.FillEventsType(apiEvents)
 	}
 
-	events := resourceEvent.CreateEventList(apiEvents, pQuery)
+	events := resourceEvent.CreateEventList(apiEvents, dsQuery)
 
 	log.Printf("Found %d events related to %s replication controller in %s namespace",
 		len(events.Events), replicationControllerName, namespace)

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist.go
@@ -44,7 +44,7 @@ type ReplicationController struct {
 
 // GetReplicationControllerList returns a list of all Replication Controllers in the cluster.
 func GetReplicationControllerList(client *client.Client, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*ReplicationControllerList, error) {
+	dsQuery *common.DataSelectQuery) (*ReplicationControllerList, error) {
 	log.Printf("Getting list of all replication controllers in the cluster")
 
 	channels := &common.ResourceChannels{
@@ -53,13 +53,13 @@ func GetReplicationControllerList(client *client.Client, nsQuery *common.Namespa
 		EventList:                 common.GetEventListChannel(client, nsQuery, 1),
 	}
 
-	return GetReplicationControllerListFromChannels(channels, pQuery)
+	return GetReplicationControllerListFromChannels(channels, dsQuery)
 }
 
 // GetReplicationControllerListFromChannels returns a list of all Replication Controllers in the cluster
 // reading required resource list once from the channels.
 func GetReplicationControllerListFromChannels(channels *common.ResourceChannels,
-	pQuery *common.PaginationQuery) (*ReplicationControllerList, error) {
+	dsQuery *common.DataSelectQuery) (*ReplicationControllerList, error) {
 
 	rcList := <-channels.ReplicationControllerList.List
 	if err := <-channels.ReplicationControllerList.Error; err != nil {
@@ -76,5 +76,5 @@ func GetReplicationControllerListFromChannels(channels *common.ResourceChannels,
 		return nil, err
 	}
 
-	return CreateReplicationControllerList(rcList.Items, pQuery, podList.Items, eventList.Items), nil
+	return CreateReplicationControllerList(rcList.Items, dsQuery, podList.Items, eventList.Items), nil
 }

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerpods.go
@@ -29,7 +29,7 @@ import (
 // GetReplicationControllerPods return list of pods targeting replication controller associated
 // to given name.
 func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	pQuery *common.PaginationQuery, rcName, namespace string) (*pod.PodList, error) {
+	dsQuery *common.DataSelectQuery, rcName, namespace string) (*pod.PodList, error) {
 	log.Printf("Getting replication controller %s pods in namespace %s", rcName, namespace)
 
 	pods, err := getRawReplicationControllerPods(client, rcName, namespace)
@@ -37,7 +37,7 @@ func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient cli
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, pQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerservices.go
@@ -23,7 +23,7 @@ import (
 
 // GetReplicationControllerServices returns list of services that are related to replication
 // controller targeted by given name.
-func GetReplicationControllerServices(client client.Interface, pQuery *common.PaginationQuery,
+func GetReplicationControllerServices(client client.Interface, dsQuery *common.DataSelectQuery,
 	namespace, rcName string) (*service.ServiceList, error) {
 
 	replicationController, err := client.ReplicationControllers(namespace).Get(rcName)
@@ -43,5 +43,5 @@ func GetReplicationControllerServices(client client.Interface, pQuery *common.Pa
 
 	matchingServices := common.FilterNamespacedServicesBySelector(services.Items, namespace,
 		replicationController.Spec.Selector)
-	return service.CreateServiceList(matchingServices, pQuery), nil
+	return service.CreateServiceList(matchingServices, dsQuery), nil
 }

--- a/src/app/backend/resource/secret/secretcommon.go
+++ b/src/app/backend/resource/secret/secretcommon.go
@@ -20,7 +20,7 @@ import (
 //	"log"
 )
 
-// The code below allows to perform complex data section on
+// The code below allows to perform complex data section on []api.Secret
 
 var propertyGetters = map[string]func(SecretCell)(common.ComparableValue){
 	"name": func(self SecretCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},

--- a/src/app/backend/resource/secret/secretcommon.go
+++ b/src/app/backend/resource/secret/secretcommon.go
@@ -17,7 +17,6 @@ package secret
 import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"k8s.io/kubernetes/pkg/api"
-//	"log"
 )
 
 // The code below allows to perform complex data section on []api.Secret
@@ -39,15 +38,15 @@ func (self SecretCell) GetProperty(name common.PropertyName) common.ComparableVa
 }
 
 
-func toCells(std []api.Secret) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Secret) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = SecretCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Secret {
+func fromCells(cells []common.DataCell) []api.Secret {
 	std := make([]api.Secret, len(cells))
 	for i := range std {
 		std[i] = api.Secret(cells[i].(SecretCell))

--- a/src/app/backend/resource/secret/secretcommon.go
+++ b/src/app/backend/resource/secret/secretcommon.go
@@ -17,29 +17,42 @@ package secret
 import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"k8s.io/kubernetes/pkg/api"
+//	"log"
 )
 
 // The code below allows to perform complex data section on
-type SelectableSecretList []api.Secret
 
-var propertyGetters = map[string]func(SelectableSecretList, int)(common.ComparableValueInterface){
-	"name": func(self SelectableSecretList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Name)},
-	"creationTimestamp": func(self SelectableSecretList, i int)(common.ComparableValueInterface){return common.StdComparableTime(self[i].ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self SelectableSecretList, i int)(common.ComparableValueInterface){return common.StdComparableString(self[i].ObjectMeta.Namespace)},
+var propertyGetters = map[string]func(SecretCell)(common.ComparableValue){
+	"name": func(self SecretCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
+	"creationTimestamp": func(self SecretCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
+	"namespace": func(self SecretCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
 }
 
-// its a bit pain to define these, just copy and paste...
-func (self SelectableSecretList) Len() int {return len(self)}
-func (self SelectableSecretList) Slice(start, end int) common.SelectableInterface {return self[start:end]}
-func (self SelectableSecretList) Swap(i int, j int) {self[i], self[j] = self[j], self[i]}
 
-func (self SelectableSecretList) GetPropertyAtIndex(name string, i int) common.ComparableValueInterface {
+type SecretCell api.Secret
+
+func (self SecretCell) GetProperty(name string) common.ComparableValue {
 	getter, isGetterPresent := propertyGetters[name]
 	if !isGetterPresent {
 		// if getter not present then just return a constant dummy value, sort will have no effect.
 		return common.StdComparableInt(0)
 	}
-	return getter(self, i)
+	return getter(self)
 }
-// -------------------
 
+
+func toCells(std []api.Secret) []common.GenericDataCell {
+	cells := make([]common.GenericDataCell, len(std))
+	for i := range std {
+		cells[i] = SecretCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []common.GenericDataCell) []api.Secret {
+	std := make([]api.Secret, len(cells))
+	for i := range std {
+		std[i] = api.Secret(cells[i].(SecretCell))
+	}
+	return std
+}

--- a/src/app/backend/resource/secret/secretcommon.go
+++ b/src/app/backend/resource/secret/secretcommon.go
@@ -22,22 +22,20 @@ import (
 
 // The code below allows to perform complex data section on []api.Secret
 
-var propertyGetters = map[string]func(SecretCell)(common.ComparableValue){
-	"name": func(self SecretCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self SecretCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self SecretCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type SecretCell api.Secret
 
-func (self SecretCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self SecretCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/secret/secretlist.go
+++ b/src/app/backend/resource/secret/secretlist.go
@@ -107,13 +107,13 @@ func NewSecret(secret *api.Secret) *Secret {
 }
 
 // NewSecret - creates a new instance of SecretList struct based on K8s Secrets array.
-func NewSecretList(secrets SelectableSecretList, dsQuery *common.DataSelectQuery) *SecretList {
+func NewSecretList(secrets []api.Secret, dsQuery *common.DataSelectQuery) *SecretList {
 	newSecretList := &SecretList{
 		ListMeta: common.ListMeta{TotalItems: len(secrets)},
 		Secrets:  make([]Secret, 0),
 	}
 
-	secrets = common.GenericDataSelect(secrets, dsQuery).(SelectableSecretList)
+	secrets = fromCells(common.GenericDataSelect(toCells(secrets), dsQuery))
 
 	for _, secret := range secrets {
 		newSecretList.Secrets = append(newSecretList.Secrets, *NewSecret(&secret))

--- a/src/app/backend/resource/secret/secretlist.go
+++ b/src/app/backend/resource/secret/secretlist.go
@@ -74,7 +74,7 @@ type SecretList struct {
 
 // GetSecretList - return all secrets in the given namespace.
 func GetSecretList(client *client.Client, namespace *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*SecretList, error) {
+	dsQuery *common.DataSelectQuery) (*SecretList, error) {
 	secretList, err := client.Secrets(namespace.ToRequestParam()).List(api.ListOptions{
 		LabelSelector: labels.Everything(),
 		FieldSelector: fields.Everything(),
@@ -82,7 +82,7 @@ func GetSecretList(client *client.Client, namespace *common.NamespaceQuery,
 	if err != nil {
 		return nil, err
 	}
-	return NewSecretList(secretList.Items, pQuery), err
+	return NewSecretList(secretList.Items, dsQuery), err
 }
 
 // CreateSecret - create a single secret using the cluster API client
@@ -107,13 +107,13 @@ func NewSecret(secret *api.Secret) *Secret {
 }
 
 // NewSecret - creates a new instance of SecretList struct based on K8s Secrets array.
-func NewSecretList(secrets []api.Secret, pQuery *common.PaginationQuery) *SecretList {
+func NewSecretList(secrets SelectableSecretList, dsQuery *common.DataSelectQuery) *SecretList {
 	newSecretList := &SecretList{
 		ListMeta: common.ListMeta{TotalItems: len(secrets)},
 		Secrets:  make([]Secret, 0),
 	}
 
-	secrets = paginate(secrets, pQuery)
+	secrets = common.GenericDataSelect(secrets, dsQuery).(SelectableSecretList)
 
 	for _, secret := range secrets {
 		newSecretList.Secrets = append(newSecretList.Secrets, *NewSecret(&secret))

--- a/src/app/backend/resource/service/servicecommon.go
+++ b/src/app/backend/resource/service/servicecommon.go
@@ -48,13 +48,13 @@ func ToServiceDetail(service *api.Service) ServiceDetail {
 
 // CreateServiceList returns paginated service list based on given service array
 // and pagination query.
-func CreateServiceList(services []api.Service, pQuery *common.PaginationQuery) *ServiceList {
+func CreateServiceList(services []api.Service, dsQuery *common.DataSelectQuery) *ServiceList {
 	serviceList := &ServiceList{
 		Services: make([]Service, 0),
 		ListMeta: common.ListMeta{TotalItems: len(services)},
 	}
 
-	services = paginate(services, pQuery)
+	services = fromCells(common.GenericDataSelect(toCells(services), dsQuery))
 
 	for _, service := range services {
 		serviceList.Services = append(serviceList.Services, ToService(&service))
@@ -63,13 +63,40 @@ func CreateServiceList(services []api.Service, pQuery *common.PaginationQuery) *
 	return serviceList
 }
 
-func paginate(services []api.Service, pQuery *common.PaginationQuery) []api.Service {
-	startIndex, endIndex := pQuery.GetPaginationSettings(len(services))
+// The code below allows to perform complex data section on []api.Service
 
-	// Return all items if provided settings do not meet requirements
-	if !pQuery.CanPaginate(len(services), startIndex) {
-		return services
-	}
-
-	return services[startIndex:endIndex]
+var propertyGetters = map[string]func(ServiceCell)(common.ComparableValue){
+	"name": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
+	"creationTimestamp": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
+	"namespace": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
 }
+
+
+type ServiceCell api.Service
+
+func (self ServiceCell) GetProperty(name string) common.ComparableValue {
+	getter, isGetterPresent := propertyGetters[name]
+	if !isGetterPresent {
+		// if getter not present then just return a constant dummy value, sort will have no effect.
+		return common.StdComparableInt(0)
+	}
+	return getter(self)
+}
+
+
+func toCells(std []api.Service) []common.GenericDataCell {
+	cells := make([]common.GenericDataCell, len(std))
+	for i := range std {
+		cells[i] = ServiceCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []common.GenericDataCell) []api.Service {
+	std := make([]api.Service, len(cells))
+	for i := range std {
+		std[i] = api.Service(cells[i].(ServiceCell))
+	}
+	return std
+}
+

--- a/src/app/backend/resource/service/servicecommon.go
+++ b/src/app/backend/resource/service/servicecommon.go
@@ -82,15 +82,15 @@ func (self ServiceCell) GetProperty(name common.PropertyName) common.ComparableV
 }
 
 
-func toCells(std []api.Service) []common.GenericDataCell {
-	cells := make([]common.GenericDataCell, len(std))
+func toCells(std []api.Service) []common.DataCell {
+	cells := make([]common.DataCell, len(std))
 	for i := range std {
 		cells[i] = ServiceCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []common.GenericDataCell) []api.Service {
+func fromCells(cells []common.DataCell) []api.Service {
 	std := make([]api.Service, len(cells))
 	for i := range std {
 		std[i] = api.Service(cells[i].(ServiceCell))

--- a/src/app/backend/resource/service/servicecommon.go
+++ b/src/app/backend/resource/service/servicecommon.go
@@ -65,22 +65,20 @@ func CreateServiceList(services []api.Service, dsQuery *common.DataSelectQuery) 
 
 // The code below allows to perform complex data section on []api.Service
 
-var propertyGetters = map[string]func(ServiceCell)(common.ComparableValue){
-	"name": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Name)},
-	"creationTimestamp": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)},
-	"namespace": func(self ServiceCell)(common.ComparableValue) {return common.StdComparableString(self.ObjectMeta.Namespace)},
-}
-
-
 type ServiceCell api.Service
 
-func (self ServiceCell) GetProperty(name string) common.ComparableValue {
-	getter, isGetterPresent := propertyGetters[name]
-	if !isGetterPresent {
-		// if getter not present then just return a constant dummy value, sort will have no effect.
-		return common.StdComparableInt(0)
+func (self ServiceCell) GetProperty(name common.PropertyName) common.ComparableValue {
+	switch name {
+	case common.NameProperty:
+		return common.StdComparableString(self.ObjectMeta.Name)
+	case common.CreationTimestampProperty:
+		return common.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case common.NamespaceProperty:
+		return common.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
 	}
-	return getter(self)
 }
 
 

--- a/src/app/backend/resource/service/servicedetail.go
+++ b/src/app/backend/resource/service/servicedetail.go
@@ -56,7 +56,7 @@ type ServiceDetail struct {
 
 // GetServiceDetail gets service details.
 func GetServiceDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient,
-	namespace, name string, pQuery *common.PaginationQuery) (*ServiceDetail, error) {
+	namespace, name string, dsQuery *common.DataSelectQuery) (*ServiceDetail, error) {
 
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
@@ -66,7 +66,7 @@ func GetServiceDetail(client k8sClient.Interface, heapsterClient client.Heapster
 		return nil, err
 	}
 
-	podList, err := GetServicePods(client, heapsterClient, namespace, name, pQuery)
+	podList, err := GetServicePods(client, heapsterClient, namespace, name, dsQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func GetServiceDetail(client k8sClient.Interface, heapsterClient client.Heapster
 
 // GetServicePods gets list of pods targeted by given label selector in given namespace.
 func GetServicePods(client k8sClient.Interface, heapsterClient client.HeapsterClient, namespace,
-	name string, pQuery *common.PaginationQuery) (*pod.PodList, error) {
+	name string, dsQuery *common.DataSelectQuery) (*pod.PodList, error) {
 
 	service, err := client.Services(namespace).Get(name)
 	if err != nil {
@@ -102,6 +102,6 @@ func GetServicePods(client k8sClient.Interface, heapsterClient client.HeapsterCl
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(apiPodList.Items, pQuery, heapsterClient)
+	podList := pod.CreatePodList(apiPodList.Items, dsQuery, heapsterClient)
 	return &podList, nil
 }

--- a/src/app/backend/resource/service/servicelist.go
+++ b/src/app/backend/resource/service/servicelist.go
@@ -57,23 +57,23 @@ type ServiceList struct {
 
 // GetServiceList returns a list of all services in the cluster.
 func GetServiceList(client client.Interface, nsQuery *common.NamespaceQuery,
-	pQuery *common.PaginationQuery) (*ServiceList, error) {
+	dsQuery *common.DataSelectQuery) (*ServiceList, error) {
 	log.Printf("Getting list of all services in the cluster")
 
 	channels := &common.ResourceChannels{
 		ServiceList: common.GetServiceListChannel(client, nsQuery, 1),
 	}
 
-	return GetServiceListFromChannels(channels, pQuery)
+	return GetServiceListFromChannels(channels, dsQuery)
 }
 
 // GetServiceListFromChannels returns a list of all services in the cluster.
 func GetServiceListFromChannels(channels *common.ResourceChannels,
-	pQuery *common.PaginationQuery) (*ServiceList, error) {
+	dsQuery *common.DataSelectQuery) (*ServiceList, error) {
 	services := <-channels.ServiceList.List
 	if err := <-channels.ServiceList.Error; err != nil {
 		return nil, err
 	}
 
-	return CreateServiceList(services.Items, pQuery), nil
+	return CreateServiceList(services.Items, dsQuery), nil
 }

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -48,7 +48,7 @@ type Workloads struct {
 
 // GetWorkloads returns a list of all workloads in the cluster.
 func GetWorkloads(client *k8sClient.Client, heapsterClient client.HeapsterClient,
-	nsQuery *common.NamespaceQuery, pQuery *common.PaginationQuery) (*Workloads, error) {
+	nsQuery *common.NamespaceQuery, dsQuery *common.DataSelectQuery) (*Workloads, error) {
 
 	log.Printf("Getting lists of all workloads")
 	channels := &common.ResourceChannels{
@@ -63,13 +63,13 @@ func GetWorkloads(client *k8sClient.Client, heapsterClient client.HeapsterClient
 		EventList:                 common.GetEventListChannel(client, nsQuery, 6),
 	}
 
-	return GetWorkloadsFromChannels(channels, heapsterClient, pQuery)
+	return GetWorkloadsFromChannels(channels, heapsterClient, dsQuery)
 }
 
 // GetWorkloadsFromChannels returns a list of all workloads in the cluster, from the
 // channel sources.
 func GetWorkloadsFromChannels(channels *common.ResourceChannels,
-	heapsterClient client.HeapsterClient, pQuery *common.PaginationQuery) (*Workloads, error) {
+	heapsterClient client.HeapsterClient, dsQuery *common.DataSelectQuery) (*Workloads, error) {
 
 	rsChan := make(chan *replicaset.ReplicaSetList)
 	jobChan := make(chan *job.JobList)
@@ -82,43 +82,43 @@ func GetWorkloadsFromChannels(channels *common.ResourceChannels,
 
 	go func() {
 		rcList, err := replicationcontroller.GetReplicationControllerListFromChannels(channels,
-			pQuery)
+			dsQuery)
 		errChan <- err
 		rcChan <- rcList
 	}()
 
 	go func() {
-		rsList, err := replicaset.GetReplicaSetListFromChannels(channels, pQuery)
+		rsList, err := replicaset.GetReplicaSetListFromChannels(channels, dsQuery)
 		errChan <- err
 		rsChan <- rsList
 	}()
 
 	go func() {
-		jobList, err := job.GetJobListFromChannels(channels, pQuery)
+		jobList, err := job.GetJobListFromChannels(channels, dsQuery)
 		errChan <- err
 		jobChan <- jobList
 	}()
 
 	go func() {
-		deploymentList, err := deployment.GetDeploymentListFromChannels(channels, pQuery)
+		deploymentList, err := deployment.GetDeploymentListFromChannels(channels, dsQuery)
 		errChan <- err
 		deploymentChan <- deploymentList
 	}()
 
 	go func() {
-		podList, err := pod.GetPodListFromChannels(channels, pQuery, heapsterClient)
+		podList, err := pod.GetPodListFromChannels(channels, dsQuery, heapsterClient)
 		errChan <- err
 		podChan <- podList
 	}()
 
 	go func() {
-		dsList, err := daemonset.GetDaemonSetListFromChannels(channels, pQuery)
+		dsList, err := daemonset.GetDaemonSetListFromChannels(channels, dsQuery)
 		errChan <- err
 		dsChan <- dsList
 	}()
 
 	go func() {
-		psList, err := petset.GetPetSetListFromChannels(channels, pQuery)
+		psList, err := petset.GetPetSetListFromChannels(channels, dsQuery)
 		errChan <- err
 		psChan <- psList
 	}()

--- a/src/test/backend/resource/common/dataselect_test.go
+++ b/src/test/backend/resource/common/dataselect_test.go
@@ -1,0 +1,208 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+type PaginationTestCase struct {
+	Info string
+	PaginationQuery *PaginationQuery
+	ExpectedOrder []int
+}
+
+type SortTestCase struct {
+	Info string
+	SortQuery *SortQuery
+	ExpectedOrder []int
+}
+
+type DataCell struct {
+	Name string
+	Id int
+}
+
+func (self DataCell) GetProperty(name PropertyName) ComparableValue {
+	switch name {
+	case NameProperty:
+		return StdComparableString(self.Name)
+	case CreationTimestampProperty:
+		return StdComparableInt(self.Id)
+	default:
+		return nil
+	}
+}
+
+func toCells(std []DataCell) []GenericDataCell {
+	cells := make([]GenericDataCell, len(std))
+	for i := range std {
+		cells[i] = DataCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []GenericDataCell) []DataCell {
+	std := make([]DataCell, len(cells))
+	for i := range std {
+		std[i] = cells[i].(DataCell)
+	}
+	return std
+}
+
+func getDataCellList() ([]GenericDataCell) {
+	return toCells([]DataCell{
+		{"ab", 1},
+		{"ab", 2},
+		{"ab", 3},
+		{"ac", 4},
+		{"ac", 5},
+		{"ad", 6},
+		{"ba", 7},
+		{"da", 8},
+		{"ea", 9},
+		{"aa", 10},
+	})
+}
+
+
+func getOrder(dataList []DataCell) []int {
+	idOrder := []int{}
+	for _, e := range dataList {
+		idOrder = append(idOrder, e.Id)
+	}
+	return idOrder
+}
+
+
+func TestSort(t *testing.T) {
+	testCases := []SortTestCase{
+		{
+			"no sort - do not change the original order",
+			NoSort,
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"ascending sort by 1 property - all items sorted by this property",
+			NewSortQuery([]string{"a", "creationTimestamp"}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"descending sort by 1 property - all items sorted by this property",
+			NewSortQuery([]string{"d", "creationTimestamp"}),
+			[]int{10,9,8,7,6,5,4,3,2,1},
+		},
+		{
+			"sort by few properties where at least one property name is invalid - no sort",
+			NewSortQuery([]string{"a", "INVALID_PROPERTY", "d", "creationTimestamp"}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"sort by 2 properties - items should first be sorted by first property and later by second",
+			NewSortQuery([]string{"a", "name", "d", "creationTimestamp"}),
+			[]int{10,3,2,1,5,4,6,7,8,9},
+		},
+		{
+			"sort by few properties where at least one property name is invalid - no sort",
+			NewSortQuery([]string{"a", "INVALID_PROPERTY", "d", "creationTimestamp"}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"sort by few properties where at least one order option is invalid - no sort",
+			NewSortQuery([]string{"d", "name", "INVALID_ORDER", "creationTimestamp"}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"sort by few properties where one order tag is missing property - no sort",
+			NewSortQuery([]string{"d", "name", "a", "creationTimestamp", "a"}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+	}
+	for _, testCase := range testCases {
+		selectableData := SelectableData{
+			getDataCellList(),
+			&DataSelectQuery{SortQuery: testCase.SortQuery},
+		}
+		paginatedData := fromCells(selectableData.Sort().GenericDataList)
+		order := getOrder(paginatedData)
+		if !reflect.DeepEqual(order, testCase.ExpectedOrder) {
+			t.Errorf(`Sort: %s. Received invalid items for %+v. Got %v, expected %v.`,
+				testCase.Info, testCase.SortQuery, order, testCase.ExpectedOrder)
+		}
+	}
+
+}
+
+
+
+func TestPagination(t *testing.T) {
+	testCases := []PaginationTestCase{
+		{
+			"no pagination - all existing elements should be returned",
+			NoPagination,
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"request one item from existing page - element should be returned",
+			NewPaginationQuery(1, 5),
+			[]int{6},
+		},
+		{
+			"request one item from non existing page - all existing elements should be returned",  // todo Do we really want this behaviour?
+			NewPaginationQuery(1, 10),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"request 2 items from existing page - 2 elements should be returned",
+			NewPaginationQuery(2, 1),
+			[]int{3,4},
+		},
+		{
+			"request 3 items from partially existing page - last few existing should be returned",
+			NewPaginationQuery(3, 3),
+			[]int{10},
+		},
+		{
+			"request more than total number of elements from page 1 - all existing elements should be returned",
+			NewPaginationQuery(11, 0),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"request 3 items from non existing page - all existing elements should be returned",  // todo Do we really want this behaviour?
+			NewPaginationQuery(3, 4),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"Invalid paginatin - all existing elements should be returned",
+			NewPaginationQuery(-1, 4),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+
+	}
+	for _, testCase := range testCases {
+		selectableData := SelectableData{
+			getDataCellList(),
+			&DataSelectQuery{PaginationQuery: testCase.PaginationQuery},
+		}
+		paginatedData := fromCells(selectableData.Paginate().GenericDataList)
+		order := getOrder(paginatedData)
+		if !reflect.DeepEqual(order, testCase.ExpectedOrder) {
+			t.Errorf(`Pagination: %s. Received invalid items for %+v. Got %v, expected %v.`,
+				testCase.Info, testCase.PaginationQuery, order, testCase.ExpectedOrder)
+		}
+	}
+
+}

--- a/src/test/backend/resource/common/dataselect_test.go
+++ b/src/test/backend/resource/common/dataselect_test.go
@@ -31,12 +31,12 @@ type SortTestCase struct {
 	ExpectedOrder []int
 }
 
-type DataCell struct {
+type TestDataCell struct {
 	Name string
 	Id int
 }
 
-func (self DataCell) GetProperty(name PropertyName) ComparableValue {
+func (self TestDataCell) GetProperty(name PropertyName) ComparableValue {
 	switch name {
 	case NameProperty:
 		return StdComparableString(self.Name)
@@ -47,24 +47,24 @@ func (self DataCell) GetProperty(name PropertyName) ComparableValue {
 	}
 }
 
-func toCells(std []DataCell) []GenericDataCell {
-	cells := make([]GenericDataCell, len(std))
+func toCells(std []TestDataCell) []DataCell {
+	cells := make([]DataCell, len(std))
 	for i := range std {
-		cells[i] = DataCell(std[i])
+		cells[i] = TestDataCell(std[i])
 	}
 	return cells
 }
 
-func fromCells(cells []GenericDataCell) []DataCell {
-	std := make([]DataCell, len(cells))
+func fromCells(cells []DataCell) []TestDataCell {
+	std := make([]TestDataCell, len(cells))
 	for i := range std {
-		std[i] = cells[i].(DataCell)
+		std[i] = cells[i].(TestDataCell)
 	}
 	return std
 }
 
-func getDataCellList() ([]GenericDataCell) {
-	return toCells([]DataCell{
+func getDataCellList() ([]DataCell) {
+	return toCells([]TestDataCell{
 		{"ab", 1},
 		{"ab", 2},
 		{"ab", 3},
@@ -79,7 +79,7 @@ func getDataCellList() ([]GenericDataCell) {
 }
 
 
-func getOrder(dataList []DataCell) []int {
+func getOrder(dataList []TestDataCell) []int {
 	idOrder := []int{}
 	for _, e := range dataList {
 		idOrder = append(idOrder, e.Id)
@@ -145,7 +145,6 @@ func TestSort(t *testing.T) {
 	}
 
 }
-
 
 
 func TestPagination(t *testing.T) {

--- a/src/test/backend/resource/common/dataselect_test.go
+++ b/src/test/backend/resource/common/dataselect_test.go
@@ -106,15 +106,21 @@ func TestSort(t *testing.T) {
 			[]int{10,9,8,7,6,5,4,3,2,1},
 		},
 		{
-			"sort by few properties where at least one property name is invalid - no sort",
-			NewSortQuery([]string{"a", "INVALID_PROPERTY", "d", "creationTimestamp"}),
-			[]int{1,2,3,4,5,6,7,8,9,10},
-		},
-		{
 			"sort by 2 properties - items should first be sorted by first property and later by second",
 			NewSortQuery([]string{"a", "name", "d", "creationTimestamp"}),
 			[]int{10,3,2,1,5,4,6,7,8,9},
 		},
+		{
+			"empty sort list - no sort",
+			NewSortQuery([]string{}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"nil - no sort",
+			NewSortQuery(nil),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		// Invalid arguments to the NewSortQuery
 		{
 			"sort by few properties where at least one property name is invalid - no sort",
 			NewSortQuery([]string{"a", "INVALID_PROPERTY", "d", "creationTimestamp"}),
@@ -127,17 +133,23 @@ func TestSort(t *testing.T) {
 		},
 		{
 			"sort by few properties where one order tag is missing property - no sort",
+			NewSortQuery([]string{""}),
+			[]int{1,2,3,4,5,6,7,8,9,10},
+		},
+		{
+			"sort by few properties where one order tag is missing property - no sort",
 			NewSortQuery([]string{"d", "name", "a", "creationTimestamp", "a"}),
 			[]int{1,2,3,4,5,6,7,8,9,10},
 		},
+
 	}
 	for _, testCase := range testCases {
 		selectableData := SelectableData{
 			getDataCellList(),
 			&DataSelectQuery{SortQuery: testCase.SortQuery},
 		}
-		paginatedData := fromCells(selectableData.Sort().GenericDataList)
-		order := getOrder(paginatedData)
+		sortedData := fromCells(selectableData.Sort().GenericDataList)
+		order := getOrder(sortedData)
 		if !reflect.DeepEqual(order, testCase.ExpectedOrder) {
 			t.Errorf(`Sort: %s. Received invalid items for %+v. Got %v, expected %v.`,
 				testCase.Info, testCase.SortQuery, order, testCase.ExpectedOrder)
@@ -155,14 +167,19 @@ func TestPagination(t *testing.T) {
 			[]int{1,2,3,4,5,6,7,8,9,10},
 		},
 		{
+			"empty pagination - no elements should be returned",
+			EmptyPagination,
+			[]int{},
+		},
+		{
 			"request one item from existing page - element should be returned",
 			NewPaginationQuery(1, 5),
 			[]int{6},
 		},
 		{
-			"request one item from non existing page - all existing elements should be returned",  // todo Do we really want this behaviour?
+			"request one item from non existing page - no elements should be returned",
 			NewPaginationQuery(1, 10),
-			[]int{1,2,3,4,5,6,7,8,9,10},
+			[]int{},
 		},
 		{
 			"request 2 items from existing page - 2 elements should be returned",
@@ -180,13 +197,18 @@ func TestPagination(t *testing.T) {
 			[]int{1,2,3,4,5,6,7,8,9,10},
 		},
 		{
-			"request 3 items from non existing page - all existing elements should be returned",  // todo Do we really want this behaviour?
+			"request 3 items from non existing page - no elements should be returned",
 			NewPaginationQuery(3, 4),
+			[]int{},
+		},
+		{
+			"Invalid pagination - all elements should be returned",
+			NewPaginationQuery(-1, 4),
 			[]int{1,2,3,4,5,6,7,8,9,10},
 		},
 		{
-			"Invalid paginatin - all existing elements should be returned",
-			NewPaginationQuery(-1, 4),
+			"Invalid pagination - all elements should be returned",
+			NewPaginationQuery(1, -4),
 			[]int{1,2,3,4,5,6,7,8,9,10},
 		},
 

--- a/src/test/backend/resource/common/pagination_test.go
+++ b/src/test/backend/resource/common/pagination_test.go
@@ -37,23 +37,24 @@ func TestNewPaginationQuery(t *testing.T) {
 	}
 }
 
-func TestCanPaginate(t *testing.T) {
+func TestIsValidPagination(t *testing.T) {
 	cases := []struct {
 		pQuery                    *PaginationQuery
-		itemsCount, startingIndex int
 		expected                  bool
 	}{
-		{&PaginationQuery{0, 0}, 10, 0, false},
-		{&PaginationQuery{5, 0}, 0, 0, false},
-		{&PaginationQuery{10, 1}, 10, 10, false},
-		{&PaginationQuery{10, 0}, 10, 0, true},
+		{&PaginationQuery{0, 0}, true},
+		{&PaginationQuery{5, 0}, true},
+		{&PaginationQuery{10, 1}, true},
+		{&PaginationQuery{0, 2}, true},
+		{&PaginationQuery{10, -1}, false},
+		{&PaginationQuery{-1, 0}, false},
+		{&PaginationQuery{-1, -1}, false},
 	}
 
 	for _, c := range cases {
-		actual := c.pQuery.CanPaginate(c.itemsCount, c.startingIndex)
+		actual := c.pQuery.IsValidPagination()
 		if actual != c.expected {
-			t.Errorf("CanPaginate(%+v, %+v) == %+v, expected %+v",
-				c.itemsCount, c.startingIndex, actual, c.expected)
+			t.Errorf("CanPaginate() == %+v, expected %+v", actual, c.expected)
 		}
 	}
 }

--- a/src/test/backend/resource/configmap/configmap_test.go
+++ b/src/test/backend/resource/configmap/configmap_test.go
@@ -42,7 +42,7 @@ func TestGetConfigMapList(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := getConfigMapList(c.configMaps, common.NoPagination)
+		actual := getConfigMapList(c.configMaps, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getConfigMapList(%#v) == \n%#v\nexpected \n%#v\n",
 				c.configMaps, actual, c.expected)

--- a/src/test/backend/resource/daemonset/daemonsetlist_test.go
+++ b/src/test/backend/resource/daemonset/daemonsetlist_test.go
@@ -191,7 +191,7 @@ func TestGetDaemonSetList(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := CreateDaemonSetList(c.daemonSets, c.pods, events, common.NoPagination)
+		actual := CreateDaemonSetList(c.daemonSets, c.pods, events, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("CreateDaemonSetList(%#v, %#v, %#v) == \n%#v\nexpected \n%#v\n",
 				c.daemonSets, c.services, events, actual, c.expected)

--- a/src/test/backend/resource/deployment/deploymentlist_test.go
+++ b/src/test/backend/resource/deployment/deploymentlist_test.go
@@ -177,7 +177,7 @@ func TestGetDeploymentListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetDeploymentListFromChannels(channels, common.NoPagination)
+		actual, err := GetDeploymentListFromChannels(channels, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetDeploymentListFromChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/event/eventcommon_test.go
+++ b/src/test/backend/resource/event/eventcommon_test.go
@@ -164,7 +164,7 @@ func TestToEventList(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := CreateEventList(c.events, common.NoPagination)
+		actual := CreateEventList(c.events, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("ToEventList(%+v, %+v) == \n%+v, expected \n%+v",
 				c.events, c.namespace, actual, c.expected)

--- a/src/test/backend/resource/job/jobdetail_test.go
+++ b/src/test/backend/resource/job/jobdetail_test.go
@@ -78,7 +78,7 @@ func TestGetJobDetail(t *testing.T) {
 		fakeHeapsterClient := FakeHeapsterClient{}
 
 		actual, _ := GetJobDetail(fakeClient, fakeHeapsterClient, c.namespace, c.name,
-			common.NoPagination)
+			common.NoDataSelect)
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {

--- a/src/test/backend/resource/job/joblist_test.go
+++ b/src/test/backend/resource/job/joblist_test.go
@@ -206,7 +206,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetJobListFromChannels(channels, common.NoPagination)
+		actual, err := GetJobListFromChannels(channels, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetJobListFromChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/persistentvolume/persistentvolume_test.go
+++ b/src/test/backend/resource/persistentvolume/persistentvolume_test.go
@@ -42,7 +42,7 @@ func TestGetPersistentVolumeList(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := getPersistentVolumeList(c.persistentVolumes, common.NoPagination)
+		actual := getPersistentVolumeList(c.persistentVolumes, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getPersistentVolumeList(%#v) == \n%#v\nexpected \n%#v\n",
 				c.persistentVolumes, actual, c.expected)

--- a/src/test/backend/resource/petset/petsetlist_test.go
+++ b/src/test/backend/resource/petset/petsetlist_test.go
@@ -177,7 +177,7 @@ func TestGetPetSetListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetPetSetListFromChannels(channels, common.NoPagination)
+		actual, err := GetPetSetListFromChannels(channels, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetPetSetListChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/replicaset/replicasetcommon_test.go
+++ b/src/test/backend/resource/replicaset/replicasetcommon_test.go
@@ -59,7 +59,7 @@ func TestCreateReplicaSetList(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := CreateReplicaSetList(c.replicaSets, c.pods, c.events, common.NoPagination)
+		actual := CreateReplicaSetList(c.replicaSets, c.pods, c.events, common.NoDataSelect)
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("CreateReplicaSetList(%#v, %#v, %#v, ...) == \ngot %#v, \nexpected %#v",

--- a/src/test/backend/resource/replicaset/replicasetdetail_test.go
+++ b/src/test/backend/resource/replicaset/replicasetdetail_test.go
@@ -76,7 +76,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 			podList, serviceList, eventList)
 		fakeHeapsterClient := FakeHeapsterClient{client: testclient.NewSimpleFake()}
 
-		actual, _ := GetReplicaSetDetail(fakeClient, fakeHeapsterClient, common.NoPagination,
+		actual, _ := GetReplicaSetDetail(fakeClient, fakeHeapsterClient, common.NoDataSelect,
 			c.namespace, c.name)
 
 		actions := fakeClient.Actions()

--- a/src/test/backend/resource/replicaset/replicasetlist_test.go
+++ b/src/test/backend/resource/replicaset/replicasetlist_test.go
@@ -177,7 +177,7 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetReplicaSetListFromChannels(channels, common.NoPagination)
+		actual, err := GetReplicaSetListFromChannels(channels, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetReplicaSetListChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
@@ -185,7 +185,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := CreateReplicationControllerList(c.replicationControllers, common.NoPagination,
+		actual := CreateReplicationControllerList(c.replicationControllers, common.NoDataSelect,
 			c.pods, events)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getReplicationControllerList(%#v, %#v) == \n%#v\nexpected \n%#v\n",

--- a/src/test/backend/resource/secret/secret_test.go
+++ b/src/test/backend/resource/secret/secret_test.go
@@ -77,7 +77,7 @@ func TestNewSecretListCreation(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := NewSecretList(c.k8sRs.Items, common.NoPagination)
+		actual := NewSecretList(c.k8sRs.Items, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("NewSecretList() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/service/servicedetail_test.go
+++ b/src/test/backend/resource/service/servicedetail_test.go
@@ -79,7 +79,7 @@ func TestGetServiceDetail(t *testing.T) {
 		fakeHeapsterClient := FakeHeapsterClient{client: testclient.NewSimpleFake()}
 
 		actual, _ := GetServiceDetail(fakeClient, fakeHeapsterClient,
-			c.namespace, c.name, common.NoPagination)
+			c.namespace, c.name, common.NoDataSelect)
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {

--- a/src/test/backend/resource/service/servicelist_test.go
+++ b/src/test/backend/resource/service/servicelist_test.go
@@ -60,7 +60,7 @@ func TestGetServiceList(t *testing.T) {
 	for _, c := range cases {
 		fakeClient := testclient.NewSimpleFake(c.serviceList)
 
-		actual, _ := GetServiceList(fakeClient, common.NewNamespaceQuery(nil), common.NoPagination)
+		actual, _ := GetServiceList(fakeClient, common.NewNamespaceQuery(nil), common.NoDataSelect)
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {

--- a/src/test/backend/resource/workload/workloads_test.go
+++ b/src/test/backend/resource/workload/workloads_test.go
@@ -311,7 +311,7 @@ func TestGetWorkloadsFromChannels(t *testing.T) {
 		channels.EventList.List <- eventList
 		channels.EventList.Error <- nil
 
-		actual, err := GetWorkloadsFromChannels(channels, nil, common.NoPagination)
+		actual, err := GetWorkloadsFromChannels(channels, nil, common.NoDataSelect)
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("GetWorkloadsFromChannels() ==\n          %#v\nExpected: %#v", actual, expected)
 		}


### PR DESCRIPTION
Added DataSelectQuery object which contains data selection instruction. Instructions currently only include pagination and sort options, but this can be easy extended to contain also filter options etc. 

DataSelectQuery works tightly with GenericDataSelect function which can perform data selection (according to options present in DataSelectQuery) on any data list composing of GenericDataCells.

I implemented GenericDataCell interface for every resource present in the dashboard and therefore any resource can be now selected according to DataSelect instructions (it is pagination and sorting as for now). Adding filtering will require minimal effort so if needed I can also add data filtering.

### Functionality

Currently data can be sorted by following parameters: name, creationTimestamp, namespace. Please let me know if you want me to add more sortable parameters. For example, adding IP sort for pods is the matter of adding one line of code to the propertyGetters of GenericPod. 

### Example Usage:

To sort pods by creationTimestamp (descending) and later by name (ascending) for pods with the same creation timestamp you can use following query:

http://0.0.0.0:9090/api/v1/pod?itemsPerPage=10&page=1&sortby=d,creationTimestamp,a,name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1098)
<!-- Reviewable:end -->
