### PR TITLE
Reuse existing translation keys to prevent renumbering

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -206,7 +206,7 @@ gulp.task('scripts:prod', ['angular-templates', 'generate-xtbs'], function(doneF
  *   * messages_for_extraction/path/foo.html.js - file with only MSG_FOO i18n message
  *         definitions - used to extract messages
  */
-gulp.task('angular-templates', function() {
+gulp.task('angular-templates', ['buildExistingI18nCache'], function() {
   return gulp.src(path.join(conf.paths.frontendSrc, '**/!(index).html'))
       .pipe(gulpHtmlmin({
         removeComments: true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp": "~3.9.1",
     "gulp-autoprefixer": "~3.1.0",
     "gulp-browserify": "~0.5.1",
+    "gulp-cheerio": "~0.6.2",
     "gulp-clang-format": "1.0.23",
     "gulp-closure-compiler": "~0.4.0",
     "gulp-codecov.io": "~1.0.1",


### PR DESCRIPTION
Load in the existing english translations and see if we can match existing translations to tokens we find. If we find a match we will reuse the 'old' key instead of just renumbering

Fixes: #1384