### PR TITLE
[WIP] auto-refresh implementation

### DIFF
--- a/src/app/frontend/common/autorefresh/autorefresh_controller.js
+++ b/src/app/frontend/common/autorefresh/autorefresh_controller.js
@@ -1,0 +1,133 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Controller for the autorefresh directive.
+ * @final
+ */
+export class AutoRefreshController {
+  /**
+   * @param {!./../../chrome/chrome_state.StateParams} $stateParams
+   * @param {!./../pagination/pagination_service.PaginationService} kdPaginationService
+   * @param {!./poll_service.PollService} kdPoll
+   * @ngInject */
+  constructor($stateParams, kdPaginationService, kdPoll) {
+    /**
+     * Initialized from the scope.
+     * @export {!angular.$resource}
+     */
+    this.source;
+
+    /**
+     * Initialized from the scope.
+     * @export {!Object}
+     */
+    this.target;
+
+    /**
+     * Initialized from the scope.
+     * @export {!string}
+     */
+    this.type;
+
+    /**
+     * Initialized from the scope
+     * @export {number}
+     */
+    this.delay;
+
+    /**
+     * Initialized from the scope
+     * @export {!boolean}
+     */
+    this.namespace;
+
+    /**
+     * @type {!./poll_service.PollService}
+     * @private
+     */
+    this.pollService_ = kdPoll;
+
+    /**
+     * @type {!./../../chrome/chrome_state.StateParams}
+     * @private
+     */
+    this.stateParams_ = $stateParams;
+
+    /**
+     * @type {!./../pagination/pagination_service.PaginationService}
+     * @private
+     */
+    this.kdPaginationService_ = kdPaginationService;
+
+    this.startAutoRefresh_();
+  }
+
+  /**
+   * Starts auto-refreshing according to settings
+   * @private
+   */
+  startAutoRefresh_() {
+    if (!this.type) {
+      return this.startRefresh(this.source, this.target, null);
+    }
+    if (this.type.toLocaleLowerCase() === TYPE_LIST) {
+      return this.startRefresh(this.source, this.target, this.createPaginationQueryWithNamespace());
+    }
+    if (this.type.toLocaleLowerCase() === TYPE_LIST_WITH_NO_NAMESPACE) {
+      return this.startRefresh(this.source, this.target, this.createPaginationQuery());
+    }
+    return this.startRefresh(this.source, this.target, null);
+  }
+
+  /**
+   * Starts auto refresh and returns notification promise for each update.
+   * @param resource {!angular.Resource}
+   * @param target {!Object}
+   * @param params {angular.Resource.ParamsOrCallback=}
+   * @return {!angular.$q.Promise}
+   * @export
+   */
+  startRefresh(resource, target, params) {
+    let promise = this.pollService_.poll(resource, params, this.delay);
+    promise.then(null, null, (newObj) => {
+      // Update target object with the new object.
+      Object.assign(target, newObj);
+    });
+    return promise;
+  }
+
+  /**
+   * Creates pagination default resource query with namespace parameter.
+   * @return {!backendApi.PaginationQuery}
+   * @export
+   */
+  createPaginationQueryWithNamespace() {
+    return this.kdPaginationService_.getDefaultResourceQuery(this.stateParams_.namespace);
+  }
+
+  /**
+   * Creates pagination default resource query.
+   * @return {!backendApi.PaginationQuery}
+   * @export
+   */
+  createPaginationQuery() {
+    return this.kdPaginationService_.getDefaultResourceQuery();
+  }
+}
+
+/** @type {number} */
+export const DEFAULT_DELAY = 30000;
+export const TYPE_LIST_WITH_NO_NAMESPACE = 'list-without-namespace';
+export const TYPE_LIST = 'list';

--- a/src/app/frontend/common/autorefresh/autorefresh_directive.js
+++ b/src/app/frontend/common/autorefresh/autorefresh_directive.js
@@ -1,0 +1,66 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AutoRefreshController} from './autorefresh_controller';
+/**
+ * Provides upload file mechanism and updates the model with file parameter for the selected file.
+ * @param {!./poll_service.PollService} kdPoll
+ * @return {!angular.Directive}
+ * @ngInject
+ */
+export default function autoRefreshDirective(kdPoll) {
+  return {
+    scope: {},
+    bindToController: {
+      // Resource object to query data.
+      'source': '=',
+      // The the model object which is updated in each poll.
+      'target': '=',
+      // Type of the page like detail list, list-without-namespace, detail page and etc.
+      'type': '@?',
+      // Polling timeout in milliseconds.
+      'delay': '@?',
+    },
+    controller: AutoRefreshController,
+    controllerAs: 'ctrl',
+    templateUrl: '',
+    link: function(scope) {
+      /**
+       * @type {./poll_service.PollService}
+       * @private
+       */
+      let kdPoll_ = kdPoll;
+
+      // Cancel all polls in case of state change to avoid accumulated polls.
+      scope.$on('$stateChangeStart', () => {
+        kdPoll_.removeAll();
+      });
+
+      // Stop all polls when any menu is open to avoid disappearing them while auto-refresh.
+      /** @type {function()} */
+      let menuOpenEvent = scope.$root.$on('$mdMenuOpen', () => {
+        kdPoll_.stopAll();
+      });
+
+      scope.$on('$destroy', menuOpenEvent);
+
+      // Continue polling if any stopped after any menu is open.
+      /** @type {function()} */
+      let menuCloseEvent = scope.$root.$on('$mdMenuClose', () => {
+        kdPoll_.startAll();
+      });
+      scope.$on('$destroy', menuCloseEvent);
+    },
+  };
+}

--- a/src/app/frontend/common/autorefresh/autorefresh_module.js
+++ b/src/app/frontend/common/autorefresh/autorefresh_module.js
@@ -1,0 +1,23 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import autoRefreshDirective from './autorefresh_directive';
+import {PollService} from './poll_service';
+
+/**
+ * Angular module containing auto refresh of component models.
+ */
+export default angular.module('kubernetesDashboard.common.autorefresh', [])
+    .directive('kdAutoRefresh', autoRefreshDirective)
+    .service('kdPoll', PollService);

--- a/src/app/frontend/common/autorefresh/poll_service.js
+++ b/src/app/frontend/common/autorefresh/poll_service.js
@@ -1,0 +1,207 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Service class for polling.
+ * @final
+ */
+export class PollService {
+  /**
+   * @param $interval {!angular.$interval}
+   * @param $q {!angular.$q}
+   * @ngInject
+   */
+  constructor($interval, $q) {
+    /**
+     * @type {!angular.$interval}
+     * @private
+     */
+    this.intervalService_ = $interval;
+
+    /**
+     * @type {!angular.$q}
+     * @private
+     */
+    this.q_ = $q;
+
+    /**
+     * @type {!Array<PollOptions>}
+     * @private
+     */
+    this.optionsList_;
+  }
+
+  /**
+   * Starts polling and returns polling promise.
+   * @param resource {!angular.$resource}
+   * @param params {angular.Resource.ParamsOrCallback=}
+   * @param delay {number}
+   * @export
+   * @returns {!angular.$q.Promise}
+   */
+  poll(resource, params, delay) {
+    this.optionsList_ = this.optionsList_ || new Array();
+    let options = this.getOptionsByResource_(resource);
+    if (!options) {
+      options = new PollOptions(resource, params, delay);
+      this.optionsList_.push(options);
+    }
+    // Stop if there is any previously running interval
+    this.cancelInterval_(options);
+    return this.createInterval_(options);
+  }
+
+  /**
+   * Stops all running polls.
+   * @export
+   */
+  stopAll() {
+    this.optionsList_.map((options) => {
+      this.cancelInterval_(options);
+    });
+  }
+
+  /**
+   * Stops all running polls and removes all registered options.
+   * @export
+   */
+  removeAll() {
+    this.stopAll();
+    this.optionsList_ = new Array();
+  }
+
+  /**
+   * Starts polling intervals for the all registered options.
+   * @export
+   */
+  startAll() {
+    this.stopAll();
+    this.optionsList_.map((options) => {
+      this.createInterval_(options);
+    });
+  }
+
+  /**
+   * Creates polling interval.
+   * @param options {!PollOptions}
+   * @returns {!angular.$q.Promise}
+   * @private
+   */
+  createInterval_(options) {
+    if (!options.deferred) {
+      options.deferred = this.q_.defer();
+    }
+
+    options.interval = this.intervalService_(() => {
+      let promise = options.pollResource.get(options.params).$promise;
+      promise.then(
+          (obj) => {
+            options.deferred.notify(obj);
+          },
+          (err) => {
+            options.deferred.reject(err);
+            // Resource can't retrieve any record. It is not necessary to continue polling anymore.
+            this.cancelInterval_(options);
+            this.removeOptions_(options);
+
+          });
+    }, options.delay);
+
+    return options.deferred.promise;
+  }
+
+  /**
+   * Stops given poll service.
+   * @param options {!PollOptions}
+   * @private
+   */
+  cancelInterval_(options) {
+    this.intervalService_.cancel(options.interval);
+  }
+
+
+  /**
+   * Checks if the options already registered with the given resource.
+   * @param resource {angular.Resource.ParamsOrCallback=}
+   * @private
+   * @returns {PollOptions}
+   */
+  getOptionsByResource_(resource) {
+    if (!this.optionsList_.length) {
+      return null;
+    }
+    let targetOptions = null;
+    this.optionsList_.map((p) => {
+      if (p.pollResource === resource) {
+        targetOptions = p;
+      }
+    });
+    return targetOptions;
+  }
+
+  /**
+   * Removes given options object from the optionList
+   * @param options {!PollOptions}
+   * @private
+   */
+  removeOptions_(options) {
+    this.optionsList_.map((p, i) => {
+      if (p === options) {
+        this.optionsList_.splice(i, 1);
+      }
+    });
+  }
+}
+
+/** @type {number} */
+export const DEFAULT_DELAY = 10000;
+
+export class PollOptions {
+  /**
+   * @param resource {!angular.$resource}
+   * @param params {angular.Resource.ParamsOrCallback=}
+   * @param delay {number}
+   */
+  constructor(resource, params, delay) {
+    /**
+     * @type {number}
+     * @export
+     */
+    this.delay = delay || DEFAULT_DELAY;
+
+    /**
+     * @type {angular.Resource.ParamsOrCallback}
+     * @export
+     */
+    this.params = params;
+
+    /**
+     * @type {angular.$resource}
+     * @export
+     */
+    this.pollResource = resource;
+
+    /**
+     * @type {!angular.$q.Promise}
+     * @export
+     */
+    this.interval;
+
+    /**
+     * @type {!angular.$q.Deferred}
+     * @export
+     */
+    this.deferred;
+  }
+}

--- a/src/app/frontend/common/components/graph/graphcard.html
+++ b/src/app/frontend/common/components/graph/graphcard.html
@@ -22,6 +22,6 @@ limitations under the License.
     </span>
   </kd-title>
   <kd-content>
-    <kd-graph metrics="::$ctrl.selectedMetrics"></kd-graph>
+    <kd-graph metrics="$ctrl.selectedMetrics"></kd-graph>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/common/components/graph/graphcard_component.js
+++ b/src/app/frontend/common/components/graph/graphcard_component.js
@@ -31,6 +31,10 @@ export class GraphCardController {
     this.selectedMetrics;
   }
 
+  $onChanges() {
+    this.selectedMetrics = this.getSelectedMetrics();
+  }
+
   $onInit() {
     this.selectedMetrics = this.getSelectedMetrics();
   }

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -18,6 +18,7 @@
  */
 import adminModule from './admin/module';
 import chromeModule from './chrome/chrome_module';
+import autoRefreshModule from './common/autorefresh/autorefresh_module';
 import csrfTokenModule from './common/csrftoken/csrftoken_module';
 import configModule from './config/module';
 import configMapDetailModule from './configmapdetail/configmapdetail_module';
@@ -97,6 +98,7 @@ export default angular
           servicesanddiscoveryModule.name,
           configModule.name,
           csrfTokenModule.name,
+          autoRefreshModule.name,
         ])
     .config(indexConfig)
     .config(routeConfig);

--- a/src/app/frontend/nodelist/nodelist.html
+++ b/src/app/frontend/nodelist/nodelist.html
@@ -30,3 +30,9 @@ limitations under the License.
     </kd-node-card-list>
   </kd-content>
 </kd-content-card>
+
+<kd-auto-refresh source="$ctrl.nodeListResource"
+                 target="$ctrl.nodeList"
+                 type="list-without-namespace"
+                 delay="10000">
+</kd-auto-refresh>

--- a/src/app/frontend/podlist/podlist.html
+++ b/src/app/frontend/podlist/podlist.html
@@ -16,12 +16,12 @@ limitations under the License.
 
 <div layout="row">
   <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of pods.]]"
-                 metrics="::$ctrl.podList.cumulativeMetrics"
+                 metrics="$ctrl.podList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of pods.]]"
                  graph-info="[[The memory usage includes the caches in these pods.|Help message detailing what is included in the memory usage]]"
-                 metrics="::$ctrl.podList.cumulativeMetrics"
+                 metrics="$ctrl.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>
@@ -34,3 +34,15 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>
+
+<kd-auto-refresh source="::$ctrl.podListResource"
+                 target="$ctrl.podList"
+                 delay="10000"
+                 type="list">
+</kd-auto-refresh>
+
+<kd-auto-refresh source="::$ctrl.podListResource"
+                 target="$ctrl.podList"
+                 delay="7000"
+                 type="list">
+</kd-auto-refresh>

--- a/src/app/frontend/replicasetlist/replicasetlist.html
+++ b/src/app/frontend/replicasetlist/replicasetlist.html
@@ -16,12 +16,12 @@ limitations under the License.
 
 <div layout="row">
   <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of replica sets.]]"
-                 metrics="::$ctrl.replicaSetList.cumulativeMetrics"
+                 metrics="$ctrl.replicaSetList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of replica sets.]]"
                  graph-info="[[The memory usage includes the caches in the pods managed by these replica sets.|Help message detailing what is included in the memory usage]]"
-                 metrics="::$ctrl.replicaSetList.cumulativeMetrics"
+                 metrics="$ctrl.replicaSetList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>
@@ -34,3 +34,9 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>
+
+<kd-auto-refresh source="::$ctrl.replicaSetListResource"
+                 target="$ctrl.replicaSetList"
+                 delay="10000"
+                 type="list">
+</kd-auto-refresh>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
@@ -16,12 +16,12 @@ limitations under the License.
 
 <div layout="row">
   <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of replication controllers.]]"
-                 metrics="::$ctrl.replicationControllerList.cumulativeMetrics"
+                 metrics="$ctrl.replicationControllerList.cumulativeMetrics"
                  selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of replication controllers.]]"
                  graph-info="[[The memory usage includes the caches in the pods managed by these replication controllers.|Help message detailing what is included in the memory usage]]"
-                 metrics="::$ctrl.replicationControllerList.cumulativeMetrics"
+                 metrics="$ctrl.replicationControllerList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>
@@ -35,3 +35,9 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>
+
+<kd-auto-refresh source="::$ctrl.rcListResource"
+                 target="$ctrl.replicationControllerList"
+                 delay="10000"
+                 type="list">
+</kd-auto-refresh>


### PR DESCRIPTION
- This is a sample auto-refresh implementation for dashboard resources which was requested at #1296
- Currently it is implemented only for replication controller list and node list but can be used for every other resources and views.
- It is not complete yet. 
- It requires improvement and discussion before further development if it is needed at all. 

Auto-refresh feature is added to desired list or detail page as a directive with parameters of data resource delay and etc. It can be also used as a service but it has some pros and cons. 

It is based on polling action in particular intervals for retrieving data from back-end. 

Auto-refresh service automatically stops when user changes the states to avoid unnecessary polling unrelated to the selected view. It also breaks if any pop up menu is open to avoid disappearing menus involuntarily on update and it continues polling after the pop up menu closes. 

Multiple polling is possible for one view also with different delays. 

The graph component wasn't suitable for auto-refresh, therefore I made some small changes there to enable it. 
