### PR TITLE
Fix graph titles for memory and CPU timelines

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -131,8 +131,8 @@
   <translation id="3519937684574926798" key="MSG_CONTAINER_DETAILS_NO_COMMANDS" desc="Label when there is no container commands.">-</translation>
   <translation id="7249897739191369792" key="MSG_CONTAINER_DETAILS_NO_ENV_VARS" desc="Label when there is no container environment variables.">-</translation>
   <translation id="8082504363137960576" key="MSG_CONTAINER_DETAILS_SUBTITLE" desc="Subtitle at the top of the container details.">Containers</translation>
-  <translation id="7085579069997805104" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage history</translation>
-  <translation id="2945523786023967034" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage history</translation>
+  <translation id="1503342925011598787" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage</translation>
+  <translation id="2835520423599206338" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage</translation>
   <translation id="7622695438451306054" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_2" desc="Title \'Services\' for the Services information section on the Daemon Set detail page.">Services</translation>
   <translation id="7688456117716782803" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_3" desc="Title for services card zerostate in daemon set details page.">There is nothing to display here</translation>
   <translation id="8526499730546237626" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_4" desc="Text for services card zerostate in daemon set details page.">There are currently no Services with the same label selector as this Daemon Set.</translation>
@@ -165,11 +165,9 @@
   <translation id="8955659027323921646" key="MSG_DAEMONSETLIST_DAEMONSETCARD_2" desc="Title \'Daemon Set\' which is used as a title for the delete/update\n   dialogs (that can be opened on the daemon set list view).">Daemon Set</translation>
   <translation id="855745345882113659" key="MSG_DAEMONSETLIST_DAEMONSETCARD_3" desc="Title \'Daemon Set\' which is used as a title for the delete/update\n   dialogs (that can be opened on the daemon set list view).">Daemon Set</translation>
   <translation id="117699576076811818" key="MSG_DAEMONSETLIST_DAEMONSETCARD_4" desc="Column \'Daemon Set\' in a Daemon Set List">Daemon Set</translation>
-  <translation id="1662479445924870715" key="MSG_DAEMONSETLIST_DAEMONSETLIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage history</translation>
-  <translation id="250379390957605876" key="MSG_DAEMONSETLIST_DAEMONSETLIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage history</translation>
-  <translation id="1583067811422592203" key="MSG_DAEMON_SET_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage history</translation>
+  <translation id="5303615337793440206" key="MSG_DAEMONSETLIST_DAEMONSETLIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage</translation>
+  <translation id="140376028532845180" key="MSG_DAEMONSETLIST_DAEMONSETLIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage</translation>
   <translation id="3665284318614920515" key="MSG_DAEMON_SET_DETAIL_EVENTS_LABEL" desc="Label 'Events' on the right navigation tab on the daemon set detail page.">Events</translation>
-  <translation id="2047372990629849468" key="MSG_DAEMON_SET_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage history</translation>
   <translation id="4300538864956302901" key="MSG_DAEMON_SET_DETAIL_OVERVIEW_LABEL" desc="Label 'Overview' on the left navigation tab on the daemon set detail page.">Overview</translation>
   <translation id="1323629914147178678" key="MSG_DAEMON_SET_DETAIL_PODS_TITLE" desc="Title 'Pods' for the pods information section on the daemon set detail page.">Pods</translation>
   <translation id="6966925142436210394" key="MSG_DAEMON_SET_DETAIL_PODS_ZEROSTATE_TEXT" desc="Text for pods card zerostate in daemon set details page.">There are currently no Pods scheduled on this Daemon Set</translation>
@@ -191,12 +189,10 @@
   <translation id="8115427792060255111" key="MSG_DAEMON_SET_INFO_PODS_STATUS_LABEL" desc="Label 'Pods status' for the status of the pods in a daemon set, on the daemon set details page.">Pods status</translation>
   <translation id="6964572476509814314" key="MSG_DAEMON_SET_INFO_STATUS_SUBTITLE" desc="Subtitle 'Status' for the right section with pod status information on the daemon set details page.">Status</translation>
   <translation id="6332752487795060801" key="MSG_DAEMON_SET_LIST_AGE_LABEL" desc="Label 'Age' which appears as a column label in the table of daemon sets (daemon set list view).">Age</translation>
-  <translation id="1147636893515320343" key="MSG_DAEMON_SET_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage history</translation>
   <translation id="1183334493862832095" key="MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the daemon set.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="5827493628743169857" key="MSG_DAEMON_SET_LIST_DAEMON_SET_TITLE" desc="Title 'Daemon set' which is used as a title for the delete/update dialogs (that can be opened on the daemon set list view.)">Daemon Set</translation>
   <translation id="6393297430328784111" key="MSG_DAEMON_SET_LIST_IMAGES_LABEL" desc="Label 'Images' which appears as a column label in the table of daemon sets (daemon set list view).">Images</translation>
   <translation id="4173398054373898245" key="MSG_DAEMON_SET_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of daemon sets (daemon set list view).">Labels</translation>
-  <translation id="1052756257716282729" key="MSG_DAEMON_SET_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage history</translation>
   <translation id="7091154364335994224" key="MSG_DAEMON_SET_LIST_NAMESPACE_LABEL" desc="Label 'Namespace' which appears as a column label in the table of daemon sets (daemon set list view).">Namespace</translation>
   <translation id="6536269801786102616" key="MSG_DAEMON_SET_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of daemon sets (daemon set list view).">Name</translation>
   <translation id="1244511811693456890" key="MSG_DAEMON_SET_LIST_PODS_LABEL" desc="Label 'Pods' which appears as a column label in the table of daemon sets (daemon set list view).">Pods</translation>
@@ -205,8 +201,8 @@
   <translation id="1375098876763337363" key="MSG_DELETE_RESOURCE_DIALOG_DELETE" desc="Label for delete button">Delete</translation>
   <translation id="6480734540585386902" key="MSG_DELETE_RESOURCE_DIALOG_TITLE" desc="Title for a delete resource dialog">Delete a <ph name="RESOURCE_KIND_NAME"/></translation>
   <translation id="4053635060615677386" key="MSG_DEPLOYMENTDETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
-  <translation id="6772290091064982817" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage history</translation>
-  <translation id="6693180081321180118" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage history</translation>
+  <translation id="1190053946078776500" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
+  <translation id="6583176718896419422" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage</translation>
   <translation id="2755870669643040350" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_2" desc="Title \'New Replica Set\' for the newly created replica set view, on the deployment details page.">New Replica Set</translation>
   <translation id="5365869365225481011" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_3" desc="Title for new replica sets card zero-state in deployment details page.">There is nothing to display here</translation>
   <translation id="8134746838306478635" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_4" desc="Text for new replica sets card zero-state in deployment details page.">There are currently no new Replication Controllers on this Deployment.</translation>
@@ -240,17 +236,15 @@
   <translation id="603844582005614830" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_1" desc="Tooltip saying that some pods in a deployment are pending.">One or more pods are in pending state</translation>
   <translation id="8978072017731186000" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_2" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
   <translation id="7647706169332437459" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_3" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
-  <translation id="9178907990038072653" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU usage history</translation>
-  <translation id="6630031240955746386" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_1" desc="Title for graph card displaying memory metric of deployments.">Memory usage history</translation>
+  <translation id="3596671845051866336" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU usage</translation>
+  <translation id="6520027878530985690" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_1" desc="Title for graph card displaying memory metric of deployments.">Memory usage</translation>
   <translation id="8215425307244096059" key="MSG_DEPLOYMENT_DETAILS_DEPLOYMENT_LABEL" desc="Label 'Deployment' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
-  <translation id="5732965494271532521" key="MSG_DEPLOYMENT_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage history</translation>
   <translation id="7624038583322136825" key="MSG_DEPLOYMENT_DETAIL_DETAILS_SUBTITLE" desc="Subtitle 'Details' for the left section with general information about a deployment on the deployment details page.">Details</translation>
   <translation id="6369912573661086313" key="MSG_DEPLOYMENT_DETAIL_EVENTS_LABEL" desc="Label 'Events' for the right navigation tab on the deployment details page.">Events</translation>
   <translation id="8073815784825425871" key="MSG_DEPLOYMENT_DETAIL_LABELS_LABEL" desc="Label 'Labels' for the deployment's labels list on the deployment details page.">Labels</translation>
   <translation id="284479654293253491" key="MSG_DEPLOYMENT_DETAIL_LABEL_SELECTOR_LABEL" desc="Label 'Label selector' for the deployment's selector on the deployment details page.">Label selector</translation>
   <translation id="7919923317290692250" key="MSG_DEPLOYMENT_DETAIL_MAX_SURGE_LABEL" desc="The message says how many replicas can be created above the desired number of replicas in a deployment (deployment details page).">Max surge: <ph name="REPLICAS"/></translation>
   <translation id="2887557544683001606" key="MSG_DEPLOYMENT_DETAIL_MAX_UNAVAILABLE_LABEL" desc="The message says how many replicas are allowed to be unavailable during an update in the deployment (deployment details page).">Max unavailable: <ph name="REPLICAS"/></translation>
-  <translation id="3499262906210756910" key="MSG_DEPLOYMENT_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one deployment.">Memory usage history</translation>
   <translation id="7227892582140926602" key="MSG_DEPLOYMENT_DETAIL_MIN_READY_LABEL" desc="Label 'Min Ready Seconds' for the deployment on the deployment details page.">Min ready seconds</translation>
   <translation id="3521351981759669886" key="MSG_DEPLOYMENT_DETAIL_NAMESPACE_LABEL" desc="Label 'Namespace' for the deployment namespace on the deployment details page.">Namespace</translation>
   <translation id="2597227860468168985" key="MSG_DEPLOYMENT_DETAIL_NAME_LABEL" desc="Label 'Name' for the deployment name on the deployment details page.">Name</translation>
@@ -271,12 +265,10 @@
   <translation id="8693504323541291367" key="MSG_DEPLOYMENT_DETAIL_STATUS_LABEL" desc="Label 'Status' for the deployment's status information on the deployment details page.">Status</translation>
   <translation id="9217577774285953145" key="MSG_DEPLOYMENT_DETAIL_STRATEGY_LABEL" desc="Label 'Strategy' for the deployment's strategy on the deployment details page.">Strategy</translation>
   <translation id="1962662987902323826" key="MSG_DEPLOYMENT_LIST_AGE_LABEL" desc="Label 'Age' which appears as a column label in the table of deployments (deployment list view).">Age</translation>
-  <translation id="4589538592640998125" key="MSG_DEPLOYMENT_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of deployments.">CPU usage history</translation>
   <translation id="8652993905127268587" key="MSG_DEPLOYMENT_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of a deployment.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="7220325945708641349" key="MSG_DEPLOYMENT_LIST_DEPLOYMENT_LABEL" desc="Label 'Deployment' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
   <translation id="805690489753911644" key="MSG_DEPLOYMENT_LIST_IMAGES_LABEL" desc="Label 'Images' which appears as a column label in the table of deployments (deployment list view).">Images</translation>
   <translation id="5619483577286901155" key="MSG_DEPLOYMENT_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of deployments (deployment list view).">Labels</translation>
-  <translation id="5942583560444944958" key="MSG_DEPLOYMENT_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of deployments.">Memory usage history</translation>
   <translation id="6537383105836584689" key="MSG_DEPLOYMENT_LIST_NAMESPACE_LABEL" desc="Label 'Namespace' which appears as a column label in the table of deployments (deployment list view).">Namespace</translation>
   <translation id="7108876815674475339" key="MSG_DEPLOYMENT_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of deployments (deployment list view).">Name</translation>
   <translation id="3625528742301331177" key="MSG_DEPLOYMENT_LIST_PODS_ERRORS_TOOLTIP" desc="Tooltip saying that some pods in a deployment have errors.">One or more pods have errors</translation>
@@ -492,8 +484,8 @@
   <translation id="4380824121111866273" key="MSG_INGRESS_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of ingresses (ingress list view).">Name</translation>
   <translation id="6014322650743882966" key="MSG_INGRESS_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the ingress.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="6315518507776012285" key="MSG_JOBDETAIL_ACTIONBAR_0" desc="Label \'Job\' which appears at the top of the dialog, opened from a job details page.">Job</translation>
-  <translation id="8719502198424174307" key="MSG_JOBDETAIL_JOBDETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU usage history</translation>
-  <translation id="4039489423754246404" key="MSG_JOBDETAIL_JOBDETAIL_1" desc="Title for graph card displaying memory metric of one job.">Memory usage history</translation>
+  <translation id="3137266053437967990" key="MSG_JOBDETAIL_JOBDETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU usage</translation>
+  <translation id="3929486061329485708" key="MSG_JOBDETAIL_JOBDETAIL_1" desc="Title for graph card displaying memory metric of one job.">Memory usage</translation>
   <translation id="9212734554184831527" key="MSG_JOBDETAIL_JOBDETAIL_2" desc="Title for a pods section.">Pods</translation>
   <translation id="8636156694564998781" key="MSG_JOBDETAIL_JOBDETAIL_3" desc="Title for pods card zerostate in job details page.">There is nothing to display here</translation>
   <translation id="8258822259098218312" key="MSG_JOBDETAIL_JOBDETAIL_4" desc="Text for pods card zerostate in job details page.">There are currently no Pods selected by this Job.</translation>
@@ -518,21 +510,17 @@
   <translation id="5803777237184315753" key="MSG_JOBLIST_JOBCARDLIST_5" desc="Label \'Images\' which appears as a column label in the table of replication controllers (Job list view).">Images</translation>
   <translation id="7105256695141232385" key="MSG_JOBLIST_JOBCARDLIST_6" desc="Column header \'Kind\' on a job list table">Kind</translation>
   <translation id="7832178859215843217" key="MSG_JOBLIST_JOBCARD_0" desc="Column \'Job\' that shows if the resource kind should be shown in a Job List">Job</translation>
-  <translation id="5939498689646501991" key="MSG_JOBLIST_JOBLIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU usage history</translation>
-  <translation id="6897665357216493463" key="MSG_JOBLIST_JOBLIST_1" desc="Title for graph card displaying memory metric of jobs.">Memory usage history</translation>
+  <translation id="357262544660295674" key="MSG_JOBLIST_JOBLIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU usage</translation>
+  <translation id="6787661994791732767" key="MSG_JOBLIST_JOBLIST_1" desc="Title for graph card displaying memory metric of jobs.">Memory usage</translation>
   <translation id="8441658278143071101" key="MSG_JOB_COMPLETIONS" desc="Job completions. Appears in details section.">Completions</translation>
   <translation id="9069442902328610253" key="MSG_JOB_DETAILS" desc="Details section header. Appears below main header.">Details</translation>
-  <translation id="2004091910788332111" key="MSG_JOB_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one job.">CPU usage history</translation>
   <translation id="2278267472990776370" key="MSG_JOB_DETAIL_JOB_LABEL" desc="Label 'Job' which appears at the top of the dialog, opened from a job details page.">Job</translation>
-  <translation id="2346878241921168871" key="MSG_JOB_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one job.">Memory usage history</translation>
   <translation id="3610014951719533291" key="MSG_JOB_DETAIL_PODS" desc="Title for a pods section.">Pods</translation>
   <translation id="7788315896863763846" key="MSG_JOB_IMAGES" desc="Job images. Appears in details section.">Images</translation>
   <translation id="8163083126193456298" key="MSG_JOB_LABELS" desc="Job labels. Appears in details section.">Labels</translation>
   <translation id="7287602791689381779" key="MSG_JOB_LIST_AGE_LABEL" desc="Label 'Age' which appears as a column label in the table of replication controllers (Job list view).">Age</translation>
-  <translation id="4368210931201633527" key="MSG_JOB_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of jobs.">CPU usage history</translation>
   <translation id="2678441499396017713" key="MSG_JOB_LIST_IMAGES_LABEL" desc="Label 'Images' which appears as a column label in the table of replication controllers (Job list view).">Images</translation>
   <translation id="6310730601576371329" key="MSG_JOB_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of replication controllers (Job list view).">Labels</translation>
-  <translation id="3552146726479283308" key="MSG_JOB_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of jobs.">Memory usage history</translation>
   <translation id="8978854967234873489" key="MSG_JOB_LIST_NAMESPACE_LABEL" desc="Label 'Namespace' which appears as a column label in the table of replication controllers (Job list view).">Namespace</translation>
   <translation id="2872431258829082433" key="MSG_JOB_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of jobs (Job list view).">Name</translation>
   <translation id="6160307955179693927" key="MSG_JOB_LIST_PODS_LABEL" desc="Label 'Pods' which appears as a column label in the table of replication controllers (Job list view).">Pods</translation>
@@ -614,8 +602,8 @@
   <translation id="63482289231704130" key="MSG_NODEDETAIL_NODECONDITIONS_3" desc="Label \'Last transition time\' for the condition table header on the node details page.">Last transition time</translation>
   <translation id="5522802928144248400" key="MSG_NODEDETAIL_NODECONDITIONS_4" desc="Label \'Reason\' for the condition table header on the node details page.">Reason</translation>
   <translation id="4773433312314812141" key="MSG_NODEDETAIL_NODECONDITIONS_5" desc="Label \'Message\' for the condition table header on the node details page.">Message</translation>
-  <translation id="983514800130038891" key="MSG_NODEDETAIL_NODEDETAIL_0" desc="Title for graph card displaying CPU metric of one node.">CPU usage history</translation>
-  <translation id="1453879988271970634" key="MSG_NODEDETAIL_NODEDETAIL_1" desc="Title for graph card displaying memory metric of one node.">Memory usage history</translation>
+  <translation id="4624650691998608382" key="MSG_NODEDETAIL_NODEDETAIL_0" desc="Title for graph card displaying CPU metric of one node.">CPU usage</translation>
+  <translation id="1343876625847209938" key="MSG_NODEDETAIL_NODEDETAIL_1" desc="Title for graph card displaying memory metric of one node.">Memory usage</translation>
   <translation id="2178267659529421715" key="MSG_NODEDETAIL_NODEDETAIL_2" desc="Label \'Pods\' for the pods section on the node details page.">Pods</translation>
   <translation id="1742343655240984361" key="MSG_NODEDETAIL_NODEDETAIL_3" desc="Title for pods card zerostate in node details page.">There is nothing to display here</translation>
   <translation id="638865099137228709" key="MSG_NODEDETAIL_NODEDETAIL_4" desc="Text for pods card zerostate in node details page.">There are currently no Pods scheduled on this Node.</translation>
@@ -642,8 +630,8 @@
   <translation id="908389976779508169" key="MSG_NODELIST_NODECARDLIST_1" desc="Label \'Labels\' which appears as a column label in the table of nodes (node list view).">Labels</translation>
   <translation id="8043532225528365541" key="MSG_NODELIST_NODECARDLIST_2" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
   <translation id="4058871826814936818" key="MSG_NODELIST_NODECARDLIST_3" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
-  <translation id="6722168120422361908" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage history</translation>
-  <translation id="4721357036233678700" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage history</translation>
+  <translation id="1139931975436155591" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
+  <translation id="4611353673808918004" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
   <translation id="2557541314727796573" key="MSG_NODE_DETAIL_ALLOCATED_RESOURCES_CPU_LIMITS" desc="Label 'CPU limits (cores)' for the allocated resources table header on the node details page.">CPU limits (cores)</translation>
   <translation id="3321130452593338857" key="MSG_NODE_DETAIL_ALLOCATED_RESOURCES_CPU_REQUESTS" desc="Label 'CPU requests (cores)' for the allocated resources table header on the node details page.">CPU requests (cores)</translation>
   <translation id="6270650074051326892" key="MSG_NODE_DETAIL_ALLOCATED_RESOURCES_LABEL" desc="Label 'Allocated resources' for the allocated resources section on the node details page.">Allocated resources</translation>
@@ -660,14 +648,12 @@
   <translation id="5537089191512972594" key="MSG_NODE_DETAIL_CONDITION_STATUS_HEADER" desc="Label 'Status' for the condition table header on the node details page.">Status</translation>
   <translation id="4732177858407681815" key="MSG_NODE_DETAIL_CONDITION_TYPE_HEADER" desc="Label 'Type' for the condition table header on the node details page.">Type</translation>
   <translation id="6259744204007513131" key="MSG_NODE_DETAIL_CONTAINER_RUNTIME_VERSION_LABEL" desc="Label 'Container Runtime Version' for the node container runtime version displayed on its details page.">Container Runtime Version</translation>
-  <translation id="5317140613056692776" key="MSG_NODE_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one node.">CPU usage history</translation>
   <translation id="6804175941266122408" key="MSG_NODE_DETAIL_DETAILS_SUBTITLE" desc="Subtitle 'Details' for the left section with general information about a node on the node details page.">Details</translation>
   <translation id="4234081832725459634" key="MSG_NODE_DETAIL_EXTERNAL_ID_LABEL" desc="Label 'External ID' for the node external ID displayed on its details page.">External ID</translation>
   <translation id="1154240901267057761" key="MSG_NODE_DETAIL_KERNEL_VERSION_LABEL" desc="Label 'Kernel Version' for the node kernel version displayed on its details page.">Kernel Version</translation>
   <translation id="176051279688267359" key="MSG_NODE_DETAIL_KUBELET_VERSION_LABEL" desc="Label 'Kubelet Version' for the node Kubelet version displayed on its details page.">Kubelet Version</translation>
   <translation id="4095768493806539550" key="MSG_NODE_DETAIL_KUBEPROXY_VERSION_LABEL" desc="Label 'Kube-Proxy Version' for the node Kube-Proxy version displayed on its details page.">Kube-Proxy Version</translation>
   <translation id="8608182576935348395" key="MSG_NODE_DETAIL_MACHINE_ID_LABEL" desc="Label 'Machine ID' for the node machine ID displayed on its details page.">Machine ID</translation>
-  <translation id="5274345272682536753" key="MSG_NODE_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one node.">Memory usage history</translation>
   <translation id="1190933892137909526" key="MSG_NODE_DETAIL_OPERATING_SYSTEM_LABEL" desc="Label 'Operating system' for the node operating system displayed on its details page.">Operating system</translation>
   <translation id="6764521951762562283" key="MSG_NODE_DETAIL_OS_IMAGE_LABEL" desc="Label 'OS Image' for the node OS image displayed on its details page.">OS Image</translation>
   <translation id="6272675231849042340" key="MSG_NODE_DETAIL_PHASE_LABEL" desc="Label 'Phase' for the node namespace on the node details page.">Phase</translation>
@@ -680,10 +666,8 @@
   <translation id="4332786308109934742" key="MSG_NODE_DETAIL_SYSTEM_UUID_LABEL" desc="Label 'System UUID' for the node system UUID displayed on its details page.">System UUID</translation>
   <translation id="3231786643565186812" key="MSG_NODE_DETAIL_UNSCHEDULABLE_LABEL" desc="Label 'Unschedulable' for the node external ID displayed on its details page.">Unschedulable</translation>
   <translation id="5132568729791755489" key="MSG_NODE_LIST_AGE_LABEL" desc="Label 'Age' which appears as a column label in the table of nodes (node list view).">Age</translation>
-  <translation id="7524676519411642380" key="MSG_NODE_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of nodes.">CPU usage history</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="8624223044783361486" key="MSG_NODE_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of nodes (node list view).">Labels</translation>
-  <translation id="586088678098641368" key="MSG_NODE_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of nodes.">Memory usage history</translation>
   <translation id="1886003934797453383" key="MSG_NODE_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of nodes (node list view).">Name</translation>
   <translation id="6440277990482217612" key="MSG_NODE_LIST_PODS_LABEL" desc="Label 'Pods' which appears as a column label in the table of nodes (node list view).">Pods</translation>
   <translation id="6987669710926523285" key="MSG_NODE_LIST_READY_LABEL" desc="Label 'Ready' which appears as a column label in the table of nodes (node list view).">Ready</translation>
@@ -797,8 +781,8 @@
   <translation id="6614356803861663597" key="MSG_PERSISTENT_VOLUME_LIST_HEADER_STATUS" desc="Persistent volume list header: status.">Status</translation>
   <translation id="1281408704476700057" key="MSG_PERSISTENT_VOLUME_LIST_PERSISTENT_VOLUME_LABEL" desc="Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">Persistent Volume</translation>
   <translation id="8607805834467306145" key="MSG_PETSETDETAIL_ACTIONBAR_0" desc="Label \'Pet Set\' which appears at the top of the delete dialog, opened from a pet set details page.">Pet Set</translation>
-  <translation id="1764042198804052522" key="MSG_PETSETDETAIL_PETSETDETAIL_0" desc="Title for graph card displaying CPU metric of one pet set.">CPU usage history</translation>
-  <translation id="7154281373003417379" key="MSG_PETSETDETAIL_PETSETDETAIL_1" desc="Title for graph card displaying memory metric of one pet set.">Memory usage history</translation>
+  <translation id="5405178090672622013" key="MSG_PETSETDETAIL_PETSETDETAIL_0" desc="Title for graph card displaying CPU metric of one pet set.">CPU usage</translation>
+  <translation id="7044278010578656683" key="MSG_PETSETDETAIL_PETSETDETAIL_1" desc="Title for graph card displaying memory metric of one pet set.">Memory usage</translation>
   <translation id="8635358901181828773" key="MSG_PETSETDETAIL_PETSETDETAIL_2" desc="Related pods card title on the pet set detail page.">Pods</translation>
   <translation id="4747200311561732193" key="MSG_PETSETDETAIL_PETSETDETAIL_3" desc="Title for pods card zerostate in pet set details page.">There is nothing to display here</translation>
   <translation id="5033121580419162700" key="MSG_PETSETDETAIL_PETSETDETAIL_4" desc="Text for pods card zerostate in pet set details page.">There are currently no Pods selected by this Pet Set.</translation>
@@ -835,12 +819,10 @@
   <translation id="367435375645492467" key="MSG_PETSETLIST_PETSETCARD_3" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
   <translation id="3227417092390767991" key="MSG_PETSETLIST_PETSETCARD_4" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
   <translation id="5034503627643896802" key="MSG_PETSETLIST_PETSETCARD_4" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
-  <translation id="8004003419862112122" key="MSG_PETSETLIST_PETSETLIST_0" desc="Title for graph card displaying CPU metric of pet sets.">CPU usage history</translation>
-  <translation id="3749699426483208751" key="MSG_PETSETLIST_PETSETLIST_1" desc="Title for graph card displaying memory metric of pet sets.">Memory usage history</translation>
+  <translation id="2421767274875905805" key="MSG_PETSETLIST_PETSETLIST_0" desc="Title for graph card displaying CPU metric of pet sets.">CPU usage</translation>
+  <translation id="3639696064058448055" key="MSG_PETSETLIST_PETSETLIST_1" desc="Title for graph card displaying memory metric of pet sets.">Memory usage</translation>
   <translation id="1157514904008403171" key="MSG_PET_SET_CARD_TOOLTIP_ERROR" desc="Tooltip text which appears on error icon hover.">One or more pods have errors</translation>
   <translation id="5677265435825016706" key="MSG_PET_SET_CARD_TOOLTIP_PENDING" desc="Tooltip text which appears on pending icon hover.">One or more pods are in pending state</translation>
-  <translation id="447959586035419698" key="MSG_PET_SET_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one pet set.">CPU usage history</translation>
-  <translation id="5672935636544074577" key="MSG_PET_SET_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one pet set.">Memory usage history</translation>
   <translation id="8113372847654373796" key="MSG_PET_SET_DETAIL_PET_SET_LABEL" desc="Label 'Pet Set' which appears at the top of the delete dialog, opened from a pet set details page.">Pet Set</translation>
   <translation id="6998996832659188031" key="MSG_PET_SET_DETAIL_PODS_CARD_TITLE" desc="Related pods card title on the pet set detail page.">Pods</translation>
   <translation id="8114606676293161910" key="MSG_PET_SET_DETAIL_PODS_CREATED_LABEL" desc="The message says how many pods were created (pet set details page)."><ph name="PODS_COUNT"/> created</translation>
@@ -855,14 +837,12 @@
   <translation id="1744330140020758003" key="MSG_PET_SET_INFO_PODS_ENTRY" desc="Pet set info status section pods entry.">Pods</translation>
   <translation id="6654869080140416303" key="MSG_PET_SET_INFO_PODS_STATUS_ENTRY" desc="Pet set info status section pods status entry.">Pods status</translation>
   <translation id="3762856444030194375" key="MSG_PET_SET_INFO_STATUS_SECTION" desc="Pet set info status section name.">Status</translation>
-  <translation id="1408565454580957092" key="MSG_PET_SET_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of pet sets.">CPU usage history</translation>
   <translation id="1739547616641575970" key="MSG_PET_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of pet set.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="1017086337822469058" key="MSG_PET_SET_LIST_HEADER_AGE" desc="Pet set list header: age.">Age</translation>
   <translation id="5744665687208066898" key="MSG_PET_SET_LIST_HEADER_IMAGES" desc="Pet set list header: images.">Images</translation>
   <translation id="8003529818786986419" key="MSG_PET_SET_LIST_HEADER_LABELS" desc="Pet set list header: labels.">Labels</translation>
   <translation id="3899323843932532450" key="MSG_PET_SET_LIST_HEADER_NAME" desc="Pet set list header: name.">Name</translation>
   <translation id="2586490478144382446" key="MSG_PET_SET_LIST_HEADER_PODS" desc="Pet set list header: pods.">Pods</translation>
-  <translation id="8355696320820505711" key="MSG_PET_SET_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of pet sets.">Memory usage history</translation>
   <translation id="3842998446932089885" key="MSG_PET_SET_LIST_NAMESPACE_LABEL" desc="Pet set list header: namespace.">Namespace</translation>
   <translation id="1719241183992408191" key="MSG_PET_SET_LIST_PET_SET_LABEL" desc="Label 'Pet Set' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
   <translation id="2274539880532747000" key="MSG_PODDETAIL_ACTIONBAR_0" desc="Label \'Pod\' which appears at the top of the delete dialog, opened from a pod details page.">Pod</translation>
@@ -877,8 +857,8 @@
   <translation id="6203718664600482216" key="MSG_PODDETAIL_CONTAINERINFO_8" desc="Label when there is no container arguments.">-</translation>
   <translation id="2796629198059640113" key="MSG_PODDETAIL_CONTAINERINFO_9" desc="Label for the container logs.">View logs</translation>
   <translation id="139541414631793455" key="MSG_PODDETAIL_CREATORINFO_0" desc="Heading for Creator card on poddetail page">Creator</translation>
-  <translation id="1121341707527002694" key="MSG_PODDETAIL_PODDETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage history</translation>
-  <translation id="3901466272227021770" key="MSG_PODDETAIL_PODDETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage history</translation>
+  <translation id="4762477599395572185" key="MSG_PODDETAIL_PODDETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
+  <translation id="3791462909802261074" key="MSG_PODDETAIL_PODDETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
   <translation id="4132223572609249238" key="MSG_PODDETAIL_PODINFO_0" desc="Subtitle \'Details\' at the top of the resource details column at the pod detail view.">Pod</translation>
   <translation id="4915755492526213647" key="MSG_PODDETAIL_PODINFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
   <translation id="4706889120804601226" key="MSG_PODDETAIL_PODINFO_2" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>
@@ -898,22 +878,18 @@
   <translation id="2198933707202852928" key="MSG_PODLIST_PODCARDLIST_7" desc="Title of a column">Memory (bytes)</translation>
   <translation id="653475364042320864" key="MSG_PODLIST_PODCARDLIST_8" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
   <translation id="8022917849813090234" key="MSG_PODLIST_PODCARDLIST_9" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
-  <translation id="983813473653204599" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage history</translation>
-  <translation id="1884457553735815191" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage history</translation>
+  <translation id="4624949365521774090" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage</translation>
+  <translation id="1774454191311054495" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage</translation>
   <translation id="7612562063769289643" key="MSG_PODS_ARE_FAILED_TOOLTIP" desc="tooltip for failed pod card icon">One or more pods have errors.</translation>
   <translation id="7471636163011126552" key="MSG_PODS_ARE_PENDING_TOOLTIP" desc="tooltip for pending pod card icon">One or more pods are in pending state.</translation>
   <translation id="9200661373319050426" key="MSG_POD_DETAILS_POD_LABEL" desc="Label 'Pod' which appears at the top of the delete dialog, opened from a pod details page.">Pod</translation>
-  <translation id="5105359601530319899" key="MSG_POD_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one pod.">CPU usage history</translation>
   <translation id="4495481790340391412" key="MSG_POD_DETAIL_DETAILS_SUBTITLE" desc="Subtitle 'Details' at the top of the resource details column at the pod detail view.">Pod</translation>
   <translation id="1489132350749911645" key="MSG_POD_DETAIL_IP_LABEL" desc="Label 'IP' for the pod internal IP, appears in the connectivity part (right) of the pod details view.">IP</translation>
   <translation id="4037734872097030714" key="MSG_POD_DETAIL_LOGS_LABEL" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>
-  <translation id="5020112798971377986" key="MSG_POD_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one pod.">Memory usage history</translation>
   <translation id="4931692549009893798" key="MSG_POD_DETAIL_NETWORK_SUBTITLE" desc="Subtitle 'Network' at the top of the column about network connectivity (right) at the pod detail view.">Network</translation>
   <translation id="3641312077053067702" key="MSG_POD_DETAIL_NODE_LABEL" desc="Label 'Node' for the node a pods is running on, appears in the connectivity part (right) of the pod details view.">Node</translation>
   <translation id="1981947217630112340" key="MSG_POD_DETAIL_OVERVIEW_LABEL" desc="Label 'Overview', which appears on the first navigation tab on the pod details page.">Overview</translation>
   <translation id="6868243110695703441" key="MSG_POD_DETAIL_STATUS_LABEL" desc="Label 'Status' for the pod status in details part (left) of the pod details view.">Status</translation>
-  <translation id="665286506485213910" key="MSG_POD_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of pods.">CPU usage history</translation>
-  <translation id="1232167840200455031" key="MSG_POD_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of pods.">Memory usage history</translation>
   <translation id="1014088790164786434" key="MSG_POD_LIST_POD_TERMINATED_STATUS" desc="Status message showing a terminated status with [reason].">Terminated: <ph name="REASON"/></translation>
   <translation id="3724043031520273690" key="MSG_POD_LIST_POD_WAITING_STATUS" desc="Status message showing a waiting status with [reason].">Waiting: <ph name="REASON"/></translation>
   <translation id="240453070925206277" key="MSG_POD_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the pod.">Started at <ph name="START_DATE"/> UTC</translation>
@@ -1021,8 +997,8 @@
   <translation id="2801805500821925068" key="MSG_RC_LIST_REPLICATION_CONTROLLER_LABEL" desc="Label 'Replication Controller' which will appear in the replication Controller delete dialogm opened from a replication controller card on the list page.">Replication Controller</translation>
   <translation id="4937002308799617006" key="MSG_RC_LIST_VIEW_DETAILS_ACTION" desc="Action 'View details' on the drop down menu for a single replication controller (replication controller list page).">View details</translation>
   <translation id="4370858496997964873" key="MSG_REPLICASETDETAIL_ACTIONBAR_0" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set details page.">Replica Set</translation>
-  <translation id="2975310696178304758" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_0" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage history</translation>
-  <translation id="1942509581954589572" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_1" desc="Title for graph card displaying memory metric of one replica set.">Memory usage history</translation>
+  <translation id="6616446588046874249" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_0" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage</translation>
+  <translation id="1832506219529828876" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_1" desc="Title for graph card displaying memory metric of one replica set.">Memory usage</translation>
   <translation id="3861794530680682896" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_2" desc="Title \'Services\' for the services information section on the replica set details page.">Services</translation>
   <translation id="4955907939819487587" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_3" desc="Title for services card zerostate in replica set details page.">There is nothing to display here</translation>
   <translation id="6617064787555026196" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_4" desc="Text for services card zerostate in replica set details page.">There are currently no Services with the same label selector as this Replica Set.</translation>
@@ -1054,13 +1030,13 @@
   <translation id="2099605549394286336" key="MSG_REPLICASETLIST_REPLICASETCARD_3" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set list page.">Replica Set</translation>
   <translation id="6619234045663975567" key="MSG_REPLICASETLIST_REPLICASETCARD_4" desc="Column \'Replica Set\' that shows if the resource kind should be shown in a Replica Set List">Replica Set</translation>
   <translation id="6987237969287534739" key="MSG_REPLICASETLIST_REPLICASETCARD_4" desc="Column \'Replica Set\' that shows if the resource kind should be shown in a Replica Set List">Replica Set</translation>
-  <translation id="419429117651797632" key="MSG_REPLICASETLIST_REPLICASETLIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage history</translation>
-  <translation id="4602542864257969760" key="MSG_REPLICASETLIST_REPLICASETLIST_1" desc="Title for graph card displaying memory metric of replica sets.">Memory usage history</translation>
+  <translation id="4060565009520367123" key="MSG_REPLICASETLIST_REPLICASETLIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage</translation>
+  <translation id="4492539501833209064" key="MSG_REPLICASETLIST_REPLICASETLIST_1" desc="Title for graph card displaying memory metric of replica sets.">Memory usage</translation>
   <translation id="6194638567193104531" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_0" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Edit number of pods</translation>
   <translation id="1117778161103271395" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_1" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Scale</translation>
   <translation id="1073944984422921935" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_2" desc="Label \'Replication Controller\' which appears at the top of the edit dialog, opened from a replication controller details page.">Replication Controller</translation>
-  <translation id="7024218021114976760" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_0" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage history</translation>
-  <translation id="2365741884975601397" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_1" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage history</translation>
+  <translation id="1441981876128770443" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_0" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage</translation>
+  <translation id="2255738522550840701" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_1" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage</translation>
   <translation id="4408710761336474425" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_2" desc="Title \'Service\', which appears at the top of the services list on the replication controller detail view.">Services</translation>
   <translation id="8595472283736146832" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_3" desc="Title for services card zerostate in replication controller details page.">There is nothing to display here</translation>
   <translation id="2205006766209565387" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_4" desc="Text for services card zerostate in replication controller details page.">There are currently no Services with the same label selector as this Replication Controller.</translation>
@@ -1104,17 +1080,11 @@
   <translation id="6808946859530903795" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERCARD_1" desc="Tooltip saying that some pods in a replication controller are pending.">One or more pods are in pending state</translation>
   <translation id="1219983969126455904" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERCARD_2" desc="Column \'Replication Controller\' in a Replication Controller list">Replication Controller</translation>
   <translation id="4093080295331521956" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERCARD_2" desc="Column \'Replication Controller\' in a Replication Controller list">Replication Controller</translation>
-  <translation id="1154441142209175805" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage history</translation>
-  <translation id="369442621071447468" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage history</translation>
-  <translation id="4923712455615046812" key="MSG_REPLICATION_CONTROLLER_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage history</translation>
-  <translation id="8858733177407158178" key="MSG_REPLICATION_CONTROLLER_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage history</translation>
-  <translation id="2537944124195669933" key="MSG_REPLICATION_CONTROLLER_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage history</translation>
-  <translation id="1343937098929564813" key="MSG_REPLICATION_CONTROLLER_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage history</translation>
-  <translation id="7117158947271183710" key="MSG_REPLICA_SET_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage history</translation>
+  <translation id="4795577034077745296" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage</translation>
+  <translation id="259439258646686772" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage</translation>
   <translation id="6752899775879284523" key="MSG_REPLICA_SET_DETAIL_DETAILS_SUBTITLE" desc="Subtitle 'Details' for the left section with general information about a replica set on the replica set details page.">Details</translation>
   <translation id="5744235193377495761" key="MSG_REPLICA_SET_DETAIL_EVENTS_LABEL" desc="Label 'Events' for the right navigation tab on the replica set details page.">Events</translation>
   <translation id="8919418206139670891" key="MSG_REPLICA_SET_DETAIL_IMAGES_LABEL" desc="Label 'Images' for the list of images used in a replica set, on its details page.">Images</translation>
-  <translation id="1706687406256719823" key="MSG_REPLICA_SET_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one replica set.">Memory usage history</translation>
   <translation id="4479562582180028876" key="MSG_REPLICA_SET_DETAIL_OVERVIEW_LABEL" desc="Label 'Overview' for the left navigation tab on the replica set details page.">Overview</translation>
   <translation id="1193713714329626256" key="MSG_REPLICA_SET_DETAIL_PODS_CREATED_LABEL" desc="The message says how many pods were created (replica set details page)."><ph name="PODS_COUNT"/> created</translation>
   <translation id="2341408397568673692" key="MSG_REPLICA_SET_DETAIL_PODS_DESIRED_LABEL" desc="The message says how many pods are desired to run (replica set details page)."><ph name="PODS_COUNT"/> desired</translation>
@@ -1133,11 +1103,9 @@
   <translation id="6349033695019335926" key="MSG_REPLICA_SET_DETAIL_SERVICES_ZEROSTATE_TITLE" desc="Title for services card zerostate in replica set details page.">There is nothing to display here</translation>
   <translation id="8210773367251942049" key="MSG_REPLICA_SET_DETAIL_STATUS_SUBTITLE" desc="Subtitle 'Status' for the right section with pod status information on the replica set details page.">Status</translation>
   <translation id="717929808301673459" key="MSG_REPLICA_SET_LIST_AGE_LABEL" desc="Label 'Age' which appears as a column label in the table of replica sets (replica set list view).">Age</translation>
-  <translation id="9148433584311570337" key="MSG_REPLICA_SET_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage history</translation>
   <translation id="8299490700020675585" key="MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of replica set.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="4177382164291072231" key="MSG_REPLICA_SET_LIST_IMAGES_LABEL" desc="Label 'Images' which appears as a column label in the table of replica sets (replica set list view).">Images</translation>
   <translation id="1993484478466532120" key="MSG_REPLICA_SET_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of replica sets (replica set list view).">Labels</translation>
-  <translation id="6852005588876841875" key="MSG_REPLICA_SET_LIST_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of replica sets.">Memory usage history</translation>
   <translation id="6174070521345623465" key="MSG_REPLICA_SET_LIST_NAMESPACE_LABEL" desc="Label 'Namespace' which appears as a column label in the table of replication controllers (RC list view).">Namespace</translation>
   <translation id="4025964858170096506" key="MSG_REPLICA_SET_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of replica sets (replica set list view).">Name</translation>
   <translation id="2197716156312771575" key="MSG_REPLICA_SET_LIST_PODS_ERRORS_TOOLTIP" desc="Tooltip saying that some pods in a replica set have errors.">One or more pods have errors</translation>
@@ -1227,17 +1195,16 @@
   <translation id="58035047264145239" key="MSG_TIME_UNIT_YEAR_LABEL" desc="Time units label, a single year.">a year</translation>
   <translation id="5168444369924204121" key="MSG_UPLOAD_FILE_ACTION" desc="The text is put on the button at the end of the YAML upload page.">Upload</translation>
   <translation id="480860823064912408" key="MSG_UPLOAD_FILE_ACTION_CANCEL" desc="The text is put on the 'Cancel' button at the end of the YAML upload page.">Cancel</translation>
-  <translation id="1611578389032486450" key="MSG_WORKLOADS_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage history</translation>
   <translation id="2381738981103286393" key="MSG_WORKLOADS_DAEMON_SETS_LABEL" desc="Label &quot;Daemon sets&quot;, which appears above the daemon sets list on the workloads page.">Daemon sets</translation>
   <translation id="3543875874833788829" key="MSG_WORKLOADS_DAEMON_SETS_LABEL" desc="Label &quot;Daemon sets&quot;, which appears above the daemon sets list on the workloads page.">Daemon sets</translation>
   <translation id="5605659611398511623" key="MSG_WORKLOADS_DEPLOYMENTS_LABEL" desc="Label &quot;Deployments&quot;, which appears above the deployments list on the workloads page.">Deployments</translation>
   <translation id="2654637773125741729" key="MSG_WORKLOADS_JOBS_LABEL" desc="Label &quot;Job&quot;, which appears above the replica sets list on the workloads page.">Jobs</translation>
-  <translation id="2764620581378008580" key="MSG_WORKLOADS_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one all resources.">Memory usage history</translation>
   <translation id="8569806629013746854" key="MSG_WORKLOADS_PET_SETS_LABEL" desc="Label &quot;Pet Sets&quot;, which appears above the replica set list on the workloads page.">Pet Sets</translation>
   <translation id="494424795601874379" key="MSG_WORKLOADS_PODS_LABEL" desc="Label &quot;Pods&quot;, which appears above the pods list on the workloads page.">Pods</translation>
   <translation id="4853525775301386469" key="MSG_WORKLOADS_REPLICATION_CONTROLLERS_LABEL" desc="Label &quot;Replication controllers&quot;, which appears above the replication controllers list on the workloads page.">Replication controllers</translation>
   <translation id="3282083729093413912" key="MSG_WORKLOADS_REPLICA_SETS_LABEL" desc="Label &quot;Replica sets&quot;, which appears above the replica sets list on the workloads page.">Replica sets</translation>
-  <translation id="661429075091310977" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage history</translation>
+  <translation id="4302564966959880468" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage</translation>
+  <translation id="1036433586363793837" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">Memory usage</translation>
   <translation id="5439112040738823046" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">Title for graph card displaying CPU metric of one all resources.</translation>
   <translation id="1673466418940035630" key="MSG_WORKLOADS_WORKLOADS_2" desc="Label &quot;Daemon sets&quot;, which appears above the daemon sets list on the workloads page.">Daemon sets</translation>
   <translation id="7669482402387678993" key="MSG_WORKLOADS_WORKLOADS_3" desc="Label &quot;Deployments&quot;, which appears above the deployments list on the workloads page.">Deployments</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -135,7 +135,9 @@
   <translation id="3519937684574926798" key="MSG_CONTAINER_DETAILS_NO_COMMANDS" desc="Label when there is no container commands.">-</translation>
   <translation id="7249897739191369792" key="MSG_CONTAINER_DETAILS_NO_ENV_VARS" desc="Label when there is no container environment variables.">-</translation>
   <translation id="8082504363137960576" key="MSG_CONTAINER_DETAILS_SUBTITLE" desc="Subtitle 'Details' at the top of the resource details column at the pod detail view.">コンテナ</translation>
+  <translation id="1503342925011598787" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage</translation>
   <translation id="7085579069997805104" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage history</translation>
+  <translation id="2835520423599206338" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage</translation>
   <translation id="2945523786023967034" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage history</translation>
   <translation id="7622695438451306054" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_2" desc="Title \'Services\' for the Services information section on the Daemon Set detail page.">Services</translation>
   <translation id="7688456117716782803" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_3" desc="Title for services card zerostate in daemon set details page.">There is nothing to display here</translation>
@@ -170,6 +172,8 @@
   <translation id="855745345882113659" key="MSG_DAEMONSETLIST_DAEMONSETCARD_3" desc="Title \'Daemon Set\' which is used as a title for the delete/update\n   dialogs (that can be opened on the daemon set list view).">Daemon Set</translation>
   <translation id="117699576076811818" key="MSG_DAEMONSETLIST_DAEMONSETCARD_4" desc="Column \'Daemon Set\' in a Daemon Set List">Daemon Set</translation>
   <translation id="1662479445924870715" key="MSG_DAEMONSETLIST_DAEMONSETLIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage history</translation>
+  <translation id="5303615337793440206" key="MSG_DAEMONSETLIST_DAEMONSETLIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage</translation>
+  <translation id="140376028532845180" key="MSG_DAEMONSETLIST_DAEMONSETLIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage</translation>
   <translation id="250379390957605876" key="MSG_DAEMONSETLIST_DAEMONSETLIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage history</translation>
   <translation id="1583067811422592203" key="MSG_DAEMON_SET_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one daemon set.">CPU使用量の履歴</translation>
   <translation id="3665284318614920515" key="MSG_DAEMON_SET_DETAIL_EVENTS_LABEL" desc="Label 'Events' on the right navigation tab on the daemon set detail page.">イベント</translation>
@@ -209,7 +213,9 @@
   <translation id="1375098876763337363" key="MSG_DELETE_RESOURCE_DIALOG_DELETE" desc="Label for delete button">削除</translation>
   <translation id="6480734540585386902" key="MSG_DELETE_RESOURCE_DIALOG_TITLE" desc="Title for a delete resource dialog"><ph name="RESOURCE_KIND_NAME"/> の削除</translation>
   <translation id="4053635060615677386" key="MSG_DEPLOYMENTDETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
+  <translation id="1190053946078776500" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
   <translation id="6772290091064982817" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage history</translation>
+  <translation id="6583176718896419422" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage</translation>
   <translation id="6693180081321180118" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage history</translation>
   <translation id="2755870669643040350" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_2" desc="Title \'New Replica Set\' for the newly created replica set view, on the deployment details page.">New Replica Set</translation>
   <translation id="5365869365225481011" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_3" desc="Title for new replica sets cards zero-state in deployment details page.">There is nothing to display here</translation>
@@ -244,7 +250,9 @@
   <translation id="603844582005614830" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_1" desc="Tooltip saying that some pods in a deployment are pending.">One or more pods are in pending state</translation>
   <translation id="8978072017731186000" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_2" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
   <translation id="7647706169332437459" key="MSG_DEPLOYMENTLIST_DEPLOYMENTCARD_3" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
+  <translation id="3596671845051866336" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU usage</translation>
   <translation id="9178907990038072653" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU usage history</translation>
+  <translation id="6520027878530985690" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_1" desc="Title for graph card displaying memory metric of deployments.">Memory usage</translation>
   <translation id="6630031240955746386" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_1" desc="Title for graph card displaying memory metric of deployments.">Memory usage history</translation>
   <translation id="8215425307244096059" key="MSG_DEPLOYMENT_DETAILS_DEPLOYMENT_LABEL" desc="Label 'Deployment' which will appear in the deployment delete dialog opened from the deployment details page.">デプロイメント</translation>
   <translation id="5732965494271532521" key="MSG_DEPLOYMENT_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one deployment.">CPU使用量の履歴</translation>
@@ -496,7 +504,9 @@
   <translation id="4380824121111866273" key="MSG_INGRESS_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of ingresss (ingress list view).">名前</translation>
   <translation id="6014322650743882966" key="MSG_INGRESS_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the ingress."><ph name="START_DATE"/> UTC に作成</translation>
   <translation id="6315518507776012285" key="MSG_JOBDETAIL_ACTIONBAR_0" desc="Label \'Job\' which appears at the top of the dialog, opened from a job details page.">Job</translation>
+  <translation id="3137266053437967990" key="MSG_JOBDETAIL_JOBDETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU usage</translation>
   <translation id="8719502198424174307" key="MSG_JOBDETAIL_JOBDETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU usage history</translation>
+  <translation id="3929486061329485708" key="MSG_JOBDETAIL_JOBDETAIL_1" desc="Title for graph card displaying memory metric of one job.">Memory usage</translation>
   <translation id="4039489423754246404" key="MSG_JOBDETAIL_JOBDETAIL_1" desc="Title for graph card displaying memory metric of one job.">Memory usage history</translation>
   <translation id="9212734554184831527" key="MSG_JOBDETAIL_JOBDETAIL_2" desc="Title for a pods section.">Pods</translation>
   <translation id="8636156694564998781" key="MSG_JOBDETAIL_JOBDETAIL_3" desc="Title for pods card zerostate in job details page.">There is nothing to display here</translation>
@@ -522,7 +532,9 @@
   <translation id="5803777237184315753" key="MSG_JOBLIST_JOBCARDLIST_5" desc="Label \'Images\' which appears as a column label in the table of replication controllers (Job list view).">Images</translation>
   <translation id="7105256695141232385" key="MSG_JOBLIST_JOBCARDLIST_6" desc="Column header \'Kind\' on a job list table">Kind</translation>
   <translation id="7832178859215843217" key="MSG_JOBLIST_JOBCARD_0" desc="Column \'Job\' that shows if the resource kind should be shown in a Job List">Job</translation>
+  <translation id="357262544660295674" key="MSG_JOBLIST_JOBLIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU usage</translation>
   <translation id="5939498689646501991" key="MSG_JOBLIST_JOBLIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU usage history</translation>
+  <translation id="6787661994791732767" key="MSG_JOBLIST_JOBLIST_1" desc="Title for graph card displaying memory metric of jobs.">Memory usage</translation>
   <translation id="6897665357216493463" key="MSG_JOBLIST_JOBLIST_1" desc="Title for graph card displaying memory metric of jobs.">Memory usage history</translation>
   <translation id="8441658278143071101" key="MSG_JOB_COMPLETIONS" desc="Job completions. Appears in details section.">完了</translation>
   <translation id="9069442902328610253" key="MSG_JOB_DETAILS" desc="Details section header. Appears below main header.">詳細</translation>
@@ -621,6 +633,8 @@
   <translation id="5522802928144248400" key="MSG_NODEDETAIL_NODECONDITIONS_4" desc="Label \'Reason\' for the condition table header on the node details page.">Reason</translation>
   <translation id="4773433312314812141" key="MSG_NODEDETAIL_NODECONDITIONS_5" desc="Label \'Message\' for the condition table header on the node details page.">Message</translation>
   <translation id="983514800130038891" key="MSG_NODEDETAIL_NODEDETAIL_0" desc="Title for graph card displaying CPU metric of one node.">CPU usage history</translation>
+  <translation id="4624650691998608382" key="MSG_NODEDETAIL_NODEDETAIL_0" desc="Title for graph card displaying CPU metric of one node.">CPU usage</translation>
+  <translation id="1343876625847209938" key="MSG_NODEDETAIL_NODEDETAIL_1" desc="Title for graph card displaying memory metric of one node.">Memory usage</translation>
   <translation id="1453879988271970634" key="MSG_NODEDETAIL_NODEDETAIL_1" desc="Title for graph card displaying memory metric of one node.">Memory usage history</translation>
   <translation id="2178267659529421715" key="MSG_NODEDETAIL_NODEDETAIL_2" desc="Label \'Pods\' for the pods section on the node details page.">Pods</translation>
   <translation id="1742343655240984361" key="MSG_NODEDETAIL_NODEDETAIL_3" desc="Title for pods card zerostate in node details page.">There is nothing to display here</translation>
@@ -648,7 +662,9 @@
   <translation id="908389976779508169" key="MSG_NODELIST_NODECARDLIST_1" desc="Label \'Labels\' which appears as a column label in the table of nodes (node list view).">Labels</translation>
   <translation id="8043532225528365541" key="MSG_NODELIST_NODECARDLIST_2" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
   <translation id="4058871826814936818" key="MSG_NODELIST_NODECARDLIST_3" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
+  <translation id="1139931975436155591" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
   <translation id="6722168120422361908" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage history</translation>
+  <translation id="4611353673808918004" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
   <translation id="4721357036233678700" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage history</translation>
   <translation id="2557541314727796573" key="MSG_NODE_DETAIL_ALLOCATED_RESOURCES_CPU_LIMITS" desc="Label 'CPU limits (cores)' for the allocated resources table header on the node details page.">CPU 上限（コア数）</translation>
   <translation id="3321130452593338857" key="MSG_NODE_DETAIL_ALLOCATED_RESOURCES_CPU_REQUESTS" desc="Label 'CPU requests (cores)' for the allocated resources table header on the node details page.">CPU 要件（コア数）</translation>
@@ -804,6 +820,8 @@
   <translation id="1281408704476700057" key="MSG_PERSISTENT_VOLUME_LIST_PERSISTENT_VOLUME_LABEL" desc="Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">永続ボリューム</translation>
   <translation id="8607805834467306145" key="MSG_PETSETDETAIL_ACTIONBAR_0" desc="Label \'Pet Set\' which appears at the top of the delete dialog, opened from a pet set details page.">Pet Set</translation>
   <translation id="1764042198804052522" key="MSG_PETSETDETAIL_PETSETDETAIL_0" desc="Title for graph card displaying CPU metric of one pet set.">CPU usage history</translation>
+  <translation id="5405178090672622013" key="MSG_PETSETDETAIL_PETSETDETAIL_0" desc="Title for graph card displaying CPU metric of one pet set.">CPU usage</translation>
+  <translation id="7044278010578656683" key="MSG_PETSETDETAIL_PETSETDETAIL_1" desc="Title for graph card displaying memory metric of one pet set.">Memory usage</translation>
   <translation id="7154281373003417379" key="MSG_PETSETDETAIL_PETSETDETAIL_1" desc="Title for graph card displaying memory metric of one pet set.">Memory usage history</translation>
   <translation id="8635358901181828773" key="MSG_PETSETDETAIL_PETSETDETAIL_2" desc="Related pods card title on the pet set detail page.">Pods</translation>
   <translation id="4747200311561732193" key="MSG_PETSETDETAIL_PETSETDETAIL_3" desc="Title for pods card zerostate in pet set details page.">There is nothing to display here</translation>
@@ -841,7 +859,9 @@
   <translation id="367435375645492467" key="MSG_PETSETLIST_PETSETCARD_3" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
   <translation id="3227417092390767991" key="MSG_PETSETLIST_PETSETCARD_4" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
   <translation id="5034503627643896802" key="MSG_PETSETLIST_PETSETCARD_4" desc="Label \'Pet Set\' which will appear in the pet set delete dialog opened from a pet set card on the list page.">Pet Set</translation>
+  <translation id="2421767274875905805" key="MSG_PETSETLIST_PETSETLIST_0" desc="Title for graph card displaying CPU metric of pet sets.">CPU usage</translation>
   <translation id="8004003419862112122" key="MSG_PETSETLIST_PETSETLIST_0" desc="Title for graph card displaying CPU metric of pet sets.">CPU usage history</translation>
+  <translation id="3639696064058448055" key="MSG_PETSETLIST_PETSETLIST_1" desc="Title for graph card displaying memory metric of pet sets.">Memory usage</translation>
   <translation id="3749699426483208751" key="MSG_PETSETLIST_PETSETLIST_1" desc="Title for graph card displaying memory metric of pet sets.">Memory usage history</translation>
   <translation id="1157514904008403171" key="MSG_PET_SET_CARD_TOOLTIP_ERROR" desc="Tooltip text which appears on error icon hover.">１つ以上のポッドがエラーです</translation>
   <translation id="5677265435825016706" key="MSG_PET_SET_CARD_TOOLTIP_PENDING" desc="Tooltip text which appears on pending icon hover.">１つ以上のポッドが待機状態です</translation>
@@ -884,6 +904,8 @@
   <translation id="2796629198059640113" key="MSG_PODDETAIL_CONTAINERINFO_9" desc="Label for the container logs.">View logs</translation>
   <translation id="139541414631793455" key="MSG_PODDETAIL_CREATORINFO_0" desc="Heading for Creator card on poddetail page">Creator</translation>
   <translation id="1121341707527002694" key="MSG_PODDETAIL_PODDETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage history</translation>
+  <translation id="4762477599395572185" key="MSG_PODDETAIL_PODDETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
+  <translation id="3791462909802261074" key="MSG_PODDETAIL_PODDETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
   <translation id="3901466272227021770" key="MSG_PODDETAIL_PODDETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage history</translation>
   <translation id="4132223572609249238" key="MSG_PODDETAIL_PODINFO_0" desc="Subtitle \'Details\' at the top of the resource details column at the pod detail view.">Pod</translation>
   <translation id="4915755492526213647" key="MSG_PODDETAIL_PODINFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
@@ -905,6 +927,8 @@
   <translation id="653475364042320864" key="MSG_PODLIST_PODCARDLIST_8" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
   <translation id="8022917849813090234" key="MSG_PODLIST_PODCARDLIST_9" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
   <translation id="983813473653204599" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage history</translation>
+  <translation id="4624949365521774090" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage</translation>
+  <translation id="1774454191311054495" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage</translation>
   <translation id="1884457553735815191" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage history</translation>
   <translation id="7612562063769289643" key="MSG_PODS_ARE_FAILED_TOOLTIP" desc="tooltip for failed pod card icon">１つ以上のポッドがエラーです。</translation>
   <translation id="7471636163011126552" key="MSG_PODS_ARE_PENDING_TOOLTIP" desc="tooltip for pending pod card icon">１つ以上のポッドが待機状態です。</translation>
@@ -1040,6 +1064,8 @@
   <translation id="4937002308799617006" key="MSG_RC_LIST_VIEW_DETAILS_ACTION" desc="Action 'View details' on the drop down menu for a single replication controller (replication controller list page).">詳細を見る</translation>
   <translation id="4370858496997964873" key="MSG_REPLICASETDETAIL_ACTIONBAR_0" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set details page.">Replica Set</translation>
   <translation id="2975310696178304758" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_0" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage history</translation>
+  <translation id="6616446588046874249" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_0" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage</translation>
+  <translation id="1832506219529828876" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_1" desc="Title for graph card displaying memory metric of one replica set.">Memory usage</translation>
   <translation id="1942509581954589572" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_1" desc="Title for graph card displaying memory metric of one replica set.">Memory usage history</translation>
   <translation id="3861794530680682896" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_2" desc="Title \'Services\' for the services information section on the replica set details page.">Services</translation>
   <translation id="4955907939819487587" key="MSG_REPLICASETDETAIL_REPLICASETDETAIL_3" desc="Title for services card zerostate in replica set details page.">There is nothing to display here</translation>
@@ -1073,11 +1099,15 @@
   <translation id="6619234045663975567" key="MSG_REPLICASETLIST_REPLICASETCARD_4" desc="Column \'Replica Set\' that shows if the resource kind should be shown in a Replica Set List">Replica Set</translation>
   <translation id="6987237969287534739" key="MSG_REPLICASETLIST_REPLICASETCARD_4" desc="Column \'Replica Set\' that shows if the resource kind should be shown in a Replica Set List">Replica Set</translation>
   <translation id="419429117651797632" key="MSG_REPLICASETLIST_REPLICASETLIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage history</translation>
+  <translation id="4060565009520367123" key="MSG_REPLICASETLIST_REPLICASETLIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage</translation>
+  <translation id="4492539501833209064" key="MSG_REPLICASETLIST_REPLICASETLIST_1" desc="Title for graph card displaying memory metric of replica sets.">Memory usage</translation>
   <translation id="4602542864257969760" key="MSG_REPLICASETLIST_REPLICASETLIST_1" desc="Title for graph card displaying memory metric of replica sets.">Memory usage history</translation>
   <translation id="6194638567193104531" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_0" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Edit number of pods</translation>
   <translation id="1117778161103271395" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_1" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Scale</translation>
   <translation id="1073944984422921935" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_2" desc="Label \'Replication Controller\' which appears at the top of the edit dialog, opened from a replication controller details page.">Replication Controller</translation>
+  <translation id="1441981876128770443" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_0" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage</translation>
   <translation id="7024218021114976760" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_0" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage history</translation>
+  <translation id="2255738522550840701" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_1" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage</translation>
   <translation id="2365741884975601397" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_1" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage history</translation>
   <translation id="4408710761336474425" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_2" desc="Title \'Service\', which appears at the top of the services list on the replication controller detail view.">Services</translation>
   <translation id="8595472283736146832" key="MSG_REPLICATIONCONTROLLERDETAIL_REPLICATIONCONTROLLERDETAIL_3" desc="Title for services card zerostate in replication controller details page.">There is nothing to display here</translation>
@@ -1123,6 +1153,8 @@
   <translation id="1219983969126455904" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERCARD_2" desc="Column \'Replication Controller\' in a Replication Controller list">Replication Controller</translation>
   <translation id="4093080295331521956" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERCARD_2" desc="Column \'Replication Controller\' in a Replication Controller list">Replication Controller</translation>
   <translation id="1154441142209175805" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage history</translation>
+  <translation id="4795577034077745296" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage</translation>
+  <translation id="259439258646686772" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage</translation>
   <translation id="369442621071447468" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage history</translation>
   <translation id="4923712455615046812" key="MSG_REPLICATION_CONTROLLER_DETAIL_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one replication controller.">CPU使用量の履歴</translation>
   <translation id="8858733177407158178" key="MSG_REPLICATION_CONTROLLER_DETAIL_MEMORY_GRAPH_CARD_TITLE" desc="Title for graph card displaying memory metric of one replication controller.">メモリー使用量の履歴</translation>
@@ -1258,6 +1290,8 @@
   <translation id="4853525775301386469" key="MSG_WORKLOADS_REPLICATION_CONTROLLERS_LABEL" desc="Label &quot;Replication controllers&quot;, which appears above the replication controllers list on the workloads page.">レプリケーションコントローラー</translation>
   <translation id="3282083729093413912" key="MSG_WORKLOADS_REPLICA_SETS_LABEL" desc="Label &quot;Replica sets&quot;, which appears above the replica sets list on the workloads page.">レプリカセット</translation>
   <translation id="661429075091310977" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage history</translation>
+  <translation id="4302564966959880468" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage</translation>
+  <translation id="1036433586363793837" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">Memory usage</translation>
   <translation id="5439112040738823046" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">Title for graph card displaying CPU metric of one all resources.</translation>
   <translation id="1673466418940035630" key="MSG_WORKLOADS_WORKLOADS_2" desc="Label &quot;Daemon sets&quot;, which appears above the daemon sets list on the workloads page.">Daemon sets</translation>
   <translation id="7669482402387678993" key="MSG_WORKLOADS_WORKLOADS_3" desc="Label &quot;Deployments&quot;, which appears above the deployments list on the workloads page.">Deployments</translation>

--- a/src/app/frontend/daemonsetdetail/daemonsetdetail.html
+++ b/src/app/frontend/daemonsetdetail/daemonsetdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one daemon set.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one daemon set.]]"
                  metrics="::ctrl.daemonSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one daemon set.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one daemon set.]]"
                  metrics="::ctrl.daemonSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/daemonsetlist/daemonsetlist.html
+++ b/src/app/frontend/daemonsetlist/daemonsetlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of daemon sets.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of daemon sets.]]"
                  metrics="::ctrl.daemonSetList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of daemon sets.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of daemon sets.]]"
                  metrics="::ctrl.daemonSetList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/deploymentdetail/deploymentdetail.html
+++ b/src/app/frontend/deploymentdetail/deploymentdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one deployment.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one deployment.]]"
                  metrics="::ctrl.deploymentDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one deployment.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one deployment.]]"
                  metrics="::ctrl.deploymentDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/deploymentlist/deploymentlist.html
+++ b/src/app/frontend/deploymentlist/deploymentlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of deployments.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of deployments.]]"
                  metrics="::$ctrl.deploymentList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of deployments.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of deployments.]]"
                  metrics="::$ctrl.deploymentList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/jobdetail/jobdetail.html
+++ b/src/app/frontend/jobdetail/jobdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one job.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one job.]]"
                  metrics="::ctrl.jobDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one job.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one job.]]"
                  metrics="::ctrl.jobDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/joblist/joblist.html
+++ b/src/app/frontend/joblist/joblist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of jobs.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of jobs.]]"
                  metrics="::$ctrl.jobList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of jobs.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of jobs.]]"
                  metrics="::$ctrl.jobList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/nodedetail/nodedetail.html
+++ b/src/app/frontend/nodedetail/nodedetail.html
@@ -15,10 +15,10 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one node.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one node.]]"
                  metrics="::ctrl.nodeDetail.metrics" selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one node.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one node.]]"
                  metrics="::ctrl.nodeDetail.metrics" selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>

--- a/src/app/frontend/nodelist/nodelist.html
+++ b/src/app/frontend/nodelist/nodelist.html
@@ -15,10 +15,10 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of nodes.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of nodes.]]"
                  metrics="$ctrl.nodeList.cumulativeMetrics" selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of nodes.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of nodes.]]"
                  metrics="$ctrl.nodeList.cumulativeMetrics" selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>

--- a/src/app/frontend/petsetdetail/petsetdetail.html
+++ b/src/app/frontend/petsetdetail/petsetdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one pet set.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one pet set.]]"
                  metrics="::ctrl.petSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one pet set.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one pet set.]]"
                  metrics="::ctrl.petSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/petsetlist/petsetlist.html
+++ b/src/app/frontend/petsetlist/petsetlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of pet sets.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of pet sets.]]"
                  metrics="::$ctrl.petSetList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of pet sets.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of pet sets.]]"
                  metrics="::$ctrl.petSetList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/poddetail/poddetail.html
+++ b/src/app/frontend/poddetail/poddetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one pod.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one pod.]]"
                  metrics="::ctrl.podDetail.metrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one pod.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one pod.]]"
                  metrics="::ctrl.podDetail.metrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/podlist/podlist.html
+++ b/src/app/frontend/podlist/podlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of pods.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of pods.]]"
                  metrics="::$ctrl.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of pods.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of pods.]]"
                  metrics="::$ctrl.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one replica set.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one replica set.]]"
                  metrics="::ctrl.replicaSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one replica set.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one replica set.]]"
                  metrics="::ctrl.replicaSetDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of replica sets.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of replica sets.]]"
                  metrics="::$ctrl.replicaSetList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of replica sets.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of replica sets.]]"
                  metrics="::$ctrl.replicaSetList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one replication controller.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one replication controller.]]"
                  metrics="::$ctrl.replicationControllerDetail.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of one replication controller.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one replication controller.]]"
                  metrics="::$ctrl.replicationControllerDetail.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of replication controllers.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of replication controllers.]]"
                  metrics="::$ctrl.replicationControllerList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Memory usage history|Title for graph card displaying memory metric of replication controllers.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of replication controllers.]]"
                  metrics="::$ctrl.replicationControllerList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>

--- a/src/app/frontend/workloads/workloads.html
+++ b/src/app/frontend/workloads/workloads.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <div layout="row">
-  <kd-graph-card graph-title="[[CPU usage history|Title for graph card displaying CPU metric of one all resources.]]"
+  <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one all resources.]]"
                  metrics="::$ctrl.workloads.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
-  <kd-graph-card graph-title="[[Title for graph card displaying CPU metric of one all resources.|Title for graph card displaying memory metric of one all resources.]]"
+  <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one all resources.]]"
                  metrics="::$ctrl.workloads.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>


### PR DESCRIPTION
Graph title on workloads page was invalid. Fixed it.

Then removed "history" suffix from all titles, since I think it is
redundant and piece of information that adds no value.