### PR TITLE
Display errors on pod list page

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -574,6 +574,11 @@
   <translation id="6443550122641250762" key="MSG_PODLIST_PODCARDLIST_7" desc="Title of a column">CPU (cores)</translation>
   <translation id="3396535268909732737" key="MSG_PODLIST_PODCARDLIST_8" desc="Title of a column">Memory (bytes)</translation>
   <translation id="7236041095972031158" key="MSG_PODLIST_PODCARDLIST_9" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
+  <translation id="1979198258258777444" key="MSG_PODLIST_PODCARD_0" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
+  <translation id="6198079975160516049" key="MSG_PODLIST_PODCARD_1" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
+  <translation id="9163686479589740365" key="MSG_PODLIST_PODCARD_2" desc="Label for logs tooltip">Logs</translation>
+  <translation id="1311816473397506166" key="MSG_PODLIST_PODCARD_3" desc="Name of the pod resource">Pod</translation>
+  <translation id="7649589521591327794" key="MSG_PODLIST_PODCARD_4" desc="Name of the pod resource">Pod</translation>
   <translation id="4624949365521774090" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage</translation>
   <translation id="1774454191311054495" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage</translation>
   <translation id="1014088790164786434" key="MSG_POD_LIST_POD_TERMINATED_STATUS" desc="Status message showing a terminated status with [reason].">Terminated: <ph name="REASON"/></translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -1085,6 +1085,11 @@
   <translation id="3396535268909732737" key="MSG_PODLIST_PODCARDLIST_8" desc="Title of a column">Memory (bytes)</translation>
   <translation id="7236041095972031158" key="MSG_PODLIST_PODCARDLIST_9" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
   <translation id="8022917849813090234" key="MSG_PODLIST_PODCARDLIST_9" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
+  <translation id="1979198258258777444" key="MSG_PODLIST_PODCARD_0" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
+  <translation id="6198079975160516049" key="MSG_PODLIST_PODCARD_1" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
+  <translation id="9163686479589740365" key="MSG_PODLIST_PODCARD_2" desc="Label for logs tooltip">Logs</translation>
+  <translation id="1311816473397506166" key="MSG_PODLIST_PODCARD_3" desc="Name of the pod resource">Pod</translation>
+  <translation id="7649589521591327794" key="MSG_PODLIST_PODCARD_4" desc="Name of the pod resource">Pod</translation>
   <translation id="983813473653204599" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage history</translation>
   <translation id="4624949365521774090" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage</translation>
   <translation id="1774454191311054495" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage</translation>

--- a/src/app/backend/resource/daemonset/daemonsetdetail/daemonsetpods.go
+++ b/src/app/backend/resource/daemonset/daemonsetdetail/daemonsetpods.go
@@ -37,7 +37,7 @@ func GetDaemonSetPods(client k8sClient.Interface, heapsterClient client.Heapster
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/deployment/deploymentpods.go
+++ b/src/app/backend/resource/deployment/deploymentpods.go
@@ -53,6 +53,6 @@ func GetDeploymentPods(client client.Interface, heapsterClient heapster.Heapster
 	pods := common.FilterNamespacedPodsBySelector(rawPods.Items, deployment.ObjectMeta.Namespace,
 		deployment.Spec.Selector.MatchLabels)
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }

--- a/src/app/backend/resource/job/jobdetail/jobpods.go
+++ b/src/app/backend/resource/job/jobdetail/jobpods.go
@@ -39,7 +39,7 @@ func GetJobPods(client k8sClient.Interface, heapsterClient client.HeapsterClient
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/node/nodedetail.go
+++ b/src/app/backend/resource/node/nodedetail.go
@@ -218,7 +218,7 @@ func GetNodePods(client k8sClient.Interface, heapsterClient client.HeapsterClien
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods.Items, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods.Items, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 	"k8s.io/kubernetes/pkg/api"
 	k8sClient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -60,15 +61,19 @@ type Pod struct {
 
 	// Pod metrics.
 	Metrics *common.PodMetrics `json:"metrics"`
+
+	// Pod warning events
+	Warnings []common.Event `json:"warnings"`
 }
 
 // GetPodList returns a list of all Pods in the cluster.
 func GetPodList(client k8sClient.Interface, heapsterClient client.HeapsterClient,
 	nsQuery *common.NamespaceQuery, dsQuery *dataselect.DataSelectQuery) (*PodList, error) {
-	log.Printf("Getting list of all pods in the cluster")
+	log.Print("Getting list of all pods in the cluster")
 
 	channels := &common.ResourceChannels{
-		PodList: common.GetPodListChannelWithOptions(client, nsQuery, api.ListOptions{}, 1),
+		PodList:   common.GetPodListChannelWithOptions(client, nsQuery, api.ListOptions{}, 1),
+		EventList: common.GetEventListChannel(client, nsQuery, 1),
 	}
 
 	return GetPodListFromChannels(channels, dsQuery, heapsterClient)
@@ -84,11 +89,16 @@ func GetPodListFromChannels(channels *common.ResourceChannels, dsQuery *datasele
 		return nil, err
 	}
 
-	podList := CreatePodList(pods.Items, dsQuery, heapsterClient)
+	eventList := <-channels.EventList.List
+	if err := <-channels.EventList.Error; err != nil {
+		return nil, err
+	}
+
+	podList := CreatePodList(pods.Items, eventList.Items, dsQuery, heapsterClient)
 	return &podList, nil
 }
 
-func CreatePodList(pods []api.Pod, dsQuery *dataselect.DataSelectQuery,
+func CreatePodList(pods []api.Pod, events []api.Event, dsQuery *dataselect.DataSelectQuery,
 	heapsterClient client.HeapsterClient) PodList {
 
 	channels := &common.ResourceChannels{
@@ -112,7 +122,10 @@ func CreatePodList(pods []api.Pod, dsQuery *dataselect.DataSelectQuery,
 	pods = fromCells(podCells)
 
 	for _, pod := range pods {
+		warnings := event.GetPodsEventWarnings(events, []api.Pod{pod})
+
 		podDetail := ToPod(&pod, metrics)
+		podDetail.Warnings = warnings
 		podList.Pods = append(podList.Pods, podDetail)
 
 	}

--- a/src/app/backend/resource/replicaset/replicasetdetail/replicasetpods.go
+++ b/src/app/backend/resource/replicaset/replicasetdetail/replicasetpods.go
@@ -39,7 +39,7 @@ func GetReplicaSetPods(client k8sClient.Interface, heapsterClient client.Heapste
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail/replicationcontrollerpods.go
+++ b/src/app/backend/resource/replicationcontroller/replicationcontrollerdetail/replicationcontrollerpods.go
@@ -38,7 +38,7 @@ func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient cli
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/service/servicedetail.go
+++ b/src/app/backend/resource/service/servicedetail.go
@@ -103,6 +103,6 @@ func GetServicePods(client k8sClient.Interface, heapsterClient client.HeapsterCl
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(apiPodList.Items, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(apiPodList.Items, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }

--- a/src/app/backend/resource/statefulset/statefulsetdetail/statefulsetpods.go
+++ b/src/app/backend/resource/statefulset/statefulsetdetail/statefulsetpods.go
@@ -37,7 +37,7 @@ func GetStatefulSetPods(client *k8sClient.Clientset, heapsterClient client.Heaps
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, dsQuery, heapsterClient)
+	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, heapsterClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/workload/workloads.go
+++ b/src/app/backend/resource/workload/workloads.go
@@ -61,7 +61,7 @@ func GetWorkloads(client *k8sClient.Clientset, heapsterClient client.HeapsterCli
 		StatefulSetList:           common.GetStatefulSetListChannel(client, nsQuery, 1),
 		ServiceList:               common.GetServiceListChannel(client, nsQuery, 1),
 		PodList:                   common.GetPodListChannel(client, nsQuery, 7),
-		EventList:                 common.GetEventListChannel(client, nsQuery, 6),
+		EventList:                 common.GetEventListChannel(client, nsQuery, 7),
 	}
 
 	return GetWorkloadsFromChannels(channels, heapsterClient, metricQuery)

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -742,7 +742,8 @@ backendApi.PodStatus;
  *   podStatus: !backendApi.PodStatus,
  *   podIP: string,
  *   restartCount: number,
- *   metrics: backendApi.PodMetrics
+ *   metrics: backendApi.PodMetrics,
+ *   warnings: !Array<!backendApi.Event>
  * }}
  */
 backendApi.Pod;

--- a/src/app/frontend/podlist/podcard.html
+++ b/src/app/frontend/podlist/podcard.html
@@ -1,0 +1,102 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-resource-card object-meta="::$ctrl.pod.objectMeta" type-meta="::$ctrl.pod.typeMeta">
+  <kd-resource-card-status layout="row">
+    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isFailed()">
+      error
+      <md-tooltip md-direction="right">
+        [[This pod has errors.|Tooltip for failed pod card icon]]
+      </md-tooltip>
+    </md-icon>
+    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+      timelapse
+      <md-tooltip md-direction="right">
+        [[This pod is in a pending state.|Tooltip for pending pod card icon]]
+      </md-tooltip>
+    </md-icon>
+    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+      check_circle
+    </md-icon>
+  </kd-resource-card-status>
+  <kd-resource-card-columns>
+    <kd-resource-card-column>
+      <div>
+        <a ng-href="{{::$ctrl.getPodDetailHref()}}" class="kd-middle-ellipsised-link">
+          <kd-middle-ellipsis display-string="{{::$ctrl.pod.objectMeta.name}}">
+          </kd-middle-ellipsis>
+        </a>
+      </div>
+    </kd-resource-card-column>
+    <kd-resource-card-column ng-if="::$ctrl.areMultipleNamespacesSelected()">
+      <div>
+        <kd-middle-ellipsis display-string="{{::$ctrl.pod.objectMeta.namespace}}">
+        </kd-middle-ellipsis>
+      </div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>{{::$ctrl.getDisplayStatus()}}</kd-resource-card-column>
+    <kd-resource-card-column>{{::$ctrl.pod.restartCount}}</kd-resource-card-column>
+    <kd-resource-card-column>
+      <div ng-if="::$ctrl.pod.objectMeta.creationTimestamp">
+        {{::$ctrl.pod.objectMeta.creationTimestamp | relativeTime}}
+        <md-tooltip>
+          {{::$ctrl.getStartedAtTooltip(pod.objectMeta.creationTimestamp)}}
+        </md-tooltip>
+      </div>
+      <div ng-if="::!$ctrl.pod.objectMeta.creationTimestamp">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <div ng-if="::$ctrl.pod.podIP">{{::$ctrl.pod.podIP}}</div>
+      <div ng-if="::!$ctrl.pod.podIP">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column ng-if="::$ctrl.showMetrics">
+      <div ng-if="::$ctrl.hasCpuUsage(pod)">
+        <kd-sparkline timeseries="::$ctrl.pod.metrics.cpuUsageHistory"
+                      class="kd-sparkline-cpu-series"></kd-sparkline>
+        {{::(pod.metrics.cpuUsage | kdCores)}}
+      </div>
+      <div ng-if="::!$ctrl.hasCpuUsage(pod)">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column ng-if="::$ctrl.showMetrics">
+      <div ng-if="::$ctrl.hasMemoryUsage()">
+        <kd-sparkline timeseries="::$ctrl.pod.metrics.memoryUsageHistory"
+                      class="kd-sparkline-memory-series"></kd-sparkline>
+        {{::($ctrl.pod.metrics.memoryUsage | kdMemory)}}
+      </div>
+      <div ng-if="::!$ctrl.hasMemoryUsage()">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
+      <md-button ng-if="::$ctrl.getPodLogsHref()"
+                 ng-href="{{::$ctrl.getPodLogsHref()}}" target="_blank" class="md-icon-button">
+        <md-icon md-font-library="material-icons">subject</md-icon>
+        <md-tooltip>[[Logs|Label for logs tooltip]]</md-tooltip>
+      </md-button>
+      <kd-resource-card-menu>
+        <kd-resource-card-delete-menu-item
+                resource-kind-name="[[Pod|Name of the pod resource]]">
+        </kd-resource-card-delete-menu-item>
+        <kd-resource-card-edit-menu-item
+                resource-kind-name="[[Pod|Name of the pod resource]]">
+        </kd-resource-card-edit-menu-item>
+      </kd-resource-card-menu>
+    </kd-resource-card-column>
+  </kd-resource-card-columns>
+  <kd-resource-card-footer ng-if="::$ctrl.isFailed()">
+    <div ng-repeat="warning in ::$ctrl.pod.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
+  </kd-resource-card-footer>
+</kd-resource-card>

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -1,0 +1,198 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {StateParams} from 'common/resource/resourcedetail';
+import {stateName as logsStateName, StateParams as LogsStateParams} from 'logs/logs_state';
+import {stateName} from 'poddetail/poddetail_state';
+
+/**
+ * @final
+ */
+export class PodCardController {
+  /**
+   * @ngInject,
+   * @param {!ui.router.$state} $state
+   * @param {!angular.$interpolate} $interpolate
+   * @param {!./../common/namespace/namespace_service.NamespaceService} kdNamespaceService
+   */
+  constructor($state, $interpolate, kdNamespaceService) {
+    /** @private {!./../common/namespace/namespace_service.NamespaceService} */
+    this.kdNamespaceService_ = kdNamespaceService;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+
+    /** @private {!angular.$interpolate} */
+    this.interpolate_ = $interpolate;
+
+    /**
+     * Initialized from the scope.
+     * @export {!backendApi.Pod}
+     */
+    this.pod;
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  areMultipleNamespacesSelected() {
+    return this.kdNamespaceService_.areMultipleNamespacesSelected();
+  }
+
+  /**
+   * Returns true if this pod has warnings, false otherwise
+   * @return {boolean}
+   */
+  hasWarnings() {
+    return this.pod.warnings.length > 0;
+  }
+
+  /**
+   * Returns true if this pod has no warnings and is in pending state, false otherwise
+   * @return {boolean}
+   * @export
+   */
+  isPending() {
+    return !this.hasWarnings() && this.pod.podStatus.podPhase === 'Pending';
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  isSuccess() {
+    return !this.isPending() && !this.isFailed();
+  }
+
+  /**
+   * Checks if pod status is failed.
+   * @return {boolean}
+   * @export
+   */
+  isFailed() {
+    return this.pod.podStatus.podPhase === 'Failed' || this.hasWarnings();
+  }
+
+  /**
+   * @return {string}
+   * @export
+   */
+  getPodLogsHref() {
+    return this.state_.href(
+        logsStateName,
+        new LogsStateParams(this.pod.objectMeta.namespace, this.pod.objectMeta.name));
+  }
+
+  /**
+   * @return {string}
+   * @export
+   */
+  getPodDetailHref() {
+    return this.state_.href(
+        stateName, new StateParams(this.pod.objectMeta.namespace, this.pod.objectMeta.name));
+  }
+
+  /**
+   * Returns a displayable status message for the pod.
+   * @return {string}
+   * @export
+   */
+  getDisplayStatus() {
+    let msgState = 'running';
+    let reason = undefined;
+    if (this.pod.podStatus.containerStates) {
+      // Container states array may be null when no containers have
+      // started yet.
+
+      for (let i = this.pod.podStatus.containerStates.length - 1; i >= 0; i--) {
+        let state = this.pod.podStatus.containerStates[i];
+
+        if (state.waiting) {
+          msgState = 'waiting';
+          reason = state.waiting.reason;
+        }
+        if (state.terminated) {
+          msgState = 'terminated';
+          reason = state.terminated.reason;
+          if (!reason) {
+            if (state.terminated.signal) {
+              reason = 'Signal:${state.terminated.signal}';
+            } else {
+              reason = 'ExitCode:${state.terminated.exitCode}';
+            }
+          }
+        }
+      }
+    }
+
+    /** @type {string} @desc Status message showing a waiting status with [reason].*/
+    let MSG_POD_LIST_POD_WAITING_STATUS = goog.getMsg('Waiting: {$reason}', {'reason': reason});
+    /** @type {string} @desc Status message showing a terminated status with [reason].*/
+    let MSG_POD_LIST_POD_TERMINATED_STATUS =
+        goog.getMsg('Terminated: {$reason}', {'reason': reason});
+
+    if (msgState === 'waiting') {
+      return MSG_POD_LIST_POD_WAITING_STATUS;
+    }
+    if (msgState === 'terminated') {
+      return MSG_POD_LIST_POD_TERMINATED_STATUS;
+    }
+    return this.pod.podStatus.podPhase;
+  }
+
+  /**
+   * @export
+   * @param  {string} startDate - start date of the pod
+   * @return {string} localized tooltip with the formated start date
+   */
+  getStartedAtTooltip(startDate) {
+    let filter = this.interpolate_(`{{date | date:'d/M/yy HH:mm':'UTC'}}`);
+    /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
+     * the pod.*/
+    let MSG_POD_LIST_STARTED_AT_TOOLTIP =
+        goog.getMsg('Started at {$startDate} UTC', {'startDate': filter({'date': startDate})});
+    return MSG_POD_LIST_STARTED_AT_TOOLTIP;
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  hasMemoryUsage() {
+    return !!this.pod && !!this.pod.metrics && !!this.pod.metrics.memoryUsageHistory &&
+        this.pod.metrics.memoryUsageHistory.length > 0;
+  }
+
+  /**
+   * @return {boolean}
+   * @export
+   */
+  hasCpuUsage() {
+    return !!this.pod && !!this.pod.metrics && !!this.pod.metrics.cpuUsageHistory &&
+        this.pod.metrics.cpuUsageHistory.length > 0;
+  }
+}
+
+/**
+ * @return {!angular.Component}
+ */
+export const podCardComponent = {
+  bindings: {
+    'pod': '=',
+    'showMetrics': '<',
+  },
+  controller: PodCardController,
+  templateUrl: 'podlist/podcard.html',
+};

--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -25,11 +25,12 @@ limitations under the License.
   <div ng-show="!$ctrl.podList.listMeta.totalItems"
       class="kd-zerostate-message" ng-transclude="zerostate"></div>
 
-  <kd-resource-card-header-columns ng-show="$ctrl.podList.listMeta.totalItems">
+  <kd-resource-card-header-columns ng-show="::$ctrl.podList.listMeta.totalItems">
     <kd-resource-card-header-column size="small" grow="2">
       [[Name|Title of a column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small" grow="2"
+                                    ng-if="::$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Title of a column]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small" grow="1">[[Status|Title of a pod status column]]
@@ -37,7 +38,8 @@ limitations under the License.
     <kd-resource-card-header-column size="small" grow="1">
       [[Restarts|Title of a restarts column for a pod]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">[[Age|Title of a column for the age of a pod]]
+    <kd-resource-card-header-column size="small" grow="1">[[Age|Title of a column for the age of a
+      pod]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small" grow="1">[[Cluster IP|Title of a column]]
     </kd-resource-card-header-column>
@@ -50,86 +52,13 @@ limitations under the License.
     <kd-resource-card-header-column size="small" grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-
-  <kd-resource-card total-items="$ctrl.podList.listMeta.totalItems"
-                    pagination-id="pods" object-meta="::pod.objectMeta" type-meta="::pod.typeMeta"
-                    dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default">
-    <kd-resource-card-status layout="row">
-      <md-icon class="material-icons kd-error" ng-if="::$ctrl.isStatusFailed(pod)">
-        error
-        <md-tooltip md-direction="right">
-          [[This pod has errors.|Tooltip for failed pod card icon]]
-        </md-tooltip>
-      </md-icon>
-      <md-icon class="material-icons" ng-if="::$ctrl.isStatusPending(pod)">
-        timelapse
-        <md-tooltip md-direction="right">
-          [[This pod is in a pending state.|Tooltip for pending pod card icon]]
-        </md-tooltip>
-      </md-icon>
-      <md-icon class="material-icons kd-success" ng-if="::$ctrl.isStatusSuccessful(pod)">
-        check_circle
-      </md-icon>
-    </kd-resource-card-status>
-    <kd-resource-card-columns>
-      <kd-resource-card-column>
-        <div>
-          <a ng-href="{{::$ctrl.getPodDetailHref(pod)}}" class="kd-middle-ellipsised-link">
-            <kd-middle-ellipsis display-string="{{::pod.objectMeta.name}}">
-            </kd-middle-ellipsis>
-          </a>
-        </div>
-      </kd-resource-card-column>
-      <kd-resource-card-column ng-if="$ctrl.areMultipleNamespacesSelected()">
-        <div>
-          <kd-middle-ellipsis display-string="{{::pod.objectMeta.namespace}}">
-          </kd-middle-ellipsis>
-        </div>
-      </kd-resource-card-column>
-      <kd-resource-card-column>{{::$ctrl.getDisplayStatus(pod)}}</kd-resource-card-column>
-      <kd-resource-card-column>{{::pod.restartCount}}</kd-resource-card-column>
-      <kd-resource-card-column>
-        <div ng-if="::pod.objectMeta.creationTimestamp">
-          {{::pod.objectMeta.creationTimestamp | relativeTime}}
-          <md-tooltip>
-            {{::$ctrl.getStartedAtTooltip(pod.objectMeta.creationTimestamp)}}
-          </md-tooltip>
-        </div>
-        <div ng-if="::!pod.objectMeta.creationTimestamp">-</div>
-      </kd-resource-card-column>
-      <kd-resource-card-column>
-        <div ng-if="::pod.podIP">{{::pod.podIP}}</div>
-        <div ng-if="::!pod.podIP">-</div>
-      </kd-resource-card-column>
-      <kd-resource-card-column ng-if="::$ctrl.showMetrics()">
-        <div ng-if="::$ctrl.hasCpuUsage(pod)">
-          <kd-sparkline timeseries="::pod.metrics.cpuUsageHistory" class="kd-sparkline-cpu-series"></kd-sparkline>
-          {{::(pod.metrics.cpuUsage | kdCores)}}
-        </div>
-        <div ng-if="::!$ctrl.hasCpuUsage(pod)">-</div>
-      </kd-resource-card-column>
-      <kd-resource-card-column ng-if="::$ctrl.showMetrics()">
-        <div ng-if="::$ctrl.hasMemoryUsage(pod)">
-          <kd-sparkline timeseries="::pod.metrics.memoryUsageHistory" class="kd-sparkline-memory-series"></kd-sparkline>
-          {{::(pod.metrics.memoryUsage | kdMemory)}}
-        </div>
-        <div ng-if="::!$ctrl.hasMemoryUsage(pod)">-</div>
-      </kd-resource-card-column>
-      <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
-        <md-button ng-if="::$ctrl.getPodLogsHref(pod)"
-                   ng-href="{{::$ctrl.getPodLogsHref(pod)}}" target="_blank" class="md-icon-button">
-          <md-icon md-font-library="material-icons">subject</md-icon>
-          <md-tooltip>[[Logs|Label for logs tooltip]]</md-tooltip>
-        </md-button>
-        <kd-resource-card-menu>
-          <kd-resource-card-delete-menu-item
-                  resource-kind-name="[[Pod|Name of the pod resource]]">
-          </kd-resource-card-delete-menu-item>
-          <kd-resource-card-edit-menu-item
-                  resource-kind-name="[[Pod|Name of the pod resource]]">
-          </kd-resource-card-edit-menu-item>
-        </kd-resource-card-menu>
-      </kd-resource-card-column>
-    </kd-resource-card-columns>
-  </kd-resource-card>
+  <kd-pod-card ng-if="::$ctrl.podListResource"
+               dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default"
+               pagination-id="pods" pod="pod" show-metrics="::$ctrl.showMetrics()"
+               total-items="::$ctrl.podList.listMeta.totalItems">
+  </kd-pod-card>
+  <kd-pod-card ng-if="::!$ctrl.podListResource" show-metrics="::$ctrl.showMetrics()"
+               dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default"
+               pagination-id="pods" pod="pod">
+  </kd-pod-card>
 </kd-resource-card-list>

--- a/src/app/frontend/podlist/podcardlist_component.js
+++ b/src/app/frontend/podlist/podcardlist_component.js
@@ -12,21 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {StateParams} from 'common/resource/resourcedetail';
-import {stateName as logsStateName, StateParams as LogsStateParams} from 'logs/logs_state';
-import {stateName} from 'poddetail/poddetail_state';
-
 /**
  * @final
  */
 export class PodCardListController {
   /**
    * @ngInject
-   * @param {!ui.router.$state} $state
-   * @param {!angular.$interpolate} $interpolate
    * @param {!./../common/namespace/namespace_service.NamespaceService} kdNamespaceService
    */
-  constructor($state, $interpolate, kdNamespaceService) {
+  constructor(kdNamespaceService) {
     /**
      * List of pods. Initialized from the scope.
      * @export {!backendApi.PodList}
@@ -36,22 +30,8 @@ export class PodCardListController {
     /** @export {!angular.Resource} Initialized from binding. */
     this.podListResource;
 
-    /** @private {!ui.router.$state} */
-    this.state_ = $state;
-
-    /** @private {!angular.$interpolate} */
-    this.interpolate_ = $interpolate;
-
     /** @private {!./../common/namespace/namespace_service.NamespaceService} */
     this.kdNamespaceService_ = kdNamespaceService;
-  }
-
-  /**
-   * @return {boolean}
-   * @export
-   */
-  areMultipleNamespacesSelected() {
-    return this.kdNamespaceService_.areMultipleNamespacesSelected();
   }
 
   /**
@@ -67,135 +47,11 @@ export class PodCardListController {
   }
 
   /**
-   * @param {!backendApi.Pod} pod
    * @return {boolean}
    * @export
    */
-  hasMemoryUsage(pod) {
-    return !!pod.metrics && !!pod.metrics.memoryUsageHistory &&
-        pod.metrics.memoryUsageHistory.length > 0;
-  }
-
-  /**
-   * @param {!backendApi.Pod} pod
-   * @return {boolean}
-   * @export
-   */
-  hasCpuUsage(pod) {
-    return !!pod.metrics && !!pod.metrics.cpuUsageHistory && pod.metrics.cpuUsageHistory.length > 0;
-  }
-
-  /**
-   * @param {!backendApi.Pod} pod
-   * @return {string}
-   * @export
-   */
-  getPodLogsHref(pod) {
-    return this.state_.href(
-        logsStateName, new LogsStateParams(pod.objectMeta.namespace, pod.objectMeta.name));
-  }
-
-  /**
-   * @param {!backendApi.Pod} pod
-   * @return {string}
-   * @export
-   */
-  getPodDetailHref(pod) {
-    return this.state_.href(
-        stateName, new StateParams(pod.objectMeta.namespace, pod.objectMeta.name));
-  }
-
-  /**
-   * Returns a displayable status message for the pod.
-   * @param {!backendApi.Pod} pod
-   * @return {string}
-   * @export
-   */
-  getDisplayStatus(pod) {
-    let msgState = 'running';
-    let reason = undefined;
-    if (pod.podStatus.containerStates) {
-      // Container states array may be null when no containers have
-      // started yet.
-
-      for (let i = pod.podStatus.containerStates.length - 1; i >= 0; i--) {
-        let state = pod.podStatus.containerStates[i];
-
-        if (state.waiting) {
-          msgState = 'waiting';
-          reason = state.waiting.reason;
-        }
-        if (state.terminated) {
-          msgState = 'terminated';
-          reason = state.terminated.reason;
-          if (!reason) {
-            if (state.terminated.signal) {
-              reason = 'Signal:${state.terminated.signal}';
-            } else {
-              reason = 'ExitCode:${state.terminated.exitCode}';
-            }
-          }
-        }
-      }
-    }
-
-    /** @type {string} @desc Status message showing a waiting status with [reason].*/
-    let MSG_POD_LIST_POD_WAITING_STATUS = goog.getMsg('Waiting: {$reason}', {'reason': reason});
-    /** @type {string} @desc Status message showing a terminated status with [reason].*/
-    let MSG_POD_LIST_POD_TERMINATED_STATUS =
-        goog.getMsg('Terminated: {$reason}', {'reason': reason});
-
-    if (msgState === 'waiting') {
-      return MSG_POD_LIST_POD_WAITING_STATUS;
-    }
-    if (msgState === 'terminated') {
-      return MSG_POD_LIST_POD_TERMINATED_STATUS;
-    }
-    return pod.podStatus.podPhase;
-  }
-
-  /**
-   * Checks if pod status is successful, i.e. running or succeeded.
-   * @param pod
-   * @return {boolean}
-   * @export
-   */
-  isStatusSuccessful(pod) {
-    return pod.podStatus.podPhase === 'Running' || pod.podStatus.podPhase === 'Succeeded';
-  }
-
-  /**
-   * Checks if pod status is pending.
-   * @param pod
-   * @return {boolean}
-   * @export
-   */
-  isStatusPending(pod) {
-    return pod.podStatus.podPhase === 'Pending';
-  }
-
-  /**
-   * Checks if pod status is failed.
-   * @param pod
-   * @return {boolean}
-   * @export
-   */
-  isStatusFailed(pod) {
-    return pod.podStatus.podPhase === 'Failed';
-  }
-
-  /**
-   * @export
-   * @param  {string} startDate - start date of the pod
-   * @return {string} localized tooltip with the formated start date
-   */
-  getStartedAtTooltip(startDate) {
-    let filter = this.interpolate_(`{{date | date:'d/M/yy HH:mm':'UTC'}}`);
-    /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
-     * the pod.*/
-    let MSG_POD_LIST_STARTED_AT_TOOLTIP =
-        goog.getMsg('Started at {$startDate} UTC', {'startDate': filter({'date': startDate})});
-    return MSG_POD_LIST_STARTED_AT_TOOLTIP;
+  areMultipleNamespacesSelected() {
+    return this.kdNamespaceService_.areMultipleNamespacesSelected();
   }
 }
 

--- a/src/app/frontend/podlist/podlist_module.js
+++ b/src/app/frontend/podlist/podlist_module.js
@@ -17,6 +17,7 @@ import filtersModule from 'common/filters/filters_module';
 import namespaceModule from 'common/namespace/namespace_module';
 import paginationModule from 'common/pagination/pagination_module';
 
+import {podCardComponent} from './podcard_component';
 import {podCardListComponent} from './podcardlist_component';
 import stateConfig from './podlist_stateconfig';
 
@@ -40,6 +41,7 @@ export default angular
         ])
     .config(stateConfig)
     .component('kdPodCardList', podCardListComponent)
+    .component('kdPodCard', podCardComponent)
     .factory('kdPodListResource', podListResource);
 
 /**

--- a/src/test/backend/resource/workload/workloads_test.go
+++ b/src/test/backend/resource/workload/workloads_test.go
@@ -241,8 +241,8 @@ func TestGetWorkloadsFromChannels(t *testing.T) {
 				Error: make(chan error, 7),
 			},
 			EventList: common.EventListChannel{
-				List:  make(chan *api.EventList, 6),
-				Error: make(chan error, 6),
+				List:  make(chan *api.EventList, 7),
+				Error: make(chan error, 7),
 			},
 		}
 
@@ -309,6 +309,8 @@ func TestGetWorkloadsFromChannels(t *testing.T) {
 		channels.PodList.Error <- nil
 
 		eventList := &api.EventList{}
+		channels.EventList.List <- eventList
+		channels.EventList.Error <- nil
 		channels.EventList.List <- eventList
 		channels.EventList.Error <- nil
 		channels.EventList.List <- eventList

--- a/src/test/frontend/podlist/podcard_component_test.js
+++ b/src/test/frontend/podlist/podcard_component_test.js
@@ -1,0 +1,219 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import podDetailModule from 'poddetail/poddetail_module';
+import podsListModule from 'podlist/podlist_module';
+
+describe('Pod card controller', () => {
+  /**
+   * @type {!podlist/podcard_component.PodCardController}
+   */
+  let ctrl;
+  /**
+   * @type {!./../common/namespace/namespace_service.NamespaceService}
+   */
+  let data;
+
+  beforeEach(() => {
+    angular.mock.module(podsListModule.name);
+    angular.mock.module(podDetailModule.name);
+
+    angular.mock.inject(($componentController, $rootScope, kdNamespaceService) => {
+      /** @type {!./../common/namespace/namespace_service.NamespaceService} */
+      data = kdNamespaceService;
+      /** @type {!PodCardController} */
+      ctrl = $componentController('kdPodCard', {$scope: $rootScope, kdNamespaceService_: data}, {});
+    });
+  });
+
+  it('should instantiate the controller properly', () => {
+    expect(ctrl).not.toBeUndefined();
+  });
+
+  it('should return the value from Namespace service', () => {
+    expect(ctrl.areMultipleNamespacesSelected()).toBe(data.areMultipleNamespacesSelected());
+  });
+
+  it('should execute logs href callback function', () => {
+    ctrl.pod = {
+      objectMeta: {
+        name: 'foo-pod',
+        namespace: 'foo-namespace',
+      },
+    };
+
+    expect(ctrl.getPodDetailHref()).toBe('#/pod/foo-namespace/foo-pod');
+  });
+
+  it('should return true when there is at least one error', () => {
+    // given
+    ctrl.pod = {
+      warnings: [{
+        message: 'test-error',
+        reason: 'test-reason',
+      }],
+    };
+
+    // then
+    expect(ctrl.hasWarnings()).toBeTruthy();
+  });
+
+  it('should return false when there are no errors', () => {
+    // given
+    ctrl.pod = {
+      warnings: [],
+      podStatus: {podPhase: 'Test Phase'},
+    };
+
+    // then
+    expect(ctrl.hasWarnings()).toBeFalsy();
+    expect(ctrl.isSuccess()).toBeTruthy;
+  });
+
+  it('should show display status correctly (running container)', () => {
+    ctrl.pod = {
+      podStatus: {podPhase: 'Test Phase', containerStates: [{running: {}}]},
+    };
+
+    // Output is expected to be equal to the podPhase.
+    expect(ctrl.getDisplayStatus()).toBe('Test Phase');
+  });
+
+  it('should handle pods with no container statuses', () => {
+    ctrl.pod = {
+      podStatus: {podPhase: 'Test Phase'},
+    };
+
+    // Output is expected to be equal to the podPhase.
+    expect(ctrl.getDisplayStatus()).toBe('Test Phase');
+  });
+
+  it('should show display status correctly (waiting container)', () => {
+    ctrl.pod = {
+      podStatus: {
+        podPhase: 'Test Phase',
+        containerStates: [{
+          waiting: {
+            reason: 'Test Reason',
+          },
+        }],
+      },
+    };
+
+    expect(ctrl.getDisplayStatus()).toBe('Waiting: Test Reason');
+  });
+
+  it('should show display status correctly (terminated container)', () => {
+    ctrl.pod = {
+      podStatus: {
+        podPhase: 'Test Phase',
+        containerStates: [{
+          terminated: {
+            reason: 'Test Reason',
+          },
+        }],
+      },
+    };
+
+    expect(ctrl.getDisplayStatus()).toBe('Terminated: Test Reason');
+  });
+
+  it('should show display status correctly (multi container)', () => {
+    ctrl.pod = {
+      podStatus: {
+        podPhase: 'Test Phase',
+        containerStates: [
+          {running: {}},
+          {
+            terminated: {
+              reason: 'Test Terminated Reason',
+            },
+          },
+          {waiting: {reason: 'Test Waiting Reason'}},
+        ],
+      },
+    };
+
+    expect(ctrl.getDisplayStatus()).toBe('Terminated: Test Terminated Reason');
+  });
+
+  it('should check pod status correctly (succeeded is successful)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Succeeded'}, warnings: []};
+    expect(ctrl.isSuccess()).toBeTruthy();
+  });
+
+  it('should check pod status correctly (running is successful)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Running'}, warnings: []};
+    expect(ctrl.isSuccess()).toBeTruthy();
+  });
+
+  it('should check pod status correctly (failed isn\'t successful)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    expect(ctrl.isSuccess()).toBeFalsy();
+  });
+
+  it('should check pod status correctly (pending is pending)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Pending'}, warnings: []};
+    expect(ctrl.isPending()).toBeTruthy();
+  });
+
+  it('should check pod status correctly (failed isn\'t pending)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    expect(ctrl.isPending()).toBeFalsy();
+  });
+
+  it('should check pod status correctly (failed is failed)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    expect(ctrl.isFailed()).toBeTruthy();
+  });
+
+  it('should check pod status correctly (running isn\'t failed)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Running'}, warnings: []};
+    expect(ctrl.isFailed()).toBeFalsy();
+  });
+
+  it('should format the "pod start date" tooltip correctly', () => {
+    expect(ctrl.getStartedAtTooltip('2016-06-06T09:13:12Z')).toBe('Started at 6/6/16 09:13 UTC');
+  });
+
+  it('should show and hide cpu metrics', () => {
+    let cases = [
+      {pod: {}, expected: false},
+      {pod: {metrics: {}}, expected: false},
+      {pod: {metrics: {cpuUsageHistory: []}}, expected: false},
+      {pod: {metrics: {cpuUsageHistory: [1]}}, expected: true},
+    ];
+
+    cases.forEach((c) => {
+      ctrl.pod = c.pod;
+
+      expect(ctrl.hasCpuUsage()).toBe(c.expected);
+    });
+  });
+
+  it('should show and hide memory metrics', () => {
+    let cases = [
+      {pod: {}, expected: false},
+      {pod: {metrics: {}}, expected: false},
+      {pod: {metrics: {memoryUsageHistory: []}}, expected: false},
+      {pod: {metrics: {memoryUsageHistory: [1]}}, expected: true},
+    ];
+
+    cases.forEach((c) => {
+      ctrl.pod = c.pod;
+
+      expect(ctrl.hasMemoryUsage()).toBe(c.expected);
+    });
+  });
+});

--- a/src/test/frontend/podlist/podcardlist_component_test.js
+++ b/src/test/frontend/podlist/podcardlist_component_test.js
@@ -32,7 +32,7 @@ describe('Pod card list controller', () => {
     angular.mock.inject(($componentController, $rootScope, kdNamespaceService) => {
       /** @type {!./../common/namespace/namespace_service.NamespaceService} */
       data = kdNamespaceService;
-      /** @type {!podCardListController} */
+      /** @type {!PodCardListController} */
       ctrl = $componentController(
           'kdPodCardList', {$scope: $rootScope, kdNamespaceService_: data}, {});
     });
@@ -44,107 +44,6 @@ describe('Pod card list controller', () => {
 
   it('should return the value from Namespace service', () => {
     expect(ctrl.areMultipleNamespacesSelected()).toBe(data.areMultipleNamespacesSelected());
-  });
-
-  it('should execute logs href callback function', () => {
-    expect(ctrl.getPodDetailHref({
-      objectMeta: {
-        name: 'foo-pod',
-        namespace: 'foo-namespace',
-      },
-    })).toBe('#/pod/foo-namespace/foo-pod');
-  });
-
-  it('should show display status correctly (running container)', () => {
-    // Output is expected to be equal to the podPhase.
-    expect(ctrl.getDisplayStatus({
-      podStatus: {podPhase: 'Test Phase', containerStates: [{running: {}}]},
-    })).toBe('Test Phase');
-  });
-
-  it('should handle pods with no container statuses', () => {
-    // Output is expected to be equal to the podPhase.
-    expect(ctrl.getDisplayStatus({
-      podStatus: {podPhase: 'Test Phase'},
-    })).toBe('Test Phase');
-  });
-
-  it('should show display status correctly (waiting container)', () => {
-    expect(ctrl.getDisplayStatus({
-      podStatus: {
-        podPhase: 'Test Phase',
-        containerStates: [{
-          waiting: {
-            reason: 'Test Reason',
-          },
-        }],
-      },
-    })).toBe('Waiting: Test Reason');
-  });
-
-  it('should show display status correctly (terminated container)', () => {
-    expect(ctrl.getDisplayStatus({
-      podStatus: {
-        podPhase: 'Test Phase',
-        containerStates: [{
-          terminated: {
-            reason: 'Test Reason',
-          },
-        }],
-      },
-    })).toBe('Terminated: Test Reason');
-  });
-
-  it('should show display status correctly (multi container)', () => {
-    expect(ctrl.getDisplayStatus({
-      podStatus: {
-        podPhase: 'Test Phase',
-        containerStates: [
-          {running: {}},
-          {
-            terminated: {
-              reason: 'Test Terminated Reason',
-            },
-          },
-          {waiting: {reason: 'Test Waiting Reason'}},
-        ],
-      },
-    })).toBe('Terminated: Test Terminated Reason');
-  });
-
-  it('should check pod status correctly (succeeded is successful)', () => {
-    expect(ctrl.isStatusSuccessful({name: 'test-pod', podStatus: {podPhase: 'Succeeded'}}))
-        .toBeTruthy();
-  });
-
-  it('should check pod status correctly (running is successful)', () => {
-    expect(ctrl.isStatusSuccessful({name: 'test-pod', podStatus: {podPhase: 'Running'}}))
-        .toBeTruthy();
-  });
-
-  it('should check pod status correctly (failed isn\'t successful)', () => {
-    expect(ctrl.isStatusSuccessful({name: 'test-pod', podStatus: {podPhase: 'Failed'}}))
-        .toBeFalsy();
-  });
-
-  it('should check pod status correctly (pending is pending)', () => {
-    expect(ctrl.isStatusPending({name: 'test-pod', podStatus: {podPhase: 'Pending'}})).toBeTruthy();
-  });
-
-  it('should check pod status correctly (failed isn\'t pending)', () => {
-    expect(ctrl.isStatusPending({name: 'test-pod', podStatus: {podPhase: 'Failed'}})).toBeFalsy();
-  });
-
-  it('should check pod status correctly (failed is failed)', () => {
-    expect(ctrl.isStatusFailed({name: 'test-pod', podStatus: {podPhase: 'Failed'}})).toBeTruthy();
-  });
-
-  it('should check pod status correctly (running isn\'t failed)', () => {
-    expect(ctrl.isStatusFailed({name: 'test-pod', podStatus: {podPhase: 'Running'}})).toBeFalsy();
-  });
-
-  it('should format the "pod start date" tooltip correctly', () => {
-    expect(ctrl.getStartedAtTooltip('2016-06-06T09:13:12Z')).toBe('Started at 6/6/16 09:13 UTC');
   });
 
   it('should show and hide metrics', () => {
@@ -159,25 +58,5 @@ describe('Pod card list controller', () => {
 
     ctrl.podList.pods = [{metrics: {}}];
     expect(ctrl.showMetrics()).toBe(true);
-  });
-
-  it('should show and hide cpu metrics', () => {
-    expect(ctrl.hasCpuUsage({})).toBe(false);
-
-    expect(ctrl.hasCpuUsage({metrics: {}})).toBe(false);
-
-    expect(ctrl.hasCpuUsage({metrics: {cpuUsageHistory: []}})).toBe(false);
-
-    expect(ctrl.hasCpuUsage({metrics: {cpuUsageHistory: [1]}})).toBe(true);
-  });
-
-  it('should show and hide memory metrics', () => {
-    expect(ctrl.hasMemoryUsage({})).toBe(false);
-
-    expect(ctrl.hasMemoryUsage({metrics: {}})).toBe(false);
-
-    expect(ctrl.hasMemoryUsage({metrics: {memoryUsageHistory: []}})).toBe(false);
-
-    expect(ctrl.hasMemoryUsage({metrics: {memoryUsageHistory: [1]}})).toBe(true);
   });
 });


### PR DESCRIPTION
- Added events retrieval on pod list page and applied same logic for error recognition as on other list pages.
- Extracted `podcard_component` from `podcardlist_component`

![zrzut ekranu z 2016-11-22 14-45-51](https://cloud.githubusercontent.com/assets/2285385/20526076/c37c6f04-b0c2-11e6-9f2a-a3ca8c7251e0.png)
