### PR TITLE
Fix empty namespace column on Pod and Service lists

### DIFF
--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -67,7 +67,7 @@ limitations under the License.
           </a>
         </div>
       </kd-resource-card-column>
-      <kd-resource-card-column ng-if="$ctrl.isMultipleNamespaces">
+      <kd-resource-card-column ng-if="$ctrl.areMultipleNamespacesSelected()">
         <div>
           <kd-middle-ellipsis display-string="{{::pod.objectMeta.namespace}}">
           </kd-middle-ellipsis>

--- a/src/app/frontend/servicelist/servicecard.html
+++ b/src/app/frontend/servicelist/servicecard.html
@@ -34,7 +34,7 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column ng-if="$ctrl.areMultipleNamespacesSelected()">
       <div>
-        <kd-middle-ellipsis display-string="{{::service.objectMeta.namespace}}">
+        <kd-middle-ellipsis display-string="{{::$ctrl.service.objectMeta.namespace}}">
         </kd-middle-ellipsis>
       </div>
     </kd-resource-card-column>


### PR DESCRIPTION
Pod card lists and Service card lists now correctly show populated namespace column
(#1131)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1133)
<!-- Reviewable:end -->
