### PR TITLE
Fail hyperkube.sh if any command fails

### DIFF
--- a/build/hyperkube.sh
+++ b/build/hyperkube.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright 2015 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
hyperkube.sh is started as part of the `gulp local-up-cluster` task. The
script can fail for example if the docker daemon is not running. This
failure was not reported to the user in anyway. By adding the -e flag we
make sure that the script returns error code if any of the commands
fail. A useful error message is also shown to the user in the example
error case.

Here are example outputs when docker daemon is not running:

`gulp local-up-cluster` output before the fix:
```
[19:07:38] Requiring external module babel-register
[19:07:40] Using gulpfile ~/projects/kubernetes-dashboard/gulpfile.babel.js
[19:07:40] Starting 'spawn-cluster'...
[19:07:40] Starting 'wait-for-cluster'...
[19:07:40] Starting 'wait-for-heapster'...
[19:07:40] Finished 'spawn-cluster' after 24 ms
[19:07:41] Waiting for a Kubernetes cluster at http://localhost:8080...
[19:07:41] Waiting for a Heapster ...
```

`gulp local-up-cluster` output after the fix:
```
[19:08:02] Requiring external module babel-register
[19:08:04] Using gulpfile ~/projects/kubernetes-dashboard/gulpfile.babel.js
[19:08:04] Starting 'spawn-cluster'...
[19:08:04] Starting 'wait-for-cluster'...
[19:08:04] Starting 'wait-for-heapster'...

docker: Cannot connect to the Docker daemon. Is the docker daemon running on this host?.
See 'docker run --help'.

[19:08:04] 'spawn-cluster' errored after 24 ms
[19:08:04] Error: Error: Command failed: /home/antti/projects/kubernetes-dashboard/build/hyperkube.sh
docker: Cannot connect to the Docker daemon. Is the docker daemon running on this host?.
See 'docker run --help'.

    at /home/antti/projects/kubernetes-dashboard/build/cluster.js:103:21
    at ChildProcess.exithandler (child_process.js:213:5)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Socket.<anonymous> (internal/child_process.js:334:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:493:12)
[19:08:05] Waiting for a Kubernetes cluster at http://localhost:8080...
[19:08:05] Waiting for a Heapster ...

Process finished with exit code 130 (interrupted by signal 2: SIGINT)
```
