### PR TITLE
Sanitize our access to $location.search().namespace

### DIFF
--- a/src/app/frontend/common/namespace/namespace_module.js
+++ b/src/app/frontend/common/namespace/namespace_module.js
@@ -36,17 +36,16 @@ export default angular
  * Ensures that namespaceParam is present in the URL.
  * @param {!angular.Scope} $rootScope
  * @param {!angular.$location} $location
- * @param {!angular.$sanitize} $sanitize
  * @ngInject
  */
-function ensureNamespaceParamPresent($rootScope, $location, $sanitize) {
+function ensureNamespaceParamPresent($rootScope, $location) {
   /**
    * Helper function which replaces namespace URL search param when the given namespace is
    * undefined.
    * @param {string|undefined} namespace
    */
   function replaceUrlIfNeeded(namespace) {
-    if (namespace === undefined || namespace !== $sanitize(namespace)) {
+    if (namespace === undefined) {
       $location.search(namespaceParam, DEFAULT_NAMESPACE);
       $location.replace();
     }

--- a/src/app/frontend/common/namespace/namespace_module.js
+++ b/src/app/frontend/common/namespace/namespace_module.js
@@ -36,16 +36,17 @@ export default angular
  * Ensures that namespaceParam is present in the URL.
  * @param {!angular.Scope} $rootScope
  * @param {!angular.$location} $location
+ * @param {!angular.$sanitize} $sanitize
  * @ngInject
  */
-function ensureNamespaceParamPresent($rootScope, $location) {
+function ensureNamespaceParamPresent($rootScope, $location, $sanitize) {
   /**
    * Helper function which replaces namespace URL search param when the given namespace is
    * undefined.
    * @param {string|undefined} namespace
    */
   function replaceUrlIfNeeded(namespace) {
-    if (namespace === undefined) {
+    if (namespace === undefined || namespace !== $sanitize(namespace)) {
       $location.search(namespaceParam, DEFAULT_NAMESPACE);
       $location.replace();
     }

--- a/src/app/frontend/common/namespace/namespaceselect_component.js
+++ b/src/app/frontend/common/namespace/namespaceselect_component.js
@@ -19,6 +19,8 @@ export const ALL_NAMESPACES = '_all';
 
 export const DEFAULT_NAMESPACE = 'default';
 
+export const NAMESPACE_REGEX = /^([a-z0-9]([-a-z0-9]*[a-z0-9])?|_all)$/;
+
 /**
  * @final
  */
@@ -27,12 +29,11 @@ export class NamespaceSelectController {
    * @param {!angular.$resource} $resource
    * @param {!ui.router.$state} $state
    * @param {!angular.Scope} $scope
-   * @param {!angular.$sanitize} $sanitize
    * @param {!./namespace_service.NamespaceService} kdNamespaceService
    * @param {!./../state/futurestate_service.FutureStateService} kdFutureStateService
    * @ngInject
    */
-  constructor($resource, $state, $scope, $sanitize, kdNamespaceService, kdFutureStateService) {
+  constructor($resource, $state, $scope, kdNamespaceService, kdFutureStateService) {
     /**
      * Initialized with all namespaces on first open.
      * @export {!Array<string>}
@@ -68,9 +69,6 @@ export class NamespaceSelectController {
     /** @private {!angular.Scope} */
     this.scope_ = $scope;
 
-    /** @private {!angular.$sanitize} */
-    this.sanitize_ = $sanitize;
-
     /** @private {!./../state/futurestate_service.FutureStateService}} */
     this.kdFutureStateService_ = kdFutureStateService;
 
@@ -105,8 +103,13 @@ export class NamespaceSelectController {
             this.selectedNamespace = DEFAULT_NAMESPACE;
           }
         } else {
-          this.namespaces = [newNamespace];
-          this.selectedNamespace = newNamespace;
+          if (NAMESPACE_REGEX.test(newNamespace)) {
+            this.namespaces = [newNamespace];
+            this.selectedNamespace = newNamespace;
+          }
+          else {
+            this.selectedNamespace = DEFAULT_NAMESPACE;
+          }
         }
       } else {
         this.selectedNamespace = DEFAULT_NAMESPACE;
@@ -125,9 +128,7 @@ export class NamespaceSelectController {
     if (namespace === ALL_NAMESPACES) {
       return this.i18n.MSG_ALL_NAMESPACES;
     } else {
-      // Might even be to forgiving, kubectl create namespace requires to
-      // satisfy m/[a-z0-9]([-a-z0-9]*[a-z0-9])?/
-      return this.sanitize_(namespace);
+      return namespace;
     }
   }
 

--- a/src/app/frontend/common/namespace/namespaceselect_component.js
+++ b/src/app/frontend/common/namespace/namespaceselect_component.js
@@ -106,8 +106,7 @@ export class NamespaceSelectController {
           if (NAMESPACE_REGEX.test(newNamespace)) {
             this.namespaces = [newNamespace];
             this.selectedNamespace = newNamespace;
-          }
-          else {
+          } else {
             this.selectedNamespace = DEFAULT_NAMESPACE;
           }
         }

--- a/src/app/frontend/common/namespace/namespaceselect_component.js
+++ b/src/app/frontend/common/namespace/namespaceselect_component.js
@@ -27,11 +27,12 @@ export class NamespaceSelectController {
    * @param {!angular.$resource} $resource
    * @param {!ui.router.$state} $state
    * @param {!angular.Scope} $scope
+   * @param {!angular.$sanitize} $sanitize
    * @param {!./namespace_service.NamespaceService} kdNamespaceService
    * @param {!./../state/futurestate_service.FutureStateService} kdFutureStateService
    * @ngInject
    */
-  constructor($resource, $state, $scope, kdNamespaceService, kdFutureStateService) {
+  constructor($resource, $state, $scope, $sanitize, kdNamespaceService, kdFutureStateService) {
     /**
      * Initialized with all namespaces on first open.
      * @export {!Array<string>}
@@ -66,6 +67,9 @@ export class NamespaceSelectController {
 
     /** @private {!angular.Scope} */
     this.scope_ = $scope;
+
+    /** @private {!angular.$sanitize} */
+    this.sanitize_ = $sanitize;
 
     /** @private {!./../state/futurestate_service.FutureStateService}} */
     this.kdFutureStateService_ = kdFutureStateService;
@@ -121,7 +125,9 @@ export class NamespaceSelectController {
     if (namespace === ALL_NAMESPACES) {
       return this.i18n.MSG_ALL_NAMESPACES;
     } else {
-      return namespace;
+      // Might even be to forgiving, kubectl create namespace requires to
+      // satisfy m/[a-z0-9]([-a-z0-9]*[a-z0-9])?/
+      return this.sanitize_(namespace);
     }
   }
 

--- a/src/test/frontend/common/namespace/namespaceselect_component_test.js
+++ b/src/test/frontend/common/namespace/namespaceselect_component_test.js
@@ -129,4 +129,12 @@ describe('Namespace select component ', () => {
     ctrl.selectedNamespace = 'foo';
     expect(ctrl.formatNamespace('foo')).toBe('foo');
   });
+
+  it('should remove xss risks from nonexisting namespaces', () => {
+    ctrl.$onInit();
+    let unsafe = '<img src="x" onerror="alert(document.domain)">';
+    state.go('fakeState', {namespace: unsafe});
+    scope.$digest();
+    expect(ctrl.selectedNamespace).toBe('default')
+  });
 });

--- a/src/test/frontend/common/namespace/namespaceselect_component_test.js
+++ b/src/test/frontend/common/namespace/namespaceselect_component_test.js
@@ -135,6 +135,6 @@ describe('Namespace select component ', () => {
     let unsafe = '<img src="x" onerror="alert(document.domain)">';
     state.go('fakeState', {namespace: unsafe});
     scope.$digest();
-    expect(ctrl.selectedNamespace).toBe('default')
+    expect(ctrl.selectedNamespace).toBe('default');
   });
 });


### PR DESCRIPTION
quick way to make sure we only show sanitized namespaces, perhaps research if this is intended behaviour of this select component and if we should do more.

#1361