### PR TITLE
Switch node 5.x to 6.x inside Docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ FROM golang
 # Install java and nodejs. go is already installed
 # A small tweak, apt-get update is already run by the nodejs setup script,
 # so there's no need to run it again
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y --no-install-recommends \
 	openjdk-7-jre \
 	nodejs \


### PR DESCRIPTION
It fixes #1272 issue by moving to `6.x` version. Tested it using `gulp docker-image:head`, app seems to be running properly.

Logs from `6.x` build:
```
Sending build context to Docker daemon 118.3 kB
Step 1 : FROM golang
 ---> ef15416724f6
Step 2 : RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -   && apt-get install -y --no-install-recommends 	openjdk-7-jre 	nodejs 	&& rm -rf /var/lib/apt/lists/* 	&& apt-get clean
 ---> Running in c8f5d31d9a19

## Installing the NodeSource Node.js v6.x repo...


## Populating apt-get cache...

+ apt-get update
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Get:3 http://deb.debian.org jessie Release.gpg [2373 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [402 kB]
Get:6 http://deb.debian.org jessie-updates/main amd64 Packages [17.6 kB]
Get:7 http://deb.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 9843 kB in 4s (2302 kB/s)
Reading package lists...

## Installing packages required for setup: apt-transport-https lsb-release...

+ apt-get install -y apt-transport-https lsb-release > /dev/null 2>&1

## Confirming "jessie" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_6.x/dists/jessie/Release'

## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
OK

## Creating apt sources list file for the NodeSource Node.js v6.x repo...

+ echo 'deb https://deb.nodesource.com/node_6.x jessie main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src https://deb.nodesource.com/node_6.x jessie main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit http://security.debian.org jessie/updates InRelease
Get:1 https://deb.nodesource.com jessie InRelease [3914 B]
Get:2 http://security.debian.org jessie/updates/main amd64 Packages [402 kB]
Ign http://deb.debian.org jessie InRelease
Hit http://deb.debian.org jessie-updates InRelease
Get:3 https://deb.nodesource.com jessie/main Sources [760 B]
Get:4 https://deb.nodesource.com jessie/main amd64 Packages [961 B]
Hit http://deb.debian.org jessie Release.gpg
Hit http://deb.debian.org jessie Release
Get:5 http://deb.debian.org jessie-updates/main amd64 Packages [17.6 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 9489 kB in 4s (2052 kB/s)
Reading package lists...

## Run `apt-get install nodejs` (as root) to install Node.js v6.x and npm

Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  ca-certificates-java fontconfig fontconfig-config fonts-dejavu-core
  java-common libasound2 libasound2-data libasyncns0 libatk-wrapper-java
  libatk-wrapper-java-jni libatk1.0-0 libatk1.0-data libavahi-client3
  libavahi-common-data libavahi-common3 libcairo2 libcups2 libdatrie1
  libdbus-1-3 libdrm2 libflac8 libfontconfig1 libfreetype6 libgdk-pixbuf2.0-0
  libgdk-pixbuf2.0-common libgif4 libgl1-mesa-glx libglapi-mesa libgraphite2-3
  libgtk2.0-0 libgtk2.0-common libharfbuzz0b libice6 libjasper1 libjbig0
  libjpeg62-turbo libjson-c2 liblcms2-2 libnspr4 libnss3 libogg0
  libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpcsclite1
  libpixman-1-0 libpng12-0 libpulse0 libsctp1 libsm6 libsndfile1 libthai-data
  libthai0 libtiff5 libvorbis0a libvorbisenc2 libwrap0 libx11-6 libx11-data
  libx11-xcb1 libxau6 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0
  libxcb-render0 libxcb-shm0 libxcb-sync1 libxcb1 libxcomposite1 libxcursor1
  libxdamage1 libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1 libxml2
  libxrandr2 libxrender1 libxshmfence1 libxtst6 libxxf86vm1
  openjdk-7-jre-headless shared-mime-info tzdata tzdata-java x11-common
Suggested packages:
  default-jre equivs libasound2-plugins alsa-utils cups-common librsvg2-common
  gvfs libjasper-runtime liblcms2-utils pcscd pulseaudio icedtea-7-plugin
  icedtea-7-jre-jamvm libnss-mdns sun-java6-fonts fonts-ipafont-gothic
  fonts-ipafont-mincho ttf-wqy-microhei ttf-wqy-zenhei fonts-indic
Recommended packages:
  dbus libgl1-mesa-dri hicolor-icon-theme libgtk2.0-bin lksctp-tools tcpd
  xml-core libgnome2-0 libgnomevfs2-0 libgconf2-4 fonts-dejavu-extra
The following NEW packages will be installed:
  ca-certificates-java fontconfig fontconfig-config fonts-dejavu-core
  java-common libasound2 libasound2-data libasyncns0 libatk-wrapper-java
  libatk-wrapper-java-jni libatk1.0-0 libatk1.0-data libavahi-client3
  libavahi-common-data libavahi-common3 libcairo2 libcups2 libdatrie1
  libdbus-1-3 libdrm2 libflac8 libfontconfig1 libfreetype6 libgdk-pixbuf2.0-0
  libgdk-pixbuf2.0-common libgif4 libgl1-mesa-glx libglapi-mesa libgraphite2-3
  libgtk2.0-0 libgtk2.0-common libharfbuzz0b libice6 libjasper1 libjbig0
  libjpeg62-turbo libjson-c2 liblcms2-2 libnspr4 libnss3 libogg0
  libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 libpcsclite1
  libpixman-1-0 libpng12-0 libpulse0 libsctp1 libsm6 libsndfile1 libthai-data
  libthai0 libtiff5 libvorbis0a libvorbisenc2 libwrap0 libx11-6 libx11-data
  libx11-xcb1 libxau6 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0
  libxcb-render0 libxcb-shm0 libxcb-sync1 libxcb1 libxcomposite1 libxcursor1
  libxdamage1 libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1 libxml2
  libxrandr2 libxrender1 libxshmfence1 libxtst6 libxxf86vm1 nodejs
  openjdk-7-jre openjdk-7-jre-headless shared-mime-info tzdata-java x11-common
The following packages will be upgraded:
  tzdata
1 upgraded, 89 newly installed, 0 to remove and 0 not upgraded.
Need to get 69.5 MB of archives.
After this operation, 178 MB of additional disk space will be used.
Get:1 http://security.debian.org/ jessie/updates/main libnspr4 amd64 2:4.12-1+debu8u1 [117 kB]
Get:2 http://security.debian.org/ jessie/updates/main libnss3 amd64 2:3.26-1+debu8u1 [1163 kB]
Get:3 https://deb.nodesource.com/node_6.x/ jessie/main nodejs amd64 6.9.1-1nodesource1~jessie1 [10.1 MB]
Get:4 http://security.debian.org/ jessie/updates/main openjdk-7-jre-headless amd64 7u111-2.6.7-2~deb8u1 [39.4 MB]
Get:5 http://deb.debian.org/debian/ jessie/main libjson-c2 amd64 0.11-4 [24.8 kB]
Get:6 http://deb.debian.org/debian/ jessie/main libwrap0 amd64 7.6.q-25 [58.5 kB]
Get:7 http://deb.debian.org/debian/ jessie/main libxml2 amd64 2.9.1+dfsg1-5+deb8u3 [802 kB]
Get:8 http://deb.debian.org/debian/ jessie/main libpng12-0 amd64 1.2.50-2+deb8u2 [173 kB]
Get:9 http://deb.debian.org/debian/ jessie/main libfreetype6 amd64 2.5.2-3+deb8u1 [466 kB]
Get:10 http://deb.debian.org/debian/ jessie/main fonts-dejavu-core all 2.34-1 [1047 kB]
Get:11 http://deb.debian.org/debian/ jessie/main fontconfig-config all 2.11.0-6.3+deb8u1 [274 kB]
Get:12 http://deb.debian.org/debian/ jessie/main libfontconfig1 amd64 2.11.0-6.3+deb8u1 [329 kB]
Get:13 http://deb.debian.org/debian/ jessie/main fontconfig amd64 2.11.0-6.3+deb8u1 [403 kB]
Get:14 http://deb.debian.org/debian/ jessie/main libasound2-data all 1.0.28-1 [64.8 kB]
Get:15 http://deb.debian.org/debian/ jessie/main libasound2 amd64 1.0.28-1 [374 kB]
Get:16 http://deb.debian.org/debian/ jessie/main libasyncns0 amd64 0.8-5 [12.5 kB]
Get:17 http://deb.debian.org/debian/ jessie/main libatk1.0-data all 2.14.0-1 [181 kB]
Get:18 http://deb.debian.org/debian/ jessie/main libatk1.0-0 amd64 2.14.0-1 [92.0 kB]
Get:19 http://deb.debian.org/debian/ jessie/main libpixman-1-0 amd64 0.32.6-3 [507 kB]
Get:20 http://deb.debian.org/debian/ jessie/main libxau6 amd64 1:1.0.8-1 [20.7 kB]
Get:21 http://deb.debian.org/debian/ jessie/main libxdmcp6 amd64 1:1.1.1-1+b1 [24.9 kB]
Get:22 http://deb.debian.org/debian/ jessie/main libxcb1 amd64 1.10-3+b1 [44.4 kB]
Get:23 http://deb.debian.org/debian/ jessie/main libx11-data all 2:1.6.2-3 [126 kB]
Get:24 http://deb.debian.org/debian/ jessie/main libx11-6 amd64 2:1.6.2-3 [729 kB]
Get:25 http://deb.debian.org/debian/ jessie/main libxcb-render0 amd64 1.10-3+b1 [17.5 kB]
Get:26 http://deb.debian.org/debian/ jessie/main libxcb-shm0 amd64 1.10-3+b1 [11.5 kB]
Get:27 http://deb.debian.org/debian/ jessie/main libxext6 amd64 2:1.3.3-1 [52.7 kB]
Get:28 http://deb.debian.org/debian/ jessie/main libxrender1 amd64 1:0.9.8-1+b1 [31.4 kB]
Get:29 http://deb.debian.org/debian/ jessie/main libcairo2 amd64 1.14.0-2.1+deb8u1 [746 kB]
Get:30 http://deb.debian.org/debian/ jessie/main libjpeg62-turbo amd64 1:1.3.1-12 [116 kB]
Get:31 http://deb.debian.org/debian/ jessie/main libjasper1 amd64 1.900.1-debian1-2.4+deb8u1 [134 kB]
Get:32 http://security.debian.org/ jessie/updates/main openjdk-7-jre amd64 7u111-2.6.7-2~deb8u1 [176 kB]
Get:33 http://deb.debian.org/debian/ jessie/main libjbig0 amd64 2.1-3.1 [30.7 kB]
Get:34 http://deb.debian.org/debian/ jessie/main libtiff5 amd64 4.0.3-12.3+deb8u1 [213 kB]
Get:35 http://deb.debian.org/debian/ jessie/main libgdk-pixbuf2.0-common all 2.31.1-2+deb8u5 [294 kB]
Get:36 http://deb.debian.org/debian/ jessie/main libgdk-pixbuf2.0-0 amd64 2.31.1-2+deb8u5 [167 kB]
Get:37 http://deb.debian.org/debian/ jessie/main libgtk2.0-common all 2.24.25-3+deb8u1 [3185 kB]
Get:38 http://deb.debian.org/debian/ jessie/main libavahi-common-data amd64 0.6.31-5 [98.6 kB]
Get:39 http://deb.debian.org/debian/ jessie/main libavahi-common3 amd64 0.6.31-5 [51.1 kB]
Get:40 http://deb.debian.org/debian/ jessie/main libdbus-1-3 amd64 1.8.20-0+deb8u1 [170 kB]
Get:41 http://deb.debian.org/debian/ jessie/main libavahi-client3 amd64 0.6.31-5 [54.4 kB]
Get:42 http://deb.debian.org/debian/ jessie/main libcups2 amd64 1.7.5-11+deb8u1 [283 kB]
Get:43 http://deb.debian.org/debian/ jessie/main libthai-data all 0.1.21-1 [159 kB]
Get:44 http://deb.debian.org/debian/ jessie/main libdatrie1 amd64 0.2.8-1 [32.6 kB]
Get:45 http://deb.debian.org/debian/ jessie/main libthai0 amd64 0.1.21-1 [46.1 kB]
Get:46 http://deb.debian.org/debian/ jessie/main libpango-1.0-0 amd64 1.36.8-3 [291 kB]
Get:47 http://deb.debian.org/debian/ jessie/main libgraphite2-3 amd64 1.3.6-1~deb8u1 [77.5 kB]
Get:48 http://deb.debian.org/debian/ jessie/main libharfbuzz0b amd64 0.9.35-2 [485 kB]
Get:49 http://deb.debian.org/debian/ jessie/main libpangoft2-1.0-0 amd64 1.36.8-3 [213 kB]
Get:50 http://deb.debian.org/debian/ jessie/main libpangocairo-1.0-0 amd64 1.36.8-3 [200 kB]
Get:51 http://deb.debian.org/debian/ jessie/main libxcomposite1 amd64 1:0.4.4-1 [17.4 kB]
Get:52 http://deb.debian.org/debian/ jessie/main libxfixes3 amd64 1:5.0.1-2+b2 [21.3 kB]
Get:53 http://deb.debian.org/debian/ jessie/main libxcursor1 amd64 1:1.1.14-1+b1 [35.1 kB]
Get:54 http://deb.debian.org/debian/ jessie/main libxdamage1 amd64 1:1.1.4-2+b1 [14.7 kB]
Get:55 http://deb.debian.org/debian/ jessie/main libxi6 amd64 2:1.7.4-1+b2 [79.7 kB]
Get:56 http://deb.debian.org/debian/ jessie/main libxinerama1 amd64 2:1.1.3-1+b1 [16.9 kB]
Get:57 http://deb.debian.org/debian/ jessie/main libxrandr2 amd64 2:1.4.2-1+b1 [35.5 kB]
Get:58 http://deb.debian.org/debian/ jessie/main shared-mime-info amd64 1.3-1 [634 kB]
Get:59 http://deb.debian.org/debian/ jessie/main libgtk2.0-0 amd64 2.24.25-3+deb8u1 [2306 kB]
Get:60 http://deb.debian.org/debian/ jessie/main libatk-wrapper-java all 0.30.5-1 [30.3 kB]
Get:61 http://deb.debian.org/debian/ jessie/main libatk-wrapper-java-jni amd64 0.30.5-1 [24.8 kB]
Get:62 http://deb.debian.org/debian/ jessie/main libdrm2 amd64 2.4.58-2 [29.9 kB]
Get:63 http://deb.debian.org/debian/ jessie/main libogg0 amd64 1.3.2-1 [19.9 kB]
Get:64 http://deb.debian.org/debian/ jessie/main libflac8 amd64 1.3.0-3 [89.3 kB]
Get:65 http://deb.debian.org/debian/ jessie/main libgif4 amd64 4.1.6-11+deb8u1 [40.0 kB]
Get:66 http://deb.debian.org/debian/ jessie/main libglapi-mesa amd64 10.3.2-1+deb8u1 [53.3 kB]
Get:67 http://deb.debian.org/debian/ jessie/main libx11-xcb1 amd64 2:1.6.2-3 [163 kB]
Get:68 http://deb.debian.org/debian/ jessie/main libxcb-dri2-0 amd64 1.10-3+b1 [12.9 kB]
Get:69 http://deb.debian.org/debian/ jessie/main libxcb-dri3-0 amd64 1.10-3+b1 [11.1 kB]
Get:70 http://deb.debian.org/debian/ jessie/main libxcb-glx0 amd64 1.10-3+b1 [27.4 kB]
Get:71 http://deb.debian.org/debian/ jessie/main libxcb-present0 amd64 1.10-3+b1 [11.1 kB]
Get:72 http://deb.debian.org/debian/ jessie/main libxcb-sync1 amd64 1.10-3+b1 [14.4 kB]
Get:73 http://deb.debian.org/debian/ jessie/main libxshmfence1 amd64 1.1-4 [6736 B]
Get:74 http://deb.debian.org/debian/ jessie/main libxxf86vm1 amd64 1:1.1.3-1+b1 [19.6 kB]
Get:75 http://deb.debian.org/debian/ jessie/main libgl1-mesa-glx amd64 10.3.2-1+deb8u1 [180 kB]
Get:76 http://deb.debian.org/debian/ jessie/main x11-common all 1:7.7+7 [287 kB]
Get:77 http://deb.debian.org/debian/ jessie/main libice6 amd64 2:1.0.9-1+b1 [58.8 kB]
Get:78 http://deb.debian.org/debian/ jessie/main liblcms2-2 amd64 2.6-3+b3 [141 kB]
Get:79 http://deb.debian.org/debian/ jessie/main libpcsclite1 amd64 1.8.13-1 [56.2 kB]
Get:80 http://deb.debian.org/debian/ jessie/main libsm6 amd64 2:1.2.2-1+b1 [33.6 kB]
Get:81 http://deb.debian.org/debian/ jessie/main libvorbis0a amd64 1.3.4-2 [92.9 kB]
Get:82 http://deb.debian.org/debian/ jessie/main libvorbisenc2 amd64 1.3.4-2 [77.9 kB]
Get:83 http://deb.debian.org/debian/ jessie/main libsndfile1 amd64 1.0.25-9.1+deb8u1 [215 kB]
Get:84 http://deb.debian.org/debian/ jessie/main libxtst6 amd64 2:1.2.2-1+b1 [27.3 kB]
Get:85 http://deb.debian.org/debian/ jessie/main libpulse0 amd64 5.0-13 [255 kB]
Get:86 http://deb.debian.org/debian/ jessie/main libsctp1 amd64 1.0.16+dfsg-2 [27.6 kB]
Get:87 http://deb.debian.org/debian/ jessie/main ca-certificates-java all 20140324 [13.7 kB]
Get:88 http://deb.debian.org/debian/ jessie-updates/main tzdata all 2016i-0+deb8u1 [186 kB]
Get:89 http://deb.debian.org/debian/ jessie-updates/main tzdata-java all 2016i-0+deb8u1 [81.2 kB]
Get:90 http://deb.debian.org/debian/ jessie/main java-common all 0.52 [136 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 69.5 MB in 16s (4315 kB/s)
Selecting previously unselected package libjson-c2:amd64.
(Reading database ... 14785 files and directories currently installed.)
Preparing to unpack .../libjson-c2_0.11-4_amd64.deb ...
Unpacking libjson-c2:amd64 (0.11-4) ...
Selecting previously unselected package libwrap0:amd64.
Preparing to unpack .../libwrap0_7.6.q-25_amd64.deb ...
Unpacking libwrap0:amd64 (7.6.q-25) ...
Selecting previously unselected package libxml2:amd64.
Preparing to unpack .../libxml2_2.9.1+dfsg1-5+deb8u3_amd64.deb ...
Unpacking libxml2:amd64 (2.9.1+dfsg1-5+deb8u3) ...
Selecting previously unselected package libpng12-0:amd64.
Preparing to unpack .../libpng12-0_1.2.50-2+deb8u2_amd64.deb ...
Unpacking libpng12-0:amd64 (1.2.50-2+deb8u2) ...
Selecting previously unselected package libfreetype6:amd64.
Preparing to unpack .../libfreetype6_2.5.2-3+deb8u1_amd64.deb ...
Unpacking libfreetype6:amd64 (2.5.2-3+deb8u1) ...
Selecting previously unselected package fonts-dejavu-core.
Preparing to unpack .../fonts-dejavu-core_2.34-1_all.deb ...
Unpacking fonts-dejavu-core (2.34-1) ...
Selecting previously unselected package fontconfig-config.
Preparing to unpack .../fontconfig-config_2.11.0-6.3+deb8u1_all.deb ...
Unpacking fontconfig-config (2.11.0-6.3+deb8u1) ...
Selecting previously unselected package libfontconfig1:amd64.
Preparing to unpack .../libfontconfig1_2.11.0-6.3+deb8u1_amd64.deb ...
Unpacking libfontconfig1:amd64 (2.11.0-6.3+deb8u1) ...
Selecting previously unselected package fontconfig.
Preparing to unpack .../fontconfig_2.11.0-6.3+deb8u1_amd64.deb ...
Unpacking fontconfig (2.11.0-6.3+deb8u1) ...
Selecting previously unselected package libasound2-data.
Preparing to unpack .../libasound2-data_1.0.28-1_all.deb ...
Unpacking libasound2-data (1.0.28-1) ...
Selecting previously unselected package libasound2:amd64.
Preparing to unpack .../libasound2_1.0.28-1_amd64.deb ...
Unpacking libasound2:amd64 (1.0.28-1) ...
Selecting previously unselected package libasyncns0:amd64.
Preparing to unpack .../libasyncns0_0.8-5_amd64.deb ...
Unpacking libasyncns0:amd64 (0.8-5) ...
Selecting previously unselected package libatk1.0-data.
Preparing to unpack .../libatk1.0-data_2.14.0-1_all.deb ...
Unpacking libatk1.0-data (2.14.0-1) ...
Selecting previously unselected package libatk1.0-0:amd64.
Preparing to unpack .../libatk1.0-0_2.14.0-1_amd64.deb ...
Unpacking libatk1.0-0:amd64 (2.14.0-1) ...
Selecting previously unselected package libpixman-1-0:amd64.
Preparing to unpack .../libpixman-1-0_0.32.6-3_amd64.deb ...
Unpacking libpixman-1-0:amd64 (0.32.6-3) ...
Selecting previously unselected package libxau6:amd64.
Preparing to unpack .../libxau6_1%3a1.0.8-1_amd64.deb ...
Unpacking libxau6:amd64 (1:1.0.8-1) ...
Selecting previously unselected package libxdmcp6:amd64.
Preparing to unpack .../libxdmcp6_1%3a1.1.1-1+b1_amd64.deb ...
Unpacking libxdmcp6:amd64 (1:1.1.1-1+b1) ...
Selecting previously unselected package libxcb1:amd64.
Preparing to unpack .../libxcb1_1.10-3+b1_amd64.deb ...
Unpacking libxcb1:amd64 (1.10-3+b1) ...
Selecting previously unselected package libx11-data.
Preparing to unpack .../libx11-data_2%3a1.6.2-3_all.deb ...
Unpacking libx11-data (2:1.6.2-3) ...
Selecting previously unselected package libx11-6:amd64.
Preparing to unpack .../libx11-6_2%3a1.6.2-3_amd64.deb ...
Unpacking libx11-6:amd64 (2:1.6.2-3) ...
Selecting previously unselected package libxcb-render0:amd64.
Preparing to unpack .../libxcb-render0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-render0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxcb-shm0:amd64.
Preparing to unpack .../libxcb-shm0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-shm0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxext6:amd64.
Preparing to unpack .../libxext6_2%3a1.3.3-1_amd64.deb ...
Unpacking libxext6:amd64 (2:1.3.3-1) ...
Selecting previously unselected package libxrender1:amd64.
Preparing to unpack .../libxrender1_1%3a0.9.8-1+b1_amd64.deb ...
Unpacking libxrender1:amd64 (1:0.9.8-1+b1) ...
Selecting previously unselected package libcairo2:amd64.
Preparing to unpack .../libcairo2_1.14.0-2.1+deb8u1_amd64.deb ...
Unpacking libcairo2:amd64 (1.14.0-2.1+deb8u1) ...
Selecting previously unselected package libjpeg62-turbo:amd64.
Preparing to unpack .../libjpeg62-turbo_1%3a1.3.1-12_amd64.deb ...
Unpacking libjpeg62-turbo:amd64 (1:1.3.1-12) ...
Selecting previously unselected package libjasper1:amd64.
Preparing to unpack .../libjasper1_1.900.1-debian1-2.4+deb8u1_amd64.deb ...
Unpacking libjasper1:amd64 (1.900.1-debian1-2.4+deb8u1) ...
Selecting previously unselected package libjbig0:amd64.
Preparing to unpack .../libjbig0_2.1-3.1_amd64.deb ...
Unpacking libjbig0:amd64 (2.1-3.1) ...
Selecting previously unselected package libtiff5:amd64.
Preparing to unpack .../libtiff5_4.0.3-12.3+deb8u1_amd64.deb ...
Unpacking libtiff5:amd64 (4.0.3-12.3+deb8u1) ...
Selecting previously unselected package libgdk-pixbuf2.0-common.
Preparing to unpack .../libgdk-pixbuf2.0-common_2.31.1-2+deb8u5_all.deb ...
Unpacking libgdk-pixbuf2.0-common (2.31.1-2+deb8u5) ...
Selecting previously unselected package libgdk-pixbuf2.0-0:amd64.
Preparing to unpack .../libgdk-pixbuf2.0-0_2.31.1-2+deb8u5_amd64.deb ...
Unpacking libgdk-pixbuf2.0-0:amd64 (2.31.1-2+deb8u5) ...
Selecting previously unselected package libgtk2.0-common.
Preparing to unpack .../libgtk2.0-common_2.24.25-3+deb8u1_all.deb ...
Unpacking libgtk2.0-common (2.24.25-3+deb8u1) ...
Selecting previously unselected package libavahi-common-data:amd64.
Preparing to unpack .../libavahi-common-data_0.6.31-5_amd64.deb ...
Unpacking libavahi-common-data:amd64 (0.6.31-5) ...
Selecting previously unselected package libavahi-common3:amd64.
Preparing to unpack .../libavahi-common3_0.6.31-5_amd64.deb ...
Unpacking libavahi-common3:amd64 (0.6.31-5) ...
Selecting previously unselected package libdbus-1-3:amd64.
Preparing to unpack .../libdbus-1-3_1.8.20-0+deb8u1_amd64.deb ...
Unpacking libdbus-1-3:amd64 (1.8.20-0+deb8u1) ...
Selecting previously unselected package libavahi-client3:amd64.
Preparing to unpack .../libavahi-client3_0.6.31-5_amd64.deb ...
Unpacking libavahi-client3:amd64 (0.6.31-5) ...
Selecting previously unselected package libcups2:amd64.
Preparing to unpack .../libcups2_1.7.5-11+deb8u1_amd64.deb ...
Unpacking libcups2:amd64 (1.7.5-11+deb8u1) ...
Selecting previously unselected package libthai-data.
Preparing to unpack .../libthai-data_0.1.21-1_all.deb ...
Unpacking libthai-data (0.1.21-1) ...
Selecting previously unselected package libdatrie1:amd64.
Preparing to unpack .../libdatrie1_0.2.8-1_amd64.deb ...
Unpacking libdatrie1:amd64 (0.2.8-1) ...
Selecting previously unselected package libthai0:amd64.
Preparing to unpack .../libthai0_0.1.21-1_amd64.deb ...
Unpacking libthai0:amd64 (0.1.21-1) ...
Selecting previously unselected package libpango-1.0-0:amd64.
Preparing to unpack .../libpango-1.0-0_1.36.8-3_amd64.deb ...
Unpacking libpango-1.0-0:amd64 (1.36.8-3) ...
Selecting previously unselected package libgraphite2-3:amd64.
Preparing to unpack .../libgraphite2-3_1.3.6-1~deb8u1_amd64.deb ...
Unpacking libgraphite2-3:amd64 (1.3.6-1~deb8u1) ...
Selecting previously unselected package libharfbuzz0b:amd64.
Preparing to unpack .../libharfbuzz0b_0.9.35-2_amd64.deb ...
Unpacking libharfbuzz0b:amd64 (0.9.35-2) ...
Selecting previously unselected package libpangoft2-1.0-0:amd64.
Preparing to unpack .../libpangoft2-1.0-0_1.36.8-3_amd64.deb ...
Unpacking libpangoft2-1.0-0:amd64 (1.36.8-3) ...
Selecting previously unselected package libpangocairo-1.0-0:amd64.
Preparing to unpack .../libpangocairo-1.0-0_1.36.8-3_amd64.deb ...
Unpacking libpangocairo-1.0-0:amd64 (1.36.8-3) ...
Selecting previously unselected package libxcomposite1:amd64.
Preparing to unpack .../libxcomposite1_1%3a0.4.4-1_amd64.deb ...
Unpacking libxcomposite1:amd64 (1:0.4.4-1) ...
Selecting previously unselected package libxfixes3:amd64.
Preparing to unpack .../libxfixes3_1%3a5.0.1-2+b2_amd64.deb ...
Unpacking libxfixes3:amd64 (1:5.0.1-2+b2) ...
Selecting previously unselected package libxcursor1:amd64.
Preparing to unpack .../libxcursor1_1%3a1.1.14-1+b1_amd64.deb ...
Unpacking libxcursor1:amd64 (1:1.1.14-1+b1) ...
Selecting previously unselected package libxdamage1:amd64.
Preparing to unpack .../libxdamage1_1%3a1.1.4-2+b1_amd64.deb ...
Unpacking libxdamage1:amd64 (1:1.1.4-2+b1) ...
Selecting previously unselected package libxi6:amd64.
Preparing to unpack .../libxi6_2%3a1.7.4-1+b2_amd64.deb ...
Unpacking libxi6:amd64 (2:1.7.4-1+b2) ...
Selecting previously unselected package libxinerama1:amd64.
Preparing to unpack .../libxinerama1_2%3a1.1.3-1+b1_amd64.deb ...
Unpacking libxinerama1:amd64 (2:1.1.3-1+b1) ...
Selecting previously unselected package libxrandr2:amd64.
Preparing to unpack .../libxrandr2_2%3a1.4.2-1+b1_amd64.deb ...
Unpacking libxrandr2:amd64 (2:1.4.2-1+b1) ...
Selecting previously unselected package shared-mime-info.
Preparing to unpack .../shared-mime-info_1.3-1_amd64.deb ...
Unpacking shared-mime-info (1.3-1) ...
Selecting previously unselected package libgtk2.0-0:amd64.
Preparing to unpack .../libgtk2.0-0_2.24.25-3+deb8u1_amd64.deb ...
Unpacking libgtk2.0-0:amd64 (2.24.25-3+deb8u1) ...
Selecting previously unselected package libatk-wrapper-java.
Preparing to unpack .../libatk-wrapper-java_0.30.5-1_all.deb ...
Unpacking libatk-wrapper-java (0.30.5-1) ...
Selecting previously unselected package libatk-wrapper-java-jni:amd64.
Preparing to unpack .../libatk-wrapper-java-jni_0.30.5-1_amd64.deb ...
Unpacking libatk-wrapper-java-jni:amd64 (0.30.5-1) ...
Selecting previously unselected package libdrm2:amd64.
Preparing to unpack .../libdrm2_2.4.58-2_amd64.deb ...
Unpacking libdrm2:amd64 (2.4.58-2) ...
Selecting previously unselected package libogg0:amd64.
Preparing to unpack .../libogg0_1.3.2-1_amd64.deb ...
Unpacking libogg0:amd64 (1.3.2-1) ...
Selecting previously unselected package libflac8:amd64.
Preparing to unpack .../libflac8_1.3.0-3_amd64.deb ...
Unpacking libflac8:amd64 (1.3.0-3) ...
Selecting previously unselected package libgif4:amd64.
Preparing to unpack .../libgif4_4.1.6-11+deb8u1_amd64.deb ...
Unpacking libgif4:amd64 (4.1.6-11+deb8u1) ...
Selecting previously unselected package libglapi-mesa:amd64.
Preparing to unpack .../libglapi-mesa_10.3.2-1+deb8u1_amd64.deb ...
Unpacking libglapi-mesa:amd64 (10.3.2-1+deb8u1) ...
Selecting previously unselected package libx11-xcb1:amd64.
Preparing to unpack .../libx11-xcb1_2%3a1.6.2-3_amd64.deb ...
Unpacking libx11-xcb1:amd64 (2:1.6.2-3) ...
Selecting previously unselected package libxcb-dri2-0:amd64.
Preparing to unpack .../libxcb-dri2-0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-dri2-0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxcb-dri3-0:amd64.
Preparing to unpack .../libxcb-dri3-0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-dri3-0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxcb-glx0:amd64.
Preparing to unpack .../libxcb-glx0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-glx0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxcb-present0:amd64.
Preparing to unpack .../libxcb-present0_1.10-3+b1_amd64.deb ...
Unpacking libxcb-present0:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxcb-sync1:amd64.
Preparing to unpack .../libxcb-sync1_1.10-3+b1_amd64.deb ...
Unpacking libxcb-sync1:amd64 (1.10-3+b1) ...
Selecting previously unselected package libxshmfence1:amd64.
Preparing to unpack .../libxshmfence1_1.1-4_amd64.deb ...
Unpacking libxshmfence1:amd64 (1.1-4) ...
Selecting previously unselected package libxxf86vm1:amd64.
Preparing to unpack .../libxxf86vm1_1%3a1.1.3-1+b1_amd64.deb ...
Unpacking libxxf86vm1:amd64 (1:1.1.3-1+b1) ...
Selecting previously unselected package libgl1-mesa-glx:amd64.
Preparing to unpack .../libgl1-mesa-glx_10.3.2-1+deb8u1_amd64.deb ...
Unpacking libgl1-mesa-glx:amd64 (10.3.2-1+deb8u1) ...
Selecting previously unselected package x11-common.
Preparing to unpack .../x11-common_1%3a7.7+7_all.deb ...
Unpacking x11-common (1:7.7+7) ...
Selecting previously unselected package libice6:amd64.
Preparing to unpack .../libice6_2%3a1.0.9-1+b1_amd64.deb ...
Unpacking libice6:amd64 (2:1.0.9-1+b1) ...
Selecting previously unselected package liblcms2-2:amd64.
Preparing to unpack .../liblcms2-2_2.6-3+b3_amd64.deb ...
Unpacking liblcms2-2:amd64 (2.6-3+b3) ...
Selecting previously unselected package libnspr4:amd64.
Preparing to unpack .../libnspr4_2%3a4.12-1+debu8u1_amd64.deb ...
Unpacking libnspr4:amd64 (2:4.12-1+debu8u1) ...
Selecting previously unselected package libnss3:amd64.
Preparing to unpack .../libnss3_2%3a3.26-1+debu8u1_amd64.deb ...
Unpacking libnss3:amd64 (2:3.26-1+debu8u1) ...
Selecting previously unselected package libpcsclite1:amd64.
Preparing to unpack .../libpcsclite1_1.8.13-1_amd64.deb ...
Unpacking libpcsclite1:amd64 (1.8.13-1) ...
Selecting previously unselected package libsm6:amd64.
Preparing to unpack .../libsm6_2%3a1.2.2-1+b1_amd64.deb ...
Unpacking libsm6:amd64 (2:1.2.2-1+b1) ...
Selecting previously unselected package libvorbis0a:amd64.
Preparing to unpack .../libvorbis0a_1.3.4-2_amd64.deb ...
Unpacking libvorbis0a:amd64 (1.3.4-2) ...
Selecting previously unselected package libvorbisenc2:amd64.
Preparing to unpack .../libvorbisenc2_1.3.4-2_amd64.deb ...
Unpacking libvorbisenc2:amd64 (1.3.4-2) ...
Selecting previously unselected package libsndfile1:amd64.
Preparing to unpack .../libsndfile1_1.0.25-9.1+deb8u1_amd64.deb ...
Unpacking libsndfile1:amd64 (1.0.25-9.1+deb8u1) ...
Selecting previously unselected package libxtst6:amd64.
Preparing to unpack .../libxtst6_2%3a1.2.2-1+b1_amd64.deb ...
Unpacking libxtst6:amd64 (2:1.2.2-1+b1) ...
Selecting previously unselected package libpulse0:amd64.
Preparing to unpack .../libpulse0_5.0-13_amd64.deb ...
Unpacking libpulse0:amd64 (5.0-13) ...
Selecting previously unselected package libsctp1:amd64.
Preparing to unpack .../libsctp1_1.0.16+dfsg-2_amd64.deb ...
Unpacking libsctp1:amd64 (1.0.16+dfsg-2) ...
Selecting previously unselected package ca-certificates-java.
Preparing to unpack .../ca-certificates-java_20140324_all.deb ...
Unpacking ca-certificates-java (20140324) ...
Preparing to unpack .../tzdata_2016i-0+deb8u1_all.deb ...
Unpacking tzdata (2016i-0+deb8u1) over (2016h-0+deb8u1) ...
Processing triggers for systemd (215-17+deb8u5) ...
Processing triggers for ca-certificates (20141019+deb8u1) ...
Updating certificates in /etc/ssl/certs... 0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Setting up tzdata (2016i-0+deb8u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline

Current default time zone: 'Etc/UTC'
Local time is now:      Wed Nov  9 10:25:04 UTC 2016.
Universal Time is now:  Wed Nov  9 10:25:04 UTC 2016.
Run 'dpkg-reconfigure tzdata' if you wish to change it.

Selecting previously unselected package tzdata-java.
(Reading database ... 16591 files and directories currently installed.)
Preparing to unpack .../tzdata-java_2016i-0+deb8u1_all.deb ...
Unpacking tzdata-java (2016i-0+deb8u1) ...
Selecting previously unselected package java-common.
Preparing to unpack .../java-common_0.52_all.deb ...
Unpacking java-common (0.52) ...
Selecting previously unselected package openjdk-7-jre-headless:amd64.
Preparing to unpack .../openjdk-7-jre-headless_7u111-2.6.7-2~deb8u1_amd64.deb ...
Unpacking openjdk-7-jre-headless:amd64 (7u111-2.6.7-2~deb8u1) ...
Selecting previously unselected package openjdk-7-jre:amd64.
Preparing to unpack .../openjdk-7-jre_7u111-2.6.7-2~deb8u1_amd64.deb ...
Unpacking openjdk-7-jre:amd64 (7u111-2.6.7-2~deb8u1) ...
Selecting previously unselected package nodejs.
Preparing to unpack .../nodejs_6.9.1-1nodesource1~jessie1_amd64.deb ...
Unpacking nodejs (6.9.1-1nodesource1~jessie1) ...
Processing triggers for mime-support (3.58) ...
Setting up libjson-c2:amd64 (0.11-4) ...
Setting up libwrap0:amd64 (7.6.q-25) ...
Setting up libxml2:amd64 (2.9.1+dfsg1-5+deb8u3) ...
Setting up libpng12-0:amd64 (1.2.50-2+deb8u2) ...
Setting up libfreetype6:amd64 (2.5.2-3+deb8u1) ...
Setting up fonts-dejavu-core (2.34-1) ...
Setting up fontconfig-config (2.11.0-6.3+deb8u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Setting up libfontconfig1:amd64 (2.11.0-6.3+deb8u1) ...
Setting up fontconfig (2.11.0-6.3+deb8u1) ...
Regenerating fonts cache... done.
Setting up libasound2-data (1.0.28-1) ...
Setting up libasound2:amd64 (1.0.28-1) ...
Setting up libasyncns0:amd64 (0.8-5) ...
Setting up libatk1.0-data (2.14.0-1) ...
Setting up libatk1.0-0:amd64 (2.14.0-1) ...
Setting up libpixman-1-0:amd64 (0.32.6-3) ...
Setting up libxau6:amd64 (1:1.0.8-1) ...
Setting up libxdmcp6:amd64 (1:1.1.1-1+b1) ...
Setting up libxcb1:amd64 (1.10-3+b1) ...
Setting up libx11-data (2:1.6.2-3) ...
Setting up libx11-6:amd64 (2:1.6.2-3) ...
Setting up libxcb-render0:amd64 (1.10-3+b1) ...
Setting up libxcb-shm0:amd64 (1.10-3+b1) ...
Setting up libxext6:amd64 (2:1.3.3-1) ...
Setting up libxrender1:amd64 (1:0.9.8-1+b1) ...
Setting up libcairo2:amd64 (1.14.0-2.1+deb8u1) ...
Setting up libjpeg62-turbo:amd64 (1:1.3.1-12) ...
Setting up libjasper1:amd64 (1.900.1-debian1-2.4+deb8u1) ...
Setting up libjbig0:amd64 (2.1-3.1) ...
Setting up libtiff5:amd64 (4.0.3-12.3+deb8u1) ...
Setting up libgdk-pixbuf2.0-common (2.31.1-2+deb8u5) ...
Setting up libgdk-pixbuf2.0-0:amd64 (2.31.1-2+deb8u5) ...
Setting up libgtk2.0-common (2.24.25-3+deb8u1) ...
Setting up libavahi-common-data:amd64 (0.6.31-5) ...
Setting up libavahi-common3:amd64 (0.6.31-5) ...
Setting up libdbus-1-3:amd64 (1.8.20-0+deb8u1) ...
Setting up libavahi-client3:amd64 (0.6.31-5) ...
Setting up libcups2:amd64 (1.7.5-11+deb8u1) ...
Setting up libthai-data (0.1.21-1) ...
Setting up libdatrie1:amd64 (0.2.8-1) ...
Setting up libthai0:amd64 (0.1.21-1) ...
Setting up libpango-1.0-0:amd64 (1.36.8-3) ...
Setting up libgraphite2-3:amd64 (1.3.6-1~deb8u1) ...
Setting up libharfbuzz0b:amd64 (0.9.35-2) ...
Setting up libpangoft2-1.0-0:amd64 (1.36.8-3) ...
Setting up libpangocairo-1.0-0:amd64 (1.36.8-3) ...
Setting up libxcomposite1:amd64 (1:0.4.4-1) ...
Setting up libxfixes3:amd64 (1:5.0.1-2+b2) ...
Setting up libxcursor1:amd64 (1:1.1.14-1+b1) ...
Setting up libxdamage1:amd64 (1:1.1.4-2+b1) ...
Setting up libxi6:amd64 (2:1.7.4-1+b2) ...
Setting up libxinerama1:amd64 (2:1.1.3-1+b1) ...
Setting up libxrandr2:amd64 (2:1.4.2-1+b1) ...
Setting up shared-mime-info (1.3-1) ...
Setting up libgtk2.0-0:amd64 (2.24.25-3+deb8u1) ...
Setting up libatk-wrapper-java (0.30.5-1) ...
Setting up libatk-wrapper-java-jni:amd64 (0.30.5-1) ...
Setting up libdrm2:amd64 (2.4.58-2) ...
Setting up libogg0:amd64 (1.3.2-1) ...
Setting up libflac8:amd64 (1.3.0-3) ...
Setting up libgif4:amd64 (4.1.6-11+deb8u1) ...
Setting up libglapi-mesa:amd64 (10.3.2-1+deb8u1) ...
Setting up libx11-xcb1:amd64 (2:1.6.2-3) ...
Setting up libxcb-dri2-0:amd64 (1.10-3+b1) ...
Setting up libxcb-dri3-0:amd64 (1.10-3+b1) ...
Setting up libxcb-glx0:amd64 (1.10-3+b1) ...
Setting up libxcb-present0:amd64 (1.10-3+b1) ...
Setting up libxcb-sync1:amd64 (1.10-3+b1) ...
Setting up libxshmfence1:amd64 (1.1-4) ...
Setting up libxxf86vm1:amd64 (1:1.1.3-1+b1) ...
Setting up libgl1-mesa-glx:amd64 (10.3.2-1+deb8u1) ...
Setting up x11-common (1:7.7+7) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
invoke-rc.d: policy-rc.d denied execution of start.
Setting up libice6:amd64 (2:1.0.9-1+b1) ...
Setting up liblcms2-2:amd64 (2.6-3+b3) ...
Setting up libnspr4:amd64 (2:4.12-1+debu8u1) ...
Setting up libnss3:amd64 (2:3.26-1+debu8u1) ...
Setting up libpcsclite1:amd64 (1.8.13-1) ...
Setting up libsm6:amd64 (2:1.2.2-1+b1) ...
Setting up libvorbis0a:amd64 (1.3.4-2) ...
Setting up libvorbisenc2:amd64 (1.3.4-2) ...
Setting up libsndfile1:amd64 (1.0.25-9.1+deb8u1) ...
Setting up libxtst6:amd64 (2:1.2.2-1+b1) ...
Setting up libpulse0:amd64 (5.0-13) ...
Setting up libsctp1:amd64 (1.0.16+dfsg-2) ...
Setting up tzdata-java (2016i-0+deb8u1) ...
Setting up java-common (0.52) ...
Setting up nodejs (6.9.1-1nodesource1~jessie1) ...
Setting up openjdk-7-jre-headless:amd64 (7u111-2.6.7-2~deb8u1) ...
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java to provide /usr/bin/java (java) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/keytool to provide /usr/bin/keytool (keytool) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/pack200 to provide /usr/bin/pack200 (pack200) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/rmiregistry to provide /usr/bin/rmiregistry (rmiregistry) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/unpack200 to provide /usr/bin/unpack200 (unpack200) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/orbd to provide /usr/bin/orbd (orbd) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/servertool to provide /usr/bin/servertool (servertool) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/tnameserv to provide /usr/bin/tnameserv (tnameserv) in auto mode
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/jexec to provide /usr/bin/jexec (jexec) in auto mode
Setting up openjdk-7-jre:amd64 (7u111-2.6.7-2~deb8u1) ...
update-alternatives: using /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/policytool to provide /usr/bin/policytool (policytool) in auto mode
Setting up ca-certificates-java (20140324) ...
Adding debian:WoSign.pem
Adding debian:Global_Chambersign_Root_-_2008.pem
Adding debian:S-TRUST_Universal_Root_CA.pem
Adding debian:GlobalSign_Root_CA_-_R2.pem
Adding debian:AddTrust_Qualified_Certificates_Root.pem
Adding debian:thawte_Primary_Root_CA_-_G2.pem
Adding debian:Sonera_Class_1_Root_CA.pem
Adding debian:Verisign_Class_1_Public_Primary_Certification_Authority.pem
Adding debian:NetLock_Business_=Class_B=_Root.pem
Adding debian:IdenTrust_Commercial_Root_CA_1.pem
Adding debian:SwissSign_Gold_CA_-_G2.pem
Adding debian:TÜRKTRUST_Elektronik_Sertifika_Hizmet_Sağlayıcısı_H6.pem
Adding debian:SecureTrust_CA.pem
Adding debian:thawte_Primary_Root_CA_-_G3.pem
Adding debian:QuoVadis_Root_CA_3_G3.pem
Adding debian:Buypass_Class_2_CA_1.pem
Adding debian:spi-cacert-2008.pem
Adding debian:COMODO_ECC_Certification_Authority.pem
Adding debian:Equifax_Secure_eBusiness_CA_1.pem
Adding debian:WoSign_China.pem
Adding debian:GeoTrust_Global_CA_2.pem
Adding debian:Cybertrust_Global_Root.pem
Adding debian:Go_Daddy_Root_Certificate_Authority_-_G2.pem
Adding debian:Certinomis_-_Root_CA.pem
Adding debian:Trustis_FPS_Root_CA.pem
Adding debian:EC-ACC.pem
Adding debian:Staat_der_Nederlanden_Root_CA.pem
Adding debian:Taiwan_GRCA.pem
Adding debian:DigiCert_High_Assurance_EV_Root_CA.pem
Adding debian:Starfield_Services_Root_Certificate_Authority_-_G2.pem
Adding debian:T-TeleSec_GlobalRoot_Class_2.pem
Adding debian:UTN_USERFirst_Email_Root_CA.pem
Adding debian:GlobalSign_ECC_Root_CA_-_R5.pem
Adding debian:StartCom_Certification_Authority_2.pem
Adding debian:Verisign_Class_3_Public_Primary_Certification_Authority.pem
Adding debian:EE_Certification_Centre_Root_CA.pem
Adding debian:UTN_USERFirst_Hardware_Root_CA.pem
Adding debian:Security_Communication_RootCA2.pem
Adding debian:SwissSign_Silver_CA_-_G2.pem
Adding debian:Hellenic_Academic_and_Research_Institutions_RootCA_2011.pem
Adding debian:Verisign_Class_3_Public_Primary_Certification_Authority_-_G3.pem
Adding debian:NetLock_Notary_=Class_A=_Root.pem
Adding debian:Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem
Adding debian:AffirmTrust_Premium.pem
Adding debian:IdenTrust_Public_Sector_Root_CA_1.pem
Adding debian:QuoVadis_Root_CA_2.pem
Adding debian:Verisign_Class_2_Public_Primary_Certification_Authority_-_G3.pem
Adding debian:QuoVadis_Root_CA_2_G3.pem
Adding debian:D-TRUST_Root_Class_3_CA_2_2009.pem
Adding debian:Starfield_Root_Certificate_Authority_-_G2.pem
Adding debian:GeoTrust_Primary_Certification_Authority_-_G2.pem
Adding debian:QuoVadis_Root_CA_3.pem
Adding debian:Root_CA_Generalitat_Valenciana.pem
Adding debian:Security_Communication_Root_CA.pem
Adding debian:GeoTrust_Primary_Certification_Authority_-_G3.pem
Adding debian:Sonera_Class_2_Root_CA.pem
Adding debian:Atos_TrustedRoot_2011.pem
Adding debian:PSCProcert.pem
Adding debian:thawte_Primary_Root_CA.pem
Adding debian:DST_ACES_CA_X6.pem
Adding debian:GlobalSign_Root_CA_-_R3.pem
Adding debian:Certigna.pem
Adding debian:COMODO_RSA_Certification_Authority.pem
Adding debian:NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem
Adding debian:Visa_eCommerce_Root.pem
Adding debian:CA_Disig_Root_R2.pem
Adding debian:Swisscom_Root_EV_CA_2.pem
Adding debian:Entrust_Root_Certification_Authority_-_EC1.pem
Adding debian:COMODO_Certification_Authority.pem
Adding debian:Comodo_Trusted_Services_root.pem
Adding debian:TeliaSonera_Root_CA_v1.pem
Adding debian:QuoVadis_Root_CA_1_G3.pem
Adding debian:QuoVadis_Root_CA.pem
Adding debian:Verisign_Class_3_Public_Primary_Certification_Authority_-_G2.pem
Adding debian:CNNIC_ROOT.pem
Adding debian:ePKI_Root_Certification_Authority.pem
Adding debian:Secure_Global_CA.pem
Adding debian:Starfield_Class_2_CA.pem
Adding debian:AffirmTrust_Premium_ECC.pem
Adding debian:AffirmTrust_Networking.pem
Adding debian:USERTrust_RSA_Certification_Authority.pem
Adding debian:Certum_Trusted_Network_CA.pem
Adding debian:TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.pem
Adding debian:DigiCert_Trusted_Root_G4.pem
Adding debian:DigiCert_Global_Root_G3.pem
Adding debian:Equifax_Secure_Global_eBusiness_CA.pem
Adding debian:Certum_Root_CA.pem
Adding debian:GeoTrust_Global_CA.pem
Adding debian:Deutsche_Telekom_Root_CA_2.pem
Adding debian:Verisign_Class_1_Public_Primary_Certification_Authority_-_G3.pem
Adding debian:SecureSign_RootCA11.pem
Adding debian:VeriSign_Class_3_Public_Primary_Certification_Authority_-_G5.pem
Adding debian:IGC_A.pem
Adding debian:Comodo_Secure_Services_root.pem
Adding debian:OISTE_WISeKey_Global_Root_GA_CA.pem
Adding debian:VeriSign_Universal_Root_Certification_Authority.pem
Adding debian:certSIGN_ROOT_CA.pem
Adding debian:Network_Solutions_Certificate_Authority.pem
Adding debian:AC_Raíz_Certicámara_S.A..pem
Adding debian:TURKTRUST_Certificate_Services_Provider_Root_2007.pem
Adding debian:Microsec_e-Szigno_Root_CA.pem
Adding debian:E-Tugra_Certification_Authority.pem
Adding debian:T-TeleSec_GlobalRoot_Class_3.pem
Adding debian:AffirmTrust_Commercial.pem
Adding debian:NetLock_Qualified_=Class_QA=_Root.pem
Adding debian:Chambers_of_Commerce_Root_-_2008.pem
Adding debian:D-TRUST_Root_Class_3_CA_2_EV_2009.pem
Adding debian:GeoTrust_Universal_CA.pem
Adding debian:Microsec_e-Szigno_Root_CA_2009.pem
Adding debian:Certplus_Class_2_Primary_CA.pem
Adding debian:Izenpe.com.pem
Adding debian:Camerfirma_Chambers_of_Commerce_Root.pem
Adding debian:DigiCert_Assured_ID_Root_CA.pem
Adding debian:VeriSign_Class_3_Public_Primary_Certification_Authority_-_G4.pem
Adding debian:AddTrust_External_Root.pem
Adding debian:GlobalSign_Root_CA.pem
Adding debian:Hongkong_Post_Root_CA_1.pem
Adding debian:Staat_der_Nederlanden_Root_CA_-_G3.pem
Adding debian:Verisign_Class_1_Public_Primary_Certification_Authority_-_G2.pem
Adding debian:ApplicationCA_-_Japanese_Government.pem
Adding debian:DigiCert_Global_Root_CA.pem
Adding debian:ACEDICOM_Root.pem
Adding debian:Baltimore_CyberTrust_Root.pem
Adding debian:StartCom_Certification_Authority.pem
Adding debian:Staat_der_Nederlanden_EV_Root_CA.pem
Adding debian:AddTrust_Low-Value_Services_Root.pem
Adding debian:Comodo_AAA_Services_root.pem
Adding debian:Verisign_Class_3_Public_Primary_Certification_Authority_2.pem
Adding debian:Buypass_Class_3_Root_CA.pem
Adding debian:ComSign_CA.pem
Adding debian:TWCA_Global_Root_CA.pem
Adding debian:WellsSecure_Public_Root_Certificate_Authority.pem
Adding debian:Buypass_Class_2_Root_CA.pem
Adding debian:DigiCert_Assured_ID_Root_G3.pem
Adding debian:Juur-SK.pem
Adding debian:TC_TrustCenter_Class_3_CA_II.pem
Adding debian:Security_Communication_EV_RootCA1.pem
Adding debian:Entrust_Root_Certification_Authority.pem
Adding debian:Staat_der_Nederlanden_Root_CA_-_G2.pem
Adding debian:Certinomis_-_Autorité_Racine.pem
Adding debian:RSA_Security_2048_v3.pem
Adding debian:CA_Disig.pem
Adding debian:AddTrust_Public_Services_Root.pem
Adding debian:EBG_Elektronik_Sertifika_Hizmet_Sağlayıcısı.pem
Adding debian:GlobalSign_ECC_Root_CA_-_R4.pem
Adding debian:GeoTrust_Primary_Certification_Authority.pem
Adding debian:Verisign_Class_2_Public_Primary_Certification_Authority_-_G2.pem
Adding debian:DigiCert_Global_Root_G2.pem
Adding debian:SwissSign_Platinum_CA_-_G2.pem
Adding debian:Swisscom_Root_CA_1.pem
Adding debian:CA_WoSign_ECC_Root.pem
Adding debian:Actalis_Authentication_Root_CA.pem
Adding debian:CFCA_EV_ROOT.pem
Adding debian:XRamp_Global_CA_Root.pem
Adding debian:NetLock_Express_=Class_C=_Root.pem
Adding debian:Entrust.net_Premium_2048_Secure_Server_CA.pem
Adding debian:CA_Disig_Root_R1.pem
Adding debian:S-TRUST_Authentication_and_Encryption_Root_CA_2005_PN.pem
Adding debian:Equifax_Secure_CA.pem
Adding debian:Camerfirma_Global_Chambersign_Root.pem
Adding debian:USERTrust_ECC_Certification_Authority.pem
Adding debian:China_Internet_Network_Information_Center_EV_Certificates_Root.pem
Adding debian:ACCVRAIZ1.pem
Adding debian:StartCom_Certification_Authority_G2.pem
Adding debian:Go_Daddy_Class_2_CA.pem
Adding debian:Entrust_Root_Certification_Authority_-_G2.pem
Adding debian:TÜRKTRUST_Elektronik_Sertifika_Hizmet_Sağlayıcısı_H5.pem
Adding debian:OISTE_WISeKey_Global_Root_GB_CA.pem
Adding debian:TWCA_Root_Certification_Authority.pem
Adding debian:DST_Root_CA_X3.pem
Adding debian:Swisscom_Root_CA_2.pem
Adding debian:DigiCert_Assured_ID_Root_G2.pem
Adding debian:Certification_Authority_of_WoSign_G2.pem
Adding debian:GeoTrust_Universal_CA_2.pem
done.
Processing triggers for libc-bin (2.19-18+deb8u6) ...
Processing triggers for systemd (215-17+deb8u5) ...
Processing triggers for ca-certificates (20141019+deb8u1) ...
Updating certificates in /etc/ssl/certs... 0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....
done.
done.
 ---> 6e9507aabb82
Removing intermediate container c8f5d31d9a19
Step 3 : RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker &&     chmod +x /usr/bin/docker
 ---> Running in 613418960f9f
 ---> 57bdc9ad6bd9
Removing intermediate container 613418960f9f
Step 4 : WORKDIR /dashboard
 ---> Running in 3e85ff8c834f
 ---> 9dc9c6cb7c9e
Removing intermediate container 3e85ff8c834f
Step 5 : COPY ./ ./
 ---> c2ea3a4ab9ee
Removing intermediate container ae1fe752f4e4
Step 6 : RUN npm install --unsafe-perm
 ---> Running in 2aad14474d77
npm WARN enoent ENOENT: no such file or directory, open '/dashboard/package.json'
npm WARN dashboard No description
npm WARN dashboard No repository field.
npm WARN dashboard No README data
npm WARN dashboard No license field.
 ---> 275e9501be6d
Removing intermediate container 2aad14474d77
Successfully built 275e9501be6d
```

As you can see there is no longer warning from `5.x` version:

```
================================================================================
================================================================================

                              DEPRECATION WARNING                            

  Node.js v5.x is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_4.x — Node.js v4 LTS "Argon" (recommended)
   * https://deb.nodesource.com/setup_6.x — Node.js v6 Current

  Please see https://github.com/nodejs/LTS/ for details about which version
  may be appropriate for you.

  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and which Linux distributions
  are supported and how to use the install scripts.
    https://github.com/nodesource/distributions

================================================================================
================================================================================

Continuing in 10 seconds ...
```


CC @colemickens