### PR TITLE
Previously some cards had 20px gutter and some 40px (due to

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -31,14 +31,15 @@ limitations under the License.
 <md-content layout="row" class="kd-app-entire-content" flex="auto">
   <kd-nav flex="none"></kd-nav>
   <md-content flex="auto" class="kd-main-content-box">
-    <div ng-switch="$ctrl.loading" class="kd-content-div kd-main-content-div">
+    <div ng-switch="$ctrl.loading" class="kd-content-div-filled kd-main-content-div">
       <div ng-switch-when="true" class="kd-spinner">
         <md-progress-circular ng-if="$ctrl.showLoadingSpinner" md-mode="indeterminate"
             md-diameter="48">
         </md-progress-circular>
       </div>
       <div ng-switch-when="false" class="kd-app-content">
-        <div ui-view class="md-body-1 kd-content-div"></div>
+        <div ui-view class="md-body-1"
+            ng-class="{'kd-content-div-filled': $ctrl.isFillContentView()}"></div>
       </div>
     </div>
   </md-content>

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -30,7 +30,7 @@
   min-height: 7 * $baseline-grid;
 }
 
-.kd-content-div {
+.kd-content-div-filled {
   height: 100%;
 }
 
@@ -70,6 +70,12 @@ body,
   height: 100%;
   max-height: 100%;
   position: relative;
+
+  >.md-body-1 {
+    &:not(.kd-content-div-filled) {
+      padding-bottom: 4 * $baseline-grid;
+    }
+  }
 }
 
 a {

--- a/src/app/frontend/chrome/chrome_component.js
+++ b/src/app/frontend/chrome/chrome_component.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {fillContentConfig} from 'chrome/chrome_state';
+
 import {actionbarViewName} from './chrome_state';
 
 /**
@@ -61,6 +63,14 @@ export class ChromeController {
   isActionbarVisible() {
     return !!this.state_.current && !!this.state_.current.views &&
         !!this.state_.current.views[actionbarViewName] && !this.showLoadingSpinner;
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  isFillContentView() {
+    return this.state_.current.data[fillContentConfig] === true;
   }
 
   /**

--- a/src/app/frontend/chrome/chrome_state.js
+++ b/src/app/frontend/chrome/chrome_state.js
@@ -33,6 +33,13 @@ export const actionbarViewName = 'actionbar';
 export const namespaceParam = 'namespace';
 
 /**
+ * To be used in data section in params. Set to true for views that should fill app content.
+ *
+ * Defaults to false.
+ */
+export const fillContentConfig = 'fillContent';
+
+/**
  * All properties are @exported and in sync with URL param names.
  */
 export class StateParams {

--- a/src/app/frontend/chrome/chrome_stateconfig.js
+++ b/src/app/frontend/chrome/chrome_stateconfig.js
@@ -29,7 +29,7 @@ export default function stateConfig($stateProvider) {
     abstract: true,
     views: {
       '': {
-        template: '<div ui-view class="kd-content-div"></div>',
+        template: '<div ui-view class="kd-content-div-filled"></div>',
       },
       [toolbarViewName]: {
         template: `<div ui-view="${toolbarViewName}"></div>`,

--- a/src/app/frontend/common/components/contentcard/contentcard.scss
+++ b/src/app/frontend/common/components/contentcard/contentcard.scss
@@ -24,6 +24,7 @@
 kd-content-card {
   display: block;
   margin: 2.5 * $baseline-grid;
+  margin-bottom: 0;
 }
 
 .kd-content-card {

--- a/src/app/frontend/logs/logs_stateconfig.js
+++ b/src/app/frontend/logs/logs_stateconfig.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {stateName as chromeStateName} from 'chrome/chrome_state';
+import {fillContentConfig} from 'chrome/chrome_state';
 import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
 import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
 
@@ -45,6 +46,7 @@ export default function stateConfig($stateProvider) {
       [breadcrumbsConfig]: {
         'label': i18n.MSG_BREADCRUMBS_LOGS_LABEL,
       },
+      [fillContentConfig]: true,
     },
     views: views,
   });

--- a/src/test/frontend/chrome/chrome_component_test.js
+++ b/src/test/frontend/chrome/chrome_component_test.js
@@ -14,6 +14,7 @@
 
 import chromeModule from 'chrome/chrome_module';
 import {actionbarViewName} from 'chrome/chrome_state';
+import {fillContentConfig} from 'chrome/chrome_state';
 
 describe('Chrome controller', () => {
   /** @type {ChromeController} */
@@ -92,5 +93,20 @@ describe('Chrome controller', () => {
     // Transitioning to another view.
     ctrl.showLoadingSpinner = true;
     expect(ctrl.isActionbarVisible()).toBe(false);
+  });
+
+  it('should fill app content', () => {
+    state.current = {data: {}};
+    expect(ctrl.isFillContentView()).toBe(false);
+    state.current.data[fillContentConfig] = 'true';
+    expect(ctrl.isFillContentView()).toBe(false);
+    state.current.data[fillContentConfig] = 1;
+    expect(ctrl.isFillContentView()).toBe(false);
+    state.current.data[fillContentConfig] = {};
+    expect(ctrl.isFillContentView()).toBe(false);
+    state.current.data[fillContentConfig] = false;
+    expect(ctrl.isFillContentView()).toBe(false);
+    state.current.data[fillContentConfig] = true;
+    expect(ctrl.isFillContentView()).toBe(true);
   });
 });


### PR DESCRIPTION
margin-collapse CSS property). Some views had page-bottom margin, some
not.

This PR fixes the issue by introducing page-filled configuration
framerowk. Pages that need to fill app content can configure it (logs
view). Other pages will have any height and bottom margin of 4 baseline
grids.