### PR TITLE
there should be not related pods for service without selector

### DIFF
--- a/src/app/backend/resource/service/servicedetail.go
+++ b/src/app/backend/resource/service/servicedetail.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
@@ -85,6 +86,14 @@ func GetServicePods(client k8sClient.Interface, heapsterClient client.HeapsterCl
 	service, err := client.Core().Services(namespace).Get(name)
 	if err != nil {
 		return nil, err
+	}
+
+	if service.Spec.Selector == nil {
+		emptyPodList := &pod.PodList {
+			Pods: []pod.Pod{},
+			CumulativeMetrics: []metric.Metric{},
+		}
+		return emptyPodList, nil
 	}
 
 	labelSelector := labels.SelectorFromSet(service.Spec.Selector)

--- a/src/test/backend/resource/service/servicedetail_test.go
+++ b/src/test/backend/resource/service/servicedetail_test.go
@@ -54,7 +54,7 @@ func TestGetServiceDetail(t *testing.T) {
 				Name: "svc-1", Namespace: "ns-1", Labels: map[string]string{},
 			}},
 			namespace: "ns-1", name: "svc-1",
-			expectedActions: []string{"get", "get", "list"},
+			expectedActions: []string{"get", "get"},
 			expected: &ServiceDetail{
 				ObjectMeta: common.ObjectMeta{
 					Name:      "svc-1",
@@ -63,6 +63,32 @@ func TestGetServiceDetail(t *testing.T) {
 				},
 				TypeMeta:         common.TypeMeta{Kind: common.ResourceKindService},
 				InternalEndpoint: common.Endpoint{Host: "svc-1.ns-1"},
+				PodList: pod.PodList{
+					Pods:              []pod.Pod{},
+					CumulativeMetrics: make([]metric.Metric, 0),
+				},
+			},
+		},
+		{
+			service: &api.Service{
+					ObjectMeta: api.ObjectMeta{
+							Name: "svc-2",
+							Namespace: "ns-2",
+					},
+					Spec: api.ServiceSpec{
+						Selector: map[string]string{"app": "app2"},
+					},
+			},
+			namespace: "ns-2", name: "svc-2",
+			expectedActions: []string{"get", "get", "list"},
+			expected: &ServiceDetail{
+				ObjectMeta: common.ObjectMeta{
+					Name:      "svc-2",
+					Namespace: "ns-2",
+				},
+				Selector: map[string]string{"app": "app2"},
+				TypeMeta:         common.TypeMeta{Kind: common.ResourceKindService},
+				InternalEndpoint: common.Endpoint{Host: "svc-2.ns-2"},
 				PodList: pod.PodList{
 					Pods:              []pod.Pod{},
 					CumulativeMetrics: make([]metric.Metric, 0),


### PR DESCRIPTION
for a service without selector, there should be not any pod.
and but in current logic, get pods by labels.SelectorFromSet(nil), all pods are selected.