### PR TITLE
Custom handle last-applied-configuration annotations

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -62,6 +62,7 @@
   <translation id="1745702155571319443" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_0" desc="Friendly name of the kubernetest.io/created-by annotation">Created by:</translation>
   <translation id="820028802315082613" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_1" desc="Text on the button to show less annotations">show less annotations</translation>
   <translation id="6884163988875905686" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_2" desc="Text on the button to show all the annotations">show all annotations</translation>
+  <translation id="6935188165410090417" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_LASTAPPLIEDCONFIGURATION_0" desc="Label for the kubectl.kubernetes.io/last-applied-configuration annotation">last applied configuration</translation>
   <translation id="2631421290135072028" key="MSG_COMMON_COMPONENTS_LABELS_LABELS_0" desc="Tooltip on the &quot;show less&quot; button for the labels of any kubernetes resource. Usually appears on the resource details pages.">show less labels</translation>
   <translation id="8950559770902715649" key="MSG_COMMON_COMPONENTS_LABELS_LABELS_1" desc="Tooltip on the &quot;show all&quot; button for the labels of any kubernetes resource. Usually appears on the resource details pages.">show all labels</translation>
   <translation id="8077948432236649947" key="MSG_COMMON_COMPONENTS_RESOURCECARD_RESOURCECARDDELETEMENUITEM_0" desc="Action &quot;Delete&quot; (verb), which appears as a menu item on the cards for kubernetes resources.">Delete</translation>
@@ -103,6 +104,8 @@
   <translation id="4743112919356949434" key="MSG_CONFIG_CONFIG_0" desc="Label that appears above the list of resources.">Secrets</translation>
   <translation id="7486548633611417214" key="MSG_CONFIG_CONFIG_1" desc="Label that appears above the list of resources.">Config Maps</translation>
   <translation id="3342283564584066330" key="MSG_CONFIG_CONFIG_MAPS_LABEL" desc="Label that appears above the list of resources.">Config Maps</translation>
+  <translation id="8072030721088093841" key="MSG_CONFIG_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; on a dialog.">Close</translation>
+  <translation id="6503474189903659041" key="MSG_CONFIG_DIALOG_TITLE" desc="Label for the kubectl.kubernetes.io/last-applied-configuration annotation.">Last applied configuration</translation>
   <translation id="8099933273342853319" key="MSG_CONFIG_MAP_DETAIL_CONFIG_MAP_LABEL" desc="Label 'Config Map' which appears at the top of the delete dialog, opened from a config map details page.">Config Map</translation>
   <translation id="8701051638018097742" key="MSG_CONFIG_MAP_INFO_DATA_SECTION" desc="Config map info details section name.">Data</translation>
   <translation id="2091041876152209152" key="MSG_CONFIG_MAP_INFO_DETAILS_SECTION" desc="Config map info details section name.">Details</translation>
@@ -285,6 +288,7 @@
   <translation id="4067701887380339834" key="MSG_DEPLOY_CREATENAMESPACE_2" desc="Label \'Namespace name\', which appears as a placeholder in an empty input field in the create namespace dialog.">Namespace name</translation>
   <translation id="157334911834120920" key="MSG_DEPLOY_CREATENAMESPACE_3" desc="The text appears when the namespace name does not match the expected pattern.">Name must be alphanumeric and may contain dashes.</translation>
   <translation id="1551048552555348002" key="MSG_DEPLOY_CREATENAMESPACE_4" desc="The text appears when the namespace name exceeds the maximal length.">Name must be up to {{::$ctrl.maxLength}} characters long.</translation>
+  <translation id="2146467965028734948" key="MSG_DEPLOY_CREATENAMESPACE_4" desc="The text appears when the namespace name exceeds the maximal length.">Name must be up to {{::$ctrl.namespaceMaxLength}} characters long.</translation>
   <translation id="8977053526123330609" key="MSG_DEPLOY_CREATENAMESPACE_5" desc="Warning which tells the user that the namespace name is required.">Name is required.</translation>
   <translation id="4442366218281676294" key="MSG_DEPLOY_CREATENAMESPACE_6" desc="User help text for the input of the \'Namespace\' data.">A namespace with the specified name will be added to the cluster.</translation>
   <translation id="691873247008682453" key="MSG_DEPLOY_CREATENAMESPACE_7" desc="The text is used as a \'Learn more\' link text in the namespace creation dialog">Learn more</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -66,6 +66,7 @@
   <translation id="1745702155571319443" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_0" desc="Friendly name of the kubernetest.io/created-by annotation">Created by:</translation>
   <translation id="820028802315082613" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_1" desc="Text on the button to show less annotations">show less annotations</translation>
   <translation id="6884163988875905686" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_ANNOTATIONS_2" desc="Text on the button to show all the annotations">show all annotations</translation>
+  <translation id="6935188165410090417" key="MSG_COMMON_COMPONENTS_ANNOTATIONS_LASTAPPLIEDCONFIGURATION_0" desc="Label for the kubectl.kubernetes.io/last-applied-configuration annotation">last applied configuration</translation>
   <translation id="2631421290135072028" key="MSG_COMMON_COMPONENTS_LABELS_LABELS_0" desc="Tooltip on the &quot;show less&quot; button for the labels of any kubernetes resource. Usually appears on the resource details pages.">show less labels</translation>
   <translation id="8950559770902715649" key="MSG_COMMON_COMPONENTS_LABELS_LABELS_1" desc="Tooltip on the &quot;show all&quot; button for the labels of any kubernetes resource. Usually appears on the resource details pages.">show all labels</translation>
   <translation id="8077948432236649947" key="MSG_COMMON_COMPONENTS_RESOURCECARD_RESOURCECARDDELETEMENUITEM_0" desc="Action &quot;Delete&quot; (verb), which appears as a menu item on the cards for kubernetes resources.">Delete</translation>
@@ -107,6 +108,8 @@
   <translation id="4743112919356949434" key="MSG_CONFIG_CONFIG_0" desc="Label that appears above the list of resources.">Secrets</translation>
   <translation id="7486548633611417214" key="MSG_CONFIG_CONFIG_1" desc="Label that appears above the list of resources.">Config Maps</translation>
   <translation id="3342283564584066330" key="MSG_CONFIG_CONFIG_MAPS_LABEL" desc="Label that appears above the list of resources.">コンフィグマップ</translation>
+  <translation id="8072030721088093841" key="MSG_CONFIG_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; on a dialog.">Close</translation>
+  <translation id="6503474189903659041" key="MSG_CONFIG_DIALOG_TITLE" desc="Label for the kubectl.kubernetes.io/last-applied-configuration annotation.">Last applied configuration</translation>
   <translation id="8099933273342853319" key="MSG_CONFIG_MAP_DETAIL_CONFIG_MAP_LABEL" desc="Label 'Config Map' which appears at the top of the delete dialog, opened from a config map details page.">コンフィグマップ</translation>
   <translation id="8701051638018097742" key="MSG_CONFIG_MAP_INFO_DATA_SECTION" desc="Config map info details section name.">データ</translation>
   <translation id="2091041876152209152" key="MSG_CONFIG_MAP_INFO_DETAILS_SECTION" desc="Config map info details section name.">詳細</translation>
@@ -289,6 +292,7 @@
   <translation id="4067701887380339834" key="MSG_DEPLOY_CREATENAMESPACE_2" desc="Label \'Namespace name\', which appears as a placeholder in an empty input field in the create namespace dialog.">Namespace name</translation>
   <translation id="157334911834120920" key="MSG_DEPLOY_CREATENAMESPACE_3" desc="The text appears when the namespace name does not match the expected pattern.">Name must be alphanumeric and may contain dashes.</translation>
   <translation id="1551048552555348002" key="MSG_DEPLOY_CREATENAMESPACE_4" desc="The text appears when the namespace name exceeds the maximal length.">Name must be up to {{::$ctrl.maxLength}} characters long.</translation>
+  <translation id="2146467965028734948" key="MSG_DEPLOY_CREATENAMESPACE_4" desc="The text appears when the namespace name exceeds the maximal length.">Name must be up to {{::$ctrl.namespaceMaxLength}} characters long.</translation>
   <translation id="8977053526123330609" key="MSG_DEPLOY_CREATENAMESPACE_5" desc="Warning which tells the user that the namespace name is required.">Name is required.</translation>
   <translation id="4442366218281676294" key="MSG_DEPLOY_CREATENAMESPACE_6" desc="User help text for the input of the \'Namespace\' data.">A namespace with the specified name will be added to the cluster.</translation>
   <translation id="691873247008682453" key="MSG_DEPLOY_CREATENAMESPACE_7" desc="The text is used as a \'Learn more\' link text in the namespace creation dialog">Learn more</translation>

--- a/src/app/frontend/common/components/annotations/annotations.html
+++ b/src/app/frontend/common/components/annotations/annotations.html
@@ -17,9 +17,12 @@ limitations under the License.
 <div ng-if="::annotationsCtrl.labels">
   <div ng-repeat="(key, value) in ::annotationsCtrl.labels"
        ng-if="annotationsCtrl.isVisible($index)" class="kd-chips">
-    <div ng-switch on="key">
+    <div ng-switch on="::key">
       <div ng-switch-when="kubernetes.io/created-by" class="kd-chip">
         [[Created by:|Friendly name of the kubernetes.io/created-by annotation]] <kd-serialized-reference reference="value">
+      </div>
+      <div ng-switch-when="kubectl.kubernetes.io/last-applied-configuration" class="kd-chip">
+        <kd-last-applied-configuration value="::value"></kd-last-applied-configuration>
       </div>
       <kd-middle-ellipsis ng-switch-default display-string="{{::key}}: {{::value}}" class="kd-chip">
       </kd-middle-ellipsis>

--- a/src/app/frontend/common/components/annotations/annotations_component.js
+++ b/src/app/frontend/common/components/annotations/annotations_component.js
@@ -15,18 +15,14 @@
 import LabelsController from '../labels/labels_controller';
 
 /**
- * Returns directive definition for annotations.
- *
- * @return {!angular.Directive}
+ * @return {!angular.Component}
  */
-export default function annotationsDirective() {
-  return {
-    controller: LabelsController,
-    controllerAs: 'annotationsCtrl',
-    templateUrl: 'common/components/annotations/annotations.html',
-    scope: {},
-    bindToController: {
-      'labels': '=',
-    },
-  };
-}
+export const annotationsComponent = {
+  controller: LabelsController,
+  controllerAs: 'annotationsCtrl',
+  templateUrl: 'common/components/annotations/annotations.html',
+  scope: {},
+  bindings: {
+    'labels': '=',
+  },
+};

--- a/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
+++ b/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
@@ -1,0 +1,19 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<a href ng-click="$ctrl.openDetails()">[[last applied configuration|
+  Label for the kubectl.kubernetes.io/last-applied-configuration annotation]]
+</a>

--- a/src/app/frontend/common/components/annotations/lastappliedconfiguration_component.js
+++ b/src/app/frontend/common/components/annotations/lastappliedconfiguration_component.js
@@ -1,0 +1,57 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class Controller {
+  /**
+   * @param {!md.$dialog} $mdDialog
+   * @ngInject
+   */
+  constructor($mdDialog) {
+    /** @export {string} Initialized from a binding */
+    this.value;
+
+    /** @private {!md.$dialog} */
+    this.mdDialog_ = $mdDialog;
+  }
+
+  /** @export */
+  openDetails() {
+    // TODO make this dialog prettier
+    let dialog = this.mdDialog_.alert()
+                     .title(i18n.MSG_CONFIG_DIALOG_TITLE)
+                     .textContent(`kubectl.kubernetes.io/last-applied-configuration: ${this.value}`)
+                     .ok(i18n.MSG_CONFIG_DIALOG_CLOSE_ACTION);
+    this.mdDialog_.show(dialog);
+  }
+}
+
+const i18n = {
+  /** @export {string} @desc Action "Close" on a dialog. */
+  MSG_CONFIG_DIALOG_CLOSE_ACTION: goog.getMsg('Close'),
+  /** @export {string} @desc Label for the
+    kubectl.kubernetes.io/last-applied-configuration annotation. */
+  MSG_CONFIG_DIALOG_TITLE: goog.getMsg('Last applied configuration'),
+};
+
+/**
+ * @return {!angular.Component}
+ */
+export const lastAppliedConfigurationComponent = {
+  controller: Controller,
+  templateUrl: 'common/components/annotations/lastappliedconfiguration.html',
+  bindings: {
+    /** type {string} */
+    'value': '<',
+  },
+};

--- a/src/app/frontend/common/components/annotations/module.js
+++ b/src/app/frontend/common/components/annotations/module.js
@@ -1,0 +1,25 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {annotationsComponent} from './annotations_component';
+import {lastAppliedConfigurationComponent} from './lastappliedconfiguration_component';
+
+export default angular
+    .module(
+        'kubernetesDashboard.common.components.annotations',
+        [
+          'ngMaterial',
+        ])
+    .component('kdAnnotations', annotationsComponent)
+    .component('kdLastAppliedConfiguration', lastAppliedConfigurationComponent);

--- a/src/app/frontend/common/components/components_module.js
+++ b/src/app/frontend/common/components/components_module.js
@@ -19,7 +19,7 @@ import filtersModule from '../filters/filters_module';
 import namespaceModule from './../namespace/namespace_module';
 import paginationModule from './../pagination/pagination_module';
 import actionbarModule from './actionbar/actionbar_module';
-import annotationsDirective from './annotations/annotations_directive';
+import annotationsModule from './annotations/module';
 import contentCardModule from './contentcard/contentcard_module';
 import endpointModule from './endpoint/endpoint_module';
 import graphModule from './graph/graph_module';
@@ -33,7 +33,6 @@ import serializedReferenceModule from './serializedreference/serializedreference
 import sparklineDirective from './sparkline/sparkline_directive';
 import warnThresholdDirective from './warnthreshold/warnthreshold_directive';
 import zeroStateModule from './zerostate/zerostate_module';
-
 
 /**
  * Module containing common components for the application.
@@ -57,8 +56,8 @@ export default angular
           stateModule.name,
           graphModule.name,
           serializedReferenceModule.name,
+          annotationsModule.name,
         ])
-    .directive('kdAnnotations', annotationsDirective)
     .directive('kdI18n', i18nDirective)
     .directive('kdLabels', labelsDirective)
     .directive('kdMiddleEllipsis', middleEllipsisDirective)

--- a/src/test/frontend/common/components/annotations/annotations_component_test.js
+++ b/src/test/frontend/common/components/annotations/annotations_component_test.js
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import componentsModule from 'common/components/components_module';
+import module from 'common/components/components_module';
 
-describe('annotations directive', () => {
+describe('annotations component', () => {
   /** @type {!angular.Scope} */
   let scope;
   /** @type {function(!angular.Scope):!angular.JQLite} */
   let compileFn;
 
   beforeEach(() => {
-    angular.mock.module(componentsModule.name);
+    angular.mock.module(module.name);
 
     angular.mock.inject(($rootScope, $compile) => {
       scope = $rootScope.$new();
@@ -40,7 +40,6 @@ describe('annotations directive', () => {
     // when
     let element = compileFn(scope);
     scope.$digest();
-
     // then
     let labels = element.find('kd-middle-ellipsis');
     expect(labels.length).toEqual(3);
@@ -77,6 +76,22 @@ describe('annotations directive', () => {
     let annotations = element.find('kd-serialized-reference');
     expect(annotations.length).toEqual(1);
     expect(annotations.eq(0).text().trim()).toBe('{bogus: "json"}');
+  });
 
+  it('should render last applied config in a special way', () => {
+    // given
+    scope.annotations = {
+      app: 'app',
+      'kubectl.kubernetes.io/last-applied-configuration': '{bogus: "json"}',
+      testLabel: 'test',
+    };
+
+    // when
+    let element = compileFn(scope);
+    scope.$digest();
+
+    // then
+    let labels = element.find('kd-last-applied-configuration');
+    expect(labels.length).toEqual(1);
   });
 });

--- a/src/test/frontend/common/components/annotations/lastappliedconfig_component_test.js
+++ b/src/test/frontend/common/components/annotations/lastappliedconfig_component_test.js
@@ -1,0 +1,37 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import module from 'common/components/annotations/module';
+
+describe('last applied config component', () => {
+  /** @type {!common/components/annotations/lastappliedconfiguration_component.Controller} */
+  let ctrl;
+  /** @type {!md.$mdDialog} */
+  let mdDialog;
+
+  beforeEach(() => {
+    angular.mock.module(module.name);
+
+    angular.mock.inject(($componentController, $mdDialog) => {
+      ctrl = $componentController('kdLastAppliedConfiguration');
+      mdDialog = $mdDialog;
+    });
+  });
+
+  it('should open the dialog with details', () => {
+    spyOn(mdDialog, 'show');
+    ctrl.openDetails();
+    expect(mdDialog.show).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This is a custom handler for the
kubectl.kubernetes.io/last-applied-configuration annotation that you
often see on your objects. This is v1 and the popup window requires some
follow-up polish.

![selection_139](https://cloud.githubusercontent.com/assets/1159999/19685054/da79eaec-9aba-11e6-8b72-a89d89129a85.png)

![selection_140](https://cloud.githubusercontent.com/assets/1159999/19685065/e32662ec-9aba-11e6-84fd-ef2ba41327ad.png)

