### PR TITLE
Fix redirect-loop issue that happens on errors

### DIFF
--- a/src/app/frontend/error/error_module.js
+++ b/src/app/frontend/error/error_module.js
@@ -42,7 +42,7 @@ function errorConfig($rootScope, $state) {
   let deregistrationHandler = $rootScope.$on(
       '$stateChangeError', (event, toState, toParams, fromState, fromParams, error) => {
         if (toState.name !== stateName) {
-          $state.go(stateName, new StateParams(error));
+          $state.go(stateName, new StateParams(error, toParams.namespace));
         }
       });
 

--- a/src/app/frontend/error/internalerror_state.js
+++ b/src/app/frontend/error/internalerror_state.js
@@ -12,17 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {StateParams as ChromeStateParams} from 'chrome/chrome_state';
+
 /** Name of the state. Can be used in, e.g., $state.go method. */
 export const stateName = 'internalerror';
 
 /**
  * Parameters for this state.
  */
-export class StateParams {
+export class StateParams extends ChromeStateParams {
   /**
    * @param {!angular.$http.Response} error
+   * @param {string} namespace
    */
-  constructor(error) {
+  constructor(error, namespace) {
+    super(namespace);
+
     /** @type {!angular.$http.Response} */
     this.error = error;
   }

--- a/src/app/frontend/error/internalerror_stateconfig.js
+++ b/src/app/frontend/error/internalerror_stateconfig.js
@@ -30,7 +30,7 @@ export default function stateConfig($stateProvider) {
     controller: InternalErrorController,
     parent: chromeStateName,
     controllerAs: 'ctrl',
-    params: new StateParams(/** @type {!angular.$http.Response} */ ({})),
+    params: new StateParams(/** @type {!angular.$http.Response} */ ({}), ''),
     templateUrl: 'error/internalerror.html',
     data: {
       [breadcrumbsConfig]: {

--- a/src/test/frontend/error/error_module_test.js
+++ b/src/test/frontend/error/error_module_test.js
@@ -17,18 +17,21 @@ import errorModule from 'error/error_module';
 describe('Error module', () => {
   beforeEach(angular.mock.module(errorModule.name));
 
-  it('should register route error handlers', angular.mock.inject(($rootScope, $state) => {
-    // given
-    let error = {error: 'bar'};
-    expect($state.current.name).toBe('');
+  it('should register route error handlers',
+     angular.mock.inject(($rootScope, $state, $stateParams) => {
+       // given
+       let error = {error: 'bar'};
+       expect($state.current.name).toBe('');
 
-    // when
-    $rootScope.$broadcast('$stateChangeError', {}, null, null, null, error);
-    $rootScope.$apply();
+       // when
+       $rootScope.$broadcast('$stateChangeError', {}, {namespace: 'foo'}, null, null, error);
+       $rootScope.$apply();
 
-    // then
-    expect($state.current.name).toBe('internalerror');
-  }));
+       // then
+       expect($state.current.name).toBe('internalerror');
+       expect($stateParams.namespace).toBe('foo');
+       expect($stateParams.error).toEqual(error);
+     }));
 
   it('should not fall into redirect loop', angular.mock.inject(($rootScope, $state) => {
     // given
@@ -36,7 +39,8 @@ describe('Error module', () => {
     expect($state.current.name).toBe('');
 
     // when
-    $rootScope.$broadcast('$stateChangeError', {name: 'internalerror'}, null, null, null, error);
+    $rootScope.$broadcast(
+        '$stateChangeError', {name: 'internalerror'}, {namespace: 'foo'}, null, null, error);
     $rootScope.$apply();
 
     // then


### PR DESCRIPTION
Previously to reprodce:
1. Start a proxy and a dev server
2. Kill the proxy
3. Open the UI
4. See that it is in a redirect loop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1203)
<!-- Reviewable:end -->
