### PR TITLE
Fix breadcrumb font

### DIFF
--- a/src/app/frontend/_variables.scss
+++ b/src/app/frontend/_variables.scss
@@ -30,6 +30,7 @@ $toolbar-height-size-base: rem(6.4) !default;
 $toolbar-height-size-base-sm: rem(4.8) !default;
 $font-family-monospace: 'Roboto Mono Regular', monospace;
 $font-family-medium-monospace: 'Roboto Mono Medium', monospace;
+$font-family-medium: 'Roboto-Medium';
 
 $primary: #326de6;
 $secondary: #f51200;

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs.scss
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs.scss
@@ -21,12 +21,16 @@
 .kd-breadcrumbs-ellipsised {
   display: inline-block;
   float: left;
-  font-family: $font-family-medium-monospace;
+  font-family: $font-family-medium;
   font-size: $subhead-font-size-base-lg;
   max-width: 100%;
 
-  >.kd-faded-breadcrumb {
+  > .kd-faded-breadcrumb {
     color: $hue-2;
+  }
+
+  .kd-middleellipsis {
+    line-height: 3 * $baseline-grid;
   }
 }
 


### PR DESCRIPTION
Changed from `Roboto Mono Medium` to `Roboto-Medium`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/dashboard/1218)
<!-- Reviewable:end -->
