### PR TITLE
Changed serve.js to use InClusterHeapsterClient by default.

### DIFF
--- a/build/serve.js
+++ b/build/serve.js
@@ -38,7 +38,6 @@ export const browserSyncInstance = browserSync.create();
 const backendDevArgs = [
   `--apiserver-host=${conf.backend.apiServerHost}`,
   `--port=${conf.backend.devServerPort}`,
-  `--heapster-host=${conf.backend.heapsterServerHost}`,
 ];
 
 /**
@@ -49,7 +48,6 @@ const backendDevArgs = [
 const backendArgs = [
   `--apiserver-host=${conf.backend.apiServerHost}`,
   `--port=${conf.frontend.serverPort}`,
-  `--heapster-host=${conf.backend.heapsterServerHost}`,
 ];
 
 /**


### PR DESCRIPTION
Most of the people use in cluster heapster.

What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1163)
<!-- Reviewable:end -->
