### PR TITLE
Fix panic on startup CreateApiserverClient when kubeconfig path does not exist

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -48,7 +48,7 @@ if ${gofmt_available}; then
   echo "${reset}"
   echo -ne "Checking go files formatting... "
   unformatted=$(gofmt -l src/app/backend)
-  if [ ! -z ${unformatted} ]; then
+  if [ ! -z "$unformatted" ]; then
     echo "${red}ERROR!"
     echo "There is an issue with file formatting."
     echo "To format go files run:"

--- a/src/app/backend/client/apiserverclient.go
+++ b/src/app/backend/client/apiserverclient.go
@@ -45,12 +45,12 @@ func CreateApiserverClient(apiserverHost string, kubeConfig string) (*client.Cli
 		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: apiserverHost}})
 
 	cfg, err := clientConfig.ClientConfig()
-	cfg.QPS = defaultQPS
-	cfg.Burst = defaultBurst
-
 	if err != nil {
 		return nil, nil, err
 	}
+
+	cfg.QPS = defaultQPS
+	cfg.Burst = defaultBurst
 
 	log.Printf("Creating API server client for %s", cfg.Host)
 

--- a/src/app/backend/resource/common/podmetrics.go
+++ b/src/app/backend/resource/common/podmetrics.go
@@ -138,11 +138,11 @@ func fillPodMetrics(cpuMetrics []heapster.MetricResult, memMetrics []heapster.Me
 			cpuMetricsList := cpuMetrics[iterator].Metrics
 
 			if len(memMetricsList) > 0 {
-				memValue = &memMetricsList[len(memMetricsList) - 1].Value
+				memValue = &memMetricsList[len(memMetricsList)-1].Value
 			}
 
 			if len(cpuMetricsList) > 0 {
-				cpuValue = &cpuMetricsList[len(cpuMetricsList) - 1].Value
+				cpuValue = &cpuMetricsList[len(cpuMetricsList)-1].Value
 			}
 
 			cpuHistory := make([]MetricResult, len(cpuMetricsList))

--- a/src/app/backend/resource/daemonset/daemonsetlist/daemonsetlist.go
+++ b/src/app/backend/resource/daemonset/daemonsetlist/daemonsetlist.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 
-	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/daemonset"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 )
 

--- a/src/app/backend/resource/dataselect/dataselectquery.go
+++ b/src/app/backend/resource/dataselect/dataselectquery.go
@@ -15,8 +15,8 @@
 package dataselect
 
 import (
-	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 )
 
 // Options for GenericDataSelect which takes []GenericDataCell and returns selected data.

--- a/src/app/backend/resource/pod/poddetail.go
+++ b/src/app/backend/resource/pod/poddetail.go
@@ -26,15 +26,14 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/daemonset/daemonsetlist"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/job/joblist"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/petset/petsetlist"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/replicaset/replicasetlist"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/replicationcontroller/replicationcontrollerlist"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/daemonset/daemonsetlist"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/petset/petsetlist"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 )
-
 
 // PodDetail is a presentation layer view of Kubernetes PodDetail resource.
 // This means it is PodDetail plus additional augumented data we can get
@@ -76,10 +75,10 @@ type Controller struct {
 	// Singleton list of the Job that controls this Pod, only set if Kind = "Job"
 	JobList *joblist.JobList `json:"joblist,omitempty"`
 
-	ReplicaSetList *replicasetlist.ReplicaSetList `json:"replicasetlist,omitempty"`
+	ReplicaSetList            *replicasetlist.ReplicaSetList                       `json:"replicasetlist,omitempty"`
 	ReplicationControllerList *replicationcontrollerlist.ReplicationControllerList `json:"replicationcontrollerlist,omitempty"`
-	DaemonSetList *daemonsetlist.DaemonSetList `json:"daemonsetlist,omitempty"`
-	PetSetList *petsetlist.PetSetList `json:"petsetlist,omitempty"`
+	DaemonSetList             *daemonsetlist.DaemonSetList                         `json:"daemonsetlist,omitempty"`
+	PetSetList                *petsetlist.PetSetList                               `json:"petsetlist,omitempty"`
 }
 
 // Container represents a docker/rkt/etc. container that lives in a pod.
@@ -138,7 +137,7 @@ func GetPodDetail(client k8sClient.Interface, heapsterClient client.HeapsterClie
 	creatorAnnotation, found := pod.ObjectMeta.Annotations[api.CreatedByAnnotation]
 	if found {
 		creatorRef, err := getPodCreator(client, creatorAnnotation, common.NewSameNamespaceQuery(namespace), heapsterClient)
-		if (err != nil) {
+		if err != nil {
 			return nil, err
 		}
 		controller = *creatorRef
@@ -160,7 +159,7 @@ func GetPodDetail(client k8sClient.Interface, heapsterClient client.HeapsterClie
 
 func getPodCreator(client k8sClient.Interface, creatorAnnotation string, nsQuery *common.NamespaceQuery, heapsterClient client.HeapsterClient) (*Controller, error) {
 	var serializedReference api.SerializedReference
-	err := json.Unmarshal([]byte(creatorAnnotation), &serializedReference);
+	err := json.Unmarshal([]byte(creatorAnnotation), &serializedReference)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +210,7 @@ func toJobPodController(client k8sClient.Interface, reference api.ObjectReferenc
 	jobs := []batch.Job{*job}
 	jobList := joblist.CreateJobList(jobs, pods, events, dataselect.StdMetricsDataSelect, &heapsterClient)
 	return &Controller{
-		Kind: "Job",
+		Kind:    "Job",
 		JobList: jobList,
 	}, nil
 }
@@ -224,7 +223,7 @@ func toReplicaSetPodController(client k8sClient.Interface, reference api.ObjectR
 	replicaSets := []extensions.ReplicaSet{*rs}
 	replicaSetList := replicasetlist.CreateReplicaSetList(replicaSets, pods, events, dataselect.StdMetricsDataSelect, &heapsterClient)
 	return &Controller{
-		Kind: "ReplicaSet",
+		Kind:           "ReplicaSet",
 		ReplicaSetList: replicaSetList,
 	}, nil
 }
@@ -251,7 +250,7 @@ func toDaemonSetPodController(client k8sClient.Interface, reference api.ObjectRe
 
 	daemonSetList := daemonsetlist.CreateDaemonSetList(daemonsets, pods, events, dataselect.StdMetricsDataSelect, &heapsterClient)
 	return &Controller{
-		Kind: "DaemonSet",
+		Kind:          "DaemonSet",
 		DaemonSetList: daemonSetList,
 	}, nil
 }
@@ -265,7 +264,7 @@ func toPetSetPodController(client k8sClient.Interface, reference api.ObjectRefer
 
 	petSetList := petsetlist.CreatePetSetList(petsets, pods, events, dataselect.StdMetricsDataSelect, &heapsterClient)
 	return &Controller{
-		Kind: "PetSet",
+		Kind:       "PetSet",
 		PetSetList: petSetList,
 	}, nil
 }

--- a/src/app/backend/resource/replicaset/replicasetcommon.go
+++ b/src/app/backend/resource/replicaset/replicasetcommon.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-
 )
 
 // ReplicaSet is a presentation layer view of Kubernetes Replica Set resource. This means

--- a/src/app/backend/resource/replicaset/replicasetlist/replicasetlist.go
+++ b/src/app/backend/resource/replicaset/replicasetlist/replicasetlist.go
@@ -25,8 +25,8 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/replicaset"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	k8serrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
@@ -35,10 +35,9 @@ type ReplicaSetList struct {
 	ListMeta common.ListMeta `json:"listMeta"`
 
 	// Unordered list of Replica Sets.
-	ReplicaSets       []replicaset.ReplicaSet    `json:"replicaSets"`
-	CumulativeMetrics []metric.Metric `json:"cumulativeMetrics"`
+	ReplicaSets       []replicaset.ReplicaSet `json:"replicaSets"`
+	CumulativeMetrics []metric.Metric         `json:"cumulativeMetrics"`
 }
-
 
 // GetReplicaSetList returns a list of all Replica Sets in the cluster.
 func GetReplicaSetList(client client.Interface, nsQuery *common.NamespaceQuery,

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerlist/replicationcontrollerlist.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerlist/replicationcontrollerlist.go
@@ -33,9 +33,8 @@ type ReplicationControllerList struct {
 
 	// Unordered list of Replication Controllers.
 	ReplicationControllers []replicationcontroller.ReplicationController `json:"replicationControllers"`
-	CumulativeMetrics      []metric.Metric         `json:"cumulativeMetrics"`
+	CumulativeMetrics      []metric.Metric                               `json:"cumulativeMetrics"`
 }
-
 
 // GetReplicationControllerList returns a list of all Replication Controllers in the cluster.
 func GetReplicationControllerList(client *client.Client, nsQuery *common.NamespaceQuery,


### PR DESCRIPTION
Fixes #1412 

Error was caused by missing error check after config creation. It was done too late. Error will be correctly displayed now.

```bash
10:24 $ ./dashboard --kubeconfig /home/xxx
Using HTTP port: 9090
Using kubeconfig file: /home/xxx
Error while initializing connection to Kubernetes apiserver. This most likely means that the cluster is misconfigured (e.g., it has invalid apiserver certificates or service accounts configuration) or the --apiserver-host param points to a server that does not exist. Reason: stat /home/xxx: no such file or directory
Refer to the troubleshooting guide for more information: https://github.com/kubernetes/dashboard/blob/master/docs/user-guide/troubleshooting.md
```

Additionally I've reformatted go files and fixed `pre-commit` hook check for go files formatting.