### PR TITLE
Fix typo in deployment detail template

### DIFF
--- a/src/app/frontend/deploymentdetail/deploymentdetail.html
+++ b/src/app/frontend/deploymentdetail/deploymentdetail.html
@@ -30,7 +30,7 @@ limitations under the License.
 <kd-content-card>
   <kd-content>
     <kd-replica-set-card-list ng-show="::ctrl.deploymentDetail.newReplicaSet.objectMeta.name"
-                              replica-set-list="::ctrl.newRpeplicaSetList">
+                              replica-set-list="::ctrl.newReplicaSetList">
       <kd-header>[[New Replica Set|Title 'New Replica Set' for the newly created replica set view, on the deployment details page.]]</kd-header>
     </kd-replica-set-card-list>
     <div class="kd-zerostate-message" layout-padding


### PR DESCRIPTION
It was causing errors on the console and broken new replica sets list