### PR TITLE
Make sure that error redirect does not cause reload-loops

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -32,7 +32,7 @@ limitations under the License.
   <div layout="column" flex="shrink" class="kd-chrome-content-container">
     <md-content flex="auto" class="kd-app-content">
       <div ng-switch="$ctrl.showLoadingSpinner" flex="auto">
-        <div ng-switch-when="true" class="kd-center-fixed">
+        <div ng-switch-when="true">
           <md-progress-circular md-mode="indeterminate" md-diameter="96">
           </md-progress-circular>
         </div>

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -60,18 +60,6 @@ a {
   position: relative;
 }
 
-.kd-center-fixed {
-  align-items: center;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-}
-
 .kd-chrome-content-container {
   width: 100%;
 }

--- a/src/app/frontend/error/error_module.js
+++ b/src/app/frontend/error/error_module.js
@@ -40,9 +40,9 @@ export default angular
 function errorConfig($rootScope, $state) {
   let deregistrationHandler = $rootScope.$on(
       '$stateChangeError', (event, toState, toParams, fromState, fromParams, error) => {
-        // Prevent default behavior of coming back to previous state.
-        event.preventDefault();
-        $state.go(stateName, new StateParams(error));
+        if (toState.name !== stateName) {
+          $state.go(stateName, new StateParams(error));
+        }
       });
 
   $rootScope.$on('$destroy', deregistrationHandler);

--- a/src/test/frontend/error/error_module_test.js
+++ b/src/test/frontend/error/error_module_test.js
@@ -23,10 +23,23 @@ describe('Error module', () => {
     expect($state.current.name).toBe('');
 
     // when
-    $rootScope.$broadcast('$stateChangeError', null, null, null, null, error);
+    $rootScope.$broadcast('$stateChangeError', {}, null, null, null, error);
     $rootScope.$apply();
 
     // then
     expect($state.current.name).toBe('internalerror');
+  }));
+
+  it('should not fall into redirect loop', angular.mock.inject(($rootScope, $state) => {
+    // given
+    let error = {error: 'bar'};
+    expect($state.current.name).toBe('');
+
+    // when
+    $rootScope.$broadcast('$stateChangeError', {name: 'internalerror'}, null, null, null, error);
+    $rootScope.$apply();
+
+    // then
+    expect($state.current.name).toBe('');
   }));
 });


### PR DESCRIPTION
This is just another safeguard.
Re #1183

Also, make error state not overlap with the page content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1186)
<!-- Reviewable:end -->
