### PR TITLE
Reformat JS after clang update and increase empty lint limit to 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
     // Disallow this keywords outside of classes or class-like objects.
     "no-invalid-this": 2,
     // Allow at most one newline between code blocks.
-    "no-multiple-empty-lines": [2, {"max": 1}],
+    "no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 1}],
     // Disallow the use of ternary operators when a simpler alternative exists.
     "no-unneeded-ternary": 2,
     // Disallow trailing spaces. This is to unify code because editors may have different

--- a/build/backend.js
+++ b/build/backend.js
@@ -16,13 +16,14 @@
  * @fileoverview Gulp tasks for compiling backend application.
  */
 import del from 'del';
+import fs from 'fs';
 import gulp from 'gulp';
 import lodash from 'lodash';
 import path from 'path';
-import fs from 'fs';
 
 import conf from './conf';
 import goCommand from './gocommand';
+
 
 /**
  * Compiles backend application in development mode and places the binary in the serve

--- a/build/build.js
+++ b/build/build.js
@@ -17,18 +17,19 @@
  */
 import del from 'del';
 import gulp from 'gulp';
-import gulpMinifyCss from 'gulp-minify-css';
 import gulpHtmlmin from 'gulp-htmlmin';
-import gulpUglify from 'gulp-uglify';
 import gulpIf from 'gulp-if';
-import gulpUseref from 'gulp-useref';
+import gulpMinifyCss from 'gulp-minify-css';
 import GulpRevAll from 'gulp-rev-all';
+import gulpUglify from 'gulp-uglify';
+import gulpUseref from 'gulp-useref';
 import mergeStream from 'merge-stream';
 import path from 'path';
 import uglifySaveLicense from 'uglify-save-license';
 
 import conf from './conf';
 import {multiDest} from './multidest';
+
 
 /**
  * Builds production package for current architecture and places it in the dist directory.

--- a/build/serve.js
+++ b/build/serve.js
@@ -19,11 +19,12 @@ import browserSync from 'browser-sync';
 import browserSyncSpa from 'browser-sync-spa';
 import child from 'child_process';
 import gulp from 'gulp';
-import url from 'url';
 import path from 'path';
 import proxyMiddleware from 'proxy-middleware';
+import url from 'url';
 
 import conf from './conf';
+
 
 /**
  * Browser sync instance that serves the application.

--- a/build/style.js
+++ b/build/style.js
@@ -17,14 +17,15 @@
  */
 import gulp from 'gulp';
 import gulpAutoprefixer from 'gulp-autoprefixer';
-import gulpMinifyCss from 'gulp-minify-css';
-import gulpSourcemaps from 'gulp-sourcemaps';
-import gulpSass from 'gulp-sass';
-import path from 'path';
 import gulpConcat from 'gulp-concat';
+import gulpMinifyCss from 'gulp-minify-css';
+import gulpSass from 'gulp-sass';
+import gulpSourcemaps from 'gulp-sourcemaps';
+import path from 'path';
 
-import {browserSyncInstance} from './serve';
 import conf from './conf';
+import {browserSyncInstance} from './serve';
+
 
 /**
  * Compiles stylesheets and places them into the serve folder. Each stylesheet file is compiled

--- a/build/test.js
+++ b/build/test.js
@@ -15,15 +15,16 @@
 /**
  * @fileoverview Gulp tasks for unit and integration tests.
  */
-import codecov from 'gulp-codecov.io';
 import gulp from 'gulp';
+import codecov from 'gulp-codecov.io';
 import gulpProtractor from 'gulp-protractor';
 import karma from 'karma';
 import path from 'path';
 
-import {browserSyncInstance} from './serve';
 import conf from './conf';
 import goCommand from './gocommand';
+import {browserSyncInstance} from './serve';
+
 
 /**
  * @param {boolean} singleRun

--- a/src/app/frontend/chrome/chrome_module.js
+++ b/src/app/frontend/chrome/chrome_module.js
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './chrome_stateconfig';
-import {chromeComponent} from './chrome_component';
 import componentsModule from 'common/components/components_module';
 import namespaceModule from 'common/namespace/namespace_module';
+
+import {chromeComponent} from './chrome_component';
+import stateConfig from './chrome_stateconfig';
 import navModule from './nav/module';
+
 
 /**
  * Angular module containing navigation chrome for the application.

--- a/src/app/frontend/chrome/nav/module.js
+++ b/src/app/frontend/chrome/nav/module.js
@@ -13,11 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import stateModule from 'common/state/module';
+
 import {hamburgerComponent} from './hamburger_component';
 import {navComponent} from './nav_component';
 import {NavService} from './nav_service';
 import {navItemComponent} from './navitem_component';
-import stateModule from 'common/state/module';
+
 
 /**
  * Angular module containing navigation for the application.

--- a/src/app/frontend/common/components/actionbar/actionbar_module.js
+++ b/src/app/frontend/common/components/actionbar/actionbar_module.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import resourceModule from 'common/resource/resource_module';
+
 import {breadcrumbsComponent} from './../breadcrumbs/breadcrumbs_component';
 import {BreadcrumbsService} from './../breadcrumbs/breadcrumbs_service';
 import {actionbarComponent} from './actionbar_component';
@@ -20,7 +22,6 @@ import {actionbarDetailButtonsComponent} from './actionbardetailbuttons_componen
 import {actionbarEditItemComponent} from './actionbaredititem_component';
 import {actionbarListButtonsComponent} from './actionbarlistbuttons_component';
 
-import resourceModule from 'common/resource/resource_module';
 
 /**
  * Module containing common actionbar.

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -12,22 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import stateModule from 'common/state/module';
+
 import filtersModule from '../filters/filters_module';
-import labelsDirective from './labels/labels_directive';
-import middleEllipsisDirective from './middleellipsis/middleellipsis_directive';
+
+import namespaceModule from './../namespace/namespace_module';
+import paginationModule from './../pagination/pagination_module';
+import actionbarModule from './actionbar/actionbar_module';
 import contentCardModule from './contentcard/contentcard_module';
 import endpointModule from './endpoint/endpoint_module';
+import graphModule from './graph/graph_module';
 import i18nDirective from './i18n/i18n_directive';
 import infoCardModule from './infocard/infocard_module';
+import labelsDirective from './labels/labels_directive';
+import middleEllipsisDirective from './middleellipsis/middleellipsis_directive';
 import resourceCardModule from './resourcecard/resourcecard_module';
-import actionbarModule from './actionbar/actionbar_module';
-import zeroStateModule from './zerostate/zerostate_module';
-import graphModule from './graph/graph_module';
-import paginationModule from './../pagination/pagination_module';
-import namespaceModule from './../namespace/namespace_module';
 import sparklineDirective from './sparkline/sparkline_directive';
 import warnThresholdDirective from './warnthreshold/warnthreshold_directive';
-import stateModule from 'common/state/module';
+import zeroStateModule from './zerostate/zerostate_module';
+
 
 /**
  * Module containing common components for the application.

--- a/src/app/frontend/common/components/resourcecard/resourcecard_module.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecard_module.js
@@ -13,18 +13,20 @@
 // limitations under the License.
 
 import resourceModule from 'common/resource/resource_module';
+
 import {resourceCardComponent} from './resourcecard_component';
+import {resourceCardColumnComponent} from './resourcecardcolumn_component';
+import {resourceCardColumnsComponent} from './resourcecardcolumns_component';
+import {resourceCardDeleteMenuItemComponent} from './resourcecarddeletemenuitem_component';
+import {resourceCardEditMenuItemComponent} from './resourcecardeditmenuitem_component';
+import {resourceCardFooterComponent} from './resourcecardfooter_component';
+import {resourceCardHeaderColumnComponent} from './resourcecardheadercolumn_component';
+import {resourceCardHeaderColumnsComponent} from './resourcecardheadercolumns_component';
 import {resourceCardListComponent} from './resourcecardlist_component';
 import {resourceCardListFooterComponent} from './resourcecardlistfooter_component';
 import {resourceCardListPaginationComponent} from './resourcecardlistpagination_component';
 import {resourceCardMenuComponent} from './resourcecardmenu_component';
-import {resourceCardDeleteMenuItemComponent} from './resourcecarddeletemenuitem_component';
-import {resourceCardEditMenuItemComponent} from './resourcecardeditmenuitem_component';
-import {resourceCardColumnComponent} from './resourcecardcolumn_component';
-import {resourceCardColumnsComponent} from './resourcecardcolumns_component';
-import {resourceCardHeaderColumnComponent} from './resourcecardheadercolumn_component';
-import {resourceCardHeaderColumnsComponent} from './resourcecardheadercolumns_component';
-import {resourceCardFooterComponent} from './resourcecardfooter_component';
+
 
 /**
  * Module containing common components for resource cards. A resource card should be used

--- a/src/app/frontend/common/components/zerostate/zerostate_module.js
+++ b/src/app/frontend/common/components/zerostate/zerostate_module.js
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {zeroStateComponent} from './zerostate_component';
 import resourceCardModule from 'common/components/resourcecard/resourcecard_module';
+
+import {zeroStateComponent} from './zerostate_component';
+
 
 /**
  * Module containing common actionbar.

--- a/src/app/frontend/common/filters/filters_module.js
+++ b/src/app/frontend/common/filters/filters_module.js
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import appConfigModule from '../appconfig/appconfig_module';
+
 import coresFilter from './cores_filter';
 import itemsPerPageFilter from './itemsperpage_filter';
 import memoryFilter from './memory_filter';
 import relativeTimeFilter from './relativetime_filter';
-import appConfigModule from '../appconfig/appconfig_module';
+
 
 /**
  * Module containing common filters for the application.

--- a/src/app/frontend/common/pagination/pagination_module.js
+++ b/src/app/frontend/common/pagination/pagination_module.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {PaginationService} from './pagination_service';
 import namespaceModule from './../namespace/namespace_module';
+import {PaginationService} from './pagination_service';
+
 
 /**
  * Module containing validators for the application.

--- a/src/app/frontend/configmapdetail/configmapdetail_module.js
+++ b/src/app/frontend/configmapdetail/configmapdetail_module.js
@@ -14,10 +14,12 @@
 
 import chromeModule from 'chrome/chrome_module';
 import componentsModule from 'common/components/components_module';
-import eventsModule from 'events/events_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './configmapdetail_stateconfig';
 import {configMapInfoComponent} from './configmapinfo_component';
+
 
 /**
  * Angular module for the Config Map details view.

--- a/src/app/frontend/configmaplist/configmaplist_module.js
+++ b/src/app/frontend/configmaplist/configmaplist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './configmaplist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import configMapDetailModule from 'configmapdetail/configmapdetail_module';
+import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
+import configMapDetailModule from 'configmapdetail/configmapdetail_module';
+
 import {configMapCardComponent} from './configmapcard_component';
 import {configMapCardListComponent} from './configmapcardlist_component';
+import stateConfig from './configmaplist_stateconfig';
+
 
 /**
  * Angular module for the Config Map list view.

--- a/src/app/frontend/daemonsetdetail/daemonsetdetail_module.js
+++ b/src/app/frontend/daemonsetdetail/daemonsetdetail_module.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './daemonsetdetail_stateconfig';
 import {daemonSetInfoComponent} from './daemonsetinfo_component';
+
 
 /**
  * Angular module for the daemon Set details view.

--- a/src/app/frontend/daemonsetlist/daemonsetlist_module.js
+++ b/src/app/frontend/daemonsetlist/daemonsetlist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
-import stateConfig from './daemonsetlist_stateconfig';
-import {daemonSetCardListComponent} from './daemonsetcardlist_component';
-import {daemonSetCardComponent} from './daemonsetcard_component';
 import daemonSetDetailModule from 'daemonsetdetail/daemonsetdetail_module';
+
+import {daemonSetCardComponent} from './daemonsetcard_component';
+import {daemonSetCardListComponent} from './daemonsetcardlist_component';
+import stateConfig from './daemonsetlist_stateconfig';
+
 
 /**
  * Angular module for the Daemon Set list view.

--- a/src/app/frontend/deploy/deploy_module.js
+++ b/src/app/frontend/deploy/deploy_module.js
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './deploy_stateconfig';
-import initConfig from './deploy_initconfig';
+import componentsModule from 'common/components/components_module';
+import historyModule from 'common/history/history_module';
+import validatorsModule from 'common/validators/validators_module';
+
 import errorHandlingModule from '../common/errorhandling/errorhandling_module';
+
+import initConfig from './deploy_initconfig';
+import stateConfig from './deploy_stateconfig';
 import deployLabelDirective from './deploylabel_directive';
-import fileReaderDirective from './filereader_directive';
-import portMappingsDirective from './portmappings_directive';
 import environmentVariablesDirective from './environmentvariables_directive';
-import uploadDirective from './upload_directive';
+import fileReaderDirective from './filereader_directive';
+import helpSectionModule from './helpsection/helpsection_module';
+import portMappingsDirective from './portmappings_directive';
 import uniqueNameDirective from './uniquename_directive';
+import uploadDirective from './upload_directive';
 import validImageReferenceDirective from './validimagereference_directive';
 import validProtocolDirective from './validprotocol_directive';
-import helpSectionModule from './helpsection/helpsection_module';
-import validatorsModule from 'common/validators/validators_module';
-import historyModule from 'common/history/history_module';
-import componentsModule from 'common/components/components_module';
+
 
 /**
  * Angular module for the deploy view.

--- a/src/app/frontend/deploy/deploy_stateconfig.js
+++ b/src/app/frontend/deploy/deploy_stateconfig.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeployController from './deploy_controller';
-import DeployFromSettingsController from './deployfromsettings_controller';
-import DeployFromFileController from './deployfromfile_controller';
-import {baseStateName, deployAppStateName, deployFileStateName} from './deploy_state';
 import {stateName as chromeStateName} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+
+import DeployController from './deploy_controller';
+import {baseStateName, deployAppStateName, deployFileStateName} from './deploy_state';
+import DeployFromFileController from './deployfromfile_controller';
+import DeployFromSettingsController from './deployfromsettings_controller';
+
 
 /**
  * Configures states for the deploy view.

--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as workloads} from 'workloads/workloads_state';
+
+import DockerImageReference from '../common/docker/dockerimagereference';
+
 import showNamespaceDialog from './createnamespace_dialog';
 import showCreateSecretDialog from './createsecret_dialog';
 import DeployLabel from './deploylabel';
 import {uniqueNameValidationKey} from './uniquename_directive';
-import DockerImageReference from '../common/docker/dockerimagereference';
-import {stateName as workloads} from 'workloads/workloads_state';
+
 
 // Label keys for predefined labels
 const APP_LABEL_KEY = 'app';

--- a/src/app/frontend/deploymentdetail/deploymentdetail_module.js
+++ b/src/app/frontend/deploymentdetail/deploymentdetail_module.js
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './deploymentdetail_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+
+import stateConfig from './deploymentdetail_stateconfig';
 import {deploymentInfoComponent} from './deploymentinfo_component';
+
 
 /**
  * Angular module for the Deployment details view.

--- a/src/app/frontend/deploymentlist/deploymentlist_module.js
+++ b/src/app/frontend/deploymentlist/deploymentlist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './deploymentlist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
-import componentsModule from 'common/components/components_module';
-import namespaceModule from 'common/namespace/namespace_module';
 import chromeModule from 'chrome/chrome_module';
+import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+import namespaceModule from 'common/namespace/namespace_module';
+import deploymentDetailModule from 'deploymentdetail/deploymentdetail_module';
+
 import {deploymentCardComponent} from './deploymentcard_component';
 import {deploymentCardListComponent} from './deploymentcardlist_component';
-import deploymentDetailModule from 'deploymentdetail/deploymentdetail_module';
+import stateConfig from './deploymentlist_stateconfig';
+
 
 /**
  * Angular module for the Replication Controller list view.

--- a/src/app/frontend/error/error_module.js
+++ b/src/app/frontend/error/error_module.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {stateName, StateParams} from './internalerror_state';
-
-import stateConfig from './internalerror_stateconfig';
 import chromeModule from 'chrome/chrome_module';
+
+import {stateName, StateParams} from './internalerror_state';
+import stateConfig from './internalerror_stateconfig';
+
 
 /**
  * Angular module for error views.

--- a/src/app/frontend/events/events_module.js
+++ b/src/app/frontend/events/events_module.js
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+
 import {eventCardListComponent} from './eventcardlist_component';
+
 
 /**
  * Angular module for the Replica Set details view.

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -17,33 +17,33 @@
  * to bootstrap the application.
  */
 import chromeModule from './chrome/chrome_module';
+import configMapDetailModule from './configmapdetail/configmapdetail_module';
+import configMapListModule from './configmaplist/configmaplist_module';
 import deployModule from './deploy/deploy_module';
 import deploymentListModule from './deploymentlist/deploymentlist_module';
 import errorModule from './error/error_module';
 import indexConfig from './index_config';
-import jobListModule from './joblist/joblist_module';
+import routeConfig from './index_route';
+import ingressDetailModule from './ingressdetail/module';
+import ingressListModule from './ingresslist/module';
 import jobDetailModule from './jobdetail/jobdetail_module';
+import jobListModule from './joblist/joblist_module';
 import logsModule from './logs/logs_module';
 import namespaceDetailModule from './namespacedetail/namespacedetail_module';
 import namespaceListModule from './namespacelist/namespacelist_module';
 import nodeListModule from './nodelist/nodelist_module';
+import persistentVolumeDetailModule from './persistentvolumedetail/persistentvolumedetail_module';
+import persistentVolumeListModule from './persistentvolumelist/persistentvolumelist_module';
+import petSetListModule from './petsetlist/petsetlist_module';
+import podDetailModule from './poddetail/poddetail_module';
 import replicaSetListModule from './replicasetlist/replicasetlist_module';
 import replicationControllerDetailModule from './replicationcontrollerdetail/replicationcontrollerdetail_module';
 import replicationControllerListModule from './replicationcontrollerlist/replicationcontrollerlist_module';
-import routeConfig from './index_route';
+import secretDetailModule from './secretdetail/module';
+import secretListModule from './secretlist/module';
 import serviceDetailModule from './servicedetail/servicedetail_module';
 import serviceListModule from './servicelist/servicelist_module';
 import workloadsModule from './workloads/workloads_module';
-import secretListModule from './secretlist/module';
-import secretDetailModule from './secretdetail/module';
-import ingressListModule from './ingresslist/module';
-import ingressDetailModule from './ingressdetail/module';
-import podDetailModule from './poddetail/poddetail_module';
-import petSetListModule from './petsetlist/petsetlist_module';
-import configMapListModule from './configmaplist/configmaplist_module';
-import configMapDetailModule from './configmapdetail/configmapdetail_module';
-import persistentVolumeDetailModule from './persistentvolumedetail/persistentvolumedetail_module';
-import persistentVolumeListModule from './persistentvolumelist/persistentvolumelist_module';
 
 export default angular
     .module(

--- a/src/app/frontend/ingressdetail/module.js
+++ b/src/app/frontend/ingressdetail/module.js
@@ -14,10 +14,12 @@
 
 import chromeModule from 'chrome/chrome_module';
 import componentsModule from 'common/components/components_module';
-import eventsModule from 'events/events_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './detail_stateconfig';
 import {ingressInfoComponent} from './info_component';
+
 
 /**
  * Angular module for the Ingress details view.

--- a/src/app/frontend/ingresslist/module.js
+++ b/src/app/frontend/ingresslist/module.js
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 import chromeModule from 'chrome/chrome_module';
-import stateConfig from './list_stateconfig';
-import paginationModule from 'common/pagination/pagination_module';
 import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
-import {ingressCardListComponent} from './cardlist_component';
-import {ingressCardComponent} from './card_component';
+import paginationModule from 'common/pagination/pagination_module';
+
 import detailModule from './../ingressdetail/module';
+import {ingressCardComponent} from './card_component';
+import {ingressCardListComponent} from './cardlist_component';
+import stateConfig from './list_stateconfig';
+
 
 /**
  * Angular module for the ingresses list view.

--- a/src/app/frontend/jobdetail/jobdetail_module.js
+++ b/src/app/frontend/jobdetail/jobdetail_module.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './jobdetail_stateconfig';
 import {jobInfoComponent} from './jobinfo_component';
+
 
 /**
  * Angular module for the Job details view.

--- a/src/app/frontend/joblist/joblist_module.js
+++ b/src/app/frontend/joblist/joblist_module.js
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './joblist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
+import jobDetailModule from 'jobdetail/jobdetail_module';
+
 import {jobCardComponent} from './jobcard_component';
 import {jobCardListComponent} from './jobcardlist_component';
-import jobDetailModule from 'jobdetail/jobdetail_module';
+import stateConfig from './joblist_stateconfig';
+
 
 /**
  * Angular module for the Job list view.

--- a/src/app/frontend/logs/logs_module.js
+++ b/src/app/frontend/logs/logs_module.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './logs_stateconfig';
 import {LogsService} from './logs_service';
+import stateConfig from './logs_stateconfig';
+
 
 /**
  * Angular module for the logs view.

--- a/src/app/frontend/logs/logs_stateconfig.js
+++ b/src/app/frontend/logs/logs_stateconfig.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as chromeStateName} from 'chrome/chrome_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
+
+import {toolbarViewName} from '../chrome/chrome_state';
+
 import {LogsController} from './logs_controller';
 import {stateName} from './logs_state';
 import LogsToolbarController from './logstoolbar/logstoolbar_controller';
-import {toolbarViewName} from '../chrome/chrome_state';
 
-import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
-import {stateName as chromeStateName} from 'chrome/chrome_state';
-import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
 
 /**
  * Configures states for the logs view.

--- a/src/app/frontend/namespacedetail/namespacedetail_module.js
+++ b/src/app/frontend/namespacedetail/namespacedetail_module.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './namespacedetail_stateconfig';
 import {namespaceInfoComponent} from './namespaceinfo_component';
+
 
 /**
  * Angular module for the Namespace details view.

--- a/src/app/frontend/namespacelist/namespacelist_module.js
+++ b/src/app/frontend/namespacelist/namespacelist_module.js
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './namespacelist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+import paginationModule from 'common/pagination/pagination_module';
+import namespaceDetailModule from 'namespacedetail/namespacedetail_module';
+
 import {namespaceCardComponent} from './namespacecard_component';
 import {namespaceCardListComponent} from './namespacecardlist_component';
-import namespaceDetailModule from 'namespacedetail/namespacedetail_module';
-import paginationModule from 'common/pagination/pagination_module';
+import stateConfig from './namespacelist_stateconfig';
+
 
 /**
  * Angular module for the Namespace list view.

--- a/src/app/frontend/nodedetail/nodedetail_module.js
+++ b/src/app/frontend/nodedetail/nodedetail_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
-import stateConfig from './nodedetail_stateconfig';
-import {nodeInfoComponent} from './nodeinfo_component';
+import eventsModule from 'events/events_module';
+
 import {nodeAllocatedResourcesComponent} from './nodeallocatedresources_component';
 import {nodeConditionsComponent} from './nodeconditions_component';
+import stateConfig from './nodedetail_stateconfig';
+import {nodeInfoComponent} from './nodeinfo_component';
+
 
 /**
  * Angular module for the Node details view.

--- a/src/app/frontend/nodelist/nodelist_module.js
+++ b/src/app/frontend/nodelist/nodelist_module.js
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './nodelist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+import paginationModule from 'common/pagination/pagination_module';
+import nodeDetailModule from 'nodedetail/nodedetail_module';
+
 import {nodeCardComponent} from './nodecard_component';
 import {nodeCardListComponent} from './nodecardlist_component';
-import nodeDetailModule from 'nodedetail/nodedetail_module';
-import paginationModule from 'common/pagination/pagination_module';
+import stateConfig from './nodelist_stateconfig';
+
 
 /**
  * Angular module for the Node list view.

--- a/src/app/frontend/persistentvolumedetail/persistentvolumedetail_module.js
+++ b/src/app/frontend/persistentvolumedetail/persistentvolumedetail_module.js
@@ -14,11 +14,13 @@
 
 import chromeModule from 'chrome/chrome_module';
 import componentsModule from 'common/components/components_module';
-import eventsModule from 'events/events_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './persistentvolumedetail_stateconfig';
 import {persistentVolumeInfoComponent} from './persistentvolumeinfo_component';
 import {persistentVolumeSourceInfoComponent} from './persistentvolumesourceinfo_component';
+
 
 /**
  * Angular module for the Persistent Volume details view.

--- a/src/app/frontend/persistentvolumelist/persistentvolumelist_module.js
+++ b/src/app/frontend/persistentvolumelist/persistentvolumelist_module.js
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './persistentvolumelist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
+import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
 import persistentVolumeDetailModule from 'persistentvolumedetail/persistentvolumedetail_module';
-import {persistentVolumeCardListComponent} from './persistentvolumecardlist_component';
+
 import {persistentVolumeCardComponent} from './persistentvolumecard_component';
+import {persistentVolumeCardListComponent} from './persistentvolumecardlist_component';
+import stateConfig from './persistentvolumelist_stateconfig';
+
 
 /**
  * Angular module for the Persistent Volume list view.

--- a/src/app/frontend/petsetdetail/petsetdetail_module.js
+++ b/src/app/frontend/petsetdetail/petsetdetail_module.js
@@ -14,10 +14,12 @@
 
 import chromeModule from 'chrome/chrome_module';
 import componentsModule from 'common/components/components_module';
-import eventsModule from 'events/events_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './petsetdetail_stateconfig';
 import {petSetInfoComponent} from './petsetinfo_component';
+
 
 /**
  * Angular module for the Pet Set details view.

--- a/src/app/frontend/petsetlist/petsetlist_module.js
+++ b/src/app/frontend/petsetlist/petsetlist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './petsetlist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
-import componentsModule from 'common/components/components_module';
-import namespaceModule from 'common/namespace/namespace_module';
 import chromeModule from 'chrome/chrome_module';
+import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
+import namespaceModule from 'common/namespace/namespace_module';
 import petSetDetailModule from 'petsetdetail/petsetdetail_module';
+
 import {petSetCardComponent} from './petsetcard_component';
 import {petSetCardListComponent} from './petsetcardlist_component';
+import stateConfig from './petsetlist_stateconfig';
+
 
 /**
  * Angular module for the Pet Set list view.

--- a/src/app/frontend/poddetail/poddetail_module.js
+++ b/src/app/frontend/poddetail/poddetail_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
-import configMapModule from 'configmapdetail/configmapdetail_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import configMapModule from 'configmapdetail/configmapdetail_module';
+import eventsModule from 'events/events_module';
+
+import {containerInfoComponent} from './containerinfo_component';
 import stateConfig from './poddetail_stateconfig';
 import {podInfoComponent} from './podinfo_component';
-import {containerInfoComponent} from './containerinfo_component';
+
 
 /**
  * Angular module for the Replica Set details view.

--- a/src/app/frontend/podlist/podlist_module.js
+++ b/src/app/frontend/podlist/podlist_module.js
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import chromeModule from 'chrome/chrome_module';
-import stateConfig from './podlist_stateconfig';
-import {podCardListComponent} from './podcardlist_component';
-import paginationModule from 'common/pagination/pagination_module';
 import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
+import paginationModule from 'common/pagination/pagination_module';
+
+import {podCardListComponent} from './podcardlist_component';
+import stateConfig from './podlist_stateconfig';
+
 
 /**
  * Angular module for the Pods list view.

--- a/src/app/frontend/replicasetdetail/replicasetdetail_module.js
+++ b/src/app/frontend/replicasetdetail/replicasetdetail_module.js
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './replicasetdetail_stateconfig';
 import {replicaSetInfoComponent} from './replicasetinfo_component';
+
 
 /**
  * Angular module for the Replica Set details view.

--- a/src/app/frontend/replicasetlist/replicasetlist_module.js
+++ b/src/app/frontend/replicasetlist/replicasetlist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicasetlist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
+import paginationModule from 'common/pagination/pagination_module';
+import replicaSetDetailModule from 'replicasetdetail/replicasetdetail_module';
+
 import {replicaSetCardComponent} from './replicasetcard_component';
 import {replicaSetCardListComponent} from './replicasetcardlist_component';
-import replicaSetDetailModule from 'replicasetdetail/replicasetdetail_module';
-import paginationModule from 'common/pagination/pagination_module';
+import stateConfig from './replicasetlist_stateconfig';
+
 
 /**
  * Angular module for the Replica Set list view.

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_module.js
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import eventsModule from 'events/events_module';
-import resourceModule from 'common/resource/resource_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import resourceModule from 'common/resource/resource_module';
+import eventsModule from 'events/events_module';
 import logsModule from 'logs/logs_module';
 import podListModule from 'podlist/podlist_module';
 import serviceListModule from 'servicelist/servicelist_module';
+
+import {ReplicationControllerService} from './replicationcontroller_service';
 import stateConfig from './replicationcontrollerdetail_stateconfig';
 import {replicationControllerInfoComponent} from './replicationcontrollerinfo_component';
-import {ReplicationControllerService} from './replicationcontroller_service';
+
 
 /**
  * Angular module for the Replication Controller details view.

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail_stateconfig.js
@@ -14,13 +14,13 @@
 
 import {actionbarViewName, stateName as chromeStateName} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
 import {stateName as replicationControllers} from 'replicationcontrollerlist/replicationcontrollerlist_state';
 
 import {ActionBarController} from './actionbar_controller';
+import ReplicationControllerDetailController from './replicationcontrollerdetail_controller';
 import {stateName} from './replicationcontrollerdetail_state';
 
-import ReplicationControllerDetailController from './replicationcontrollerdetail_controller';
-import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
 
 /**
  * Configures states for the service view.

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_module.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist_module.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import stateConfig from './replicationcontrollerlist_stateconfig';
-import filtersModule from 'common/filters/filters_module';
 import componentsModule from 'common/components/components_module';
+import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
-import {replicationControllerCardComponent} from './replicationcontrollercard_component';
-import {replicationControllerCardMenuComponent} from './replicationcontrollercardmenu_component';
-import {replicationControllerCardListComponent} from './replicationcontrollercardlist_component';
 import replicationControllerDetailModule from 'replicationcontrollerdetail/replicationcontrollerdetail_module';
+
+import {replicationControllerCardComponent} from './replicationcontrollercard_component';
+import {replicationControllerCardListComponent} from './replicationcontrollercardlist_component';
+import {replicationControllerCardMenuComponent} from './replicationcontrollercardmenu_component';
+import stateConfig from './replicationcontrollerlist_stateconfig';
+
 
 /**
  * Angular module for the Replication Controller list view.

--- a/src/app/frontend/secretdetail/module.js
+++ b/src/app/frontend/secretdetail/module.js
@@ -14,10 +14,12 @@
 
 import chromeModule from 'chrome/chrome_module';
 import componentsModule from 'common/components/components_module';
-import eventsModule from 'events/events_module';
 import filtersModule from 'common/filters/filters_module';
+import eventsModule from 'events/events_module';
+
 import stateConfig from './detail_stateconfig';
 import {secretInfoComponent} from './info_component';
+
 
 /**
  * Angular module for the Secret details view.

--- a/src/app/frontend/secretlist/module.js
+++ b/src/app/frontend/secretlist/module.js
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 import chromeModule from 'chrome/chrome_module';
-import stateConfig from './list_stateconfig';
-import paginationModule from 'common/pagination/pagination_module';
 import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
-import {secretCardListComponent} from './cardlist_component';
+import paginationModule from 'common/pagination/pagination_module';
+
 import {secretCardComponent} from './card_component';
+import {secretCardListComponent} from './cardlist_component';
+import stateConfig from './list_stateconfig';
+
 
 /**
  * Angular module for the Secrets list view.

--- a/src/app/frontend/servicedetail/servicedetail_module.js
+++ b/src/app/frontend/servicedetail/servicedetail_module.js
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from './../common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+
+import componentsModule from './../common/components/components_module';
 import stateConfig from './servicedetail_stateconfig';
 import {serviceInfoComponent} from './servicedetailinfo_component';
+
 
 /**
  * Angular module for the Service details view.

--- a/src/app/frontend/servicelist/servicelist_module.js
+++ b/src/app/frontend/servicelist/servicelist_module.js
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
-import stateConfig from './servicelist_stateconfig';
-import {serviceCardListComponent} from './servicecardlist_component';
+
 import {serviceCardComponent} from './servicecard_component';
+import {serviceCardListComponent} from './servicecardlist_component';
+import stateConfig from './servicelist_stateconfig';
+
 
 /**
  * Angular module for the Service list view.

--- a/src/app/frontend/workloads/workloads_module.js
+++ b/src/app/frontend/workloads/workloads_module.js
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
 import chromeModule from 'chrome/chrome_module';
-import deploymentListModule from 'deploymentlist/deploymentlist_module';
-import daemonSetListModule from 'daemonsetlist/daemonsetlist_module';
-import jobListModule from 'joblist/joblist_module';
+import componentsModule from 'common/components/components_module';
 import filtersModule from 'common/filters/filters_module';
+import daemonSetListModule from 'daemonsetlist/daemonsetlist_module';
+import deploymentListModule from 'deploymentlist/deploymentlist_module';
+import jobListModule from 'joblist/joblist_module';
 import petSetListModule from 'petsetlist/petsetlist_module';
-import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
 import replicaSetListModule from 'replicasetlist/replicasetlist_module';
+import replicationControllerListModule from 'replicationcontrollerlist/replicationcontrollerlist_module';
+
 import stateConfig from './workloads_stateconfig';
+
 
 /**
  * Module with a view that displays resources categorized as workloads, e.g., Replica Sets or

--- a/src/test/frontend/common/components/breadcrumbs/breadcrumbs_service_test.js
+++ b/src/test/frontend/common/components/breadcrumbs/breadcrumbs_service_test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
-import {stateName as defaultStateName} from 'workloads/workloads_state';
 import componentsModule from 'common/components/components_module';
+import {stateName as defaultStateName} from 'workloads/workloads_state';
 
 describe('Breadcrumbs service ', () => {
   /** @type {ui.router.$state} */

--- a/src/test/frontend/common/components/labels/labels_controller_test.js
+++ b/src/test/frontend/common/components/labels/labels_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import LabelsController from 'common/components/labels/labels_controller';
 import componentsModule from 'common/components/components_module';
+import LabelsController from 'common/components/labels/labels_controller';
 
 describe('Labels controller', () => {
   /**

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import MiddleEllipsisController from 'common/components/middleellipsis/middleellipsis_controller';
 import componentsModule from 'common/components/components_module';
+import MiddleEllipsisController from 'common/components/middleellipsis/middleellipsis_controller';
 
 describe('Middle ellipsis controller', () => {
   /**

--- a/src/test/frontend/common/components/resource/deleteresource_controller_test.js
+++ b/src/test/frontend/common/components/resource/deleteresource_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import resourceModule from 'common/resource/resource_module';
 import {DeleteResourceController} from 'common/resource/deleteresource_controller';
+import resourceModule from 'common/resource/resource_module';
 
 describe('Delete resource controller', () => {
   /** @type !{!common/resource/deleteresource_controller.DeleteResourceController} */

--- a/src/test/frontend/common/components/resource/editresource_controller_test.js
+++ b/src/test/frontend/common/components/resource/editresource_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import resourceModule from 'common/resource/resource_module';
 import {EditResourceController} from 'common/resource/editresource_controller';
+import resourceModule from 'common/resource/resource_module';
 
 describe('Edit resource controller', () => {
   /** @type !{!common/resource/editresource_controller.EditResourceController} */

--- a/src/test/frontend/common/components/resourcecard/resourcecardlistpagination_component_test.js
+++ b/src/test/frontend/common/components/resourcecard/resourcecardlistpagination_component_test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import resourceCardModule from 'common/components/resourcecard/resourcecard_module';
-import paginationModule from 'common/pagination/pagination_module';
 import errorHandlingModule from 'common/errorhandling/errorhandling_module';
+import paginationModule from 'common/pagination/pagination_module';
 
 describe('Resource card list pagination', () => {
   /** @type

--- a/src/test/frontend/common/components/sparkline/sparkline_controller_test.js
+++ b/src/test/frontend/common/components/sparkline/sparkline_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SparklineController from 'common/components/sparkline/sparkline_controller';
 import componentsModule from 'common/components/components_module';
+import SparklineController from 'common/components/sparkline/sparkline_controller';
 
 describe('Sparkline controller', () => {
   /**

--- a/src/test/frontend/common/namespace/namespace_module_test.js
+++ b/src/test/frontend/common/namespace/namespace_module_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import module from 'common/namespace/namespace_module';
 import {namespaceParam} from 'chrome/chrome_state';
+import module from 'common/namespace/namespace_module';
 
 describe('Namespace module ', () => {
   beforeEach(() => { angular.mock.module(module.name); });

--- a/src/test/frontend/common/namespace/namespaceselect_component_test.js
+++ b/src/test/frontend/common/namespace/namespaceselect_component_test.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import module from 'common/namespace/namespace_module';
 import chromeModule from 'chrome/chrome_module';
 import {StateParams} from 'chrome/chrome_state';
+import module from 'common/namespace/namespace_module';
 
 describe('Namespace select component ', () => {
   /** @type {!angular.Scope} */

--- a/src/test/frontend/common/validators/validator_factory_test.js
+++ b/src/test/frontend/common/validators/validator_factory_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import validatorsModule from 'common/validators/validators_module';
 import {IntegerValidator} from 'common/validators/integervalidator';
+import validatorsModule from 'common/validators/validators_module';
 import {LabelKeyNameLengthValidator} from 'deploy/validators/labelkeynamelengthvalidator';
 import {LabelKeyNamePatternValidator} from 'deploy/validators/labelkeynamepatternvalidator';
 

--- a/src/test/frontend/deploy/deployfromfile_controller_test.js
+++ b/src/test/frontend/deploy/deployfromfile_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeployFromFileController from 'deploy/deployfromfile_controller';
 import deployModule from 'deploy/deploy_module';
+import DeployFromFileController from 'deploy/deployfromfile_controller';
 
 describe('DeployFromFile controller', () => {
   /** @type {!DeployFromFileController} */

--- a/src/test/frontend/deploy/deployfromsettings_controller_test.js
+++ b/src/test/frontend/deploy/deployfromsettings_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeployFromSettingController from 'deploy/deployfromsettings_controller';
 import deployModule from 'deploy/deploy_module';
+import DeployFromSettingController from 'deploy/deployfromsettings_controller';
 import DeployLabel from 'deploy/deploylabel';
 import {uniqueNameValidationKey} from 'deploy/uniquename_directive';
 

--- a/src/test/frontend/deploy/deploylabel_controller_test.js
+++ b/src/test/frontend/deploy/deploylabel_controller_test.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeployLabelController from 'deploy/deploylabel_controller';
-import DeployLabel from 'deploy/deploylabel';
 import deployModule from 'deploy/deploy_module';
+import DeployLabel from 'deploy/deploylabel';
+import DeployLabelController from 'deploy/deploylabel_controller';
 
 describe('DeployLabel controller', () => {
   let ctrl;

--- a/src/test/frontend/deploy/portmappings_controller_test.js
+++ b/src/test/frontend/deploy/portmappings_controller_test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import deployModule from 'deploy/deploy_module';
-import PortMappingsController from 'deploy/portmappings_controller';
 import * as serviceTypes from 'deploy/portmappings_controller';
+import PortMappingsController from 'deploy/portmappings_controller';
 
 describe('PortMappingsController controller', () => {
   /** @type {!PortMappingsController} */

--- a/src/test/frontend/ingressdetail/detail_stateconfig_test.js
+++ b/src/test/frontend/ingressdetail/detail_stateconfig_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {getIngressDetail, getIngressDetailResource} from 'ingressdetail/detail_stateconfig';
 import module from 'ingressdetail/module';
-import {getIngressDetailResource, getIngressDetail} from 'ingressdetail/detail_stateconfig';
 
 describe('StateConfig for ingress detail', () => {
   beforeEach(() => { angular.mock.module(module.name); });

--- a/src/test/frontend/ingresslist/list_stateconfig_test.js
+++ b/src/test/frontend/ingresslist/list_stateconfig_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ingressListModule from 'ingresslist/module';
 import {resolveIngressList} from 'ingresslist/list_stateconfig';
+import ingressListModule from 'ingresslist/module';
 
 describe('StateConfig for ingress list', () => {
   /** @type {!common/pagination/pagination_service.PaginationService} */

--- a/src/test/frontend/logs/logstoolbar/logstoolbar_controller_test.js
+++ b/src/test/frontend/logs/logstoolbar/logstoolbar_controller_test.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import LogsToolbarController from 'logs/logstoolbar/logstoolbar_controller';
 import LogsModule from 'logs/logs_module';
 import {StateParams} from 'logs/logs_state';
+import LogsToolbarController from 'logs/logstoolbar/logstoolbar_controller';
 
 describe('Logs toolbar controller', () => {
 

--- a/src/test/frontend/podlist/podcardlist_component_test.js
+++ b/src/test/frontend/podlist/podcardlist_component_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import podsListModule from 'podlist/podlist_module';
 import podDetailModule from 'poddetail/poddetail_module';
+import podsListModule from 'podlist/podlist_module';
 
 describe('Pod card list controller', () => {
   /**

--- a/src/test/frontend/replicationcontrollerdetail/updatereplicas_controller_test.js
+++ b/src/test/frontend/replicationcontrollerdetail/updatereplicas_controller_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UpdateReplicasDialogController from 'replicationcontrollerdetail/updatereplicas_controller';
 import replicationControllerDetailModule from 'replicationcontrollerdetail/replicationcontrollerdetail_module';
+import UpdateReplicasDialogController from 'replicationcontrollerdetail/updatereplicas_controller';
 
 describe('Update Replicas controller', () => {
   /**

--- a/src/test/frontend/secretlist/list_stateconfig_test.js
+++ b/src/test/frontend/secretlist/list_stateconfig_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import secretListModule from 'secretlist/module';
 import {resolveSecretList} from 'secretlist/list_stateconfig';
+import secretListModule from 'secretlist/module';
 
 describe('StateConfig for secret list', () => {
   /** @type {!common/pagination/pagination_service.PaginationService} */

--- a/src/test/frontend/servicelist/servicecard_component_test.js
+++ b/src/test/frontend/servicelist/servicecard_component_test.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import serviceListModule from 'servicelist/servicelist_module';
 import serviceDetailModule from 'servicedetail/servicedetail_module';
+import serviceListModule from 'servicelist/servicelist_module';
 
 describe('Service card controller', () => {
   /**

--- a/src/test/integration/stories/deploy_and_delete_replication_controller.js
+++ b/src/test/integration/stories/deploy_and_delete_replication_controller.js
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DeleteReplicationControllerDialogObject from '../replicationcontrollerdetail/deletereplicationcontroller_po';
 import DeployPageObject from '../deploy/deploy_po';
+import DeleteReplicationControllerDialogObject from '../replicationcontrollerdetail/deletereplicationcontroller_po';
 import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
+
 
 // Test assumes, that there are no replication controllers in the cluster at the beginning.
 // TODO(#494): Reenable this test when fixed.

--- a/src/test/integration/stories/deploy_from_valid_file_test.js
+++ b/src/test/integration/stories/deploy_from_valid_file_test.js
@@ -16,8 +16,9 @@ import path from 'path';
 import remote from 'selenium-webdriver/remote';
 
 import DeployFromFilePageObject from '../deploy/deployfromfile_po';
-import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
 import DeleteReplicationControllerDialogObject from '../replicationcontrollerdetail/deletereplicationcontroller_po';
+import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
+
 
 // Test assumes, that there are no replication controllers in the cluster at the beginning.
 describe('Deploy from valid file user story test', () => {

--- a/src/test/integration/stories/deploy_not_existing_img_test.js
+++ b/src/test/integration/stories/deploy_not_existing_img_test.js
@@ -14,8 +14,9 @@
 
 import DeployPageObject from '../deploy/deploy_po';
 import DeleteReplicationControllerDialogObject from '../replicationcontrollerdetail/deletereplicationcontroller_po';
-import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
 import ReplicationControllerDetailPageObject from '../replicationcontrollerdetail/replicationcontrollerdetail_po';
+import ReplicationControllersPageObject from '../replicationcontrollerslist/replicationcontrollers_po';
+
 
 /**
  * This integration test will check complete user story in given order:


### PR DESCRIPTION
The update PR: https://github.com/kubernetes/dashboard/pull/1189

Increase of empty line limit was required due to cefault clang
formatting now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1190)
<!-- Reviewable:end -->
