### PR TITLE
Refs #1110, fix a nil reference related to job completions

### DIFF
--- a/src/app/backend/resource/job/joblist.go
+++ b/src/app/backend/resource/job/joblist.go
@@ -106,9 +106,13 @@ func CreateJobList(jobs []batch.Job, pods []api.Pod, events []api.Event,
 	jobs = paginate(jobs, pQuery)
 
 	for _, job := range jobs {
+		var completions int32
 		matchingPods := common.FilterNamespacedPodsBySelector(pods, job.ObjectMeta.Namespace,
 			job.Spec.Selector.MatchLabels)
-		podInfo := common.GetPodInfo(job.Status.Active, *job.Spec.Completions, matchingPods)
+		if job.Spec.Completions != nil {
+			completions = *job.Spec.Completions
+		}
+		podInfo := common.GetPodInfo(job.Status.Active, completions, matchingPods)
 		podInfo.Warnings = event.GetPodsEventWarnings(events, matchingPods)
 
 		jobList.Jobs = append(jobList.Jobs, ToJob(&job, &podInfo))

--- a/src/test/backend/resource/job/joblist_test.go
+++ b/src/test/backend/resource/job/joblist_test.go
@@ -95,7 +95,22 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Status: batch.JobStatus{
 						Active: 7,
 					},
-				}},
+				},
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name:              "rs-name",
+							Namespace:         "rs-namespace",
+							Labels:            map[string]string{"key": "value"},
+							CreationTimestamp: unversioned.Unix(111, 222),
+						},
+						Spec: batch.JobSpec{
+							Selector: &unversioned.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+						},
+						Status: batch.JobStatus{
+							Active: 7,
+						},
+					},
+				},
 			},
 			nil,
 			&api.PodList{
@@ -117,7 +132,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 				},
 			},
 			&JobList{
-				common.ListMeta{TotalItems: 1},
+				common.ListMeta{TotalItems: 2},
 				[]Job{{
 					ObjectMeta: common.ObjectMeta{
 						Name:              "rs-name",
@@ -129,6 +144,20 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  21,
+						Failed:   1,
+						Warnings: []common.Event{},
+					},
+				}, {
+					ObjectMeta: common.ObjectMeta{
+						Name:              "rs-name",
+						Namespace:         "rs-namespace",
+						Labels:            map[string]string{"key": "value"},
+						CreationTimestamp: unversioned.Unix(111, 222),
+					},
+					TypeMeta: common.TypeMeta{Kind: common.ResourceKindJob},
+					Pods: common.PodInfo{
+						Current:  7,
+						Desired:  0,
 						Failed:   1,
 						Warnings: []common.Event{},
 					},


### PR DESCRIPTION
We had a batch job in our cluster that hadn't completed. The dashboard seemed to be crashing, and this stack trace was observed in the dashboard logs

```
Starting HTTP server on port 9090
Creating API server client for https://172.16.0.1:443
Successful initial request to the apiserver, version: v1.3.2
Creating in-cluster Heapster client
Getting application global configuration
Application configuration {"serverTime":1470682165503}
Incoming HTTP/1.1 GET /api/v1/workload request from x.x.x.x:51407
Getting lists of all workloads
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x6bb368]

goroutine 38 [running]:
panic(0x18da5a0, 0xc820014060)
	/usr/lib/google-golang/src/runtime/panic.go:483 +0x3ef
github.com/kubernetes/dashboard/resource/job.getPodInfo(0xc820163830, 0xc82035b400, 0x4, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/google/home/bryk/src/github.com/kubernetes/dashboard/.tmp/backend/src/github.com/kubernetes/dashboard/resource/job/jobcommon.go:25 +0x48
github.com/kubernetes/dashboard/resource/job.ToJobList(0xc820292000, 0x1, 0x1, 0xc8205cc900, 0xf, 0x10, 0xc8201ec000, 0x10, 0x10, 0x2)
	/usr/local/google/home/bryk/src/github.com/kubernetes/dashboard/.tmp/backend/src/github.com/kubernetes/dashboard/resource/job/joblist.go:100 +0x20c
github.com/kubernetes/dashboard/resource/job.GetJobListFromChannels(0xc820178dc0, 0x0, 0x0, 0x0)
	/usr/local/google/home/bryk/src/github.com/kubernetes/dashboard/.tmp/backend/src/github.com/kubernetes/dashboard/resource/job/joblist.go:88 +0x491
github.com/kubernetes/dashboard/resource/workload.GetWorkloadsFromChannels.func3(0xc820178dc0, 0xc8200505a0, 0xc820050360)
	/usr/local/google/home/bryk/src/github.com/kubernetes/dashboard/.tmp/backend/src/github.com/kubernetes/dashboard/resource/workload/workloads.go:96 +0x25
created by github.com/kubernetes/dashboard/resource/workload.GetWorkloadsFromChannels
	/usr/local/google/home/bryk/src/github.com/kubernetes/dashboard/.tmp/backend/src/github.com/kubernetes/dashboard/resource/workload/workloads.go:99 +0x207
```

It looked like job.Spec.Completions was being referenced for the job, although it was never set.

This PR adds a test case and a fix for the case when Completions is not set, and remains nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1113)
<!-- Reviewable:end -->
