### PR TITLE
Add deployment files for ARM platform

### DIFF
--- a/src/deploy/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/kubernetes-dashboard-arm-head.yaml
@@ -1,0 +1,69 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration to deploy head version of the Dashboard UI.
+#
+# Example usage: kubectl create -f <this_file>
+
+kind: List
+apiVersion: v1
+items:
+- kind: ReplicationController
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-head
+    name: kubernetes-dashboard-head
+    namespace: kube-system
+  spec:
+    replicas: 1
+    selector:
+      app: kubernetes-dashboard-head
+    template:
+      metadata:
+        labels:
+          app: kubernetes-dashboard-head
+      spec:
+        containers:
+        - name: kubernetes-dashboard-head
+          image: kubernetesdashboarddev/kubernetes-dashboard-arm:head
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 9090
+            protocol: TCP
+          args:
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+- kind: Service
+  apiVersion: v1
+  metadata:
+    labels:
+      app: kubernetes-dashboard-head
+    name: dashboard-head
+    namespace: kube-system
+  spec:
+    type: NodePort
+    ports:
+    - port: 80
+      targetPort: 9090
+    selector:
+      app: kubernetes-dashboard-head

--- a/src/deploy/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/kubernetes-dashboard-arm.yaml
@@ -1,0 +1,79 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration to deploy release version of the Dashboard UI.
+#
+# Example usage: kubectl create -f <this_file>
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        app: kubernetes-dashboard
+      # Comment the following annotation if Dashboard must not be deployed on master
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated",
+              "operator": "Equal",
+              "value": "master",
+              "effect": "NoSchedule"
+            }
+          ]
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: gcr.io/google_containers/kubernetes-dashboard-arm:v1.5.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        args:
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 9090
+  selector:
+    app: kubernetes-dashboard


### PR DESCRIPTION
Just followed the [dashboard installation tutorial](http://kubernetes.io/docs/user-guide/ui/) to install dashboard and get the deployment went to crash loopback. 

After a while I realised that current deployment files are targeting to linux_x64 and ARM images are already available at [Google Container Registry](http://gcr.io/google_containers/kubernetes-dashboard-arm), so I decided to create two deployment files for ARM platform.

If the PR is accepted, I will also update the documentation to reflect this change.