### PR TITLE
Removing a superfluous period

### DIFF
--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -40,7 +40,7 @@ limitations under the License.
     <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.pod}}">[[Pods|Pods menu item in the nav.]]</kd-nav-item>
   </div>
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.serviceDiscovery}}">[[Services and discovery|Services and discovery menu item in the nav.]].</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.serviceDiscovery}}">[[Services and discovery|Services and discovery menu item in the nav.]]</kd-nav-item>
     <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.service}}">[[Services|Services menu item in the nav.]]</kd-nav-item>
     <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.ingress}}">[[Ingress|Ingress item in the nav.]]</kd-nav-item>
   </div>


### PR DESCRIPTION
This change removes a `.` behind the `Services and Discovery` menu item label. See screenshot:

![image](https://cloud.githubusercontent.com/assets/273727/19977208/25433238-a1f3-11e6-9aa2-6a735c58a466.png)
