### PR TITLE
Check pod conditions when displaying state icon

### DIFF
--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -62,12 +62,14 @@ func getPodStatusStatus(pod api.Pod, warnings []common.Event) string {
 		}
 	}
 
-	if (pod.Status.Phase == api.PodPending || !initialized) && len(warnings) > 0 {
-		return "failed"
-	}
-
 	if initialized && ready {
 		return "success"
+	}
+
+	// If the pod would otherwise be pending but has warning then label it as
+	// failed and show and error to the user.
+	if len(warnings) > 0 {
+		return "failed"
 	}
 
 	// Unknown?

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -40,7 +40,6 @@ func getPodStatus(pod api.Pod, warnings []common.Event) PodStatus {
 	return PodStatus{
 		Status:          getPodStatusStatus(pod, warnings),
 		PodPhase:        pod.Status.Phase,
-		PodConditions:   pod.Status.Conditions,
 		ContainerStates: states,
 	}
 }

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -31,7 +31,6 @@ func getRestartCount(pod api.Pod) int32 {
 }
 
 // getPodStatus returns a PodStatus object containing a summary of the pod's status.
-// func getPodStatus(pod api.Pod) PodStatus {
 func getPodStatus(pod api.Pod, warnings []common.Event) PodStatus {
 	var states []api.ContainerState
 	for _, containerStatus := range pod.Status.ContainerStatuses {

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -39,6 +39,7 @@ func getPodStatus(pod api.Pod) PodStatus {
 
 	return PodStatus{
 		PodPhase:        pod.Status.Phase,
+		PodConditions:   pod.Status.Conditions,
 		ContainerStates: states,
 	}
 }

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -31,25 +31,56 @@ func getRestartCount(pod api.Pod) int32 {
 }
 
 // getPodStatus returns a PodStatus object containing a summary of the pod's status.
-func getPodStatus(pod api.Pod) PodStatus {
+// func getPodStatus(pod api.Pod) PodStatus {
+func getPodStatus(pod api.Pod, warnings []common.Event) PodStatus {
 	var states []api.ContainerState
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		states = append(states, containerStatus.State)
 	}
 
 	return PodStatus{
+		Status:          getPodStatusStatus(pod, warnings),
 		PodPhase:        pod.Status.Phase,
 		PodConditions:   pod.Status.Conditions,
 		ContainerStates: states,
 	}
 }
 
+// getPodStatus returns one of three pod statuses (pending, success, failed)
+func getPodStatusStatus(pod api.Pod, warnings []common.Event) string {
+	if pod.Status.Phase == api.PodFailed {
+		return "failed"
+	}
+
+	ready := false
+	initialized := false
+	for _, c := range pod.Status.Conditions {
+		if c.Type == api.PodReady {
+			ready = c.Status == "True"
+		}
+		if c.Type == api.PodInitialized {
+			initialized = c.Status == "True"
+		}
+	}
+
+	if (pod.Status.Phase == api.PodPending || !initialized) && len(warnings) > 0 {
+		return "failed"
+	}
+
+	if initialized && ready {
+		return "success"
+	}
+
+	// Unknown?
+	return "pending"
+}
+
 // ToPod transforms Kubernetes pod object into object returned by API.
-func ToPod(pod *api.Pod, metrics *common.MetricsByPod) Pod {
+func ToPod(pod *api.Pod, metrics *common.MetricsByPod, warnings []common.Event) Pod {
 	podDetail := Pod{
 		ObjectMeta:   common.NewObjectMeta(pod.ObjectMeta),
 		TypeMeta:     common.NewTypeMeta(common.ResourceKindPod),
-		PodStatus:    getPodStatus(*pod),
+		PodStatus:    getPodStatus(*pod, warnings),
 		RestartCount: getRestartCount(*pod),
 	}
 

--- a/src/app/backend/resource/pod/podcommon.go
+++ b/src/app/backend/resource/pod/podcommon.go
@@ -56,10 +56,10 @@ func getPodStatusStatus(pod api.Pod, warnings []common.Event) string {
 	initialized := false
 	for _, c := range pod.Status.Conditions {
 		if c.Type == api.PodReady {
-			ready = c.Status == "True"
+			ready = c.Status == api.ConditionTrue
 		}
 		if c.Type == api.PodInitialized {
-			initialized = c.Status == "True"
+			initialized = c.Status == api.ConditionTrue
 		}
 	}
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -38,8 +38,8 @@ type PodList struct {
 
 type PodStatus struct {
 	// Status of the Pod. See Kubernetes API for reference.
-	PodPhase api.PodPhase `json:"podPhase"`
-
+	PodPhase        api.PodPhase         `json:"podPhase"`
+	PodConditions   []api.PodCondition   `json:"conditions"`
 	ContainerStates []api.ContainerState `json:"containerStates"`
 }
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -40,7 +40,6 @@ type PodStatus struct {
 	// Status of the Pod. See Kubernetes API for reference.
 	Status          string               `json:"status"`
 	PodPhase        api.PodPhase         `json:"podPhase"`
-	PodConditions   []api.PodCondition   `json:"conditions"`
 	ContainerStates []api.ContainerState `json:"containerStates"`
 }
 

--- a/src/app/backend/resource/pod/podlist.go
+++ b/src/app/backend/resource/pod/podlist.go
@@ -38,6 +38,7 @@ type PodList struct {
 
 type PodStatus struct {
 	// Status of the Pod. See Kubernetes API for reference.
+	Status          string               `json:"status"`
 	PodPhase        api.PodPhase         `json:"podPhase"`
 	PodConditions   []api.PodCondition   `json:"conditions"`
 	ContainerStates []api.ContainerState `json:"containerStates"`
@@ -121,7 +122,7 @@ func CreatePodList(pods []api.Pod, events []api.Event, dsQuery *dataselect.DataS
 	for _, pod := range pods {
 		warnings := event.GetPodsEventWarnings(events, []api.Pod{pod})
 
-		podDetail := ToPod(&pod, metrics)
+		podDetail := ToPod(&pod, metrics, warnings)
 		podDetail.Warnings = warnings
 		podList.Pods = append(podList.Pods, podDetail)
 

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -730,6 +730,7 @@ backendApi.ConditionList;
 /**
  * @typedef {{
  *   podPhase: string,
+ *   status: string,
  *   containerStates: !Array<!backendApi.ContainerState>
  * }}
  */

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -82,7 +82,24 @@ export class PodCardController {
    * @export
    */
   isFailed() {
-    return this.pod.podStatus.podPhase === 'Failed' || this.hasWarnings();
+    if (this.pod.podStatus.podPhase === 'Failed' || this.hasWarnings()) {
+      return true;
+    }
+
+    // Check the pod's readiness state.
+    let ready = false;
+    let initialized = false;
+    for (let i = this.pod.podStatus.conditions.length - 1; i >= 0; i--) {
+      let state = this.pod.podStatus.conditions[i];
+      if (state.type == "Initialized") {
+        initialized = state.status === "True";
+      }
+      if (state.type == "Ready") {
+        ready = state.status === "True";
+      }
+    }
+
+    return initialized && !ready;
   }
 
   /**

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -66,7 +66,7 @@ export class PodCardController {
    */
   isPending() {
     // podPhase should be Pending if init containers are running but we are being extra thorough.
-    return this.pod.podStatus.status === "pending";
+    return this.pod.podStatus.status === 'pending';
   }
 
   /**
@@ -74,7 +74,7 @@ export class PodCardController {
    * @export
    */
   isSuccess() {
-    return this.pod.podStatus.status === "success";
+    return this.pod.podStatus.status === 'success';
   }
 
   /**
@@ -83,7 +83,7 @@ export class PodCardController {
    * @export
    */
   isFailed() {
-    return this.pod.podStatus.status === "failed";
+    return this.pod.podStatus.status === 'failed';
   }
 
   /**

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -66,7 +66,7 @@ export class PodCardController {
    */
   isPending() {
     // podPhase should be Pending if init containers are running but we are being extra thorough.
-    return (this.pod.podStatus.podPhase === 'Pending' || !this.isInitialized()) && !this.isFailed();
+    return this.pod.podStatus.status === "pending"
   }
 
   /**
@@ -74,7 +74,7 @@ export class PodCardController {
    * @export
    */
   isSuccess() {
-    return !this.isPending() && !this.isFailed();
+    return this.pod.podStatus.status === "success"
   }
 
   /**
@@ -83,59 +83,7 @@ export class PodCardController {
    * @export
    */
   isFailed() {
-    if (this.pod.podStatus.podPhase === 'Failed') {
-      return true;
-    }
-
-    if (this.pod.podStatus.podPhase === 'Succeeded') {
-        return false;
-    }
-
-    // This will return true if the pod has events that indicate warnings while in a Pending state.
-    if (this.hasWarnings() && this.pod.podStatus.podPhase !== 'Running') {
-        return true;
-    }
-
-    return this.isInitialized() && !this.isReady();
-  }
-
-  /**
-   * Checks if pod status is ready. i.e. it's running and passess readiness checks.
-   * @return {boolean}
-   * @export
-   */
-  isReady() {
-    let ready = false;
-    // Need to check for existance of conditions because they will be absent on Pending pods.
-    if (this.pod.podStatus.conditions) {
-      for (let i = this.pod.podStatus.conditions.length - 1; i >= 0; i--) {
-        let state = this.pod.podStatus.conditions[i];
-        if (state.type == "Ready") {
-          ready = state.status === "True";
-        }
-      }
-    }
-    return ready;
-  }
-
-  /**
-   * Checks if pod status is initalized. i.e. pod init containers have run. 
-   * @return {boolean}
-   * @export
-   */
-  isInitialized() {
-    // Check the pod's readiness state.
-    let initialized = false;
-    // Need to check for existance of conditions because they will be absent on Pending pods.
-    if (this.pod.podStatus.conditions) {
-      for (let i = this.pod.podStatus.conditions.length - 1; i >= 0; i--) {
-        let state = this.pod.podStatus.conditions[i];
-        if (state.type == "Initialized") {
-          initialized = state.status === "True";
-        }
-      }
-    }
-    return initialized;
+    return this.pod.podStatus.status === "failed"
   }
 
   /**

--- a/src/app/frontend/podlist/podcard_component.js
+++ b/src/app/frontend/podlist/podcard_component.js
@@ -66,7 +66,7 @@ export class PodCardController {
    */
   isPending() {
     // podPhase should be Pending if init containers are running but we are being extra thorough.
-    return this.pod.podStatus.status === "pending"
+    return this.pod.podStatus.status === "pending";
   }
 
   /**
@@ -74,7 +74,7 @@ export class PodCardController {
    * @export
    */
   isSuccess() {
-    return this.pod.podStatus.status === "success"
+    return this.pod.podStatus.status === "success";
   }
 
   /**
@@ -83,7 +83,7 @@ export class PodCardController {
    * @export
    */
   isFailed() {
-    return this.pod.podStatus.status === "failed"
+    return this.pod.podStatus.status === "failed";
   }
 
   /**

--- a/src/test/backend/resource/event/event_test.go
+++ b/src/test/backend/resource/event/event_test.go
@@ -236,7 +236,7 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 }
 
-func TestIsRunningOrSucceeded(t *testing.T) {
+func TestIsReadyOrSucceeded(t *testing.T) {
 	cases := []struct {
 		pod      api.Pod
 		expected bool
@@ -245,6 +245,12 @@ func TestIsRunningOrSucceeded(t *testing.T) {
 			api.Pod{
 				Status: api.PodStatus{
 					Phase: api.PodRunning,
+					Conditions: []api.PodCondition{
+						api.PodCondition{
+							Type:   api.PodReady,
+							Status: api.ConditionTrue,
+						},
+					},
 				},
 			},
 			true,
@@ -273,12 +279,26 @@ func TestIsRunningOrSucceeded(t *testing.T) {
 			},
 			false,
 		},
+		{
+			api.Pod{
+				Status: api.PodStatus{
+					Phase: api.PodRunning,
+					Conditions: []api.PodCondition{
+						api.PodCondition{
+							Type:   api.PodReady,
+							Status: api.ConditionFalse,
+						},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, c := range cases {
-		actual := isRunningOrSucceeded(c.pod)
+		actual := isReadyOrSucceeded(c.pod)
 		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("isRunningOrSucceded(%#v) == \n%#v\nexpected \n%#v\n",
+			t.Errorf("isReadyOrSucceded(%#v) == \n%#v\nexpected \n%#v\n",
 				c.pod, actual, c.expected)
 		}
 	}

--- a/src/test/backend/resource/pod/podcommon_test.go
+++ b/src/test/backend/resource/pod/podcommon_test.go
@@ -41,12 +41,6 @@ func TestToPodPodStatusFailed(t *testing.T) {
 		PodStatus: PodStatus{
 			Status:   "failed",
 			PodPhase: api.PodFailed,
-			PodConditions: []api.PodCondition{
-				api.PodCondition{
-					Type:   api.PodInitialized,
-					Status: api.ConditionTrue,
-				},
-			},
 		},
 	}
 
@@ -79,16 +73,6 @@ func TestToPodPodStatusSuccess(t *testing.T) {
 		PodStatus: PodStatus{
 			Status:   "success",
 			PodPhase: api.PodRunning,
-			PodConditions: []api.PodCondition{
-				api.PodCondition{
-					Type:   api.PodInitialized,
-					Status: api.ConditionTrue,
-				},
-				api.PodCondition{
-					Type:   api.PodReady,
-					Status: api.ConditionTrue,
-				},
-			},
 		},
 	}
 
@@ -117,12 +101,6 @@ func TestToPodPodStatusPending(t *testing.T) {
 		PodStatus: PodStatus{
 			Status:   "pending",
 			PodPhase: api.PodPending,
-			PodConditions: []api.PodCondition{
-				api.PodCondition{
-					Type:   api.PodInitialized,
-					Status: api.ConditionFalse,
-				},
-			},
 		},
 	}
 

--- a/src/test/backend/resource/pod/podcommon_test.go
+++ b/src/test/backend/resource/pod/podcommon_test.go
@@ -23,6 +23,116 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 )
 
+func TestToPodPodStatusFailed(t *testing.T) {
+	pod := &api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodFailed,
+			Conditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	expected := Pod{
+		TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
+		PodStatus: PodStatus{
+			Status:   "failed",
+			PodPhase: api.PodFailed,
+			PodConditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	actual := ToPod(pod, &common.MetricsByPod{}, []common.Event{})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("ToPod(%#v) == \ngot %#v, \nexpected %#v", pod, actual, expected)
+	}
+}
+
+func TestToPodPodStatusSuccess(t *testing.T) {
+	pod := &api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			Conditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionTrue,
+				},
+				api.PodCondition{
+					Type:   api.PodReady,
+					Status: api.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	expected := Pod{
+		TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
+		PodStatus: PodStatus{
+			Status:   "success",
+			PodPhase: api.PodRunning,
+			PodConditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionTrue,
+				},
+				api.PodCondition{
+					Type:   api.PodReady,
+					Status: api.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	actual := ToPod(pod, &common.MetricsByPod{}, []common.Event{})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("ToPod(%#v) == \ngot %#v, \nexpected %#v", pod, actual, expected)
+	}
+}
+
+func TestToPodPodStatusPending(t *testing.T) {
+	pod := &api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodPending,
+			Conditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	expected := Pod{
+		TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
+		PodStatus: PodStatus{
+			Status:   "pending",
+			PodPhase: api.PodPending,
+			PodConditions: []api.PodCondition{
+				api.PodCondition{
+					Type:   api.PodInitialized,
+					Status: api.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	actual := ToPod(pod, &common.MetricsByPod{}, []common.Event{})
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("ToPod(%#v) == \ngot %#v, \nexpected %#v", pod, actual, expected)
+	}
+}
+
 // TestToPodContainerStates tests that ToPod returns the correct container states
 func TestToPodContainerStates(t *testing.T) {
 	pod := &api.Pod{
@@ -51,6 +161,7 @@ func TestToPodContainerStates(t *testing.T) {
 		TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
 		PodStatus: PodStatus{
 			PodPhase: api.PodRunning,
+			Status:   "pending",
 			ContainerStates: []api.ContainerState{
 				api.ContainerState{
 					Terminated: &api.ContainerStateTerminated{
@@ -66,7 +177,7 @@ func TestToPodContainerStates(t *testing.T) {
 		},
 	}
 
-	actual := ToPod(pod, &common.MetricsByPod{})
+	actual := ToPod(pod, &common.MetricsByPod{}, []common.Event{})
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("ToPod(%#v) == \ngot %#v, \nexpected %#v", pod, actual, expected)
@@ -80,8 +191,12 @@ func TestGetPodDetail(t *testing.T) {
 		expected Pod
 	}{
 		{
-			pod: &api.Pod{}, metrics: &common.MetricsByPod{}, expected: Pod{
+			pod: &api.Pod{}, metrics: &common.MetricsByPod{},
+			expected: Pod{
 				TypeMeta: common.TypeMeta{Kind: common.ResourceKindPod},
+				PodStatus: PodStatus{
+					Status: "pending",
+				},
 			},
 		}, {
 			pod: &api.Pod{
@@ -95,12 +210,15 @@ func TestGetPodDetail(t *testing.T) {
 					Name:      "test-pod",
 					Namespace: "test-namespace",
 				},
+				PodStatus: PodStatus{
+					Status: "pending",
+				},
 			},
 		},
 	}
 
 	for _, c := range cases {
-		actual := ToPod(c.pod, c.metrics)
+		actual := ToPod(c.pod, c.metrics, []common.Event{})
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("ToPod(%#v) == \ngot %#v, \nexpected %#v", c.pod, actual,

--- a/src/test/frontend/podlist/podcard_component_test.js
+++ b/src/test/frontend/podlist/podcard_component_test.js
@@ -148,38 +148,33 @@ describe('Pod card controller', () => {
     expect(ctrl.getDisplayStatus()).toBe('Terminated: Test Terminated Reason');
   });
 
-  it('should check pod status correctly (succeeded is successful)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Succeeded'}, warnings: []};
-    expect(ctrl.isSuccess()).toBeTruthy();
-  });
-
-  it('should check pod status correctly (running is successful)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Running'}, warnings: []};
+  it('should check pod status correctly (success is successful)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {status: 'success'}, warnings: []};
     expect(ctrl.isSuccess()).toBeTruthy();
   });
 
   it('should check pod status correctly (failed isn\'t successful)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    ctrl.pod = {name: 'test-pod', podStatus: {status: 'failed'}, warnings: []};
     expect(ctrl.isSuccess()).toBeFalsy();
   });
 
   it('should check pod status correctly (pending is pending)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Pending'}, warnings: []};
+    ctrl.pod = {name: 'test-pod', podStatus: {status: 'pending'}, warnings: []};
     expect(ctrl.isPending()).toBeTruthy();
   });
 
   it('should check pod status correctly (failed isn\'t pending)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    ctrl.pod = {name: 'test-pod', podStatus: {status: 'failed'}, warnings: []};
     expect(ctrl.isPending()).toBeFalsy();
   });
 
   it('should check pod status correctly (failed is failed)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Failed'}, warnings: []};
+    ctrl.pod = {name: 'test-pod', podStatus: {status: 'failed'}, warnings: []};
     expect(ctrl.isFailed()).toBeTruthy();
   });
 
-  it('should check pod status correctly (running isn\'t failed)', () => {
-    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'Running'}, warnings: []};
+  it('should check pod status correctly (success isn\'t failed)', () => {
+    ctrl.pod = {name: 'test-pod', podStatus: {podPhase: 'success'}, warnings: []};
     expect(ctrl.isFailed()).toBeFalsy();
   });
 


### PR DESCRIPTION
Shows an error icon in pod lists when the pod's readiness is false. This has the benefit of not relying on events. It should also show an error icon when the pod is failing readiness probes.

I'll clean this up and add tests if the concept looks ok. It's meant as a solution for #1349 