### PR TITLE
Show empty pods message on Node details page

### DIFF
--- a/src/app/frontend/nodedetail/nodeinfo.html
+++ b/src/app/frontend/nodedetail/nodeinfo.html
@@ -106,10 +106,14 @@ limitations under the License.
     <kd-node-conditions conditions="::$ctrl.node.conditions"></kd-node-conditions>
   </kd-content>
 </kd-content-card>
-<kd-content-card ng-show="::$ctrl.node.podList.pods.length">
+<kd-content-card>
   <kd-title>{{::$ctrl.i18n.MSG_NODE_DETAIL_PODS_LABEL}}</kd-title>
   <kd-content>
-    <kd-pod-card-list pod-list="$ctrl.node.podList" with-statuses="true">
+    <kd-pod-card-list pod-list="$ctrl.node.podList" with-statuses="true" ng-show="::$ctrl.node.podList.pods.length">
     </kd-pod-card-list>
+    <div class="kd-zerostate-message" layout-padding ng-hide="::$ctrl.node.podList.pods.length">
+      <div class="kd-zerostate-title">{{::$ctrl.i18n.MSG_NODE_DETAIL_PODS_ZEROSTATE_TITLE}}</div>
+      <div class="kd-zerostate-text">{{::$ctrl.i18n.MSG_NODE_DETAIL_PODS_ZEROSTATE_TEXT}}</div>
+    </div>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/nodedetail/nodeinfo_component.js
+++ b/src/app/frontend/nodedetail/nodeinfo_component.js
@@ -129,4 +129,9 @@ const i18n = {
   MSG_NODE_DETAIL_CONDITIONS_LABEL: goog.getMsg('Conditions'),
   /** @export {string} @desc Label 'Pods' for the pods section on the node details page. */
   MSG_NODE_DETAIL_PODS_LABEL: goog.getMsg('Pods'),
+  /** @export {string} @desc Title for pods card zerostate in node details page. */
+  MSG_NODE_DETAIL_PODS_ZEROSTATE_TITLE: goog.getMsg('There is nothing to display here'),
+  /** @export {string} @desc Text for pods card zerostate in node details page. */
+  MSG_NODE_DETAIL_PODS_ZEROSTATE_TEXT:
+      goog.getMsg('There are currently no Pods scheduled on this Node'),
 };


### PR DESCRIPTION
Node detail page shows a zerostate message in the Pods section when there are currently no pods scheduled on that node.
(#1095)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1128)
<!-- Reviewable:end -->
