### PR TITLE
Fix navigation menu on IE

### DIFF
--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -63,6 +63,9 @@ body,
 .kd-app-entire-content {
   background-color: $body;
   max-height: 100%;
+  // Move entire app content below toolbar to avoid elements overlap with
+  // shadow (there was propblem with it on IE).
+  z-index: 0;
 }
 
 .kd-app-content {

--- a/src/app/frontend/chrome/nav/nav.scss
+++ b/src/app/frontend/chrome/nav/nav.scss
@@ -36,6 +36,11 @@
       background-color: transparent;
     }
   }
+
+  // Children of kd-nav should not shrink to prevent layout issues on IE. 
+  &>* {
+    flex-shrink: 0;
+  }
 }
 
 kd-nav,


### PR DESCRIPTION
* nav elements were collapsing into each other
* scrollbar was overlaping with the toolbar

Re #1447

Tested on other browsers. All ok there.