### PR TITLE
Fix time tooltip on podlist

### DIFF
--- a/src/app/frontend/common/components/resourcedetail/infocard.html
+++ b/src/app/frontend/common/components/resourcedetail/infocard.html
@@ -36,5 +36,5 @@ limitations under the License.
 </kd-info-card-entry>
 
 <kd-info-card-entry title="[[Creation time|Label 'Creation time' for a resource.]]">
-  {{::$ctrl.objectMeta.creationTimestamp | date:'yyyy-MM-ddTHH:mm':'UTC'}}
+  {{::$ctrl.objectMeta.creationTimestamp | date}}
 </kd-info-card-entry>

--- a/src/app/frontend/common/filters/date_filter.js
+++ b/src/app/frontend/common/filters/date_filter.js
@@ -15,7 +15,7 @@
 /**
  * Returns filter function to display date in the default format
  *
- * @param {function(string, string, string):string}} $delegate
+ * @param {function(string, string, string):string} $delegate
  * @return {function(string,string,string): string}
  * @ngInject
  */

--- a/src/app/frontend/common/filters/date_filter.js
+++ b/src/app/frontend/common/filters/date_filter.js
@@ -1,0 +1,45 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Returns filter function to display date in the default format
+ *
+ * @param {function(string, string, string):string}} $delegate
+ * @return {function(string,string,string): string}
+ * @ngInject
+ */
+export default function dateFilter($delegate) {
+  let original = $delegate;
+  const defaultFormat = 'yyyy-MM-ddTHH:mm';
+  const defaultTZ = 'UTC';
+  /**
+   * If no format or TZ are given use the default ones.
+   *
+   * @param {string} date
+   * @param {string} format
+   * @param {string} timezone
+   * @return {string}
+   */
+  let filterFunction = function(date, format, timezone) {
+    if (!format) {
+      format = defaultFormat;
+    }
+    if (!timezone) {
+      timezone = defaultTZ;
+    }
+    return original(date, format, timezone);
+  };
+
+  return filterFunction;
+}

--- a/src/app/frontend/common/filters/filters_module.js
+++ b/src/app/frontend/common/filters/filters_module.js
@@ -15,6 +15,7 @@
 import appConfigModule from '../appconfig/appconfig_module';
 
 import coresFilter from './cores_filter';
+import dateFilter from './date_filter.js';
 import itemsPerPageFilter from './itemsperpage_filter';
 import memoryFilter from './memory_filter';
 import relativeTimeFilter from './relativetime_filter';
@@ -34,4 +35,5 @@ export default angular
     .filter('kdMemory', memoryFilter)
     .filter('kdCores', coresFilter)
     .filter('relativeTime', relativeTimeFilter)
+    .decorator('dateFilter', dateFilter)
     .decorator('itemsPerPageFilter', itemsPerPageFilter);

--- a/src/app/frontend/configmaplist/configmapcard_component.js
+++ b/src/app/frontend/configmaplist/configmapcard_component.js
@@ -68,7 +68,7 @@ export default class ConfigMapCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * config map. */
     let MSG_CONFIG_MAP_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/daemonsetlist/daemonsetcard_component.js
+++ b/src/app/frontend/daemonsetlist/daemonsetcard_component.js
@@ -91,7 +91,7 @@ export class DaemonSetCardController {
    * @return {string} localized tooltip with the formatted creation date
    */
   getCreatedAtTooltip() {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * the daemon set.*/
     let MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP = goog.getMsg(

--- a/src/app/frontend/deploymentlist/deploymentcard_component.js
+++ b/src/app/frontend/deploymentlist/deploymentcard_component.js
@@ -95,7 +95,7 @@ export default class DeploymentCardController {
    * @return {string} localized tooltip with the formatted creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * a deployment. */
     let MSG_DEPLOYMENT_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/events/eventcardlist.html
+++ b/src/app/frontend/events/eventcardlist.html
@@ -68,10 +68,10 @@ limitations under the License.
           </kd-resource-card-column>
           <kd-resource-card-column>{{event.count}}</kd-resource-card-column>
           <kd-resource-card-column>
-            {{event.firstSeen | date:'yyyy-MM-ddTHH:mm':'UTC'}} UTC
+            {{event.firstSeen | date}} UTC
           </kd-resource-card-column>
           <kd-resource-card-column>
-            {{event.lastSeen | date:'yyyy-MM-ddTHH:mm':'UTC'}} UTC
+            {{event.lastSeen | date}} UTC
           </kd-resource-card-column>
         </kd-resource-card-columns>
       </kd-resource-card>

--- a/src/app/frontend/horizontalpodautoscalerdetail/horizontalpodautoscalerinfo_component.js
+++ b/src/app/frontend/horizontalpodautoscalerdetail/horizontalpodautoscalerinfo_component.js
@@ -64,7 +64,7 @@ export default class HorizontalPodAutoscalerInfoController {
    * @return {string} localized tooltip with the formatted creation date
    */
   getLatScaledTooltip() {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Last scaled at [some date]' showing the exact time of
      * the last time the horizontal pod autoscaler was scaled.*/
     let MSG_HORIZONTAL_POD_AUTOSCALER_DETAIL_LAST_SCALED_TOOLTIP = goog.getMsg(

--- a/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercard_component.js
+++ b/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercard_component.js
@@ -86,7 +86,7 @@ export class HorizontalPodAutoscalerCardController {
    * @return {string} localized tooltip with the formatted creation date
    */
   getCreatedAtTooltip() {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * the horizontal pod autoscaler.*/
     let MSG_HORIZONTAL_POD_AUTOSCALER_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/ingresslist/card_component.js
+++ b/src/app/frontend/ingresslist/card_component.js
@@ -42,7 +42,7 @@ class IngressCardController {
    * @return {string} localized tooltip with the formated start date
    */
   getStartedAtTooltip(startDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
      * the ingress.*/
     let MSG_INGRESS_LIST_STARTED_AT_TOOLTIP =

--- a/src/app/frontend/joblist/jobcard.html
+++ b/src/app/frontend/joblist/jobcard.html
@@ -62,7 +62,7 @@ limitations under the License.
     <kd-resource-card-column>
       {{::$ctrl.job.objectMeta.creationTimestamp | relativeTime}}
       <md-tooltip>
-        Created at {{::$ctrl.job.objectMeta.creationTimestamp | date:'yyyy-MM-ddTHH:mm':'UTC'}}
+        Created at {{::$ctrl.job.objectMeta.creationTimestamp | date}}
       </md-tooltip>
     </kd-resource-card-column>
     <kd-resource-card-column>

--- a/src/app/frontend/namespacelist/namespacecard_component.js
+++ b/src/app/frontend/namespacelist/namespacecard_component.js
@@ -72,7 +72,7 @@ export default class NamespaceCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * namespace. */
     let MSG_NAMESPACE_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/nodelist/nodecard_component.js
+++ b/src/app/frontend/nodelist/nodecard_component.js
@@ -81,7 +81,7 @@ export default class NodeCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * node. */
     let MSG_NODE_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcard_component.js
+++ b/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcard_component.js
@@ -95,7 +95,7 @@ export default class PersistentVolumeClaimCardController {
    * @return {string} localized tooltip with the formatted creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * persistent volume claim. */
     let MSG_PERSISTENT_VOLUME_CLAIM_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/persistentvolumelist/persistentvolumecard_component.js
+++ b/src/app/frontend/persistentvolumelist/persistentvolumecard_component.js
@@ -54,7 +54,7 @@ export default class PersistentVolumeCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * persistent volume. */
     let MSG_PERSISTENT_VOLUME_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/podlist/podcard.html
+++ b/src/app/frontend/podlist/podcard.html
@@ -58,7 +58,7 @@ limitations under the License.
       <div ng-if="::$ctrl.pod.objectMeta.creationTimestamp">
         {{::$ctrl.pod.objectMeta.creationTimestamp | relativeTime}}
         <md-tooltip>
-          {{::$ctrl.getStartedAtTooltip(pod.objectMeta.creationTimestamp)}}
+          {{::$ctrl.getStartedAtTooltip($ctrl.pod.objectMeta.creationTimestamp)}}
         </md-tooltip>
       </div>
       <div ng-if="::!$ctrl.pod.objectMeta.creationTimestamp">-</div>

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -158,7 +158,7 @@ export class PodCardController {
    * @return {string} localized tooltip with the formated start date
    */
   getStartedAtTooltip(startDate) {
-    let filter = this.interpolate_(`{{date | date:'d/M/yy HH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
      * the pod.*/
     let MSG_POD_LIST_STARTED_AT_TOOLTIP =

--- a/src/app/frontend/replicasetlist/replicasetcard_component.js
+++ b/src/app/frontend/replicasetlist/replicasetcard_component.js
@@ -95,7 +95,7 @@ export default class ReplicaSetCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * replica set. */
     let MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard_component.js
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard_component.js
@@ -97,7 +97,7 @@ export default class ReplicationControllerCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * replication controller. */
     let MSG_RC_LIST_CREATED_AT_TOOLTIP =

--- a/src/app/frontend/secretlist/card_component.js
+++ b/src/app/frontend/secretlist/card_component.js
@@ -42,7 +42,7 @@ class SecretCardController {
    * @return {string} localized tooltip with the formated start date
    */
   getStartedAtTooltip(startDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
      * the secret.*/
     let MSG_SECRET_LIST_STARTED_AT_TOOLTIP =

--- a/src/app/frontend/statefulsetlist/statefulsetcard_component.js
+++ b/src/app/frontend/statefulsetlist/statefulsetcard_component.js
@@ -95,7 +95,7 @@ export default class StatefulSetCardController {
    * @return {string} localized tooltip with the formated creation date
    */
   getCreatedAtTooltip(creationDate) {
-    let filter = this.interpolate_(`{{date | date:'yyyy-MM-ddTHH:mm':'UTC'}}`);
+    let filter = this.interpolate_(`{{date | date}}`);
     /** @type {string} @desc Tooltip 'Created at [some date]' showing the exact creation time of
      * stateful set. */
     let MSG_STATEFUL_SET_LIST_CREATED_AT_TOOLTIP =

--- a/src/test/frontend/common/filters/date_filter_test.js
+++ b/src/test/frontend/common/filters/date_filter_test.js
@@ -16,7 +16,7 @@ import filtersModule from 'common/filters/filters_module';
 
 describe('Items per page filter', () => {
   /** @type {function(string, string, string): string} */
-  let dateFilter
+  let dateFilter;
 
   beforeEach(() => {
     angular.mock.module(filtersModule.name);

--- a/src/test/frontend/common/filters/date_filter_test.js
+++ b/src/test/frontend/common/filters/date_filter_test.js
@@ -1,0 +1,39 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import filtersModule from 'common/filters/filters_module';
+
+describe('Items per page filter', () => {
+  /** @type {function(string, string, string): string} */
+  let dateFilter
+
+  beforeEach(() => {
+    angular.mock.module(filtersModule.name);
+
+    angular.mock.inject((_dateFilter_) => {
+      dateFilter = _dateFilter_;
+    });
+  });
+
+  it('should format date with a default format', () => {
+    expect(dateFilter('2016-06-06T19:13:12Z')).toEqual('2016-06-06T19:13');
+  });
+  it('should format date with an explicit format', () => {
+    expect(dateFilter('2016-06-06T19:13:12Z', 'yyyy-MM-ddThh:mm:ss'))
+        .toEqual('2016-06-06T07:13:12');
+  });
+  it('should format date with an explicit timezone', () => {
+    expect(dateFilter('2016-06-06T19:13:12Z', null, 'CEST')).toEqual('2016-06-06T21:13');
+  });
+});

--- a/src/test/frontend/common/filters/date_filter_test.js
+++ b/src/test/frontend/common/filters/date_filter_test.js
@@ -34,6 +34,6 @@ describe('Items per page filter', () => {
         .toEqual('2016-06-06T07:13:12');
   });
   it('should format date with an explicit timezone', () => {
-    expect(dateFilter('2016-06-06T19:13:12Z', null, 'CEST')).toEqual('2016-06-06T21:13');
+    expect(dateFilter('2016-06-06T19:13:12Z', null, '+0200')).toEqual('2016-06-06T21:13');
   });
 });

--- a/src/test/frontend/podlist/podcard_component_test.js
+++ b/src/test/frontend/podlist/podcard_component_test.js
@@ -184,7 +184,8 @@ describe('Pod card controller', () => {
   });
 
   it('should format the "pod start date" tooltip correctly', () => {
-    expect(ctrl.getStartedAtTooltip('2016-06-06T09:13:12Z')).toBe('Started at 6/6/16 09:13 UTC');
+    expect(ctrl.getStartedAtTooltip('2016-06-06T09:13:12Z'))
+        .toBe('Started at 2016-06-06T09:13 UTC');
   });
 
   it('should show and hide cpu metrics', () => {


### PR DESCRIPTION
Time display used wrong reference
Also the time format was the wrong format. To prevent that happening in the future decorated the default format to use a different default format and timezone.