### PR TITLE
Add bug report button

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -303,6 +303,12 @@
   <translation id="1706523109425956587" key="MSG_DEPLOY_UPLOAD_3" desc="The text is used as a \'Learn more\' link text besides the file upload on the deploy page.">Learn more</translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">Close</translation>
   <translation id="6510078647741040827" key="MSG_ERROR_INTERNALERROR_0" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error.</translation>
+  <translation id="4145537915999486390" key="MSG_ERROR_INTERNALERROR_1" desc="This is a label for button displayed on error page used to report bugs on GitHub.">Report a bug</translation>
+  <translation id="7320935166128929457" key="MSG_ERROR_UKNOWN_WARNING" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error</translation>
+  <translation id="7527074982331141078" key="MSG_EVENTS_ALL_LABEL" desc="Label 'All' for the event selection drop-down.">All</translation>
+  <translation id="9183905402242013542" key="MSG_EVENTS_CARD" desc="Label for the events card.">Events</translation>
+  <translation id="6413199566846581831" key="MSG_EVENTS_COUNT_LABEL" desc="Label 'Count' for event count column of the events table (events list page).">Count</translation>
+  <translation id="4179338997362096957" key="MSG_EVENTS_EVENTCARDLIST_0" desc="Label for the events card.">Events</translation>
   <translation id="4179338997362096957" key="MSG_EVENTS_EVENTCARDLIST_0" desc="Label which appears above the list of such objects.">Events</translation>
   <translation id="7618020634310257225" key="MSG_EVENTS_EVENTCARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">Message</translation>
   <translation id="7495297439436040330" key="MSG_EVENTS_EVENTCARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">Source</translation>

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -302,6 +302,7 @@
   <translation id="7942197803383171833" key="MSG_DEPLOY_UPLOAD_2" desc="User help for the YAML/JSON file upload form on the deploy page.">Select a YAML or JSON file, specifying the resources to deploy.</translation>
   <translation id="1706523109425956587" key="MSG_DEPLOY_UPLOAD_3" desc="The text is used as a \'Learn more\' link text besides the file upload on the deploy page.">Learn more</translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">Close</translation>
+  <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">Send feedback</translation>
   <translation id="6510078647741040827" key="MSG_ERROR_INTERNALERROR_0" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error.</translation>
   <translation id="4145537915999486390" key="MSG_ERROR_INTERNALERROR_1" desc="This is a label for button displayed on error page used to report bugs on GitHub.">Report a bug</translation>
   <translation id="7320935166128929457" key="MSG_ERROR_UKNOWN_WARNING" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error</translation>
@@ -460,6 +461,7 @@
   <translation id="1139931975436155591" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
   <translation id="4611353673808918004" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node.">Created at <ph name="CREATION_DATE"/></translation>
+  <translation id="2230058550547139309" key="MSG_NO_ERROR_DATA" desc="String to display when error object has no data.">No error data available</translation>
   <translation id="6997507737763635005" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume Claim\' which appears at the top of the delete dialog, opened from a persistent volume claim details page.">Persistent Volume Claim</translation>
   <translation id="1297935396913654466" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_PERSISTENTVOLUMECLAIMINFO_0" desc="Header in a detail view">Details</translation>
   <translation id="4504917958472688873" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_PERSISTENTVOLUMECLAIMINFO_1" desc="Persistent volume claim info details section status entry.">Status</translation>
@@ -690,6 +692,7 @@
   <translation id="3641265385665997534" key="MSG_RESOURCE_CARD_LIST_PAGINATION_ERROR" desc="Message shown to the user when there is a pagination error.">Pagination error</translation>
   <translation id="1320482404001625698" key="MSG_SECRETDETAIL_ACTIONBAR_0" desc="Label \'Secret\' which appears at the top of the delete dialog, opened from a secret details page.">Secret</translation>
   <translation id="1561742373508692276" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">Data </translation>
+  <translation id="7988357395949564443" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">Data</translation>
   <translation id="1940368443923988450" key="MSG_SECRETDETAIL_DETAIL_1" desc="Secrets info details section bytes.">bytes </translation>
   <translation id="7488314601782256695" key="MSG_SECRETDETAIL_DETAIL_1" desc="Tooltip label for showing secret content">Show secret content</translation>
   <translation id="1451479307509203762" key="MSG_SECRETDETAIL_DETAIL_2" desc="Tooltip label for hiding secret content">Hide secret content</translation>
@@ -763,6 +766,7 @@
   <translation id="3967360362065546967" key="MSG_TIME_UNIT_SECOND_LABEL" desc="Time units label, a single second.">a second</translation>
   <translation id="270964281826728358" key="MSG_TIME_UNIT_YEARS_LABEL" desc="Time units label, many years (plural).">years</translation>
   <translation id="58035047264145239" key="MSG_TIME_UNIT_YEAR_LABEL" desc="Time units label, a single year.">a year</translation>
+  <translation id="4037658160328783864" key="MSG_UNKNOWN_SERVER_ERROR" desc="String to display when error object has invalid structure.">Unknown Server Error</translation>
   <translation id="4302564966959880468" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage</translation>
   <translation id="1036433586363793837" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">Memory usage</translation>
 </translationbundle>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -485,6 +485,7 @@
   <translation id="3684607543489263600" key="MSG_ENV_FROM_CONFIG_MAP" desc="Label for environment variable that comes from a Config Map">コンフィグマップからの値 <ph name="NAME"/>/<ph name="KEY"/></translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">閉じる</translation>
   <translation id="6510078647741040827" key="MSG_ERROR_INTERNALERROR_0" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error.</translation>
+  <translation id="4145537915999486390" key="MSG_ERROR_INTERNALERROR_1" desc="This is a label for button displayed on error page used to report bugs on GitHub.">Report a bug</translation>
   <translation id="7320935166128929457" key="MSG_ERROR_UKNOWN_WARNING" desc="This message appears in an error dialog when the returned error code is not recognized.">不明なサーバーエラーです</translation>
   <translation id="7527074982331141078" key="MSG_EVENTS_ALL_LABEL" desc="Label 'All' for the event selection drop-down.">すべて</translation>
   <translation id="9183905402242013542" key="MSG_EVENTS_CARD" desc="Label for the events card.">イベント</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -484,6 +484,7 @@
   <translation id="8463528551217463399" key="MSG_EDIT_RESOURCE_DIALOG_UPDATE" desc="Label for update button">アップデート</translation>
   <translation id="3684607543489263600" key="MSG_ENV_FROM_CONFIG_MAP" desc="Label for environment variable that comes from a Config Map">コンフィグマップからの値 <ph name="NAME"/>/<ph name="KEY"/></translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">閉じる</translation>
+  <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">Send feedback</translation>
   <translation id="6510078647741040827" key="MSG_ERROR_INTERNALERROR_0" desc="This message appears in an error dialog when the returned error code is not recognized.">Unknown Server Error.</translation>
   <translation id="4145537915999486390" key="MSG_ERROR_INTERNALERROR_1" desc="This is a label for button displayed on error page used to report bugs on GitHub.">Report a bug</translation>
   <translation id="7320935166128929457" key="MSG_ERROR_UKNOWN_WARNING" desc="This message appears in an error dialog when the returned error code is not recognized.">不明なサーバーエラーです</translation>
@@ -829,6 +830,7 @@
   <translation id="1886003934797453383" key="MSG_NODE_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of nodes (node list view).">名前</translation>
   <translation id="6440277990482217612" key="MSG_NODE_LIST_PODS_LABEL" desc="Label 'Pods' which appears as a column label in the table of nodes (node list view).">ポッド</translation>
   <translation id="6987669710926523285" key="MSG_NODE_LIST_READY_LABEL" desc="Label 'Ready' which appears as a column label in the table of nodes (node list view).">準備完了</translation>
+  <translation id="2230058550547139309" key="MSG_NO_ERROR_DATA" desc="String to display when error object has no data.">No error data available</translation>
   <translation id="6997507737763635005" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume Claim\' which appears at the top of the delete dialog, opened from a persistent volume claim details page.">Persistent Volume Claim</translation>
   <translation id="1297935396913654466" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_PERSISTENTVOLUMECLAIMINFO_0" desc="Persistent volume claim info details section name.">Details</translation>
   <translation id="4504917958472688873" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_PERSISTENTVOLUMECLAIMINFO_1" desc="Persistent volume claim info details section status entry.">Status</translation>
@@ -1557,6 +1559,7 @@
   <translation id="3967360362065546967" key="MSG_TIME_UNIT_SECOND_LABEL" desc="Time units label, a single second.">1 秒</translation>
   <translation id="270964281826728358" key="MSG_TIME_UNIT_YEARS_LABEL" desc="Time units label, many years (plural).">年</translation>
   <translation id="58035047264145239" key="MSG_TIME_UNIT_YEAR_LABEL" desc="Time units label, a single year.">1 年</translation>
+  <translation id="4037658160328783864" key="MSG_UNKNOWN_SERVER_ERROR" desc="String to display when error object has invalid structure.">Unknown Server Error</translation>
   <translation id="5168444369924204121" key="MSG_UPLOAD_FILE_ACTION" desc="The text is put on the button at the end of the YAML upload page.">アップロード</translation>
   <translation id="480860823064912408" key="MSG_UPLOAD_FILE_ACTION_CANCEL" desc="The text is put on the 'Cancel' button at the end of the YAML upload page.">キャンセル</translation>
   <translation id="1611578389032486450" key="MSG_WORKLOADS_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of one all resources.">CPU使用量の履歴</translation>

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -20,11 +20,11 @@
 
 .kd-error-view-icon {
   color: $foreground-2;
+  display: inline-flex;
   font-size: $headline-font-size-base;
   line-height: 4 * $baseline-grid;
-  vertical-align: top;
-  display: inline-flex;
   margin-right: $baseline-grid;
+  vertical-align: top;
 }
 
 .kd-error-feedback-button {

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -18,3 +18,17 @@
   color: $foreground-2;
   font-size: $display-4-font-size-base;
 }
+
+.kd-error-report-button {
+  margin: $baseline-grid 0;
+}
+
+.kd-error-center-fixed {
+  align-content: center;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+}

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -14,12 +14,20 @@
 
 @import '../variables';
 
-.kd-error-view-icon {
+.kd-error-view-header {
   color: $foreground-2;
-  font-size: $display-4-font-size-base;
 }
 
-.kd-error-report-button {
+.kd-error-view-icon {
+  color: $foreground-2;
+  font-size: $headline-font-size-base;
+  line-height: 4 * $baseline-grid;
+  vertical-align: top;
+  display: inline-flex;
+  margin-right: $baseline-grid;
+}
+
+.kd-error-feedback-button {
   margin: $baseline-grid 0;
 }
 
@@ -31,4 +39,13 @@
   justify-content: center;
   position: absolute;
   width: 100%;
+}
+
+.kd-error-block {
+  background-color: $content-background;
+  border: 1px solid $border;
+  border-radius: $baseline-grid / 4;
+  box-shadow: $whiteframe-shadow-1dp;
+  display: block;
+  padding: (1.5 * $baseline-grid) (3.5 * $baseline-grid);
 }

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -19,7 +19,6 @@
 }
 
 .kd-error-view-icon {
-  color: $foreground-2;
   display: inline-flex;
   font-size: $headline-font-size-base;
   line-height: 4 * $baseline-grid;

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -14,22 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-center-fixed">
+<div class="kd-error-center-fixed">
   <div layout="column"  layout-align="center center">
     <i flex="auto" class="material-icons kd-error-view-icon">error_outline</i>
     <div flex="auto" >
       <h2 class="md-headline">
-        <span ng-if="::ctrl.error.statusText">
-          {{ctrl.error.statusText}}
-        </span>
+        <span ng-if="::ctrl.error.statusText">{{ctrl.error.statusText}}</span>
         <span ng-if="::!ctrl.error.statusText">
-          [[Unknown Server Error.|This message appears in an error dialog when the returned error code is not recognized.]]
+          [[Unknown Server Error.|This message appears in an error dialog when the returned error
+          code is not recognized.]]
         </span>
-        <span ng-if="::ctrl.showStatus()">
-         ({{ctrl.error.status}})
-        </span>
+        <span ng-if="::ctrl.showStatus()">({{ctrl.error.status}})</span>
       </h2>
       <pre ng-if="::ctrl.error.data">{{ctrl.error.data}}</pre>
+      <div layout="row" layout-align="end center">
+        <a ng-href="{{ctrl.getLinkToBugReport()}}">
+          <md-button  class="md-raised md-primary kd-error-report-button">
+            [[Report a bug|This is a label for button displayed on error page used to report bugs
+            on GitHub.]]
+          </md-button>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -18,15 +18,10 @@ limitations under the License.
   <div layout="column"  layout-align="center center">
     <div flex="auto" class="kd-error-block">
       <h2 class="md-headline kd-error-view-header">
-        <i  class="material-icons kd-error-view-icon">error_outline</i>
-        <span ng-if="::ctrl.error.statusText">{{ctrl.error.statusText}}</span>
-        <span ng-if="::!ctrl.error.statusText">
-          [[Unknown Server Error.|This message appears in an error dialog when the returned error
-          code is not recognized.]]
-        </span>
-        <span ng-if="::ctrl.showStatus()">({{ctrl.error.status}})</span>
+        <i class="material-icons kd-error-view-icon">error_outline</i>
+        <span>{{ctrl.getErrorStatus()}}</span>
       </h2>
-      <pre ng-if="::ctrl.error.data">{{ctrl.error.data}}</pre>
+      <pre>{{ctrl.getErrorData()}}</pre>
       <div layout="row" layout-align="end center">
         <a ng-href="{{ctrl.getLinkToFeedbackPage()}}">
           <md-button  class="kd-error-feedback-button">

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -16,9 +16,9 @@ limitations under the License.
 
 <div class="kd-error-center-fixed">
   <div layout="column"  layout-align="center center">
-    <i flex="auto" class="material-icons kd-error-view-icon">error_outline</i>
-    <div flex="auto" >
-      <h2 class="md-headline">
+    <div flex="auto" class="kd-error-block">
+      <h2 class="md-headline kd-error-view-header">
+        <i  class="material-icons kd-error-view-icon">error_outline</i>
         <span ng-if="::ctrl.error.statusText">{{ctrl.error.statusText}}</span>
         <span ng-if="::!ctrl.error.statusText">
           [[Unknown Server Error.|This message appears in an error dialog when the returned error
@@ -28,10 +28,10 @@ limitations under the License.
       </h2>
       <pre ng-if="::ctrl.error.data">{{ctrl.error.data}}</pre>
       <div layout="row" layout-align="end center">
-        <a ng-href="{{ctrl.getLinkToBugReport()}}">
-          <md-button  class="md-raised md-primary kd-error-report-button">
-            [[Report a bug|This is a label for button displayed on error page used to report bugs
-            on GitHub.]]
+        <a ng-href="{{ctrl.getLinkToFeedbackPage()}}">
+          <md-button  class="kd-error-feedback-button">
+            [[Send feedback|This is a label for button displayed on error page used to send feedback
+            to GitHub new issue.]]
           </md-button>
         </a>
       </div>

--- a/src/app/frontend/error/internalerror_controller.js
+++ b/src/app/frontend/error/internalerror_controller.js
@@ -32,4 +32,33 @@ export class InternalErrorController {
   showStatus() {
     return angular.isNumber(this.error.status) && this.error.status > 0;
   }
+
+  /**
+   * Returns URL of GitHub page used to report bugs with partly filled issue template
+   * (check .github/ISSUE_TEMPLATE.md file)
+   *
+   * @export
+   * @return {string} URL of GitHub page used to report bugs.
+   */
+  getLinkToBugReport() {
+    let link = 'https://github.com/kubernetes/dashboard/issues/new';
+
+    if (this.error) {
+      let title = `Dashboard reported ${this.error.statusText} (${this.error.status})`;
+      let body = `#### Issue details\n\n##### Environment\n<!-- Describe how do you run ` +
+          `Kubernetes and Dashboard.\n      Versions of Node.js, Go etc. are needed only from ` +
+          `developers.To get them use console:\n      $ node --version\n      $ go version\n-->\n` +
+          `\n\`\`\`\nDashboard version:\nKubernetes version:\nOperating system:\nNode.js version:` +
+          `\nGo version:\n\`\`\`\n##### Steps to reproduce\n<!-- Describe all steps needed to ` +
+          `reproduce the issue. It is a good place to use numbered list. -->\n\n##### Observed ` +
+          `result\nDashboard reported ${this.error.statusText} (${this.error.status}):\n\`\`\`\n` +
+          `${this.error.data}\n\`\`\`\n\n##### Expected result\n<!-- Describe expected result ` +
+          `as precisely as possible. -->\n\n##### Comments\n<!-- If you have any comments or more` +
+          ` details, put them here. -->`;
+
+      link += `?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+    }
+
+    return link;
+  }
 }

--- a/src/app/frontend/error/internalerror_controller.js
+++ b/src/app/frontend/error/internalerror_controller.js
@@ -23,14 +23,39 @@ export class InternalErrorController {
   constructor($stateParams) {
     /** @export {!angular.$http.Response} */
     this.error = $stateParams.error;
+
+    /** @export */
+    this.i18n = i18n;
   }
 
   /**
    * @export
-   * @return {boolean}
+   * @return {string}
    */
-  showStatus() {
-    return angular.isNumber(this.error.status) && this.error.status > 0;
+  getErrorStatus() {
+    let errorStatus = '';
+    if (this.error && this.error.statusText && this.error.statusText.length > 0) {
+      errorStatus = this.error.statusText;
+    } else {
+      errorStatus = this.i18n.MSG_UNKNOWN_SERVER_ERROR;
+    }
+
+    if (this.error && angular.isNumber(this.error.status) && this.error.status > 0) {
+      errorStatus += ` (${this.error.status})`;
+    }
+
+    return errorStatus;
+  }
+
+  /**
+     * @export
+     * @return {string}
+     */
+  getErrorData() {
+    if (this.error && this.error.data && this.error.data.length > 0) {
+      return this.error.data;
+    }
+    return this.i18n.MSG_NO_ERROR_DATA;
   }
 
   /**
@@ -41,24 +66,24 @@ export class InternalErrorController {
    * @return {string} URL of GitHub page used to report bugs.
    */
   getLinkToFeedbackPage() {
-    let link = 'https://github.com/kubernetes/dashboard/issues/new';
-
-    if (this.error) {
-      let title = `Dashboard reported ${this.error.statusText} (${this.error.status})`;
-      let body = `#### Issue details\n\n##### Environment\n<!-- Describe how do you run ` +
-          `Kubernetes and Dashboard.\n      Versions of Node.js, Go etc. are needed only from ` +
-          `developers.To get them use console:\n      $ node --version\n      $ go version\n-->\n` +
-          `\n\`\`\`\nDashboard version:\nKubernetes version:\nOperating system:\nNode.js version:` +
-          `\nGo version:\n\`\`\`\n##### Steps to reproduce\n<!-- Describe all steps needed to ` +
-          `reproduce the issue. It is a good place to use numbered list. -->\n\n##### Observed ` +
-          `result\nDashboard reported ${this.error.statusText} (${this.error.status}):\n\`\`\`\n` +
-          `${this.error.data}\n\`\`\`\n\n##### Expected result\n<!-- Describe expected result ` +
-          `as precisely as possible. -->\n\n##### Comments\n<!-- If you have any comments or more` +
-          ` details, put them here. -->`;
-
-      link += `?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
-    }
-
-    return link;
+    let title = `Dashboard reported ${this.getErrorStatus()}`;
+    let body = `#### Issue details\n\n##### Environment\n<!-- Describe how do you run Kubernetes ` +
+        `and Dashboard.\n      Versions of Node.js, Go etc. are needed only from developers. To ` +
+        `get them use console:\n      $ node --version\n      $ go version\n-->\n\n\`\`\`\n` +
+        `Dashboard version:\nKubernetes version:\nOperating system:\nNode.js version:\nGo version` +
+        `:\n\`\`\`\n##### Steps to reproduce\n<!-- Describe all steps needed to reproduce the ` +
+        `issue. It is a good place to use numbered list. -->\n\n##### Observed result\nDashboard ` +
+        `reported ${this.getErrorStatus()}:\n\`\`\`\n${this.getErrorData()}\n\`\`\`\n\n##### ` +
+        `Expected result\n<!-- Describe expected result as precisely as possible. -->\n\n##### ` +
+        `Comments\n<!-- If you have any comments or more details, put them here. -->`;
+    return `https://github.com/kubernetes/dashboard/issues/new?title=${encodeURIComponent(title)}` +
+        `&body=${encodeURIComponent(body)}`;
   }
 }
+
+const i18n = {
+  /** @export {string} @desc String to display when error object has invalid structure. */
+  MSG_UNKNOWN_SERVER_ERROR: goog.getMsg('Unknown Server Error'),
+  /** @export {string} @desc String to display when error object has no data. */
+  MSG_NO_ERROR_DATA: goog.getMsg('No error data available'),
+};

--- a/src/app/frontend/error/internalerror_controller.js
+++ b/src/app/frontend/error/internalerror_controller.js
@@ -35,7 +35,7 @@ export class InternalErrorController {
 
   /**
    * Returns URL of GitHub page used to report bugs with partly filled issue template
-   * (check .github/ISSUE_TEMPLATE.md file)
+   * (check .github/ISSUE_TEMPLATE.md file). IMPORTANT: Remember to keep these templates in sync.
    *
    * @export
    * @return {string} URL of GitHub page used to report bugs.

--- a/src/app/frontend/error/internalerror_controller.js
+++ b/src/app/frontend/error/internalerror_controller.js
@@ -40,7 +40,7 @@ export class InternalErrorController {
    * @export
    * @return {string} URL of GitHub page used to report bugs.
    */
-  getLinkToBugReport() {
+  getLinkToFeedbackPage() {
     let link = 'https://github.com/kubernetes/dashboard/issues/new';
 
     if (this.error) {

--- a/src/test/frontend/error/internalerror_controller_test.js
+++ b/src/test/frontend/error/internalerror_controller_test.js
@@ -31,23 +31,54 @@ describe('Internal error controller', () => {
     });
   });
 
-  it('should hide status when no error', () => {
-    expect(ctrl.showStatus()).toBe(false);
+  it('should return default error status when unknown error', () => {
+    expect(ctrl.getErrorStatus()).toBe(ctrl.i18n.MSG_UNKNOWN_SERVER_ERROR);
   });
 
-  it('should hide status when there is unknown error', () => {
+  it('should return valid error status when error occurs', () => {
     // given
-    stateParams.error.status = -1;
+    stateParams.error.status = 500;
 
     // then
-    expect(ctrl.showStatus()).toBe(false);
+    expect(ctrl.getErrorStatus())
+        .toBe(`${ctrl.i18n.MSG_UNKNOWN_SERVER_ERROR} (${stateParams.error.status})`);
   });
 
-  it('should show status when there known error', () => {
+  it('should return valid error status when error occurs', () => {
     // given
-    stateParams.error.status = 404;
+    stateParams.error.status = 500;
+    stateParams.error.statusText = 'Random error';
 
     // then
-    expect(ctrl.showStatus()).toBe(true);
+    expect(ctrl.getErrorStatus())
+        .toBe(`${stateParams.error.statusText} (${stateParams.error.status})`);
+  });
+
+  it('should return valid error status when error occurs', () => {
+    // given
+    stateParams.error.statusText = 'Random error';
+
+    // then
+    expect(ctrl.getErrorStatus()).toBe(`${stateParams.error.statusText}`);
+  });
+
+  it('should return default error data when unknown error', () => {
+    expect(ctrl.getErrorData()).toBe(ctrl.i18n.MSG_NO_ERROR_DATA);
+  });
+
+  it('should return default error data when empty error', () => {
+    // given
+    stateParams.error.data = '';
+
+    // then
+    expect(ctrl.getErrorData()).toBe(ctrl.i18n.MSG_NO_ERROR_DATA);
+  });
+
+  it('should return valid error data when error occurs', () => {
+    // given
+    stateParams.error.data = 'something is broken';
+
+    // then
+    expect(ctrl.getErrorData()).toBe(stateParams.error.data);
   });
 });


### PR DESCRIPTION
Previously:

![image](https://cloud.githubusercontent.com/assets/2823399/20488572/cf1f0814-b007-11e6-8142-ac1d2b84f98b.png)

Centered message on error page and added `Report a bug` button:

![image](https://cloud.githubusercontent.com/assets/2823399/20487536/079719e2-b004-11e6-8186-8eba1c74592c.png)

Button redirects to GitHub issue creation:

![image](https://cloud.githubusercontent.com/assets/2823399/20487586/39c7b048-b004-11e6-9306-73c50757507a.png)

With partly filled template (title and observed result).

Closes #1456.