### PR TITLE
Reenable test disabled when switching to govendor from godeps

### DIFF
--- a/src/test/backend/resource/deployment/deploymentdeploy_test.go
+++ b/src/test/backend/resource/deployment/deploymentdeploy_test.go
@@ -181,27 +181,26 @@ func TestGetAvailableProtocols(t *testing.T) {
 	}
 }
 
-// TODO(bryk): This test started failing during a large scale refactor. Reenable it in earliest convinience.
-//func TestDeployAppFromFileWithValidContent(t *testing.T) {
-//	validContent := "{\"kind\": \"Namespace\"," +
-//		"\"apiVersion\": \"v1\"," +
-//		"\"metadata\": {" +
-//		"\"name\": \"test-deployfile-namespace\"," +
-//		"\"labels\": {\"name\": \"development\"}}}"
-//	spec := &AppDeploymentFromFileSpec{
-//		Name:    "foo-name",
-//		Content: validContent,
-//	}
-//	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
-//
-//	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
-//	if err != nil {
-//		t.Errorf("Expected err to be %#v but got %#v", nil, err)
-//	}
-//	if !isDeployed {
-//		t.Errorf("Expected return value to have %#v but got %#v", true, isDeployed)
-//	}
-//}
+func TestDeployAppFromFileWithValidContent(t *testing.T) {
+	validContent := "{\"kind\": \"Namespace\"," +
+		"\"apiVersion\": \"v1\"," +
+		"\"metadata\": {" +
+		"\"name\": \"test-deployfile-namespace\"," +
+		"\"labels\": {\"name\": \"development\"}}}"
+	spec := &AppDeploymentFromFileSpec{
+		Name:    "foo-name",
+		Content: validContent,
+	}
+	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
+
+	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
+	if err != nil {
+		t.Errorf("Expected err to be %#v but got %#v", nil, err)
+	}
+	if !isDeployed {
+		t.Errorf("Expected return value to have %#v but got %#v", true, isDeployed)
+	}
+}
 
 func TestDeployAppFromFileWithInvalidContent(t *testing.T) {
 	spec := &AppDeploymentFromFileSpec{


### PR DESCRIPTION
While grepping for something in the code I accidentally found this test, and when I re enabled it it worked. So why not fix the todo :)

