### PR TITLE
added about page

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -217,6 +217,7 @@ function patchBuildInformation() {
                   patterns: [
                     {match: 'BUILD_GIT_COMMIT', replacement: commit},
                     {match: 'BUILD_DASHBOARD_VERSION', replacement: conf.deploy.version.release},
+                    {match: 'BUILD_YEAR', replacement: new Date().getFullYear()},
                   ],
                 }));
 }

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE translationbundle><translationbundle lang="en">
+  <translation id="961242340990264399" key="MSG_ABOUT_ABOUT_0" desc="This is a label for button displayed on about page used to open documentaion in browser">Documentation</translation>
+  <translation id="3846688850575044887" key="MSG_ABOUT_ABOUT_0" desc="Header in a about view">About</translation>
+  <translation id="5154196819042094229" key="MSG_ABOUT_ABOUT_0" desc="Title text which appears on zero state view.">There is nothing to display here</translation>
+  <translation id="5634646746226609179" key="MSG_ABOUT_ABOUT_1" desc="Label \'Dashboard Version\' for the about page.">Dashboard Version</translation>
+  <translation id="4718120324314749596" key="MSG_ABOUT_ABOUT_2" desc="Label \'Git Commit\' for the about page.">Git Commit</translation>
+  <translation id="5788105450172886273" key="MSG_ABOUT_ABOUT_3" desc="This is a label for button displayed on about page used to send feedback to GitHub new issue.">Send feedback</translation>
+  <translation id="4249662097435421699" key="MSG_ABOUT_ABOUT_4" desc="This is the copyright statement displayed on the about page">Copyright 2015-{{ $ctrl.latestCopyrightYear}} The Kubernetes Authors.</translation>
+  <translation id="4171916442768740608" key="MSG_ABOUT_ABOUT_5" desc="This is the creator reference on the footer of the about page"> Kubernetes Dashboard is made possible by the Dashboard &lt;a href="https://github.com/kubernetes/dashboard/graphs/contributors"&gt;community&lt;/a&gt; as an &lt;a href="https://github.com/kubernetes/dashboard"&gt;open source project&lt;/a&gt;. </translation>
+  <translation id="4426231252111230009" key="MSG_ABOUT_ABOUT_6" desc="Dashbord moto on the about page, just below the header">General-Purpose Web UI for Kubernetes Clusters</translation>
   <translation id="6783150167357318030" key="MSG_ACTION_BAR_DELETE_TOOLTIP" desc="Generic &quot;Delete some resource&quot; tooltip text which appears over the delete icon on the global action bar.">Delete <ph name="RESOURCE_NAME"/></translation>
   <translation id="1421031463694814701" key="MSG_ACTION_BAR_EDIT_TOOLTIP" desc="Generic &quot;Edit some resource&quot; tooltip text which appears over the edit icon on the global action bar.">Edit <ph name="RESOURCE_NAME"/></translation>
   <translation id="1024358167652076581" key="MSG_ALL_NAMESPACES" desc="Text for dropdown item that indicates that no namespace was selected">All namespaces</translation>
+  <translation id="6614117428496734699" key="MSG_BREADCRUMBS_ABOUT_LABEL" desc="Label 'About' that appears as a breadcrumbs on the action bar.">About</translation>
   <translation id="837746496620402371" key="MSG_BREADCRUMBS_ACCESS_CONTROL_LABEL" desc="Label 'Access Control' that appears as a breadcrumbs on the action bar.">Access Control</translation>
   <translation id="4466763630197200161" key="MSG_BREADCRUMBS_ADMIN_LABEL" desc="Label 'Admin' that appears as a breadcrumbs on the action bar.">Admin</translation>
   <translation id="954605561178153927" key="MSG_BREADCRUMBS_CONFIG_LABEL" desc="Label 'Config' that appears as a breadcrumbs on the action bar.">Config</translation>
@@ -46,7 +56,8 @@
   <translation id="8736839163304985332" key="MSG_CHROME_NAV_NAV_19" desc="Config Maps item in the nav.">Config Maps</translation>
   <translation id="1743316598408730775" key="MSG_CHROME_NAV_NAV_2" desc="Nodes menu item in the nav.">Nodes</translation>
   <translation id="3009175856839976873" key="MSG_CHROME_NAV_NAV_20" desc="Storage Classes menu item in the nav.">Storage Classes</translation>
-  <translation id="2880965389211634878" key="MSG_CHROME_NAV_NAV_21" desc="Access Control menu item in the nav.">Access Control</translation>
+  <translation id="3473506392835594145" key="MSG_CHROME_NAV_NAV_21" desc="Access Control menu item in the nav.">Access control</translation>
+  <translation id="7929882062201514695" key="MSG_CHROME_NAV_NAV_22" desc="About menu item in the nav.">About</translation>
   <translation id="4957526140740745953" key="MSG_CHROME_NAV_NAV_3" desc="Persistent Volumes menu item in the nav.">Persistent Volumes</translation>
   <translation id="4398523516847444868" key="MSG_CHROME_NAV_NAV_4" desc="Workloads menu item in the nav.">Workloads</translation>
   <translation id="6003139668988832289" key="MSG_CHROME_NAV_NAV_5" desc="Deployments menu item in the nav.">Deployments</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE translationbundle><translationbundle lang="ja">
+  <translation id="961242340990264399" key="MSG_ABOUT_ABOUT_0" desc="This is a label for button displayed on about page used to open documentaion in browser">Documentation</translation>
+  <translation id="3846688850575044887" key="MSG_ABOUT_ABOUT_0" desc="Header in a about view">About</translation>
+  <translation id="5154196819042094229" key="MSG_ABOUT_ABOUT_0" desc="Title text which appears on zero state view.">There is nothing to display here</translation>
+  <translation id="5634646746226609179" key="MSG_ABOUT_ABOUT_1" desc="Label \'Dashboard Version\' for the about page.">Dashboard Version</translation>
+  <translation id="4718120324314749596" key="MSG_ABOUT_ABOUT_2" desc="Label \'Git Commit\' for the about page.">Git Commit</translation>
+  <translation id="5788105450172886273" key="MSG_ABOUT_ABOUT_3" desc="This is a label for button displayed on about page used to send feedback to GitHub new issue.">Send feedback</translation>
+  <translation id="4249662097435421699" key="MSG_ABOUT_ABOUT_4" desc="This is the copyright statement displayed on the about page">Copyright 2015-{{ $ctrl.latestCopyrightYear}} The Kubernetes Authors.</translation>
+  <translation id="4171916442768740608" key="MSG_ABOUT_ABOUT_5" desc="This is the creator reference on the footer of the about page"> Kubernetes Dashboard is made possible by the Dashboard &lt;a href="https://github.com/kubernetes/dashboard/graphs/contributors"&gt;community&lt;/a&gt; as an &lt;a href="https://github.com/kubernetes/dashboard"&gt;open source project&lt;/a&gt;. </translation>
+  <translation id="4426231252111230009" key="MSG_ABOUT_ABOUT_6" desc="Dashbord moto on the about page, just below the header">General-Purpose Web UI for Kubernetes Clusters</translation>
   <translation id="3195481899172694103" key="MSG_ACTION_BAR_CREATE_ACTION" desc="Label for global action bar create button.">作成</translation>
   <translation id="6165413233411120289" key="MSG_ACTION_BAR_CREATE_ACTION_TOOLTIP" desc="Label for global action bar create button tooltip.">アプリケーションまたはKubernetesリソースを作成</translation>
   <translation id="1364836516629464964" key="MSG_ACTION_BAR_DELETE_ACTION" desc="Action 'Delete', which is a button on the actionbar and is there for every resource type.">削除</translation>
@@ -14,6 +23,7 @@
   <translation id="6870889542203892242" key="MSG_ADMIN_PERSISTENT_VOLUMES_LABEL" desc="Label that appears above the list of resources.">永続ボリューム</translation>
   <translation id="7747923130541982538" key="MSG_ADMIN_RESOURCE_QUOTAS_LABEL" desc="Label that appears above the list of resources.">リソースクォータ</translation>
   <translation id="1024358167652076581" key="MSG_ALL_NAMESPACES" desc="Text for dropdown item that indicates that no namespace was selected">すべてのネームスペース</translation>
+  <translation id="6614117428496734699" key="MSG_BREADCRUMBS_ABOUT_LABEL" desc="Label 'About' that appears as a breadcrumbs on the action bar.">About</translation>
   <translation id="837746496620402371" key="MSG_BREADCRUMBS_ACCESS_CONTROL_LABEL" desc="Label 'Access Control' that appears as a breadcrumbs on the action bar.">Access Control</translation>
   <translation id="4466763630197200161" key="MSG_BREADCRUMBS_ADMIN_LABEL" desc="Label 'Admin' that appears as a breadcrumbs on the action bar.">管理者</translation>
   <translation id="954605561178153927" key="MSG_BREADCRUMBS_CONFIG_LABEL" desc="Label 'Config' that appears as a breadcrumbs on the action bar.">コンフィグ</translation>
@@ -58,7 +68,8 @@
   <translation id="8736839163304985332" key="MSG_CHROME_NAV_NAV_19" desc="Config Maps item in the nav.">コンフィグマップ</translation>
   <translation id="1743316598408730775" key="MSG_CHROME_NAV_NAV_2" desc="Nodes menu item in the nav.">ノード</translation>
   <translation id="3009175856839976873" key="MSG_CHROME_NAV_NAV_20" desc="Storage Classes menu item in the nav.">ストレージクラス</translation>
-  <translation id="2880965389211634878" key="MSG_CHROME_NAV_NAV_21" desc="Access Control menu item in the nav.">Access Control</translation>
+  <translation id="3473506392835594145" key="MSG_CHROME_NAV_NAV_21" desc="Access Control menu item in the nav.">Access control</translation>
+  <translation id="7929882062201514695" key="MSG_CHROME_NAV_NAV_22" desc="About menu item in the nav.">About</translation>
   <translation id="4957526140740745953" key="MSG_CHROME_NAV_NAV_3" desc="Persistent Volumes menu item in the nav.">永続ボリューム</translation>
   <translation id="4398523516847444868" key="MSG_CHROME_NAV_NAV_4" desc="Workloads menu item in the nav.">ワークロード</translation>
   <translation id="6003139668988832289" key="MSG_CHROME_NAV_NAV_5" desc="Deployments menu item in the nav.">デプロイメント</translation>

--- a/src/app/frontend/_variables.scss
+++ b/src/app/frontend/_variables.scss
@@ -29,6 +29,7 @@ $body-font-size-base:      rem(1.4) !default;
 $caption-font-size-base:   rem(1.2) !default;
 $toolbar-height-size-base: rem(6.4) !default;
 $toolbar-height-size-base-sm: rem(4.8) !default;
+$footer-font-size-base:   rem(1) !default;
 $font-family-monospace: 'Roboto Mono Regular', monospace;
 $font-family-medium-monospace: 'Roboto Mono Medium', monospace;
 $font-family-medium: 'Roboto-Medium';

--- a/src/app/frontend/about/about.html
+++ b/src/app/frontend/about/about.html
@@ -1,0 +1,57 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-info-card>
+  <kd-info-card-section>
+    <div layout="row">
+      <img src="assets/images/kubernetes-logo.svg" class="kd-about-kubernetes-logo" >
+    </img>
+      <div layout="column" layout-align="start start">
+        <div class="md-headline">Dashboard</div>
+        <div class="md-subhead">[[General-Purpose Web UI for Kubernetes Clusters|
+          Dashbord moto on the about page, just below the header]]</div>
+    </div>
+    </div>
+    <a href="https://kubernetes.io/docs/user-guide/ui/">
+      <md-button class="kd-about-button">
+        [[Documentation|This is a label for button displayed on about page used to
+        open documentaion in browser]]
+      </md-button>
+    </a>
+    <a ng-href="{{$ctrl.getLinkToFeedbackPage()}}">
+      <md-button class="kd-about-button">
+        [[Send feedback|This is a label for button displayed on about page used to send feedback
+        to GitHub new issue.]]
+      </md-button>
+    </a>
+    <kd-info-card-entry title="[[Dashboard Version|Label 'Dashboard Version' for the about page.]]"
+                        ng-if="::$ctrl.dashboardVersion">
+      {{$ctrl.dashboardVersion}}
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Git Commit|Label 'Git Commit' for the about page.]]"
+                        ng-if="::$ctrl.gitCommit">
+      {{$ctrl.gitCommit}}
+    </kd-info-card-entry>
+    <div class="kd-footer kd-copyright-title">[[Copyright 2015-{{$ctrl.latestCopyrightYear}}
+      The Kubernetes Authors.| This is the copyright statement displayed on the about page]]</div>
+    <div class="kd-footer">
+      [[ Kubernetes Dashboard is made possible by the Dashboard
+      <a href="https://github.com/kubernetes/dashboard/graphs/contributors">community</a>
+      as an <a href="https://github.com/kubernetes/dashboard">open source project</a>. |
+      This is the creator reference on the footer of the about page]]
+  </div>
+  </kd-info-card-section>
+</kd-info-card>

--- a/src/app/frontend/about/about.scss
+++ b/src/app/frontend/about/about.scss
@@ -1,0 +1,34 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../variables';
+
+
+.kd-about-kubernetes-logo {
+  height: $logo-height;
+  padding-right: $baseline-grid * 2;
+}
+
+.kd-about-button {
+  margin: ($baseline-grid * 2) 0;
+}
+
+.kd-copyright-title {
+  padding-top: $baseline-grid * 8;
+}
+
+.kd-footer {
+  color: $foreground-2;
+  font-size: $footer-font-size-base;
+}

--- a/src/app/frontend/about/about_controller.js
+++ b/src/app/frontend/about/about_controller.js
@@ -1,0 +1,55 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Controller for the about view. The view shows details about the installation
+ * enviornment. The information can be used when creating issues.
+ *
+ * @final
+ */
+export class AboutController {
+  /**
+   *   @param {!../common/appconfig/appconfig_service.AppConfigService} kdAppConfigService
+   * @ngInject
+   */
+  constructor(kdAppConfigService) {
+    /** @export {string} */
+    this.dashboardVersion = kdAppConfigService.getDashboardVersion();
+
+    /** @export {string} */
+    this.gitCommit = kdAppConfigService.getGitCommit();
+
+    /** @export {string} */
+    this.latestCopyrightYear = kdAppConfigService.getBuildYear();
+  }
+
+  /**
+   * Returns URL of GitHub page used to report bugs with partly filled issue template
+   * (check .github/ISSUE_TEMPLATE.md file). IMPORTANT: Remember to keep these templates in sync.
+   *
+   * @export
+   * @return {string} URL of GitHub page used to report bugs.
+   */
+  getLinkToFeedbackPage() {
+    let title = ``;
+    let body = `##### Steps to reproduce\n<!-- Describe all steps needed to reproduce the ` +
+        `issue. It is a good place to use numbered list. -->\n\n\n##### Environment\n\`\`\`\n` +
+        `Installation method: \nKubernetes version:\nDashboard version: ` +
+        `${this.dashboardVersion}\nCommit: ${this.gitCommit}\n\`\`\`\n\n##### Observed result\n` +
+        `<!-- Describe observed result as precisely as possible. -->\n\n\n` +
+        `##### Comments\n<!-- If you have any comments or more details, put them here. -->`;
+    return `https://github.com/kubernetes/dashboard/issues/new?title=${encodeURIComponent(title)}` +
+        `&body=${encodeURIComponent(body)}`;
+  }
+}

--- a/src/app/frontend/about/about_module.js
+++ b/src/app/frontend/about/about_module.js
@@ -1,0 +1,30 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import stateConfig from './about_stateconfig';
+
+/**
+ * Angular module for the about view.
+ *
+ * The view shows details about the installation enviornment. The information
+ * can be used when creating issues.
+ */
+export default angular
+    .module(
+        'kubernetesDashboard.about',
+        [
+          'ngMaterial',
+          'ui.router',
+        ])
+    .config(stateConfig);

--- a/src/app/frontend/about/about_state.js
+++ b/src/app/frontend/about/about_state.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'about';
+
+/** Absolute URL of the state. */
+export const stateUrl = '/about';

--- a/src/app/frontend/about/about_stateconfig.js
+++ b/src/app/frontend/about/about_stateconfig.js
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import {stateName as chromeStateName} from 'chrome/chrome_state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/breadcrumbs_service';
+
+import {AboutController} from './about_controller';
+import {stateName, stateUrl} from './about_state';
+
+/**
+ * Configures states for the about view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state(stateName, {
+    url: stateUrl,
+    parent: chromeStateName,
+    views: {
+      '': {
+        controller: AboutController,
+        controllerAs: '$ctrl',
+        templateUrl: 'about/about.html',
+      },
+    },
+    data: {
+      [breadcrumbsConfig]: {
+        'label': i18n.MSG_BREADCRUMBS_ABOUT_LABEL,
+      },
+    },
+  });
+}
+
+const i18n = {
+  /** @type {string} @desc Label 'About' that appears as a breadcrumbs on the action bar. */
+  MSG_BREADCRUMBS_ABOUT_LABEL: goog.getMsg('About'),
+};

--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -83,4 +83,7 @@ limitations under the License.
   </div>
   <!-- Enabled dynamically if there are third party resources registered in the system -->
   <kd-third-party-resource-nav states="$ctrl.states"></kd-third-party-resource-nav>
+  <div class="kd-nav-group">
+    <kd-nav-item class="kd-nav-group-item kd-about" state="{{::$ctrl.states.about}}">[[About|About menu item in the nav.]]</kd-nav-item>
+  </div>
 </md-sidenav>

--- a/src/app/frontend/chrome/nav/nav.scss
+++ b/src/app/frontend/chrome/nav/nav.scss
@@ -37,7 +37,7 @@
     }
   }
 
-  // Children of kd-nav should not shrink to prevent layout issues on IE. 
+  // Children of kd-nav should not shrink to prevent layout issues on IE.
   &>* {
     flex-shrink: 0;
   }
@@ -65,4 +65,8 @@ kd-nav,
   margin-bottom: 2 * $baseline-grid;
   margin-right: 1 * $baseline-grid;
   margin-top: $baseline-grid;
+}
+
+.kd-about {
+  color: $foreground-3;
 }

--- a/src/app/frontend/chrome/nav/nav_component.js
+++ b/src/app/frontend/chrome/nav/nav_component.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stateName as aboutState} from 'about/about_state';
 import {stateName as accessControlState} from 'accesscontrol/state';
 import {stateName as adminState} from 'admin/state';
 import {stateName as configState} from 'config/state';
@@ -74,6 +75,7 @@ export class NavController {
       'config': configState,
       'storageClass': storageClassState,
       'accessControl': accessControlState,
+      'about': aboutState,
     };
   }
 

--- a/src/app/frontend/common/appconfig/appconfig_service.js
+++ b/src/app/frontend/common/appconfig/appconfig_service.js
@@ -62,4 +62,14 @@ export class AppConfigService {
   getGitCommit() {
     return '@@BUILD_GIT_COMMIT';
   }
+
+  /**
+   * The year of the build. It used in the copyright statement.
+   * The token is replaced by the build process
+   * @export
+   * @return {string}
+   */
+  getBuildYear() {
+    return '@@BUILD_YEAR';
+  }
 }

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -16,6 +16,7 @@
  * @fileoverview Entry point module to the application. Loads and configures other modules needed
  * to bootstrap the application.
  */
+import aboutModule from './about/about_module';
 import accessControlModule from './accesscontrol/module';
 import adminModule from './admin/module';
 import chromeModule from './chrome/chrome_module';
@@ -70,6 +71,7 @@ export default angular
           'ngResource',
           'ngSanitize',
           'ui.router',
+          aboutModule.name,
           chromeModule.name,
           deployModule.name,
           errorModule.name,

--- a/src/test/frontend/about/about_controller_test.js
+++ b/src/test/frontend/about/about_controller_test.js
@@ -1,0 +1,42 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AboutController} from 'about/about_controller';
+import module from 'about/about_module';
+import appconfig_module from 'common/appconfig/appconfig_module';
+
+describe('About controller', () => {
+  /** @type {!about/about_controller.AboutController} */
+  let ctrl;
+
+  beforeEach(() => {
+    angular.mock.module(module.name);
+    angular.mock.module(appconfig_module.name);
+    angular.mock.inject(($controller, kdAppConfigService) => {
+      ctrl = $controller(AboutController, {
+        'kdAppConfigService': kdAppConfigService,
+      });
+    });
+  });
+
+  it('should create github link with all environment information', () => {
+    ctrl.dashboardVersion = 'v10.0';
+    ctrl.gitCommit = '23dd7085953f7aeef15b13dba90fb21b88d772aa';
+    let url = ctrl.getLinkToFeedbackPage();
+    expect(url.indexOf('https://github.com') === 0).toBeTruthy();
+    expect(url.indexOf('v10.0') > 0).toBeTruthy();
+    expect(url.indexOf('23dd7085953f7aeef15b13dba90fb21b88d772aa') > 0).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
First version of about page. 

Currently the page shows only Dashboard release version in case of release and Dashboard release version + Git commit in case of head

I have added this information also to the error dialog in a previous PR

TODO:
- find a place to link to this page (or leave it hidden?)
- add Kubernetes version
- think about other information that should be added .e.g. license 