### PR TITLE
added prometheus metrics for api calls

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -24,6 +24,8 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/handler"
 	"github.com/spf13/pflag"
+	"github.com/prometheus/client_golang/prometheus"
+
 )
 
 var (
@@ -77,6 +79,7 @@ func main() {
 	http.Handle("/api/", handler.CreateHTTPAPIHandler(apiserverClient, heapsterRESTClient, config))
 	// TODO(maciaszczykm): Move to /appConfig.json as it was discussed in #640.
 	http.Handle("/api/appConfig.json", handler.AppHandler(handler.ConfigHandler))
+	http.Handle("/metrics",prometheus.Handler())
 	log.Print(http.ListenAndServe(fmt.Sprintf(":%d", *argPort), nil))
 }
 

--- a/src/app/backend/handler/metrics.go
+++ b/src/app/backend/handler/metrics.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+	"time"
+)
+
+var (
+	requestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "apiserver_request_count",
+			Help: "Counter of apiserver requests broken out for each verb, API resource, client, and HTTP response contentType and code.",
+		},
+		[]string{"verb", "resource", "client", "contentType", "code"},
+	)
+	requestLatencies = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "apiserver_request_latencies",
+			Help: "Response latency distribution in microseconds for each verb, resource and client.",
+			// Use buckets ranging from 125 ms to 8 seconds.
+			Buckets: prometheus.ExponentialBuckets(125000, 2.0, 7),
+		},
+		[]string{"verb", "resource"},
+	)
+	requestLatenciesSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "apiserver_request_latencies_summary",
+			Help: "Response latency summary in microseconds for each verb and resource.",
+			// Make the sliding window of 1h.
+			MaxAge: time.Hour,
+		},
+		[]string{"verb", "resource"},
+	)
+)
+
+// Initialize all metrics in prometheus
+func RegisterMetrics() {
+	prometheus.MustRegister(requestCounter)
+	prometheus.MustRegister(requestLatencies)
+	prometheus.MustRegister(requestLatenciesSummary)
+}
+
+// Track API call in prometheus
+func Monitor(verb, resource string, client, contentType string, httpCode int, reqStart time.Time) {
+	elapsed := float64((time.Since(reqStart)) / time.Microsecond)
+	requestCounter.WithLabelValues(verb, resource, client, contentType, strconv.Itoa(httpCode)).Inc()
+	requestLatencies.WithLabelValues(verb, resource).Observe(elapsed)
+	requestLatenciesSummary.WithLabelValues(verb, resource).Observe(elapsed)
+}


### PR DESCRIPTION
I added prometheus instrumentation to dashboard backend. I think most Kubernetes components do so, except Dashboard.

Raw metrics are available at /metrics

I tried keep the format similar to k8s-apiserver, but I had two problems:
1. I could not distinguish between Get and List easily. So everything is GET or PUT
2. I could not describe the resource properly in all cases. 

Of course, both aspects could be achieved by cluttering the dashboard-apihandler a bit. Maybe there is another clever option.

So, overall the metrics are not as precise as for kubernetes apiserver. Unless someone has clever idea, I would suggest to start with current solution and improve later on.

Some code changes to consider:
1. I added a dependency to k8s.io/kubernetes/pkg/util/net. The utility method is not of much use. I can copy or remove if we try to get rid of k8s dependency.
2. I wanted to add a simple test for the metrics collection. Basically check that no error is thrown. And verify that metric reached prometheus. However, I could not read from prometheus. Suggestion welcome...

BTW: after this is merged we should instrument more code. E.g. I would suggest to _consider_ adding metrics at places we make debug output.











