### PR TITLE
Clean up the messages for extraction before extracting new ones

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -180,6 +180,13 @@ gulp.task('clean', ['clean-dist'], function() {
 });
 
 /**
+ * Cleans all message for extraction files.
+ */
+gulp.task('clean-messages-for-extraction', [], function() {
+  return del([conf.paths.messagesForExtraction]);
+});
+
+/**
  * Cleans all build artifacts in the dist/ folder.
  */
 gulp.task('clean-dist', function() {

--- a/build/i18n.js
+++ b/build/i18n.js
@@ -62,11 +62,16 @@ gulp.task('generate-xtbs', ['extract-translations', 'sort-translations']);
 
 /**
  * Extracts all translation messages into XTB bundles.
+ *
+ * Cleans up the data from the previous run to prevent crosspolination between
+ * branches
  */
-gulp.task('extract-translations', ['scripts', 'angular-templates'], function() {
-  let promises = conf.translations.map((translation) => extractForLanguage(translation.key));
-  return q.all(promises);
-});
+gulp.task(
+    'extract-translations', ['scripts', 'angular-templates', 'clean-messages-for-extraction'],
+    function() {
+      let promises = conf.translations.map((translation) => extractForLanguage(translation.key));
+      return q.all(promises);
+    });
 
 gulp.task('sort-translations', ['extract-translations'], function() {
   return gulp.src('i18n/messages-*.xtb').pipe(xslt('build/sortxtb.xslt')).pipe(gulp.dest('i18n'));


### PR DESCRIPTION
When working on multiple branches and introducing new files in one of
them, the translation tokens stay in the messages for extraction folder
and thus mess up your messages- files in other branches.