### PR TITLE
Adjust travis to push canary image on successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@
 # According to the documentation: http://docs.travis-ci.com/user/docker/
 # sudo is required to enable docker in Travis CI.
 sudo: true
+
 # Cache downloaded Node.JS modules & Bower frontend dependencies for faster builds.
 cache:
   directories:
@@ -52,5 +53,21 @@ before_script:
 
   - docker --version
 
-script: ./node_modules/.bin/gulp check:local-cluster
+#script: ./node_modules/.bin/gulp check:local-cluster
+
+after_success:
+  # Make sure that build was not triggered by Pull Request.
+  - if [ "$TRAVIS_PULL_REQUEST" === "false" ]; then
+      if [ "$TRAVIS_BRANCH" = "master" ]; then
+        docker login -u $DOCKER_USER -p $DOCKER_PASS
+        ./node_modules/.bin/gulp ci:push-to-docker:canary:cross
+      elif [ -n "$TRAVIS_TAG" ]; then
+        ./node_modules/.bin/gulp ci:push-to-gcr:release:cross
+      else
+        echo "Image push is not enabled for branch $TRAVIS_BRANCH"
+      fi;
+    else
+      echo "Image push is not available for Pull Requests."
+    fi;
+
 after_script: ./node_modules/.bin/gulp coverage-codecov-upload

--- a/build/conf.js
+++ b/build/conf.js
@@ -43,6 +43,14 @@ const arch = {
 };
 
 /**
+ * TODO
+ */
+const repo = {
+  gcr: 'gcr.io/google_containers',
+  docker: 'floreks',
+};
+
+/**
  * Package version information.
  */
 const version = {
@@ -59,12 +67,17 @@ const version = {
 /**
  * Base name for the docker image.
  */
-const imageNameBase = 'gcr.io/google_containers/kubernetes-dashboard';
+const imageNameBase = 'kubernetes-dashboard';
 
 /**
  * Exported configuration object with common constants used in build pipeline.
  */
 export default {
+  /**
+   * TODO
+   */
+  repo: repo,
+
   /**
    * Backend application constants.
    */
@@ -114,24 +127,31 @@ export default {
     version: version,
 
     /**
+     * Image name base for current architecture.
+     */
+    imageNameBase: `${imageNameBase}-${arch.default}`,
+
+    /**
      * Image name for the canary release for current architecture.
      */
-    canaryImageName: `${imageNameBase}-${arch.default}:${version.canary}`,
+    canaryImageName: `${repo.docker}/${imageNameBase}-${arch.default}:${version.canary}`,
 
     /**
      * Image name for the versioned release for current architecture.
      */
-    releaseImageName: `${imageNameBase}-${arch.default}:${version.release}`,
+    releaseImageName: `${repo.gcr}/${imageNameBase}-${arch.default}:${version.release}`,
 
     /**
      * Image name for the canary release for all supported architecture.
      */
-    canaryImageNames: arch.list.map((arch) => `${imageNameBase}-${arch}:${version.canary}`),
+    canaryImageNames:
+        arch.list.map((arch) => `${repo.docker}/${imageNameBase}-${arch}:${version.canary}`),
 
     /**
      * Image name for the versioned release for all supported architecture.
      */
-    releaseImageNames: arch.list.map((arch) => `${imageNameBase}-${arch}:${version.release}`),
+    releaseImageNames:
+        arch.list.map((arch) => `${repo.gcr}/${imageNameBase}-${arch}:${version.release}`),
   },
 
   /**

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -19,9 +19,62 @@ import child from 'child_process';
 import gulp from 'gulp';
 import lodash from 'lodash';
 import path from 'path';
+import gutil from 'gulp-util';
 
 import conf from './conf';
 import {multiDest} from './multidest';
+
+/**
+ * Creates canary Docker image for the application for current architecture.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:canary', ['build', 'docker-file'], function() {
+  buildDockerImage([[conf.deploy.canaryImageName, conf.paths.dist]]);
+});
+
+/**
+ * Creates canary Docker image for the application for all architectures.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:canary:cross', ['build:cross', 'docker-file:cross'], function() {
+  return buildDockerImage(lodash.zip(conf.deploy.canaryImageNames, conf.paths.distCross));
+});
+
+/**
+ * Creates release Docker image for the application for all architectures.
+ * The image is tagged with the image name configuration constant.
+ */
+gulp.task('docker-image:release:cross', ['build:cross', 'docker-file:cross'], function() {
+  return buildDockerImage(lodash.zip(conf.deploy.releaseImageNames, conf.paths.distCross));
+});
+
+/**
+ * Pushes cross compiled canary images to Docker Hub.
+ */
+gulp.task('push-to-docker:canary:cross', ['docker-image:canary:cross'], function() {
+  pushToDocker(conf.deploy.canaryImageNames);
+});
+
+/**
+ * Pushes cross-compiled release images to GCR.
+ */
+gulp.task('push-to-gcr:release:cross', ['docker-image:release:cross'], function() {
+  pushToGcr(conf.deploy.releaseImageNames);
+});
+
+/**
+ * Processes the Docker file and places it in the dist folder for building.
+ */
+gulp.task('docker-file', ['clean-dist'], function() {
+  dockerFile(conf.paths.dist, doneFn);
+});
+
+/**
+ * Processes the Docker file and places it in the dist folder for all architectures.
+ */
+gulp.task('docker-file:cross', ['clean-dist'], function(doneFn) {
+  dockerFile(conf.paths.distCross, doneFn);
+});
 
 /**
  * @param {!Array<string>} args
@@ -40,66 +93,6 @@ function spawnDockerProcess(args, doneFn) {
     }
   });
 }
-
-/**
- * Creates canary Docker image for the application for current architecture.
- * The image is tagged with the image name configuration constant.
- */
-gulp.task('docker-image:canary', ['build', 'docker-file'], function(doneFn) {
-  buildDockerImage([[conf.deploy.canaryImageName, conf.paths.dist]], doneFn);
-});
-
-/**
- * Creates release Docker image for the application for current architecture.
- * The image is tagged with the image name configuration constant.
- */
-gulp.task('docker-image:release', ['build', 'docker-file'], function(doneFn) {
-  buildDockerImage([[conf.deploy.releaseImageName, conf.paths.dist]], doneFn);
-});
-
-/**
- * Creates canary Docker image for the application for all architectures.
- * The image is tagged with the image name configuration constant.
- */
-gulp.task('docker-image:canary:cross', ['build:cross', 'docker-file:cross'], function(doneFn) {
-  buildDockerImage(lodash.zip(conf.deploy.canaryImageNames, conf.paths.distCross), doneFn);
-});
-
-/**
- * Creates release Docker image for the application for all architectures.
- * The image is tagged with the image name configuration constant.
- */
-gulp.task('docker-image:release:cross', ['build:cross', 'docker-file:cross'], function(doneFn) {
-  buildDockerImage(lodash.zip(conf.deploy.releaseImageNames, conf.paths.distCross), doneFn);
-});
-
-/**
- * Pushes cross-compiled canary images to GCR.
- */
-gulp.task('push-to-gcr:canary', ['docker-image:canary:cross'], function(doneFn) {
-  pushToGcr(conf.deploy.versionCanary, doneFn);
-});
-
-/**
- * Pushes cross-compiled release images to GCR.
- */
-gulp.task('push-to-gcr:release', ['docker-image:release:cross'], function(doneFn) {
-  pushToGcr(conf.deploy.versionRelease, doneFn);
-});
-
-/**
- * Processes the Docker file and places it in the dist folder for building.
- */
-gulp.task('docker-file', ['clean-dist'], function() {
-  dockerFile(conf.paths.dist);
-});
-
-/**
- * Processes the Docker file and places it in the dist folder for all architectures.
- */
-gulp.task('docker-file:cross', ['clean-dist'], function() {
-  dockerFile(conf.paths.distCross);
-});
 
 /**
  * @param {!Array<!Array<string>>} imageNamesAndDirs (image name, directory) pairs
@@ -132,27 +125,77 @@ function buildDockerImage(imageNamesAndDirs) {
 }
 
 /**
- * @param {string} version
+ * @param {!Array<string>} imageNames
+ */
+function pushToDocker(imageNames) {
+  let spawnPromises = imageNames.forEach((imageName) => {
+    return new Promise((resolve, reject) => {
+      spawnDockerProcess(
+        [
+          'push',
+          imageName,
+        ],
+        (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+    });
+  });
+
+  return Promise.all(spawnPromises);
+}
+
+/**
+ * @param {!Array<string>} args
  * @param {function(?Error=)} doneFn
  */
-function pushToGcr(version, doneFn) {
-  let imageUri = `${conf.deploy.imageName}:${version}`;
+function spawnGCloudProcess(args, doneFn) {
+  let gcloudTask = child.spawn('gcloud', args, {stdio: 'inherit'});
 
-  let childTask = child.spawn('gcloud', ['docker', 'push', imageUri], {stdio: 'inherit'});
-
-  childTask.on('exit', function(code) {
+  // Call Gulp callback on task exit. This has to be done to make Gulp dependency management
+  // work.
+  gcloudTask.on('exit', function(code) {
     if (code === 0) {
       doneFn();
     } else {
-      doneFn(new Error(`gcloud command error, code: ${code}`));
+      doneFn(new Error(`GCloud command error, code: ${code}`));
     }
   });
 }
 
 /**
+ * @param {!Array<string>} imageNames
+ */
+function pushToGcr(imageNames) {
+  let spawnPromises = imageNames.forEach((imageName) => {
+    return new Promise((resolve, reject) => {
+      spawnGCloudProcess(
+        [
+          'docker',
+          'push',
+          imageName,
+        ],
+        (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+    });
+  });
+
+  return Promise.all(spawnPromises);
+}
+
+/**
  * @param {string|!Array<string>} outputDirs
+ * @param {function(?Error=)} doneFn
  * @return {stream}
  */
-function dockerFile(outputDirs) {
-  return gulp.src(path.join(conf.paths.deploySrc, 'Dockerfile')).pipe(multiDest(outputDirs));
+function dockerFile(outputDirs, doneFn) {
+  return gulp.src(path.join(conf.paths.deploySrc, 'Dockerfile')).pipe(multiDest(outputDirs, doneFn));
 }


### PR DESCRIPTION
**Do not merge**

It is for testing purposes and not yet finished as docker credentials are set to my docker hub account.

## Changes

- [ ] Push image for every Pull Request to Docker Hub. 

**Format**: `kubernetes/kubernetes-dashboard-amd64:<pr_number>`

- [ ] Push canary image to Docker Hub after every merge to master. 

**Format**: `kubernetes/kubernetes-dashboard-amd64:canary`

- [ ] Push cross compiled images to GCR after creating a tag. 

**Format**: `gcr.io/google_containers/kubernetes-dashboard-<architecture>:<tag_name>`

