### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,6 @@ before_script:
   # Install go 1.6.1. It is not there by default.
   - eval "$(gimme 1.6.1)"
 
-  # Upgrade to docker 1.10+. Answer all questions with yes.
-  # List available docker versions with "apt-cache madison docker-engine"
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.11.2-0~trusty
   - sudo ./build/setup-docker.sh
   - docker --version
 


### PR DESCRIPTION
@bryk Not sure if someone already looked into this issue. I had a quick look and could fix 2 issues

1. I assume the base image of travis was upgraded. The manual docker installation is no longer needed.

2. There seems to be additional bower caching problems. I have cleaned cache and passed this problem.

There is one issue left "Error: Govendor is not on the path." Not sure. I leaf office now. Feel free to merge - better than before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1119)
<!-- Reviewable:end -->
