### PR TITLE
Added metrics support for ReplicaSets and ReplicationControllers.

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -603,7 +603,8 @@ func (apiHandler *APIHandler) handleGetReplicationControllerList(
 
 	namespace := parseNamespacePathParameter(request)
 	dataSelect := parseDataSelectPathParameter(request)
-	result, err := replicationcontroller.GetReplicationControllerList(apiHandler.client, namespace, dataSelect)
+	dataSelect.MetricQuery = dataselect.StandardMetrics
+	result, err := replicationcontroller.GetReplicationControllerList(apiHandler.client, namespace, dataSelect, &apiHandler.heapsterClient)
 	if err != nil {
 		handleInternalError(response, err)
 		return
@@ -634,7 +635,8 @@ func (apiHandler *APIHandler) handleGetReplicaSets(
 
 	namespace := parseNamespacePathParameter(request)
 	dataSelect := parseDataSelectPathParameter(request)
-	result, err := replicaset.GetReplicaSetList(apiHandler.client, namespace, dataSelect)
+	dataSelect.MetricQuery = dataselect.StandardMetrics
+	result, err := replicaset.GetReplicaSetList(apiHandler.client, namespace, dataSelect, &apiHandler.heapsterClient)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/resource/dataselect/dataselect.go
+++ b/src/app/backend/resource/dataselect/dataselect.go
@@ -111,7 +111,7 @@ func (self *DataSelector) Sort() *DataSelector {
 
 // GetCumulativeMetrics downloads and aggregates metrics for data cells currently present in self.GenericDataList as instructed
 // by MetricQuery and inserts resulting MetricPromises to self.CumulativeMetricsPromises.
-func (self *DataSelector) GetCumulativeMetrics(client client.HeapsterClient) *DataSelector {
+func (self *DataSelector) GetCumulativeMetrics(heapsterClient *client.HeapsterClient) *DataSelector {
 	metricNames := self.DataSelectQuery.MetricQuery.MetricNames
 	if metricNames == nil {
 		// Don't download any metrics
@@ -123,18 +123,23 @@ func (self *DataSelector) GetCumulativeMetrics(client client.HeapsterClient) *Da
 	for i, dataCell := range self.GenericDataList {
 		// make sure data cells support metrics
 		metricDataCell := dataCell.(MetricDataCell)
+
 		// get its heapster selector
 		heapsterSelector, err := metricDataCell.GetResourceSelector().GetHeapsterSelector(self.CachedResources.Pods)
 		if err != nil {
 			// Programming error. Notify immediately.
-			panic(fmt.Sprintf(`Failed to create heapster selector for resource "%s". Probably pods were not available in CachedResources.`, metricDataCell.GetResourceSelector().ResourceType))
+			panic(fmt.Sprintf(`Failed to create heapster selector for resource "%s". Error: %s`, metricDataCell.GetResourceSelector().ResourceType, err))
 		}
 		heapsterSelectors[i] = heapsterSelector
 	}
 	if aggregations == nil {
 		aggregations = metric.OnlyDefaultAggregation
 	}
-	self.CumulativeMetricsPromises = heapsterSelectors.DownloadAndAggregate(client, metricNames, aggregations)
+	// panic if someone tries to download metrics without providing heapster client.
+	if heapsterClient == nil {
+		panic("Tried to download metrics without providing heapster client. Use dataselect.NoMetrics or provide heapster!")
+	}
+	self.CumulativeMetricsPromises = heapsterSelectors.DownloadAndAggregate(*heapsterClient, metricNames, aggregations)
 	return self
 }
 
@@ -168,7 +173,7 @@ func GenericDataSelect(dataList []DataCell, dsQuery *DataSelectQuery) []DataCell
 }
 
 // GenericDataSelect takes a list of GenericDataCells and DataSelectQuery and returns selected data as instructed by dsQuery.
-func GenericDataSelectWithMetrics(dataList []DataCell, dsQuery *DataSelectQuery, cachedResources *CachedResources, heapsterClient client.HeapsterClient) ([]DataCell, metric.MetricPromises) {
+func GenericDataSelectWithMetrics(dataList []DataCell, dsQuery *DataSelectQuery, cachedResources *CachedResources, heapsterClient *client.HeapsterClient) ([]DataCell, metric.MetricPromises) {
 	SelectableData := DataSelector{
 		GenericDataList: dataList,
 		DataSelectQuery: dsQuery,

--- a/src/app/backend/resource/deployment/deploymentdetail.go
+++ b/src/app/backend/resource/deployment/deploymentdetail.go
@@ -156,7 +156,7 @@ func getDeploymentDetail(deployment *extensions.Deployment,
 		oldReplicaSets[i] = *replicaSet
 	}
 	oldReplicaSetList := replicaset.CreateReplicaSetList(oldReplicaSets, pods, rawEvents,
-		dataselect.NoDataSelect)
+		dataselect.NoDataSelect, nil)
 
 	var rollingUpdateStrategy *RollingUpdateStrategy
 	if deployment.Spec.Strategy.RollingUpdate != nil {

--- a/src/app/backend/resource/metric/resourceselector.go
+++ b/src/app/backend/resource/metric/resourceselector.go
@@ -60,7 +60,7 @@ func (self *ResourceSelector) GetHeapsterSelector(cachedPods []api.Pod) (Heapste
 func (self *ResourceSelector) getMyPodsFromCache(cachedPods []api.Pod) ([]api.Pod, error) {
 	// make sure we have the full list of pods. you have to make sure the cache has pod list for all namespaces!
 	if cachedPods == nil {
-		return nil, fmt.Errorf("GetMyPodsFromCache: namespace of the pod not in cachedPods")
+		return nil, fmt.Errorf(`GetMyPodsFromCache: pods were not available in cache. Required for resource type: "%s"`, self.ResourceType)
 	}
 
 	// now decide whether to match by ResourceSelector or by ResourceLabelSelector

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -99,7 +99,7 @@ func CreatePodList(pods []api.Pod, dsQuery *dataselect.DataSelectQuery,
 	}
 
 	podCells, cumulativeMetricsPromises := dataselect.GenericDataSelectWithMetrics(toCells(pods), dsQuery,
-		dataselect.NoResourceCache, heapsterClient)
+		dataselect.NoResourceCache, &heapsterClient)
 	pods = fromCells(podCells)
 
 	for _, pod := range pods {

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -83,13 +83,13 @@ func GetWorkloadsFromChannels(channels *common.ResourceChannels,
 
 	go func() {
 		rcList, err := replicationcontroller.GetReplicationControllerListFromChannels(channels,
-			dsQuery)
+			dsQuery, nil)
 		errChan <- err
 		rcChan <- rcList
 	}()
 
 	go func() {
-		rsList, err := replicaset.GetReplicaSetListFromChannels(channels, dsQuery)
+		rsList, err := replicaset.GetReplicaSetListFromChannels(channels, dsQuery, nil)
 		errChan <- err
 		rsChan <- rsList
 	}()

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<kd-graph metrics="$ctrl.replicaSetList.cumulativeMetrics"></kd-graph>
+
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
     <kd-replica-set-card-list replica-set-list="$ctrl.replicaSetList"

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<kd-graph metrics="$ctrl.replicationControllerList.cumulativeMetrics"></kd-graph>
+
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
     <kd-replication-controller-card-list

--- a/src/test/backend/resource/replicaset/replicasetcommon_test.go
+++ b/src/test/backend/resource/replicaset/replicasetcommon_test.go
@@ -60,7 +60,7 @@ func TestCreateReplicaSetList(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := CreateReplicaSetList(c.replicaSets, c.pods, c.events, dataselect.NoDataSelect)
+		actual := CreateReplicaSetList(c.replicaSets, c.pods, c.events, dataselect.NoDataSelect, nil)
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("CreateReplicaSetList(%#v, %#v, %#v, ...) == \ngot %#v, \nexpected %#v",

--- a/src/test/backend/resource/replicaset/replicasetlist_test.go
+++ b/src/test/backend/resource/replicaset/replicasetlist_test.go
@@ -40,7 +40,9 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 			extensions.ReplicaSetList{},
 			nil,
 			&api.PodList{},
-			&ReplicaSetList{common.ListMeta{}, []ReplicaSet{}},
+			&ReplicaSetList{
+				ListMeta: common.ListMeta{},
+				ReplicaSets: []ReplicaSet{}},
 			nil,
 		},
 		{
@@ -118,8 +120,8 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 				},
 			},
 			&ReplicaSetList{
-				common.ListMeta{TotalItems: 1},
-				[]ReplicaSet{{
+				ListMeta: common.ListMeta{TotalItems: 1},
+				ReplicaSets: []ReplicaSet{{
 					ObjectMeta: common.ObjectMeta{
 						Name:              "rs-name",
 						Namespace:         "rs-namespace",
@@ -178,7 +180,7 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 		channels.EventList.List <- &api.EventList{}
 		channels.EventList.Error <- nil
 
-		actual, err := GetReplicaSetListFromChannels(channels, dataselect.NoDataSelect)
+		actual, err := GetReplicaSetListFromChannels(channels, dataselect.NoDataSelect, nil)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetReplicaSetListChannels() ==\n          %#v\nExpected: %#v", actual, c.expected)
 		}

--- a/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
+++ b/src/test/backend/resource/replicationcontroller/replicationcontrollerlist_test.go
@@ -187,7 +187,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 	}
 	for _, c := range cases {
 		actual := CreateReplicationControllerList(c.replicationControllers, dataselect.NoDataSelect,
-			c.pods, events)
+			c.pods, events, nil)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("getReplicationControllerList(%#v, %#v) == \n%#v\nexpected \n%#v\n",
 				c.replicationControllers, c.services, actual, c.expected)


### PR DESCRIPTION
Added graph displaying cumulative use of CPU and Memory for replica sets and replication controller lists.

![nnn](https://cloud.githubusercontent.com/assets/4052440/18084574/0d266dd8-6ea8-11e6-85e9-e0dd0fb6da17.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1164)
<!-- Reviewable:end -->
