### PR TITLE
Updated CLA to be CNCF instead of Google

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,12 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+Want to contribute? Great! First, read this page.
 
 ### Before you contribute
 Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement]
-(https://cla.developers.google.com/about/google-individual)
-(CLA), which you can do online. The CLA is necessary mainly because you own the
+[Cloud Native Computing Foundation Contributor License Agreement](https://github.com/kubernetes/community/blob/master/CLA.md)
+(CLA). The CLA is necessary mainly because you own the
 copyright to your changes, even after your contribution becomes part of our
 codebase, so we need your permission to use and distribute your code. We also
-need to be sure of various other things—for instance that you'll tell us if you
+need to be sure of various other things—for instance, that you'll tell us if you
 know that your code infringes on other people's patents. You don't have to sign
 the CLA until after you've submitted your code for review and a member has
 approved it, but you must do it before we can put your code into our codebase.
@@ -18,11 +17,5 @@ frustration later on.
 
 ### Code reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
-
-### The small print
-Contributions made by corporations are covered by a different agreement than
-the one above, the
-[Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+use [pull requests](https://help.github.com/articles/about-pull-requests/) for this purpose.
 


### PR DESCRIPTION
This is as per @bryk's suggestion in my Dashboard design doc. In reviewing the [main K8s repo CLA guidelines](https://github.com/kubernetes/community/blob/master/CLA.md), they didn't have the "small print" section mentioning corporations, so I took that to mean that was no longer applicable?