### PR TITLE
improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ itself.
 
 ## Deployment
 It is likely that the Dashboard is already installed on your cluster. Check with the following command:
-```bash
-kubectl get pods --all-namespaces | grep dashboard
+```shell
+$ kubectl get pods --all-namespaces | grep dashboard
 ```
 
 
 If it is missing, you can install the latest stable release by running the following command:
-```bash
-kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+```shell
+$ kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
 ```
 
 You can also install unstable HEAD builds with the newest features that the team works on by
@@ -28,24 +28,20 @@ Note that for the metrics and graphs to be available you need to
 have [Heapster](https://github.com/kubernetes/heapster/) running in your cluster.
 
 ## Usage
-You may access the UI via the apiserver proxy. Open a browser and navigate to `https://<kubernetes-master>/ui`.
+The easiest way to access Dashboard is to use kubectl. Run the following command in your desktop environment:
+```shell
+$ kubectl proxy
+```
+kubectl will handle authentication with apiserver and make Dashboard available at [http://localhost:8001/ui](http://localhost:8001/ui)
 
-Please note, this works only if the apiserver is setup to allow authentication
-with username and password. Currently, the setup tool `kubeadm` is not doing so.
-If username and password is unknown to you then use `kubectl config view` to find it.
+The UI can _only_ be accessed from the machine where the command is executed. See `kubectl proxy --help` for more options.
 
 ## Alternative Usage
-Alternatively, you may access the UI via the kubectl proxy. This is useful if you have a `kubectl`
-configured with access to the cluster, but lack password credentials for use in a browser:
+You may access the UI directly via the apiserver proxy. Open a browser and navigate to `https://<kubernetes-master>/ui`.
 
-```bash
-kubectl proxy
-```
+Please note, this works only if the apiserver is set up to allow authentication with username and password. This is not currently the case with the setup tool `kubeadm`. See [documentation](http://kubernetes.io/docs/admin/authentication/) if you want to configure it manually.
 
-This will make the dashboard available at [http://localhost:8001/ui](http://localhost:8001/ui)
-
-This will only be available from the machine where the command is executed, but you can see
-`kubectl proxy --help` for more options.
+If the username and password is configured but unknown to you, then use `kubectl config view` to find it.
 
 ## Documentation
 


### PR DESCRIPTION
Once again, I tried to simplify the installation instructions. 

1. I switched to order of apiserver proxy and kubectl proxy. kubectl proxy is first, now. This seems to be better, because kubectl proxy should always work (and secure). BTW: in GKE only kubectl proxy is documented. 

2. Improved the wording a bit, e.g. "Run the following command in your desktop environment", to make sure users do not start kubectl proxy on master (like some people did)

@digitalfishpond would you be so kind and review it again?
