### PR TITLE
Add pre-commit hooks

### DIFF
--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -143,6 +143,24 @@ It can be executed with:
 $ gulp check
 ```
 
+## Committing changes to your fork
+   
+Before committing any changes, please link/copy the pre-commit hook into your .git directory. This will keep you from accidentally committing non formatted code.
+   
+The hook requires gofmt to be in your PATH.
+   
+```shell
+cd <dashboard_home>/.git/hooks/
+ln -s ../../hooks/pre-commit .
+```
+   
+Then you can commit your changes and push them to your fork:
+   
+```shell
+git commit
+git push -f origin my-feature
+```
+
 ## Building Dashboard Inside a Container
 
 It's possible to run `gulp` and all the dependencies inside a development container. To do this,

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+readonly reset=$(tput sgr0)
+readonly red=$(tput bold; tput setaf 1)
+readonly green=$(tput bold; tput setaf 2)
+
+exit_code=0
+gofmt_available=false
+gulp_available=false
+
+# Pre checks
+echo -ne "Checking if gulp is available... "
+if ! OUT=$(ls node_modules/.bin/gulp 2>&1); then
+  echo "${red}ERROR!"
+  echo "${red}${OUT}"
+  exit_code=1
+else
+  gulp_available=true
+  echo "${green}OK"
+fi
+
+echo "${reset}"
+echo -ne "Checking if gofmt is available in your PATH... "
+if ! OUT=$(which gofmt 2>&1); then
+  echo "${red}ERROR!"
+  echo "Please add gofmt to your PATH"
+  exit_code=1
+else
+  gofmt_available=true
+  echo "${green}OK"
+fi
+
+if ${gulp_available}; then
+  echo "${reset}"
+  echo -ne "Checking javascript formatting... "
+  if ! OUT=$(node_modules/.bin/gulp check-javascript-format 2>&1); then
+    echo "${red}ERROR!"
+    echo "There is an issue with file formatting."
+    echo "To format javascript files run:"
+    echo "  ./node_modules/.bin/gulp format-javascript"
+    exit_code=1
+  else
+    echo "${green}OK"
+  fi
+fi
+
+if ${gofmt_available}; then
+  echo "${reset}"
+  echo -ne "Checking go files formatting... "
+  unformatted=$(gofmt -l src/app/backend)
+  if [ ! -z ${unformatted} ]; then
+    echo "${red}ERROR!"
+    echo "There is an issue with file formatting."
+    echo "To format go files run:"
+    echo "  gofmt -w src/app/backend"
+    exit_code=1
+  else
+    echo "${green}OK"
+  fi
+fi
+
+echo -ne "${reset}\n"
+if [[ "${exit_code}" != 0 ]]; then
+  echo "${red}Aborting commit${reset}"
+fi
+exit ${exit_code}
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/src/app/backend/resource/resourcequota/resourcequotadetail.go
+++ b/src/app/backend/resource/resourcequota/resourcequotadetail.go
@@ -39,8 +39,8 @@ type ResourceQuotaDetail struct {
 
 // ResourceQuotaDetailList
 type ResourceQuotaDetailList struct {
-	ListMeta common.ListMeta `json:"listMeta"`
-	Items []ResourceQuotaDetail `json:"items"`
+	ListMeta common.ListMeta       `json:"listMeta"`
+	Items    []ResourceQuotaDetail `json:"items"`
 }
 
 func ToResourceQuotaDetail(rawResourceQuota *api.ResourceQuota) *ResourceQuotaDetail {


### PR DESCRIPTION
Often travis builds fail due to file formatting. This is a little help to automatically check that before committing our changes. Just as a start I've added file formatting checks but we could extend that and i.e. execute tests.

![zrzut ekranu z 2016-10-24 15-06-29](https://cloud.githubusercontent.com/assets/2285385/19647330/e212d3a8-99fd-11e6-9c91-3ea8e09f252f.png)
