### PR TITLE
Add basic html/go formatting and common gulp format script

### DIFF
--- a/build/check.js
+++ b/build/check.js
@@ -130,7 +130,7 @@ gulp.task('format-go', function(doneFn) {
         '-w',
         path.relative(conf.paths.base, conf.paths.backendSrc),
       ],
-      doneFn)
+      doneFn);
 });
 
 /**
@@ -143,6 +143,9 @@ gulp.task('format-go', function(doneFn) {
  *     .pipe(gulp.dest(out))
  *
  * All config options can be found on: https://github.com/beautify-web/js-beautify#css--html
+ *
+ * @param {Object} config
+ * @return {Function}
  */
 function formatHtml(config) {
   function format(file, encoding, callback) {
@@ -158,5 +161,5 @@ function formatHtml(config) {
     return callback(null, file);
   }
 
-  return through.obj(format)
+  return through.obj(format);
 }

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -200,7 +200,9 @@ function spawnProcess(processName, args, envOverride) {
  * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
  * @return {Q.Promise} A promise object.
  */
-function spawnGoProcess(args, envOverride){return spawnProcess('go', args, envOverride)}
+function spawnGoProcess(args, envOverride) {
+  return spawnProcess('go', args, envOverride);
+}
 
 /**
  * Spawns gofmt process.
@@ -211,6 +213,5 @@ function spawnGoProcess(args, envOverride){return spawnProcess('go', args, envOv
  * @return {Q.Promise} A promise object.
  */
 function spawnGofmtProcess(args, envOverride) {
-  return spawnProcess('gofmt', args, envOverride)
-
+  return spawnProcess('gofmt', args, envOverride);
 }

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -47,9 +47,23 @@ const minGoVersion = '1.6.1';
  * @param {function(?Error=)} doneFn - Callback.
  * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
  */
-export default function spawnGoProcess(args, doneFn, envOverride) {
+export default function goCommand(args, doneFn, envOverride) {
   checkPrerequisites()
-      .then(() => spawnProcess(args, envOverride))
+      .then(() => spawnGoProcess(args, envOverride))
+      .then(doneFn)
+      .fail((error) => doneFn(error));
+}
+
+/**
+ * Spawns a Gofmt process after making sure all Go prerequisites are present.
+ *
+ * @param {!Array<string>} args - Arguments of the go command.
+ * @param {function(?Error=)} doneFn - Callback.
+ * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
+ */
+export function gofmtCommand(args, doneFn, envOverride) {
+  checkPrerequisites()
+      .then(() => spawnGofmtProcess(args, envOverride))
       .then(doneFn)
       .fail((error) => doneFn(error));
 }
@@ -151,17 +165,18 @@ function checkGovendor() {
 }
 
 /**
- * Spawns Go process.
+ * Spawns a process.
  * Promises an error if the go command process fails.
  *
+ * @param {string} processName - Process name to spawn.
  * @param {!Array<string>} args - Arguments of the go command.
  * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
  * @return {Q.Promise} A promise object.
  */
-function spawnProcess(args, envOverride) {
+function spawnProcess(processName, args, envOverride) {
   let deferred = q.defer();
   let envLocal = lodash.merge(env, envOverride);
-  let goTask = child.spawn('go', args, {
+  let goTask = child.spawn(processName, args, {
     env: envLocal,
     stdio: 'inherit',
   });
@@ -175,4 +190,27 @@ function spawnProcess(args, envOverride) {
     deferred.resolve();
   });
   return deferred.promise;
+}
+
+/**
+ * Spawns go process.
+ * Promises an error if the go command process fails.
+ *
+ * @param {!Array<string>} args - Arguments of the go command.
+ * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
+ * @return {Q.Promise} A promise object.
+ */
+function spawnGoProcess(args, envOverride){return spawnProcess('go', args, envOverride)}
+
+/**
+ * Spawns gofmt process.
+ * Promises an error if the go command process fails.
+ *
+ * @param {!Array<string>} args - Arguments of the go command.
+ * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
+ * @return {Q.Promise} A promise object.
+ */
+function spawnGofmtProcess(args, envOverride) {
+  return spawnProcess('gofmt', args, envOverride)
+
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp-xslt": "~2.0.0",
     "html-minifier": "~3.4.1",
     "isparta": "~4.0.0",
+    "js-beautify": "^1.6.12",
     "jsesc": "~2.4.0",
     "karma": "1.5.0",
     "karma-browserify": "~5.1.0",

--- a/src/app/frontend/admin/admin.html
+++ b/src/app/frontend/admin/admin.html
@@ -17,23 +17,25 @@ limitations under the License.
 <div ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content-card ng-if="$ctrl.admin.namespaceList.namespaces.length">
     <kd-content>
-      <kd-namespace-card-list namespace-list="$ctrl.admin.namespaceList" with-statuses="true"
-                               namespace-list-resource="$ctrl.kdNamespaceListResource">
+      <kd-namespace-card-list namespace-list="$ctrl.admin.namespaceList"
+                              with-statuses="true"
+                              namespace-list-resource="$ctrl.kdNamespaceListResource">
       </kd-namespace-card-list>
     </kd-content>
   </kd-content-card>
   <kd-content-card ng-if="$ctrl.admin.nodeList.nodes.length">
     <kd-content>
-      <kd-node-card-list node-list="$ctrl.admin.nodeList" with-statuses="true"
-                               node-list-resource="$ctrl.kdNodeListResource">
+      <kd-node-card-list node-list="$ctrl.admin.nodeList"
+                         with-statuses="true"
+                         node-list-resource="$ctrl.kdNodeListResource">
       </kd-node-card-list>
     </kd-content>
   </kd-content-card>
   <kd-content-card ng-if="$ctrl.admin.persistentVolumeList.items.length">
     <kd-content>
       <kd-persistent-volume-card-list persistent-volume-list="$ctrl.admin.persistentVolumeList"
-          with-statuses="true"
-          persistent-volume-list-resource="$ctrl.kdPersistentVolumeListResource">
+                                      with-statuses="true"
+                                      persistent-volume-list-resource="$ctrl.kdPersistentVolumeListResource">
       </kd-persistent-volume-card-list>
     </kd-content>
   </kd-content-card>

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,29 +17,42 @@ limitations under the License.
 <md-toolbar class="kd-toolbar">
   <div class="md-toolbar-tools kd-toolbar-tools">
     <kd-nav-hamburger flex="none"></kd-nav-hamburger>
-    <h2 class="kd-logo-menu" flex="none">
-      <md-icon md-svg-icon="assets/images/kubernetes-logo-text.svg" class="kd-toolbar-logo">
+    <h2 class="kd-logo-menu"
+        flex="none">
+      <md-icon md-svg-icon="assets/images/kubernetes-logo-text.svg"
+               class="kd-toolbar-logo">
       </md-icon>
     </h2>
-    <kd-breadcrumbs class="kd-actionbar-breadcrumbs" limit="3"
-        flex="auto" layout="row"></kd-breadcrumbs>
-    <div flex="auto" ui-view="toolbar"></div>
+    <kd-breadcrumbs class="kd-actionbar-breadcrumbs"
+                    limit="3"
+                    flex="auto"
+                    layout="row"></kd-breadcrumbs>
+    <div flex="auto"
+         ui-view="toolbar"></div>
     <kd-actionbar></kd-actionbar>
   </div>
 </md-toolbar>
 
-<md-content layout="row" class="kd-app-entire-content" flex="auto">
+<md-content layout="row"
+            class="kd-app-entire-content"
+            flex="auto">
   <kd-nav flex="none"></kd-nav>
-  <md-content flex="auto" class="kd-main-content-box">
-    <div ng-switch="$ctrl.loading" class="kd-content-div-filled kd-main-content-div">
-      <div ng-switch-when="true" class="kd-spinner">
-        <md-progress-circular ng-if="$ctrl.showLoadingSpinner" md-mode="indeterminate"
-            md-diameter="48">
+  <md-content flex="auto"
+              class="kd-main-content-box">
+    <div ng-switch="$ctrl.loading"
+         class="kd-content-div-filled kd-main-content-div">
+      <div ng-switch-when="true"
+           class="kd-spinner">
+        <md-progress-circular ng-if="$ctrl.showLoadingSpinner"
+                              md-mode="indeterminate"
+                              md-diameter="48">
         </md-progress-circular>
       </div>
-      <div ng-switch-when="false" class="kd-app-content">
-        <div ui-view class="md-body-1"
-            ng-class="{'kd-content-div-filled': $ctrl.isFillContentView()}"></div>
+      <div ng-switch-when="false"
+           class="kd-app-content">
+        <div ui-view
+             class="md-body-1"
+             ng-class="{'kd-content-div-filled': $ctrl.isFillContentView()}"></div>
       </div>
     </div>
   </md-content>

--- a/src/app/frontend/chrome/nav/hamburger.html
+++ b/src/app/frontend/chrome/nav/hamburger.html
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="$ctrl.toggle()" class="md-icon-button">
+<md-button ng-click="$ctrl.toggle()"
+           class="md-icon-button">
   <md-icon md-font-library="material-icons">menu</md-icon>
 </md-button>

--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-sidenav md-is-locked-open="$ctrl.isVisible" class="kd-nav" layout="column">
+<md-sidenav md-is-locked-open="$ctrl.isVisible"
+            class="kd-nav"
+            layout="column">
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.admin}}">[[Admin|Admin menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.namespace}}">[[Namespaces|Namespaces menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.node}}">[[Nodes|Nodes menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.persistentVolume}}">[[Persistent Volumes|Persistent Volumes menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.storageClass}}">[[Storage Classes|Storage Classes menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item"
+                 state="{{::$ctrl.states.admin}}">[[Admin|Admin menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.namespace}}">[[Namespaces|Namespaces menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.node}}">[[Nodes|Nodes menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.persistentVolume}}">[[Persistent Volumes|Persistent Volumes menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.storageClass}}">[[Storage Classes|Storage Classes menu item in the nav.]]</kd-nav-item>
   </div>
   <div class="kd-nav-group-divider"></div>
   <kd-namespace-select></kd-namespace-select>
@@ -31,28 +38,44 @@ limitations under the License.
   </div>
   -->
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.workload}}">[[Workloads|Workloads menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.deployment}}">[[Deployments|Deployments menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.replicaSet}}">[[Replica Sets|Replica Sets menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.replicationController}}">[[Replication Controllers|Replication Controllers menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.daemonSet}}">[[Daemon Sets|Daemon Sets menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.statefulSet}}">[[Stateful Sets|Stateful Sets menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.job}}">[[Jobs|Jobs menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.pod}}">[[Pods|Pods menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item"
+                 state="{{::$ctrl.states.workload}}">[[Workloads|Workloads menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.deployment}}">[[Deployments|Deployments menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.replicaSet}}">[[Replica Sets|Replica Sets menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.replicationController}}">[[Replication Controllers|Replication Controllers menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.daemonSet}}">[[Daemon Sets|Daemon Sets menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.statefulSet}}">[[Stateful Sets|Stateful Sets menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.job}}">[[Jobs|Jobs menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.pod}}">[[Pods|Pods menu item in the nav.]]</kd-nav-item>
   </div>
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.serviceDiscovery}}">[[Services and discovery|Services and discovery menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.service}}">[[Services|Services menu item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.ingress}}">[[Ingresses|Ingresses item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item"
+                 state="{{::$ctrl.states.serviceDiscovery}}">[[Services and discovery|Services and discovery menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.service}}">[[Services|Services menu item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.ingress}}">[[Ingresses|Ingresses item in the nav.]]</kd-nav-item>
   </div>
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.storage}}">[[Storage|Storage item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.persistentVolumeClaim}}">[[Persistent Volume Claims|Persistent Volume Claims item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item"
+                 state="{{::$ctrl.states.storage}}">[[Storage|Storage item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.persistentVolumeClaim}}">[[Persistent Volume Claims|Persistent Volume Claims item in the nav.]]</kd-nav-item>
   </div>
   <div class="kd-nav-group">
-    <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.config}}">[[Config|Config item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.secret}}">[[Secrets|Secrets item in the nav.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item" state="{{::$ctrl.states.configMap}}">[[Config Maps|Config Maps item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-group-item"
+                 state="{{::$ctrl.states.config}}">[[Config|Config item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.secret}}">[[Secrets|Secrets item in the nav.]]</kd-nav-item>
+    <kd-nav-item class="kd-nav-item"
+                 state="{{::$ctrl.states.configMap}}">[[Config Maps|Config Maps item in the nav.]]</kd-nav-item>
   </div>
   <!-- Enabled dynamically if there are third party resources registered in the system -->
   <kd-third-party-resource-nav states="$ctrl.states"></kd-third-party-resource-nav>

--- a/src/app/frontend/chrome/nav/navitem.html
+++ b/src/app/frontend/chrome/nav/navitem.html
@@ -14,8 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-href="{{$ctrl.getHref()}}" ng-if="::$ctrl.getHref()" class="kd-nav-item-button"
-  ng-class="{'kd-nav-item-active': $ctrl.isActive()}">
+<md-button ng-href="{{$ctrl.getHref()}}"
+           ng-if="::$ctrl.getHref()"
+           class="kd-nav-item-button"
+           ng-class="{'kd-nav-item-active': $ctrl.isActive()}">
   <span ng-transclude></span>
 </md-button>
-<span ng-transclude ng-if="::!$ctrl.getHref()" class="kd-nav-item-button"></span>
+<span ng-transclude
+      ng-if="::!$ctrl.getHref()"
+      class="kd-nav-item-button"></span>

--- a/src/app/frontend/chrome/nav/thirdpartyresourcenav.html
+++ b/src/app/frontend/chrome/nav/thirdpartyresourcenav.html
@@ -14,13 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-nav-group" ng-if="$ctrl.isVisible">
-  <kd-nav-item class="kd-nav-group-item" state="{{::$ctrl.states.thirdpartyresource}}"
+<div class="kd-nav-group"
+     ng-if="$ctrl.isVisible">
+  <kd-nav-item class="kd-nav-group-item"
+               state="{{::$ctrl.states.thirdpartyresource}}"
                active="$ctrl.isGroupActive()">
     [[Third Party Resources|Third Party Resources menu item in the nav.]]
   </kd-nav-item>
   <div ng-repeat="tpr in $ctrl.thirdPartyResourceList.thirdPartyResources">
-    <kd-nav-item class="kd-nav-item" href="{{::$ctrl.getThirdPartyResourceDetailHref(tpr.objectMeta.name)}}"
+    <kd-nav-item class="kd-nav-item"
+                 href="{{::$ctrl.getThirdPartyResourceDetailHref(tpr.objectMeta.name)}}"
                  active="$ctrl.isActive(tpr.objectMeta.name)">
       {{::tpr.objectMeta.name}}
     </kd-nav-item>

--- a/src/app/frontend/common/components/actionbar/actionbar.html
+++ b/src/app/frontend/common/components/actionbar/actionbar.html
@@ -14,15 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div layout="row" layout-align="center center">
-  <div ui-view="actionbar" class="kd-actionbar-view-part"></div>
-  <div ng-if="$ctrl.hasCustomActions()" class="kd-actionbar-divider"></div>
+<div layout="row"
+     layout-align="center center">
+  <div ui-view="actionbar"
+       class="kd-actionbar-view-part"></div>
+  <div ng-if="$ctrl.hasCustomActions()"
+       class="kd-actionbar-divider"></div>
   <div>
     <md-button ng-click="$ctrl.create()">
       <md-icon class="kd-actionbar-icon-button">add</md-icon>
       <md-tooltip md-direction="bottom">
-        [[Create an application or any Kubernetes resource|Tooltip for global action bar
-          create button tooltip.]]
+        [[Create an application or any Kubernetes resource|Tooltip for global action bar create button tooltip.]]
       </md-tooltip>
       [[Create|Label for global action bar create button.]]
     </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
+++ b/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
@@ -19,6 +19,5 @@ limitations under the License.
   <md-tooltip md-direction="bottom">
     {{::$ctrl.getDeleteTooltip()}}
   </md-tooltip>
-  [[Delete|Action 'Delete', which is a button on the actionbar and is there
-    for every resource type.]]
+  [[Delete|Action 'Delete', which is a button on the actionbar and is there for every resource type.]]
 </md-button>

--- a/src/app/frontend/common/components/annotations/annotations.html
+++ b/src/app/frontend/common/components/annotations/annotations.html
@@ -16,28 +16,38 @@ limitations under the License.
 
 <div ng-if="::annotationsCtrl.labels">
   <div ng-repeat="(key, value) in ::annotationsCtrl.labels"
-       ng-if="annotationsCtrl.isVisible($index)" class="kd-chips">
-    <div ng-switch on="::key">
-      <div ng-switch-when="kubernetes.io/created-by" class="kd-chip">
-        [[Created by:|Friendly name of the kubernetes.io/created-by annotation]] <kd-serialized-reference reference="value"></kd-serialized-reference>
+       ng-if="annotationsCtrl.isVisible($index)"
+       class="kd-chips">
+    <div ng-switch
+         on="::key">
+      <div ng-switch-when="kubernetes.io/created-by"
+           class="kd-chip">
+        [[Created by:|Friendly name of the kubernetes.io/created-by annotation]]
+        <kd-serialized-reference reference="value"></kd-serialized-reference>
       </div>
-      <div ng-switch-when="kubectl.kubernetes.io/last-applied-configuration" class="kd-chip">
+      <div ng-switch-when="kubectl.kubernetes.io/last-applied-configuration"
+           class="kd-chip">
         <kd-last-applied-configuration value="::value"></kd-last-applied-configuration>
       </div>
-      <div ng-switch-default class="kd-chip">
+      <div ng-switch-default
+           class="kd-chip">
         <span>{{::key}}:&nbsp;</span>
-        <kd-middle-ellipsis class="kd-chip-value" ng-if="!annotationsCtrl.isHref(value)" display-string=" {{::value}}" ></kd-middle-ellipsis>
-        <a ng-if="annotationsCtrl.isHref(value)" class="kd-chip-value" href="{{::value}}" target="_blank">
-          <kd-middle-ellipsis  display-string=" {{::value}}" ></kd-middle-ellipsis>
+        <kd-middle-ellipsis class="kd-chip-value"
+                            ng-if="!annotationsCtrl.isHref(value)"
+                            display-string=" {{::value}}"></kd-middle-ellipsis>
+        <a ng-if="annotationsCtrl.isHref(value)"
+           class="kd-chip-value"
+           href="{{::value}}"
+           target="_blank">
+          <kd-middle-ellipsis display-string=" {{::value}}"></kd-middle-ellipsis>
         </a>
       </div>
     </div>
   </div>
-  <div class="kd-chips kd-chips-switch" ng-show="annotationsCtrl.isMoreAvailable()"
+  <div class="kd-chips kd-chips-switch"
+       ng-show="annotationsCtrl.isMoreAvailable()"
        ng-click="annotationsCtrl.switchLabelsView()">
-    {{annotationsCtrl.isShowingAll() ?
-      "[[show fewer annotations|Text on the button to show fewer annotations.]]" :
-      "[[show all annotations|Text on the button to show all the annotations.]]"}}
+    {{annotationsCtrl.isShowingAll() ? "[[show fewer annotations|Text on the button to show fewer annotations.]]" : "[[show all annotations|Text on the button to show all the annotations.]]"}}
   </div>
 </div>
 <div ng-hide="::annotationsCtrl.labels">-</div>

--- a/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
+++ b/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<a href ng-click="$ctrl.openDetails()">[[last applied configuration|
+<a href
+   ng-click="$ctrl.openDetails()">[[last applied configuration|
   Label for the kubectl.kubernetes.io/last-applied-configuration annotation]]
 </a>

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
@@ -14,16 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div ng-switch="$last" ng-repeat="breadcrumb in ctrl.breadcrumbs" flex="shrink"
+<div ng-switch="$last"
+     ng-repeat="breadcrumb in ctrl.breadcrumbs"
+     flex="shrink"
      class="md-title kd-breadcrumbs-ellipsised kd-breadcrumbs-spacing"
      ng-class="{'kd-inline-breadcrumb': !$last}">
-  <a ng-switch-when="false" href="{{::breadcrumb.stateLink}}" class="kd-faded-breadcrumb">
+  <a ng-switch-when="false"
+     href="{{::breadcrumb.stateLink}}"
+     class="kd-faded-breadcrumb">
     {{::breadcrumb.label}}
   </a>
-  <div ng-switch-when="true" class="kd-breadcrumbs-ellipsised">
+  <div ng-switch-when="true"
+       class="kd-breadcrumbs-ellipsised">
     <kd-middle-ellipsis display-string="{{::breadcrumb.label}}"></kd-middle-ellipsis>
   </div>
-  <md-icon ng-switch-when="false" class="kd-faded-breadcrumb">
+  <md-icon ng-switch-when="false"
+           class="kd-faded-breadcrumb">
     keyboard_arrow_right
   </md-icon>
 </div>

--- a/src/app/frontend/common/components/conditions/conditionslist.html
+++ b/src/app/frontend/common/components/conditions/conditionslist.html
@@ -14,31 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="false">
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
   <kd-resource-card-list-header>
     [[Conditions|Label 'Conditions' for the conditions section.]]
   </kd-resource-card-list-header>
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Type|Label 'Type' for the condition table header.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Status|Label 'Status' for the condition table header.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Last heartbeat time|Label 'Last heartbeat time' for the condition table header.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Last transition time|Label 'Last transition time' for the condition table header.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="medium" grow="2">
+    <kd-resource-card-header-column size="medium"
+                                    grow="2">
       [[Reason|Label 'Reason' for the condition table header.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="medium" grow="4">
+    <kd-resource-card-header-column size="medium"
+                                    grow="4">
       [[Message|Label 'Message' for the condition table header.]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-resource-card ng-repeat="condition in $ctrl.conditions" omit-meta="true">
+  <kd-resource-card ng-repeat="condition in $ctrl.conditions"
+                    omit-meta="true">
     <kd-resource-card-columns>
       <kd-resource-card-column>
         <div ng-if="::condition.type">{{condition.type}}</div>
@@ -48,24 +56,24 @@ limitations under the License.
         <div ng-if="::condition.status">{{condition.status}}</div>
         <div ng-if="::!condition.status">[[-|Label when there is no data.]]</div>
       </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div ng-if="::condition.lastProbeTime">{{condition.lastProbeTime | relativeTime}}</div>
-      <div ng-if="::!condition.lastProbeTime">[[-|Label when there is no data.]]</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div ng-if="::condition.lastTransitionTime">
-        {{condition.lastTransitionTime | relativeTime}}
-      </div>
-      <div ng-if="::!condition.lastTransitionTime">[[-|Label when there is no data.]]</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div ng-if="::condition.reason">{{condition.reason}}</div>
-      <div ng-if="::!condition.reason">[[-|Label when there is no data.]]</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div ng-if="::condition.message">{{condition.message}}</div>
-      <div ng-if="::!condition.message">[[-|Label when there is no data.]]</div>
-    </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div ng-if="::condition.lastProbeTime">{{condition.lastProbeTime | relativeTime}}</div>
+        <div ng-if="::!condition.lastProbeTime">[[-|Label when there is no data.]]</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div ng-if="::condition.lastTransitionTime">
+          {{condition.lastTransitionTime | relativeTime}}
+        </div>
+        <div ng-if="::!condition.lastTransitionTime">[[-|Label when there is no data.]]</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div ng-if="::condition.reason">{{condition.reason}}</div>
+        <div ng-if="::!condition.reason">[[-|Label when there is no data.]]</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div ng-if="::condition.message">{{condition.message}}</div>
+        <div ng-if="::!condition.message">[[-|Label when there is no data.]]</div>
+      </kd-resource-card-column>
     </kd-resource-card-columns>
   </kd-resource-card>
 </kd-resource-card-list>

--- a/src/app/frontend/common/components/contentcard/contentcard.html
+++ b/src/app/frontend/common/components/contentcard/contentcard.html
@@ -16,11 +16,14 @@ limitations under the License.
 
 <div class="kd-content-card">
   <div class="kd-content-card-content">
-    <h1 ng-if="$ctrl.isTitleSlotFilled()" layout-padding
-         class="kd-content-card-content-title md-title"
-         ng-transclude="title"></h1>
-    <div ng-transclude="content" class="kd-content-card-transclude-content"></div>
-    <div class="kd-content-card-content-footer" ng-if="$ctrl.isFooterSlotFilled()"
+    <h1 ng-if="$ctrl.isTitleSlotFilled()"
+        layout-padding
+        class="kd-content-card-content-title md-title"
+        ng-transclude="title"></h1>
+    <div ng-transclude="content"
+         class="kd-content-card-transclude-content"></div>
+    <div class="kd-content-card-content-footer"
+         ng-if="$ctrl.isFooterSlotFilled()"
          ng-transclude="footer"></div>
   </div>
 </div>

--- a/src/app/frontend/common/components/endpoint/externalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/externalendpoint.html
@@ -23,8 +23,10 @@ limitations under the License.
   <div ng-repeat="endpoint in ::$ctrl.endpoints">
     <div ng-repeat="port in ::endpoint.ports">
       <div>
-        <a href="http://{{::endpoint.host}}:{{::port.port}}" target="_blank"
-           layout layout-align="start center">
+        <a href="http://{{::endpoint.host}}:{{::port.port}}"
+           target="_blank"
+           layout
+           layout-align="start center">
           <kd-middle-ellipsis display-string="{{::endpoint.host}}:{{::port.port}}">
           </kd-middle-ellipsis>
           &nbsp;
@@ -32,8 +34,10 @@ limitations under the License.
         </a>
       </div>
       <div ng-if="::!port.port">
-        <a href="http://{{::endpoint.host}}:{{::port.nodePort}}" target="_blank"
-           layout layout-align="start center">
+        <a href="http://{{::endpoint.host}}:{{::port.nodePort}}"
+           target="_blank"
+           layout
+           layout-align="start center">
           <kd-middle-ellipsis display-string="{{::endpoint.host}}:{{::port.nodePort}}">
           </kd-middle-ellipsis>
           &nbsp;
@@ -42,8 +46,10 @@ limitations under the License.
       </div>
     </div>
     <div ng-if="::!endpoint.ports.length">
-      <a href="http://{{::endpoint.host}}" target="_blank"
-         layout layout-align="start center">
+      <a href="http://{{::endpoint.host}}"
+         target="_blank"
+         layout
+         layout-align="start center">
         <kd-middle-ellipsis display-string="{{::endpoint.host}}">
         </kd-middle-ellipsis>
         &nbsp;

--- a/src/app/frontend/common/components/endpoint/internalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/internalendpoint.html
@@ -17,13 +17,11 @@ limitations under the License.
 <div>
   <div ng-repeat="port in ::$ctrl.endpoint.ports">
     <div>
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.endpoint.host}}:{{::port.port}} {{::port.protocol}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.endpoint.host}}:{{::port.port}} {{::port.protocol}}">
       </kd-middle-ellipsis>
     </div>
     <div>
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.endpoint.host}}:{{::port.nodePort}} {{::port.protocol}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.endpoint.host}}:{{::port.nodePort}} {{::port.protocol}}">
       </kd-middle-ellipsis>
     </div>
   </div>

--- a/src/app/frontend/common/components/infocard/infocard.html
+++ b/src/app/frontend/common/components/infocard/infocard.html
@@ -18,7 +18,10 @@ limitations under the License.
   <kd-title ng-transclude="header"></kd-title>
   <kd-content>
     <div layout="column">
-      <div class="kd-info-card-section" ng-transclude="section" layout="row" layout-padding>
+      <div class="kd-info-card-section"
+           ng-transclude="section"
+           layout="row"
+           layout-padding>
       </div>
     </div>
   </kd-content>
@@ -28,7 +31,10 @@ limitations under the License.
 <kd-content-card ng-if="::!$ctrl.isHeaderFilled()">
   <kd-content>
     <div layout="column">
-      <div class="kd-info-card-section" ng-transclude="section" layout="row" layout-padding>
+      <div class="kd-info-card-section"
+           ng-transclude="section"
+           layout="row"
+           layout-padding>
       </div>
     </div>
   </kd-content>

--- a/src/app/frontend/common/components/infocard/infocardentry.html
+++ b/src/app/frontend/common/components/infocard/infocardentry.html
@@ -14,9 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div layout="row" class="kd-info-card-entry">
-  <div ng-if="::$ctrl.title" flex="nogrow">{{$ctrl.title}}:</div>
-  <div ng-if="::$ctrl.title" flex="auto" class="kd-info-card-entry-content" ng-transclude></div>
+<div layout="row"
+     class="kd-info-card-entry">
+  <div ng-if="::$ctrl.title"
+       flex="nogrow">{{$ctrl.title}}:</div>
+  <div ng-if="::$ctrl.title"
+       flex="auto"
+       class="kd-info-card-entry-content"
+       ng-transclude></div>
   <!--Use the content as title if the title is not given-->
-  <div ng-if="::!$ctrl.title" flex="nogrow" ng-transclude></div>
+  <div ng-if="::!$ctrl.title"
+       flex="nogrow"
+       ng-transclude></div>
 </div>

--- a/src/app/frontend/common/components/infocard/infocardsection.html
+++ b/src/app/frontend/common/components/infocard/infocardsection.html
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div layout="column" class="kd-info-card-section-container">
-  <div class="kd-info-card-section-name" ng-if="::$ctrl.name">{{$ctrl.name}}</div>
-  <div flex="auto" ng-transclude></div>
+<div layout="column"
+     class="kd-info-card-section-container">
+  <div class="kd-info-card-section-name"
+       ng-if="::$ctrl.name">{{$ctrl.name}}</div>
+  <div flex="auto"
+       ng-transclude></div>
 </div>

--- a/src/app/frontend/common/components/labels/labels.html
+++ b/src/app/frontend/common/components/labels/labels.html
@@ -16,16 +16,17 @@ limitations under the License.
 
 <div ng-if="::labelsCtrl.labels">
   <div ng-repeat="(key, value) in ::labelsCtrl.labels"
-       ng-if="labelsCtrl.isVisible($index)" class="kd-chips">
-    <kd-middle-ellipsis display-string="{{::key}}: {{::value}}" class="kd-chip">
+       ng-if="labelsCtrl.isVisible($index)"
+       class="kd-chips">
+    <kd-middle-ellipsis display-string="{{::key}}: {{::value}}"
+                        class="kd-chip">
     </kd-middle-ellipsis>
   </div>
   <div class="kd-chips kd-chips-switch"
        ng-show="labelsCtrl.isMoreAvailable()"
        ng-click="labelsCtrl.switchLabelsView()">
-    {{labelsCtrl.isShowingAll() ?
-      '[[show fewer labels|Tooltip on the "show less" button for the labels of any kubernetes resource. Usually appears on the resource details pages.]]' :
-      '[[show all labels|Tooltip on the "show all" button for the labels of any kubernetes resource. Usually appears on the resource details pages.]]' }}
+    {{labelsCtrl.isShowingAll() ? '[[show fewer labels|Tooltip on the "show less" button for the labels of any kubernetes resource. Usually appears on the resource details pages.]]' : '[[show all labels|Tooltip on the "show all" button for the labels of any
+    kubernetes resource. Usually appears on the resource details pages.]]' }}
   </div>
 </div>
 <div ng-hide="::labelsCtrl.labels">-</div>

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-tooltip md-direction="top" ng-if="ellipsisCtrl.shouldTruncate()">
+<md-tooltip md-direction="top"
+            ng-if="ellipsisCtrl.shouldTruncate()">
   {{ellipsisCtrl.displayString}}
 </md-tooltip>
 <div class="kd-middleellipsis">{{ellipsisCtrl.displayString}}</div>

--- a/src/app/frontend/common/components/resourcecard/resourcecard.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecard.html
@@ -15,16 +15,25 @@ limitations under the License.
 -->
 
 <div class="kd-resource-card">
-  <div layout="row" class="kd-resource-card-columns-container" flex="grow">
-    <div ng-if="$ctrl.isSelectable()" flex="none" class="kd-resource-card-select">
+  <div layout="row"
+       class="kd-resource-card-columns-container"
+       flex="grow">
+    <div ng-if="$ctrl.isSelectable()"
+         flex="none"
+         class="kd-resource-card-select">
       <md-checkbox aria-label="Select the resource"></md-checkbox>
     </div>
-    <ng-transclude ng-if="$ctrl.hasStatus()" ng-transclude-slot="status"
-        class="kd-resource-card-status" flex="none">
+    <ng-transclude ng-if="$ctrl.hasStatus()"
+                   ng-transclude-slot="status"
+                   class="kd-resource-card-status"
+                   flex="none">
     </ng-transclude>
-    <ng-transclude ng-transclude-slot="columns" class="kd-resource-card-columns-slot" flex="shrink">
+    <ng-transclude ng-transclude-slot="columns"
+                   class="kd-resource-card-columns-slot"
+                   flex="shrink">
     </ng-transclude>
   </div>
-  <ng-transclude ng-transclude-slot="footer" class="kd-resource-card-footer-slot">
+  <ng-transclude ng-transclude-slot="footer"
+                 class="kd-resource-card-footer-slot">
   </ng-transclude>
 </div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardcolumns.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardcolumns.html
@@ -14,4 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-resource-card-columns" flex="grow" ng-transclude></div>
+<div class="kd-resource-card-columns"
+     flex="grow"
+     ng-transclude></div>

--- a/src/app/frontend/common/components/resourcecard/resourcecarddeletemenuitem.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecarddeletemenuitem.html
@@ -16,7 +16,6 @@ limitations under the License.
 
 <md-menu-item>
   <md-button ng-click="$ctrl.remove()">
-    [[Delete|Action "Delete" (verb), which appears as a menu item on the cards for
-      kubernetes resources.]]
+    [[Delete|Action "Delete" (verb), which appears as a menu item on the cards for kubernetes resources.]]
   </md-button>
 </md-menu-item>

--- a/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.html
@@ -14,4 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-resource-card-header-columns" flex="grow" ng-transclude></div>
+<div class="kd-resource-card-header-columns"
+     flex="grow"
+     ng-transclude></div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlist.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlist.html
@@ -16,15 +16,20 @@ limitations under the License.
 
 <div class="kd-resource-card-list-wrapper">
   <div class="kd-resource-card-list-header-wrapper">
-    <div ng-transclude="header" class="kd-resource-card-list-header md-title" ng-if="::$ctrl.hasHeader()"></div>
-    <div ng-transclude="pagination" class="kd-resource-card-list-pagination"></div>
+    <div ng-transclude="header"
+         class="kd-resource-card-list-header md-title"
+         ng-if="::$ctrl.hasHeader()"></div>
+    <div ng-transclude="pagination"
+         class="kd-resource-card-list-pagination"></div>
   </div>
   <div class="kd-resource-card-list"
-      ng-class="{'kd-resource-card-list-selectable': $ctrl.selectable, 'kd-resource-card-list-with-statuses': $ctrl.withStatuses}"
-      ng-transclude>
+       ng-class="{'kd-resource-card-list-selectable': $ctrl.selectable, 'kd-resource-card-list-with-statuses': $ctrl.withStatuses}"
+       ng-transclude>
   </div>
-  <div class="kd-resource-card-list-pending-overlay" ng-if="$ctrl.pending">
-    <md-progress-circular md-mode="indeterminate" md-diameter="48">
+  <div class="kd-resource-card-list-pending-overlay"
+       ng-if="$ctrl.pending">
+    <md-progress-circular md-mode="indeterminate"
+                          md-diameter="48">
     </md-progress-circular>
   </div>
 </div>

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div ng-if="::$ctrl.shouldShowPagination()" flex="auto" layout="row" class="kd-list-pagination">
-  <dir-pagination-controls ng-if="::!$ctrl.serverSided" pagination-id="::$ctrl.paginationId"
-                           class="kd-list-pagination-controls" boundary-links="true"
+<div ng-if="::$ctrl.shouldShowPagination()"
+     flex="auto"
+     layout="row"
+     class="kd-list-pagination">
+  <dir-pagination-controls ng-if="::!$ctrl.serverSided"
+                           pagination-id="::$ctrl.paginationId"
+                           class="kd-list-pagination-controls"
+                           boundary-links="true"
                            template-url="common/pagination/pagination.html">
   </dir-pagination-controls>
-  <dir-pagination-controls ng-if="::$ctrl.serverSided" pagination-id="::$ctrl.paginationId"
-                           class="kd-list-pagination-controls" boundary-links="true"
+  <dir-pagination-controls ng-if="::$ctrl.serverSided"
+                           pagination-id="::$ctrl.paginationId"
+                           class="kd-list-pagination-controls"
+                           boundary-links="true"
                            template-url="common/pagination/pagination.html"
                            on-page-change="$ctrl.pageChanged(newPageNumber)">
   </dir-pagination-controls>

--- a/src/app/frontend/common/components/resourcecard/resourcecardmenu.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardmenu.html
@@ -15,10 +15,10 @@ limitations under the License.
 -->
 
 <md-menu>
-  <md-button ng-click="$mdOpenMenu($event)" class="md-icon-button">
+  <md-button ng-click="$mdOpenMenu($event)"
+             class="md-icon-button">
     <md-icon md-font-library="material-icons">more_vert</md-icon>
-    <md-tooltip>[[Actions|Tooltip "Actions", which appears when you hover over the menu icon on
-       any resource card.]]</md-tooltip>
+    <md-tooltip>[[Actions|Tooltip "Actions", which appears when you hover over the menu icon on any resource card.]]</md-tooltip>
   </md-button>
   <md-menu-content ng-transclude>
   </md-menu-content>

--- a/src/app/frontend/common/components/resourcedetail/infocard.html
+++ b/src/app/frontend/common/components/resourcedetail/infocard.html
@@ -15,23 +15,22 @@ limitations under the License.
 -->
 
 <kd-info-card-entry title="[[Name|Label 'Name' for a resource.]]">
-  <kd-middle-ellipsis
-          display-string="{{::$ctrl.objectMeta.name}}">
+  <kd-middle-ellipsis display-string="{{::$ctrl.objectMeta.name}}">
   </kd-middle-ellipsis>
 </kd-info-card-entry>
 
 <kd-info-card-entry ng-if="::$ctrl.objectMeta.namespace"
-    title="[[Namespace|Label 'Namespace' for a resource.]]">
+                    title="[[Namespace|Label 'Namespace' for a resource.]]">
   {{::$ctrl.objectMeta.namespace}}
 </kd-info-card-entry>
 
 <kd-info-card-entry ng-if="::$ctrl.objectMeta.labels"
-    title="[[Labels|Label 'Labels' for a resource.]]">
+                    title="[[Labels|Label 'Labels' for a resource.]]">
   <kd-labels labels="::$ctrl.objectMeta.labels"></kd-labels>
 </kd-info-card-entry>
 
 <kd-info-card-entry ng-if="::$ctrl.objectMeta.annotations"
-    title="[[Annotations|Label 'Annotations' for a resource.]]">
+                    title="[[Annotations|Label 'Annotations' for a resource.]]">
   <kd-annotations labels="::$ctrl.objectMeta.annotations"></kd-annotations>
 </kd-info-card-entry>
 

--- a/src/app/frontend/common/components/serializedreference/serializedreference.html
+++ b/src/app/frontend/common/components/serializedreference/serializedreference.html
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<a ng-if="$ctrl.valid" ng-href="{{$ctrl.href}}">{{$ctrl.kind}} {{$ctrl.name}}</a>
+<a ng-if="$ctrl.valid"
+   ng-href="{{$ctrl.href}}">{{$ctrl.kind}} {{$ctrl.name}}</a>
 <span ng-if="!$ctrl.valid">{{$ctrl.reference}}</span>

--- a/src/app/frontend/common/components/togglehiddentext/togglehiddentext.html
+++ b/src/app/frontend/common/components/togglehiddentext/togglehiddentext.html
@@ -1,7 +1,11 @@
-<pre ng-if="$ctrl.active" class="kd-pre-block">{{::$ctrl.text}}</pre>
+<pre ng-if="$ctrl.active"
+     class="kd-pre-block">{{::$ctrl.text}}</pre>
 <span ng-if="!$ctrl.active">
   <span ng-if="::$ctrl.placeholder.length">{{::$ctrl.placeholder}}</span>
-  <input ng-if="::!$ctrl.placeholder.length" type="password" readonly
-         flex="nogrow" class="kd-toggle-hidden-text-input"
-         value="{{::$ctrl.text}}">
+<input ng-if="::!$ctrl.placeholder.length"
+       type="password"
+       readonly
+       flex="nogrow"
+       class="kd-toggle-hidden-text-input"
+       value="{{::$ctrl.text}}">
 </span>

--- a/src/app/frontend/common/components/zerostate/zerostate.html
+++ b/src/app/frontend/common/components/zerostate/zerostate.html
@@ -16,9 +16,9 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <div class="kd-zerostate-message" layout-padding>
-      <div class="kd-zerostate-title">[[There is nothing to display here|Title text which appears
-        on zero state view.]]</div>
+    <div class="kd-zerostate-message"
+         layout-padding>
+      <div class="kd-zerostate-title">[[There is nothing to display here|Title text which appears on zero state view.]]</div>
       <div class="kd-zerostate-text">
         <span>
           [[You can <a href="{{::$ctrl.getStateHref()}}">deploy a containerized app</a>,

--- a/src/app/frontend/common/namespace/namespaceselect.html
+++ b/src/app/frontend/common/namespace/namespaceselect.html
@@ -1,18 +1,20 @@
 <div class="kd-namespace-select-title">[[Namespace|Title for namespace select.]]</div>
 <md-input-container class="kd-namespace-select-input-container">
   <md-select ng-model="$ctrl.selectedNamespace"
-      md-on-open="$ctrl.loadNamespacesIfNeeded()"
-      md-on-close="$ctrl.changeNamespace()"
-      class="kd-namespace-select"
-      aria-label="[[Selector for namespaces|Text describing what namespace selector is]]"
-      md-container-class="kd-namespace-select-container"
-      md-selected-text="$ctrl.formatNamespace()">
-    <md-option ng-value="::$ctrl.ALL_NAMESPACES" class="kd-namespace-select-all">
+             md-on-open="$ctrl.loadNamespacesIfNeeded()"
+             md-on-close="$ctrl.changeNamespace()"
+             class="kd-namespace-select"
+             aria-label="[[Selector for namespaces|Text describing what namespace selector is]]"
+             md-container-class="kd-namespace-select-container"
+             md-selected-text="$ctrl.formatNamespace()">
+    <md-option ng-value="::$ctrl.ALL_NAMESPACES"
+               class="kd-namespace-select-all">
       [[All namespaces|Text for dropdown item that indicates that no namespace was selected.]]
     </md-option>
     <md-optgroup label="[[Namespaces|Label atop a list of namespaces]]"
-        class="kd-namespace-select-namespace-list">
-      <md-option ng-value="namespace" ng-repeat="namespace in $ctrl.namespaces">
+                 class="kd-namespace-select-namespace-list">
+      <md-option ng-value="namespace"
+                 ng-repeat="namespace in $ctrl.namespaces">
         {{::namespace}}
       </md-option>
     </md-optgroup>

--- a/src/app/frontend/common/resource/deleteresource.html
+++ b/src/app/frontend/common/resource/deleteresource.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-dialog aria-label="[[Delete a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]" layout="column">
+<md-dialog aria-label="[[Delete a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]"
+           layout="column">
   <md-dialog-content layout-padding>
     <h4 class="md-title">[[Delete a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]</h4>
     <div ng-if="::$ctrl.objectMeta.namespace">
@@ -24,10 +25,12 @@ limitations under the License.
       [[Are you sure you want to delete {{::$ctrl.resourceKindName}} <i>{{::$ctrl.objectMeta.name}}</i>?|Confirmation question, appears before any dashboard resource will be deleted. (unnamespaced resources)]]
     </div>
     <md-dialog-actions>
-      <md-button class="md-primary kd-cancel-btn" ng-click="$ctrl.cancel()">
+      <md-button class="md-primary kd-cancel-btn"
+                 ng-click="$ctrl.cancel()">
         [[Cancel|Label for cancel button.]]
       </md-button>
-      <md-button class="md-primary kd-delete-btn" ng-click="$ctrl.remove()">
+      <md-button class="md-primary kd-delete-btn"
+                 ng-click="$ctrl.remove()">
         [[Delete|Label for delete button.]]
       </md-button>
     </md-dialog-actions>

--- a/src/app/frontend/common/resource/editresource.html
+++ b/src/app/frontend/common/resource/editresource.html
@@ -14,18 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-dialog aria-label="[[Edit a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]" layout="column">
-  <md-dialog-content layout-padding class="kd-json-edit-dialog-content">
+<md-dialog aria-label="[[Edit a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]"
+           layout="column">
+  <md-dialog-content layout-padding
+                     class="kd-json-edit-dialog-content">
     <h4 class="md-title">[[Edit a {{::$ctrl.resourceKindName}}|Title for a delete resource dialog.]]</h4>
-    <div ng-if="$ctrl.data" ng-jsoneditor ng-model="$ctrl.data"
+    <div ng-if="$ctrl.data"
+         ng-jsoneditor
+         ng-model="$ctrl.data"
          options="{ mode: 'tree', name: $ctrl.resourceKindName, history: false, expanded: true}"
          class="kd-json-edit-editor">
     </div>
     <md-dialog-actions>
-      <md-button class="md-primary kd-cancel-btn" ng-click="$ctrl.cancel()">
+      <md-button class="md-primary kd-cancel-btn"
+                 ng-click="$ctrl.cancel()">
         [[Cancel|Label for cancel button.]]
       </md-button>
-      <md-button class="md-primary kd-delete-btn" ng-click="$ctrl.update()">
+      <md-button class="md-primary kd-delete-btn"
+                 ng-click="$ctrl.update()">
         [[Update|Label for update button.]]
       </md-button>
     </md-dialog-actions>

--- a/src/app/frontend/config/config.html
+++ b/src/app/frontend/config/config.html
@@ -17,14 +17,16 @@ limitations under the License.
 <div ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content-card ng-if="$ctrl.config.secretList.secrets.length">
     <kd-content>
-      <kd-secret-card-list secret-list="$ctrl.config.secretList" with-statuses="true"
+      <kd-secret-card-list secret-list="$ctrl.config.secretList"
+                           with-statuses="true"
                            secret-list-resource="$ctrl.kdSecretListResource">
       </kd-secret-card-list>
     </kd-content>
   </kd-content-card>
   <kd-content-card ng-if="$ctrl.config.configMapList.items.length">
     <kd-content>
-      <kd-config-map-card-list config-map-list="$ctrl.config.configMapList" with-statuses="true"
+      <kd-config-map-card-list config-map-list="$ctrl.config.configMapList"
+                               with-statuses="true"
                                config-map-list-resource="$ctrl.kdConfigMapListResource">
       </kd-config-map-card-list>
     </kd-content>

--- a/src/app/frontend/configmapdetail/actionbar.html
+++ b/src/app/frontend/configmapdetail/actionbar.html
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Config Map|Label 'Config Map' which appears at the top of the
+<kd-actionbar-detail-buttons resource-kind-name="[[Config Map|Label 'Config Map' which appears at the top of the
       delete dialog, opened from a config map details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/configmapdetail/configmapdetail.html
+++ b/src/app/frontend/configmapdetail/configmapdetail.html
@@ -20,7 +20,7 @@ limitations under the License.
     <kd-info-card-header>[[Data|Header in a detail view of config map deta]]</kd-info-card-header>
     <kd-info-card-section>
       <kd-info-card-entry ng-repeat="(key, value) in ::$ctrl.configMapDetail.data"
-          title="{{::key}}">
+                          title="{{::key}}">
         <pre class="kd-pre-block">{{::value}}</pre>
       </kd-info-card-entry>
     </kd-info-card-section>

--- a/src/app/frontend/configmapdetail/configmapinfo.html
+++ b/src/app/frontend/configmapdetail/configmapinfo.html
@@ -18,8 +18,7 @@ limitations under the License.
   <kd-info-card-header>[[Details|Header in a detail view]]</kd-info-card-header>
   <kd-info-card-section>
     <kd-info-card-entry title="[[Name|Config map info details section name entry.]]">
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.configMap.objectMeta.name}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.configMap.objectMeta.name}}">
       </kd-middle-ellipsis>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Namespace|Config map info details section namespace entry.]]">

--- a/src/app/frontend/configmaplist/configmapcard.html
+++ b/src/app/frontend/configmaplist/configmapcard.html
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.configMap.objectMeta" type-meta="$ctrl.configMap.typeMeta">
+<kd-resource-card object-meta="$ctrl.configMap.objectMeta"
+                  type-meta="$ctrl.configMap.typeMeta">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getConfigMapDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getConfigMapDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{$ctrl.configMap.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -41,12 +43,10 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>
-        <kd-resource-card-delete-menu-item
-              resource-kind-name="[[Config Map|Label 'Config Map' which will appear in the config map
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Config Map|Label 'Config Map' which will appear in the config map
       delete dialog opened from a config map card on the list page.]]">
         </kd-resource-card-delete-menu-item>
-        <kd-resource-card-edit-menu-item
-              resource-kind-name="[[Config Map|Label 'Config Map' which will appear in the config map
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Config Map|Label 'Config Map' which will appear in the config map
       delete dialog opened from a config map card on the list page.]]">
         </kd-resource-card-edit-menu-item>
       </kd-resource-card-menu>

--- a/src/app/frontend/configmaplist/configmapcardlist.html
+++ b/src/app/frontend/configmaplist/configmapcardlist.html
@@ -14,32 +14,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="false">
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
   <kd-resource-card-list-header ng-transclude="header">
     [[Config Maps|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="configmaps" list="$ctrl.configMapList"
+  <kd-resource-card-list-pagination pagination-id="configmaps"
+                                    list="$ctrl.configMapList"
                                     list-resource="$ctrl.configMapListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Config map list header: name.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Config map list header: namespace.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Config map list header: labels.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
       [[Age|Config map list header: age.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-config-map-card dir-paginate="configMap in $ctrl.configMapList.items | itemsPerPage: default"
-                      config-map="configMap" pagination-id="configmaps"
+                      config-map="configMap"
+                      pagination-id="configmaps"
                       total-items="::$ctrl.configMapList.listMeta.totalItems">
   </kd-config-map-card>
 </kd-resource-card-list>

--- a/src/app/frontend/daemonsetdetail/actionbar.html
+++ b/src/app/frontend/daemonsetdetail/actionbar.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <kd-actionbar-detail-buttons resource-kind-name="Daemon Set"
-                        type-meta="$ctrl.details.typeMeta"
-                        object-meta="$ctrl.details.objectMeta">
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/daemonsetdetail/daemonsetdetail.html
+++ b/src/app/frontend/daemonsetdetail/daemonsetdetail.html
@@ -44,7 +44,7 @@ limitations under the License.
   <kd-content>
     <kd-pod-card-list pod-list="::ctrl.daemonSetDetail.podList"
                       pod-list-resource="::ctrl.daemonSetPodsResource"
-                      with-statuses="true" >
+                      with-statuses="true">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for pods card zerostate in daemon set details page.]]</div>
         <div class="kd-zerostate-text">[[There are currently no Pods scheduled on this Daemon Set.|Text for pods card zerostate in daemon set details page.]]</div>
@@ -53,4 +53,5 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 
-<kd-event-card-list event-list="::ctrl.daemonSetDetail.eventList" event-list-resource="::ctrl.daemonSetEventsResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.daemonSetDetail.eventList"
+                    event-list-resource="::ctrl.daemonSetEventsResource"></kd-event-card-list>

--- a/src/app/frontend/daemonsetdetail/daemonsetinfo.html
+++ b/src/app/frontend/daemonsetdetail/daemonsetinfo.html
@@ -18,8 +18,7 @@ limitations under the License.
   <kd-info-card-header>[[Details|Header in a detail view]]</kd-info-card-header>
   <kd-info-card-section>
     <kd-info-card-entry title="[[Name|Label 'Name' for the daemon set name on the details page.]]">
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.daemonSet.objectMeta.name}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.daemonSet.objectMeta.name}}">
       </kd-middle-ellipsis>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Namespace|Label 'Namespace' for the daemon set namespace on the details page]]">
@@ -38,21 +37,24 @@ limitations under the License.
   <kd-info-card-section name="[[Status|Subtitle 'Status' for the right section with pod status information on the daemon set details page.]]">
     <kd-info-card-entry title="[[Pods|Label 'Pods' for the pods in a daemon set on its details page.]]">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        [[{{::$ctrl.daemonSet.podInfo.current}} created|The message describes how many pods were created (daemon set details page).]],
-        [[{{::$ctrl.daemonSet.podInfo.desired}} desired|The message describes how many pods are desired to run (daemon set details page).]]
+        [[{{::$ctrl.daemonSet.podInfo.current}} created|The message describes how many pods were created (daemon set details page).]], [[{{::$ctrl.daemonSet.podInfo.desired}} desired|The message describes how many pods are desired to run (daemon set details page).]]
       </div>
       <div ng-if="$ctrl.areDesiredPodsRunning()">
         [[{{::$ctrl.daemonSet.podInfo.running}} running|The message describes how many pods are running (daemon set details page).]]
       </div>
     </kd-info-card-entry>
-    <kd-info-card-entry title="[[Pods status|Label 'Pods status' for the status of the pods in a daemon set, on the daemon set details page.]]" ng-if="!$ctrl.areDesiredPodsRunning()">
+    <kd-info-card-entry title="[[Pods status|Label 'Pods status' for the status of the pods in a daemon set, on the daemon set details page.]]"
+                        ng-if="!$ctrl.areDesiredPodsRunning()">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        <div ng-if="::$ctrl.daemonSet.podInfo.pending" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.daemonSet.podInfo.pending"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.daemonSet.podInfo.pending}} pending|The message says how many pods are pending (daemon set details page).]]
         </div>
-        <div ng-if="::$ctrl.daemonSet.podInfo.failed" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.daemonSet.podInfo.failed"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.daemonSet.podInfo.failed}} failed|The message says how many pods have failed (daemon set details page).]]</div>
-        <div ng-if="::$ctrl.daemonSet.podInfo.running" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.daemonSet.podInfo.running"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.daemonSet.podInfo.running}} running|The message describes how many pods are running (daemon set details page).]]
         </div>
       </div>

--- a/src/app/frontend/daemonsetlist/daemonsetcard.html
+++ b/src/app/frontend/daemonsetlist/daemonsetcard.html
@@ -14,17 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.daemonSet.objectMeta" type-meta="::$ctrl.daemonSet.typeMeta">
+<kd-resource-card object-meta="::$ctrl.daemonSet.objectMeta"
+                  type-meta="::$ctrl.daemonSet.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.hasWarnings()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.hasWarnings()">
       error
       <md-tooltip md-direction="right">[[One or more pods have errors.|Tooltip for failed pod card icon.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">[[One or more pods are in pending state.|Tooltip for pending pod card icon.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
@@ -65,12 +69,10 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>
-        <kd-resource-card-delete-menu-item
-                resource-kind-name="[[Daemon Set|Title 'Daemon Set' which is used as a title for the delete/update
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Daemon Set|Title 'Daemon Set' which is used as a title for the delete/update
    dialogs (that can be opened on the daemon set list view).]]">
         </kd-resource-card-delete-menu-item>
-        <kd-resource-card-edit-menu-item
-                resource-kind-name="[[Daemon Set|Title 'Daemon Set' which is used as a title for the delete/update
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Daemon Set|Title 'Daemon Set' which is used as a title for the delete/update
    dialogs (that can be opened on the daemon set list view).]]">
         </kd-resource-card-edit-menu-item>
       </kd-resource-card-menu>

--- a/src/app/frontend/daemonsetlist/daemonsetcardlist.html
+++ b/src/app/frontend/daemonsetlist/daemonsetcardlist.html
@@ -14,53 +14,63 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="::$ctrl.selectable" with-statuses="::$ctrl.withStatuses">
+<kd-resource-card-list selectable="::$ctrl.selectable"
+                       with-statuses="::$ctrl.withStatuses">
   <kd-resource-card-list-header ng-transclude="header">
     [[Daemon Sets|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="daemonsets" list="$ctrl.daemonSetList"
+  <kd-resource-card-list-pagination pagination-id="daemonsets"
+                                    list="$ctrl.daemonSetList"
                                     list-resource="$ctrl.daemonSetListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
-      [[Name|Label 'Name' which appears as a column label in the
-      table of daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Name|Label 'Name' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showResourceKind">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showResourceKind">
       [[Kind|Column header 'Kind' on Daemon Set lists]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column ng-if="$ctrl.areMultipleNamespacesSelected()" size="small" grow="2">
-      [[Namespace|Label 'Namespace' which appears as a column label in the
-      table of daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column ng-if="$ctrl.areMultipleNamespacesSelected()"
+                                    size="small"
+                                    grow="2">
+      [[Namespace|Label 'Namespace' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
-      [[Labels|Label 'Labels' which appears as a column label in the table of
-      daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Labels|Label 'Labels' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Pods|Label 'Pods' which appears as a column label in the table of
-      daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Pods|Label 'Pods' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Age|Label 'Age' which appears as a column label in the table of
-      daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Age|Label 'Age' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
-      [[Images|Label 'Images' which appears as a column label in the table of
-      daemon sets (daemon set list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Images|Label 'Images' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-daemon-set-card ng-if="::$ctrl.daemonSetListResource" pagination-id="daemonsets"
+  <kd-daemon-set-card ng-if="::$ctrl.daemonSetListResource"
+                      pagination-id="daemonsets"
                       dir-paginate="daemonSet in $ctrl.daemonSetList.daemonSets | itemsPerPage: default"
                       total-items="::$ctrl.daemonSetList.listMeta.totalItems"
-                      daemon-set="daemonSet" show-resource-kind="::$ctrl.showResourceKind">
+                      daemon-set="daemonSet"
+                      show-resource-kind="::$ctrl.showResourceKind">
   </kd-daemon-set-card>
 
-  <kd-daemon-set-card ng-if="::!$ctrl.daemonSetListResource" pagination-id="daemonsets"
+  <kd-daemon-set-card ng-if="::!$ctrl.daemonSetListResource"
+                      pagination-id="daemonsets"
                       dir-paginate="daemonSet in $ctrl.daemonSetList.daemonSets | itemsPerPage: default"
-                      daemon-set="daemonSet" show-resource-kind="::$ctrl.showResourceKind">
+                      daemon-set="daemonSet"
+                      show-resource-kind="::$ctrl.showResourceKind">
   </kd-daemon-set-card>
 </kd-resource-card-list>

--- a/src/app/frontend/deploy/createnamespace.html
+++ b/src/app/frontend/deploy/createnamespace.html
@@ -14,16 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-dialog aria-label="Create a new namespace" layout="column">
+<md-dialog aria-label="Create a new namespace"
+           layout="column">
   <md-dialog-content layout-padding>
-    <h4 class="md-title" >[[Create a new namespace|Create namespace dialog title. The message appears at the top of the dialog box.]]</h4>
+    <h4 class="md-title">[[Create a new namespace|Create namespace dialog title. The message appears at the top of the dialog box.]]</h4>
     <div>[[The new namespace will be added to the cluster.|Create namespace dialog subtitle. Appears right below the title.]]</div>
 
-    <form name="ctrl.namespaceForm" ng-submit="ctrl.createNamespace()" novalidate>
+    <form name="ctrl.namespaceForm"
+          ng-submit="ctrl.createNamespace()"
+          novalidate>
       <kd-help-section>
         <md-input-container class="md-block">
           <label>[[Namespace name|Label 'Namespace name', which appears as a placeholder in an empty input field in the create namespace dialog.]]</label>
-          <input name="namespace" ng-model="ctrl.namespace"
+          <input name="namespace"
+                 ng-model="ctrl.namespace"
                  md-maxlength="{{ctrl.namespaceMaxLength}}"
                  ng-pattern="ctrl.namespacePattern"
                  required>
@@ -35,14 +39,18 @@ limitations under the License.
         </md-input-container>
         <kd-user-help>
           [[A namespace with the specified name will be added to the cluster.|User help text for the input of the 'Namespace' data.]]
-          <a href="http://kubernetes.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
+          <a href="http://kubernetes.io/docs/admin/namespaces/"
+             target="_blank"
+             tabindex="-1">
             [[Learn more|The text is used as a 'Learn more' link text in the namespace creation dialog]]
             <i class="material-icons">open_in_new</i>
           </a>
         </kd-user-help>
       </kd-help-section>
       <md-dialog-actions layout="row">
-        <md-button ng-disabled="ctrl.isDisabled()" class="md-primary" type="submit">
+        <md-button ng-disabled="ctrl.isDisabled()"
+                   class="md-primary"
+                   type="submit">
           [[Create|The text is put on the 'Create' button in the namespace creation dialog.]]
         </md-button>
         <md-button ng-click="ctrl.cancel()">[[Cancel|The text is put on the 'Cancel' button in the namespace creation dialog.]]</md-button>

--- a/src/app/frontend/deploy/createsecret.html
+++ b/src/app/frontend/deploy/createsecret.html
@@ -14,31 +14,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-dialog aria-label="Create a new secret" layout="column" class="kd-create-secret-dialog">
+<md-dialog aria-label="Create a new secret"
+           layout="column"
+           class="kd-create-secret-dialog">
   <md-dialog-content layout-padding>
     <h4 class="md-title">[[Create a new image pull secret|Create image pull secret dialog title. The message appears at the top of the dialog box.]]</h4>
     <div>[[The new secret will be added to the cluster|Create image pull secret dialog subtitle. Appears right below the title.]]</div>
 
-    <form name="ctrl.secretForm" ng-submit="ctrl.createSecret()" novalidate>
+    <form name="ctrl.secretForm"
+          ng-submit="ctrl.createSecret()"
+          novalidate>
       <kd-help-section>
-        <md-input-container class="md-block" layout-wrap>
+        <md-input-container class="md-block"
+                            layout-wrap>
           <label>[[Secret name|Label 'Secret name', which appears as a placeholder in an empty input field in the image pull secret creation dialog.]]</label>
-          <input name="secretName" ng-model="ctrl.secretName"
-                 md-maxlength="{{ctrl.secretNameMaxLength}}" ng-pattern="ctrl.secretNamePattern"
+          <input name="secretName"
+                 ng-model="ctrl.secretName"
+                 md-maxlength="{{ctrl.secretNameMaxLength}}"
+                 ng-pattern="ctrl.secretNamePattern"
                  required>
-          <div ng-messages="ctrl.secretForm.secretName.$error" role="alert" multiple>
+          <div ng-messages="ctrl.secretForm.secretName.$error"
+               role="alert"
+               multiple>
             <div ng-message="pattern">
               [[Name must follow the DNS domain name syntax (e.g. new.image-pull.secret).|The text appears when the image pull secret name does not match the expected pattern.]]
             </div>
             <div ng-message="md-maxlength">
-                [[Name must be up to {{::$ctrl.secretNameMaxLength}} characters long.|The text appears when the image pull secret name exceeds the maximal length.]]
+              [[Name must be up to {{::$ctrl.secretNameMaxLength}} characters long.|The text appears when the image pull secret name exceeds the maximal length.]]
             </div>
             <div ng-message="required">[[Name is required.|Warning which tells the user that the image pull secret name is required.]]</div>
           </div>
         </md-input-container>
         <kd-user-help>
           [[A secret with the specified name will be added to the cluster in the namespace.|User help text for the create image pull secret dialog. Directly after this text a specific namespace is specified.]] <span class="kd-emphasized">{{ctrl.namespace}}.</span>
-          <a href="http://kubernetes.io/docs/user-guide/secrets/" target="_blank">
+          <a href="http://kubernetes.io/docs/user-guide/secrets/"
+             target="_blank">
             [[Learn more|The text is used as a 'Learn more' link text in the image pull secret creation dialog.]]
             <i class="material-icons">open_in_new</i>
           </a>
@@ -46,11 +56,19 @@ limitations under the License.
       </kd-help-section>
 
       <kd-help-section>
-        <md-input-container class="md-block" layout-wrap>
+        <md-input-container class="md-block"
+                            layout-wrap>
           <label>[[Image pull secret data|Label 'Image pull secret data', which appears as a placeholder in an empty input field in the image pull secret creation dialog.]]</label>
-          <input name="data" ng-model="ctrl.data" class="kd-secret-data"
-                    columns="1" rows="5"  ng-pattern="ctrl.dataPattern" required>
-          <div ng-messages="ctrl.secretForm.data.$error" role="alert" multiple>
+          <input name="data"
+                 ng-model="ctrl.data"
+                 class="kd-secret-data"
+                 columns="1"
+                 rows="5"
+                 ng-pattern="ctrl.dataPattern"
+                 required>
+          <div ng-messages="ctrl.secretForm.data.$error"
+               role="alert"
+               multiple>
             <div ng-message="required">[[Data is required.|Warning which tells the user that the image pull secret data is required.]]</div>
             <div ng-message="pattern">[[Data must be Base64 encoded.|The text appears when the image pull secret data is not Base64 encoded.]]</div>
           </div>
@@ -65,7 +83,8 @@ limitations under the License.
       </kd-help-section>
 
       <md-dialog-actions layout="row">
-        <md-button class="md-primary" type="submit">[[Create|The text is put on the 'Create' button in the image pull secret creation dialog.]]</md-button>
+        <md-button class="md-primary"
+                   type="submit">[[Create|The text is put on the 'Create' button in the image pull secret creation dialog.]]</md-button>
         <md-button ng-click="ctrl.cancel()">[[Cancel|The text is put on the 'Cancel' button in the image pull secret creation dialog.]]</md-button>
       </md-dialog-actions>
     </form>

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -18,16 +18,21 @@ limitations under the License.
   <kd-title>[[Deploy a Containerized App|Title text which appears on top of the deploy page.]]</kd-title>
   <kd-content class="kd-content-padded">
     <kd-help-section>
-      <md-radio-group ng-model="ctrl.selection" ng-change="ctrl.changeSelection()">
-        <md-radio-button value="{{::ctrl.appOption}}" class="md-primary">
+      <md-radio-group ng-model="ctrl.selection"
+                      ng-change="ctrl.changeSelection()">
+        <md-radio-button value="{{::ctrl.appOption}}"
+                         class="md-primary">
           [[Specify app details below|Text for a selection option, which the user must click to manually enter the app details on the deploy page.]]
         </md-radio-button>
-        <md-radio-button value="{{::ctrl.fileOption}}" class="md-primary">
+        <md-radio-button value="{{::ctrl.fileOption}}"
+                         class="md-primary">
           [[Upload a YAML or JSON file|Text for a selection option, which the user must click to upload a YAML/JSON file to deploy from on the deploy page.]]
         </md-radio-button>
       </md-radio-group>
       <kd-user-help>
-        [[To learn more, <a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank" tabindex="-1"> take the Dashboard Tour <i class="material-icons">open_in_new</i></a>|User help with a link redirecting to the "Dashboard tour" on the deploy page.]]
+        [[To learn more, <a href="http://kubernetes.io/docs/user-guide/ui/"
+           target="_blank"
+           tabindex="-1"> take the Dashboard Tour <i class="material-icons">open_in_new</i></a>|User help with a link redirecting to the "Dashboard tour" on the deploy page.]]
       </kd-user-help>
     </kd-help-section>
     <div ui-view></div>

--- a/src/app/frontend/deploy/deployfromfile.html
+++ b/src/app/frontend/deploy/deployfromfile.html
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<form name="ctrl.form" ng-submit="ctrl.deploy()" novalidate>
-  <kd-upload file="ctrl.file" form="ctrl.form"></kd-upload>
+<form name="ctrl.form"
+      ng-submit="ctrl.deploy()"
+      novalidate>
+  <kd-upload file="ctrl.file"
+             form="ctrl.form"></kd-upload>
   <div></div>
-  <md-button class="md-raised md-primary kd-deploy-submit-button" type="submit"
+  <md-button class="md-raised md-primary kd-deploy-submit-button"
+             type="submit"
              ng-disabled="ctrl.isDeployDisabled()">
     [[Upload|The text is put on the button at the end of the YAML upload page.]]
   </md-button>
-  <md-button class="md-raised kd-deploy-cancel-button" ng-click="ctrl.cancel()">
+  <md-button class="md-raised kd-deploy-cancel-button"
+             ng-click="ctrl.cancel()">
     [[Cancel|The text is put on the 'Cancel' button at the end of the YAML upload page.]]
   </md-button>
 </form>

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -14,19 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<form name="ctrl.form" ng-submit="ctrl.deploy()" novalidate>
+<form name="ctrl.form"
+      ng-submit="ctrl.deploy()"
+      novalidate>
   <kd-help-section>
-    <md-input-container class="md-block" md-is-error="ctrl.isNameError()">
+    <md-input-container class="md-block"
+                        md-is-error="ctrl.isNameError()">
       <label>[[App name|Label 'App name', which appears as a placeholder in an empty input field on the deploy from settings page.]]</label>
       <div>
-        <input ng-model="ctrl.name" name="name" namespace="ctrl.namespace" required
+        <input ng-model="ctrl.name"
+               name="name"
+               namespace="ctrl.namespace"
+               required
                ng-pattern="ctrl.namePattern"
                ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
-               kd-unique-name md-maxlength="{{ctrl.nameMaxLength}}">
-        <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate"
-          ng-class="{'kd-deploy-form-progress-show': ctrl.form.name.$pending}">
+               kd-unique-name
+               md-maxlength="{{ctrl.nameMaxLength}}">
+        <md-progress-linear class="kd-deploy-form-progress"
+                            md-mode="indeterminate"
+                            ng-class="{'kd-deploy-form-progress-show': ctrl.form.name.$pending}">
         </md-progress-linear>
-        <ng-messages for="ctrl.form.name.$error" role="alert" multiple>
+        <ng-messages for="ctrl.form.name.$error"
+                     role="alert"
+                     multiple>
           <ng-message when="required">[[Application name is required.|Appears to tell the user that app name input on the deploy from settings page is required.]]</ng-message>
           <ng-message when="uniqueName">
             [[Replication controller or service with this name already exists within namespace.|Appears as warning when the user has typed in an app name that already exists. The text is followed by a specific namespace name.]]
@@ -44,7 +54,9 @@ limitations under the License.
 
     <kd-user-help>
       {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_APP_NAME_USER_HELP}}
-      <a href="http://kubernetes.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/user-guide/labels/"
+         target="_blank"
+         tabindex="-1">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -53,10 +65,15 @@ limitations under the License.
   <kd-help-section>
     <md-input-container class="md-block">
       <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CONTAINER_IMAGE_LABEL}}</label>
-      <input ng-model="ctrl.containerImage" name="containerImage" required
+      <input ng-model="ctrl.containerImage"
+             name="containerImage"
+             required
              ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
-             kd-valid-imagereference invalid-image-error-message="ctrl.containerImageErrorMessage">
-      <ng-messages for="ctrl.form.containerImage.$error" role="alert" multiple>
+             kd-valid-imagereference
+             invalid-image-error-message="ctrl.containerImageErrorMessage">
+      <ng-messages for="ctrl.form.containerImage.$error"
+                   role="alert"
+                   multiple>
         <ng-message when="required">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CONTAINER_IMAGE_REQUIRED_WARNING}}</ng-message>
         <ng-message when="validImageReference">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CONTAINER_IMAGE_INVALID_WARNING}} {{ ctrl.containerImageErrorMessage }}
@@ -64,8 +81,10 @@ limitations under the License.
       </ng-messages>
     </md-input-container>
     <kd-user-help>
-    {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CONTAINER_IMAGE_USER_HELP}}
-      <a href="http://kubernetes.io/docs/user-guide/images/" target="_blank" tabindex="-1">
+      {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CONTAINER_IMAGE_USER_HELP}}
+      <a href="http://kubernetes.io/docs/user-guide/images/"
+         target="_blank"
+         tabindex="-1">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -74,22 +93,32 @@ limitations under the License.
   <kd-help-section>
     <md-input-container class="md-block">
       <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_LABEL}}</label>
-      <input ng-model="ctrl.replicas" type="number" required min="1" name="replicas"
-             kd-validate="integer" kd-warn-threshold="100" kd-warn-threshold-bind="showWarning">
-      <ng-messages for="ctrl.form.replicas.$error" role="alert" multiple>
+      <input ng-model="ctrl.replicas"
+             type="number"
+             required
+             min="1"
+             name="replicas"
+             kd-validate="integer"
+             kd-warn-threshold="100"
+             kd-warn-threshold-bind="showWarning">
+      <ng-messages for="ctrl.form.replicas.$error"
+                   role="alert"
+                   multiple>
         <ng-message when="required">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_REQUIRED_WARNING}}</ng-message>
         <ng-message when="number, kdValidInteger">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_INT_WARNING}}
         </ng-message>
         <ng-message when="min">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_MIN_WARNING}}</ng-message>
       </ng-messages>
-      <span class="kd-warn-threshold" ng-show="showWarning">
+      <span class="kd-warn-threshold"
+            ng-show="showWarning">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_HIGH_WARNING}}
       </span>
     </md-input-container>
     <kd-user-help>
       {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NUMBER_OF_PODS_USER_HELP}}
-      <a href="http://kubernetes.io/docs/user-guide/replication-controller/" target="_blank"
+      <a href="http://kubernetes.io/docs/user-guide/replication-controller/"
+         target="_blank"
          tabindex="-1">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
       </a>
@@ -97,15 +126,18 @@ limitations under the License.
   </kd-help-section>
 
   <kd-help-section>
-    <kd-port-mappings port-mappings="ctrl.portMappings" protocols="ctrl.protocols"
-        is-external="ctrl.isExternal">
+    <kd-port-mappings port-mappings="ctrl.portMappings"
+                      protocols="ctrl.protocols"
+                      is-external="ctrl.isExternal">
     </kd-port-mappings>
     <kd-user-help>
       {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_PORT_MAPPINGS_USER_HELP}}
       <span ng-if="ctrl.name">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_SERVICE_DNS_NAME_USER_HELP}} <span class="kd-emphasized">{{ctrl.name}}</span>.
       </span>
-      <a href="http://kubernetes.io/docs/user-guide/services/" target="_blank" tabindex="-1">
+      <a href="http://kubernetes.io/docs/user-guide/services/"
+         target="_blank"
+         tabindex="-1">
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
       </a>
     </kd-user-help>
@@ -126,20 +158,26 @@ limitations under the License.
     <kd-help-section>
       <div layout="column">
         <div class="kd-label-title md-body-2">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LABELS_TITLE}}</div>
-        <div layout="row" class="kd-label-header-row">
+        <div layout="row"
+             class="kd-label-header-row">
           <div flex="45">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LABELS_KEY_LABEL}}</div>
           <div flex="5"></div>
           <div flex="40">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LABELS_VALUE_LABEL}}</div>
         </div>
         <div ng-repeat="label in ctrl.labels">
-           <kd-deploy-label layout="row" flex="auto" label="label" labels="ctrl.labels">
-           </kd-deploy-label>
+          <kd-deploy-label layout="row"
+                           flex="auto"
+                           label="label"
+                           labels="ctrl.labels">
+          </kd-deploy-label>
         </div>
       </div>
 
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LABELS_USER_HELP}}
-        <a href="http://kubernetes.io/docs/user-guide/labels/" target="_blank" tabindex="-1">
+        <a href="http://kubernetes.io/docs/user-guide/labels/"
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -148,8 +186,11 @@ limitations under the License.
     <kd-help-section>
       <md-input-container class="md-block">
         <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NAMESPACE_LABEL}}</label>
-        <md-select ng-model="ctrl.namespace" ng-click="ctrl.resetImagePullSecret()" required>
-          <md-option ng-repeat="namespace in ctrl.namespaces" ng-value="namespace">
+        <md-select ng-model="ctrl.namespace"
+                   ng-click="ctrl.resetImagePullSecret()"
+                   required>
+          <md-option ng-repeat="namespace in ctrl.namespaces"
+                     ng-value="namespace">
             {{namespace}}
           </md-option>
           <md-option ng-click="ctrl.handleNamespaceDialog($event)">
@@ -159,7 +200,9 @@ limitations under the License.
       </md-input-container>
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_NAMESPACE_USER_HELP}}
-        <a href="http://kubernetes.io/docs/admin/namespaces/" target="_blank" tabindex="-1">
+        <a href="http://kubernetes.io/docs/admin/namespaces/"
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -168,8 +211,10 @@ limitations under the License.
     <kd-help-section>
       <md-input-container class="md-block">
         <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_IMAGE_PULL_SECRET_LABEL}}</label>
-        <md-select ng-model="ctrl.imagePullSecret" ng-click="ctrl.getSecrets(ctrl.namespace)">
-          <md-option ng-repeat="secret in ctrl.secrets" ng-value="secret">
+        <md-select ng-model="ctrl.imagePullSecret"
+                   ng-click="ctrl.getSecrets(ctrl.namespace)">
+          <md-option ng-repeat="secret in ctrl.secrets"
+                     ng-value="secret">
             {{secret}}
           </md-option>
           <md-option ng-click="ctrl.handleCreateSecretDialog($event)">
@@ -179,7 +224,9 @@ limitations under the License.
       </md-input-container>
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_IMAGE_PULL_SECRET_USER_HELP}}
-        <a href="http://kubernetes.io/docs/user-guide/secrets/" target="_blank" tabindex="-1">
+        <a href="http://kubernetes.io/docs/user-guide/secrets/"
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -187,19 +234,29 @@ limitations under the License.
 
     <kd-help-section>
       <div layout="row">
-        <md-input-container flex="auto" >
+        <md-input-container flex="auto">
           <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CPU_REQUIREMENT_LABEL}}</label>
-          <input ng-model="ctrl.cpuRequirement" type="number" name="cpuRequirement" min="0">
-          <ng-messages for="ctrl.form.cpuRequirement.$error" role="alert" multiple>
+          <input ng-model="ctrl.cpuRequirement"
+                 type="number"
+                 name="cpuRequirement"
+                 min="0">
+          <ng-messages for="ctrl.form.cpuRequirement.$error"
+                       role="alert"
+                       multiple>
             <ng-message when="number">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CPU_NOT_A_NUMBER_WARNING}}</ng-message>
             <ng-message when="min">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CPU_NEGATIVE_WARNING}}</ng-message>
           </ng-messages>
         </md-input-container>
         <div flex="5"></div>
-        <md-input-container flex="auto" >
+        <md-input-container flex="auto">
           <label>{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_MEMORY_REQUIREMENT_LABEL}}</label>
-          <input ng-model="ctrl.memoryRequirement" type="number" name="memoryRequirement" min="0">
-          <ng-messages for="ctrl.form.memoryRequirement.$error" role="alert" multiple>
+          <input ng-model="ctrl.memoryRequirement"
+                 type="number"
+                 name="memoryRequirement"
+                 min="0">
+          <ng-messages for="ctrl.form.memoryRequirement.$error"
+                       role="alert"
+                       multiple>
             <ng-message when="number">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_MEMORY_NOT_A_NUMBER_WARNING}}</ng-message>
             <ng-message when="min">{{::ctrl.i18n.MSG_DEPLOY_SETTINGS_MEMORY_NEGATIVE_WARNING}}</ng-message>
           </ng-messages>
@@ -207,7 +264,9 @@ limitations under the License.
       </div>
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_CPU_MEM_USER_HELP}}
-        <a href="http://kubernetes.io/docs/admin/limitrange/" target="_blank" tabindex="-1">
+        <a href="http://kubernetes.io/docs/admin/limitrange/"
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -227,7 +286,8 @@ limitations under the License.
       </div>
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_RUN_COMMAND_USER_HELP}}
-        <a href="http://kubernetes.io/docs/user-guide/containers/" target="_blank"
+        <a href="http://kubernetes.io/docs/user-guide/containers/"
+           target="_blank"
            tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
@@ -236,14 +296,16 @@ limitations under the License.
 
     <kd-help-section>
       <div class="md-block">
-        <md-checkbox ng-model="ctrl.runAsPrivileged" class="md-primary">
+        <md-checkbox ng-model="ctrl.runAsPrivileged"
+                     class="md-primary">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_RUN_AS_PRIVILEGED_LABEL}}
         </md-checkbox>
       </div>
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_RUN_PRIVILEGED_USER_HELP}}
         <a href="http://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers"
-           target="_blank" tabindex="-1">
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -255,7 +317,8 @@ limitations under the License.
       <kd-user-help>
         {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_ENV_VARIABLES_USER_HELP}}
         <a href="http://kubernetes.io/docs/user-guide/configuring-containers/#environment-variables-and-variable-expansion"
-           target="_blank" tabindex="-1">
+           target="_blank"
+           tabindex="-1">
           {{::ctrl.i18n.MSG_DEPLOY_SETTINGS_LEARN_MORE_ACTION}} <i class="material-icons">open_in_new</i>
         </a>
       </kd-user-help>
@@ -263,21 +326,27 @@ limitations under the License.
   </div>
 
   <!-- show/hide advanced options toggle -->
-  <md-button class="md-primary kd-deploy-moreoptions-button" type="button"
-             ng-click="ctrl.switchMoreOptions()" ng-hide="ctrl.isMoreOptionsEnabled()">
+  <md-button class="md-primary kd-deploy-moreoptions-button"
+             type="button"
+             ng-click="ctrl.switchMoreOptions()"
+             ng-hide="ctrl.isMoreOptionsEnabled()">
     <md-icon>arrow_drop_down</md-icon>{{::ctrl.i18n.MSG_DEPLOY_SHOW_ADVANCED_ACTION}}
   </md-button>
-  <md-button class="md-primary kd-deploy-moreoptions-button" type="button"
-             ng-click="ctrl.switchMoreOptions()" ng-show="ctrl.isMoreOptionsEnabled()">
+  <md-button class="md-primary kd-deploy-moreoptions-button"
+             type="button"
+             ng-click="ctrl.switchMoreOptions()"
+             ng-show="ctrl.isMoreOptionsEnabled()">
     <md-icon>arrow_drop_up</md-icon>{{::ctrl.i18n.MSG_DEPLOY_HIDE_ADVANCED_ACTION}}
   </md-button>
 
   <div></div>
-  <md-button class="md-raised md-primary kd-deploy-submit-button" type="submit"
+  <md-button class="md-raised md-primary kd-deploy-submit-button"
+             type="submit"
              ng-disabled="ctrl.isDeployDisabled()">
     {{::ctrl.i18n.MSG_DEPLOY_APP_DEPLOY_ACTION}}
   </md-button>
-  <md-button class="md-raised kd-deploy-cancel-button" ng-click="ctrl.cancel()">
+  <md-button class="md-raised kd-deploy-cancel-button"
+             ng-click="ctrl.cancel()">
     {{::ctrl.i18n.MSG_DEPLOY_APP_CANCEL_ACTION}}
   </md-button>
 </form>

--- a/src/app/frontend/deploy/deploylabel.html
+++ b/src/app/frontend/deploy/deploylabel.html
@@ -14,13 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<ng-form layout="row" flex="auto" name="labelForm">
-  <md-input-container md-no-float class="kd-deploy-input-row" flex="45">
-    <input name="key" ng-model="labelCtrl.label.key" ng-change="labelCtrl.check(labelForm)"
-           placeholder="{{labelCtrl.label.key}}" ng-disabled="!labelCtrl.label.editable"
+<ng-form layout="row"
+         flex="auto"
+         name="labelForm">
+  <md-input-container md-no-float
+                      class="kd-deploy-input-row"
+                      flex="45">
+    <input name="key"
+           ng-model="labelCtrl.label.key"
+           ng-change="labelCtrl.check(labelForm)"
+           placeholder="{{labelCtrl.label.key}}"
+           ng-disabled="!labelCtrl.label.editable"
            kd-validate="labelKeyNameLength,labelKeyPrefixLength,labelKeyNamePattern,labelKeyPrefixPattern"
            ng-model-options="{allowInvalid: true}">
-    <ng-messages for="labelForm.key.$error" ng-if="labelForm.key.$touched && labelForm.key.$invalid">
+    <ng-messages for="labelForm.key.$error"
+                 ng-if="labelForm.key.$touched && labelForm.key.$invalid">
       <ng-message when="unique">
         {{::labelCtrl.getLabelKeyUniqueWarning()}}
       </ng-message>
@@ -35,19 +43,27 @@ limitations under the License.
     </ng-messages>
   </md-input-container>
   <p flex="5"></p>
-  <md-input-container md-no-float class="kd-deploy-input-row" flex="40">
-    <input name="value" ng-model="labelCtrl.label.value"
-           placeholder="{{labelCtrl.label.value}}" ng-disabled="!labelCtrl.label.editable"
-           kd-validate="labelValuePattern" ng-change="labelCtrl.check()" md-maxlength="253"
+  <md-input-container md-no-float
+                      class="kd-deploy-input-row"
+                      flex="40">
+    <input name="value"
+           ng-model="labelCtrl.label.value"
+           placeholder="{{labelCtrl.label.value}}"
+           ng-disabled="!labelCtrl.label.editable"
+           kd-validate="labelValuePattern"
+           ng-change="labelCtrl.check()"
+           md-maxlength="253"
            ng-model-options="{ getterSetter: true, allowInvalid: true }">
-    <ng-messages for="labelForm.value.$error" ng-if="labelForm.value.$touched && labelForm.value.$invalid">
+    <ng-messages for="labelForm.value.$error"
+                 ng-if="labelForm.value.$touched && labelForm.value.$invalid">
       <ng-message when="kdValidLabelValuePattern">
         [[Label value must be alphanumeric separated by '.' , '-' or '_'.|This warning appears when the value of a specified kubernetes label (on the deploy page) does not match the required pattern.]]
       </ng-message>
       <ng-message when="md-maxlength">[[Label Value must not exceed 253 characters.|This warning appears when the value of a specified kubernetes label (on the deploy page) is too long.]]</ng-message>
     </ng-messages>
   </md-input-container>
-  <md-button type="button" ng-show="labelCtrl.isRemovable()"
+  <md-button type="button"
+             ng-show="labelCtrl.isRemovable()"
              ng-click="labelCtrl.deleteLabel()"
              class="material-icons md-icon-button">delete
   </md-button>

--- a/src/app/frontend/deploy/environmentvariables.html
+++ b/src/app/frontend/deploy/environmentvariables.html
@@ -16,22 +16,31 @@ limitations under the License.
 
 <div class="kd-environment-variables-title md-body-2">[[Environment variables|Title of the Environment Variables section on the deploy page.]]</div>
 <div ng-repeat="variable in ctrl.variables">
-  <ng-form name="variablesForm" layout="row">
-    <md-input-container flex="auto" class="kd-deploy-input-row">
+  <ng-form name="variablesForm"
+           layout="row">
+    <md-input-container flex="auto"
+                        class="kd-deploy-input-row">
       <label>[[Name|Label "Name" which appears as a placeholder for the input of an environment variable name on the deploy page.]]</label>
-      <input ng-model="variable.name" name="name" ng-change="ctrl.addVariableIfNeeed()"
-          ng-pattern="ctrl.namePattern">
-      <ng-messages for="variablesForm.name.$error" role="alert" multiple>
+      <input ng-model="variable.name"
+             name="name"
+             ng-change="ctrl.addVariableIfNeeed()"
+             ng-pattern="ctrl.namePattern">
+      <ng-messages for="variablesForm.name.$error"
+                   role="alert"
+                   multiple>
         <ng-message when="pattern">[[Variable name must be a valid C identifier.|Label "Value" which appears as a placeholder for the input of an environment variable value on the deploy page.]]</ng-message>
       </ng-messages>
     </md-input-container>
     <div flex="5"></div>
-    <md-input-container flex="auto" class="kd-deploy-input-row">
+    <md-input-container flex="auto"
+                        class="kd-deploy-input-row">
       <label>[[Value|Label "Value" which appears as a placeholder for the input of an environment variable value on the deploy page.]]</label>
-      <input ng-model="variable.value" name="value">
+      <input ng-model="variable.value"
+             name="value">
     </md-input-container>
     <div flex="10">
-      <md-button type="button" ng-if="ctrl.isRemovable($index)"
+      <md-button type="button"
+                 ng-if="ctrl.isRemovable($index)"
                  ng-click="ctrl.remove($index)"
                  class="material-icons md-icon-button">
         delete

--- a/src/app/frontend/deploy/helpsection/helpsection.html
+++ b/src/app/frontend/deploy/helpsection/helpsection.html
@@ -14,4 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<ng-transclude class="kd-help-section" layout="row" layout-xs="column" layout-sm="column"> </ng-transclude>
+<ng-transclude class="kd-help-section"
+               layout="row"
+               layout-xs="column"
+               layout-sm="column"> </ng-transclude>

--- a/src/app/frontend/deploy/helpsection/userhelp.html
+++ b/src/app/frontend/deploy/helpsection/userhelp.html
@@ -14,4 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div ng-transclude class="kd-user-help" layout-align="start center"> </div>
+<div ng-transclude
+     class="kd-user-help"
+     layout-align="start center"> </div>

--- a/src/app/frontend/deploy/portmappings.html
+++ b/src/app/frontend/deploy/portmappings.html
@@ -16,19 +16,30 @@ limitations under the License.
 
 <md-input-container class="md-block kd-deploy-input-row ">
   <label>[[Service|Label 'Service' above the service type selection box on the deploy page.]]</label>
-<md-select ng-model="ctrl.serviceType" ng-change="ctrl.changeServiceType()" required>
-  <md-option ng-repeat="serviceType in ctrl.serviceTypes" ng-value="serviceType" class="md-block">
-    {{serviceType.label}}
-  </md-option>
-</md-select>
+  <md-select ng-model="ctrl.serviceType"
+             ng-change="ctrl.changeServiceType()"
+             required>
+    <md-option ng-repeat="serviceType in ctrl.serviceTypes"
+               ng-value="serviceType"
+               class="md-block">
+      {{serviceType.label}}
+    </md-option>
+  </md-select>
 </md-input-container>
 <div ng-repeat="portMapping in ctrl.portMappings">
-  <ng-form name="portMappingForm" layout="row">
+  <ng-form name="portMappingForm"
+           layout="row">
     <md-input-container flex="50">
       <label>[[Port|Label 'Port', which serves as a placeholder for the port input field in the port mappings section on the deploy page.]]</label>
-      <input ng-model="portMapping.port" ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
-             type="number" min="1" max="65535" name="port" ng-required="ctrl.isFirst($index)">
-      <ng-messages for="portMappingForm.port.$error" role="alert" >
+      <input ng-model="portMapping.port"
+             ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
+             type="number"
+             min="1"
+             max="65535"
+             name="port"
+             ng-required="ctrl.isFirst($index)">
+      <ng-messages for="portMappingForm.port.$error"
+                   role="alert">
         <ng-message when="number">[[Port must be an integer.|This warning appears when the user specifies a non-integer port number in the port mappings section on the deploy page.]]</ng-message>
         <ng-message when="min">[[Port must be greater than 0.|This warning appears when the user specifies a negative port number in the port mappings section on the deploy page.]]</ng-message>
         <ng-message when="max">[[Port must be less than 65536.|This warning appears when a typed in port number exceeds the maximum allowed value (in the port mappings section on the deploy page).]]</ng-message>
@@ -40,8 +51,13 @@ limitations under the License.
       <label>[[Target port|Label 'Target port', which serves as a placeholder for the target port input field in the port mappings section on the deploy page.]]</label>
       <input ng-model="portMapping.targetPort"
              ng-change="ctrl.checkPortMapping(portMappingForm, $index)"
-             type="number" min="1" max="65535" name="targetPort" ng-required="ctrl.isFirst($index)">
-      <ng-messages for="portMappingForm.targetPort.$error" role="alert" >
+             type="number"
+             min="1"
+             max="65535"
+             name="targetPort"
+             ng-required="ctrl.isFirst($index)">
+      <ng-messages for="portMappingForm.targetPort.$error"
+                   role="alert">
         <ng-message when="number">[[Target port must be an integer.|This warning appears when the user specifies a non-integer target port number in the port mappings section on the deploy page.]]</ng-message>
         <ng-message when="min">[[Target port must be greater than 0.|This warning appears when the user specifies a negative target port number in the port mappings section on the deploy page.]]</ng-message>
         <ng-message when="max">[Target port must be less than 65536.|This warning appears when a typed in target port number exceeds the maximum allowed value (in the port mappings section on the deploy page).]]</ng-message>
@@ -51,21 +67,29 @@ limitations under the License.
     <div flex="5"></div>
     <md-input-container flex="none">
       <label>[[Protocol|Label 'Protocol' above the protocol selection box in the port mappings section, on the deploy page.]]</label>
-      <md-select ng-model="portMapping.protocol" name="protocol" is-external="ctrl.isExternal"
-                 required kd-valid-protocol>
-        <md-option ng-repeat="protocol in ctrl.protocols" ng-value="protocol">
+      <md-select ng-model="portMapping.protocol"
+                 name="protocol"
+                 is-external="ctrl.isExternal"
+                 required
+                 kd-valid-protocol>
+        <md-option ng-repeat="protocol in ctrl.protocols"
+                   ng-value="protocol">
           {{protocol}}
         </md-option>
       </md-select>
-      <md-progress-linear class="kd-deploy-form-progress" md-mode="indeterminate"
+      <md-progress-linear class="kd-deploy-form-progress"
+                          md-mode="indeterminate"
                           ng-show="portMappingForm.protocol.$pending">
       </md-progress-linear>
-      <ng-messages for="portMappingForm.protocol.$error" role="alert" multiple>
+      <ng-messages for="portMappingForm.protocol.$error"
+                   role="alert"
+                   multiple>
         <ng-message when="required">[[Protocol is required.|This warning appears when the user does not specify a protocol for an existing port mapping (in the port mappings section, on the deploy page).]]</ng-message>
         <ng-message when="validProtocol">[[Invalid protocol.|This warning appears when the user specifies an invalid protocol for a port mapping (in the port mappings section, on the deploy page).]]</ng-message>
     </md-input-container>
     <div flex="10">
-      <md-button type="button" ng-if="ctrl.isRemovable($index)"
+      <md-button type="button"
+                 ng-if="ctrl.isRemovable($index)"
                  ng-click="ctrl.remove($index)"
                  class="material-icons md-icon-button">
         delete

--- a/src/app/frontend/deploy/upload.html
+++ b/src/app/frontend/deploy/upload.html
@@ -15,30 +15,44 @@ limitations under the License.
 -->
 
 <kd-help-section>
-  <div layout="row" layout-align="space-between start">
-    <div flex="auto" >
-      <md-input-container class="md-block kd-upload-file-container" md-is-error="ctrl.isFileNameError()">
+  <div layout="row"
+       layout-align="space-between start">
+    <div flex="auto">
+      <md-input-container class="md-block kd-upload-file-container"
+                          md-is-error="ctrl.isFileNameError()">
         <label>[[YAML or JSON file|A 'YAML or JSON file' label, serving as placeholder for an empty file input field on the deploy page.]]</label>
         <!--TODO: Browse file on focus doesn't work in Firefox. It is to be investigated.-->
-        <input ng-model="ctrl.file.name" ng-focus="ctrl.browseFile()" ng-readonly="true" name="fileName" required/>
-          <ng-messages for="ctrl.form.fileName.$error" role="alert" multiple>
-            <ng-message when="required">[[File is required.|Appears to tell the user that he/she must upload a YAML or a JSON file on the deploy page.]]</ng-message>
-            </ng-message>
-          </ng-messages>
+        <input ng-model="ctrl.file.name"
+               ng-focus="ctrl.browseFile()"
+               ng-readonly="true"
+               name="fileName"
+               required/>
+        <ng-messages for="ctrl.form.fileName.$error"
+                     role="alert"
+                     multiple>
+          <ng-message when="required">[[File is required.|Appears to tell the user that he/she must upload a YAML or a JSON file on the deploy page.]]</ng-message>
+          </ng-message>
+        </ng-messages>
       </md-input-container>
     </div>
-    <md-button type="button" class="md-raised kd-upload-button" ng-click="ctrl.browseFile()">
+    <md-button type="button"
+               class="md-raised kd-upload-button"
+               ng-click="ctrl.browseFile()">
       <label class="kd-upload-label">
         <md-icon>
           <i class="material-icons">more_horiz</i>
         </md-icon>
       </label>
     </md-button>
-    <input type="file" class="kd-upload-file-picker" kd-file-reader ng-model="ctrl.file">
+    <input type="file"
+           class="kd-upload-file-picker"
+           kd-file-reader
+           ng-model="ctrl.file">
   </div>
   <kd-user-help>
     [[Select a YAML or JSON file, specifying the resources to deploy.|User help for the YAML/JSON file upload form on the deploy page.]]
-    <a href="http://kubernetes.io/docs/user-guide/deploying-applications/" target="_blank">
+    <a href="http://kubernetes.io/docs/user-guide/deploying-applications/"
+       target="_blank">
       [[Learn more|The text is used as a 'Learn more' link text besides the file upload on the deploy page.]] <i class="material-icons">open_in_new</i>
     </a>
   </kd-user-help>

--- a/src/app/frontend/deploymentdetail/actionbar.html
+++ b/src/app/frontend/deploymentdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                  resource-kind-name="[[Deployment|Label 'Deployment' which will appear in the deployment delete dialog opened from the deployment details page.]]"
-                  type-meta="$ctrl.details.typeMeta"
-                  object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Deployment|Label 'Deployment' which will appear in the deployment delete dialog opened from the deployment details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/deploymentdetail/deploymentdetail.html
+++ b/src/app/frontend/deploymentdetail/deploymentdetail.html
@@ -46,9 +46,8 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-replica-set-card-list
-            replica-set-list="::ctrl.deploymentDetail.oldReplicaSetList"
-            replica-set-list-resource="::ctrl.oldReplicaSetListResource">
+    <kd-replica-set-card-list replica-set-list="::ctrl.deploymentDetail.oldReplicaSetList"
+                              replica-set-list-resource="::ctrl.oldReplicaSetListResource">
       <kd-header>[[Old Replica Sets|Title 'Old Replica Sets' for the old replica sets view, on the deployment details page.]]</kd-header>
       <kd-zerostate>
         <div class="kd-zerostate-title">
@@ -64,8 +63,7 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-horizontal-pod-autoscaler-card-list
-             horizontal-pod-autoscaler-list="::ctrl.deploymentDetail.horizontalPodAutoscalerList">
+    <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::ctrl.deploymentDetail.horizontalPodAutoscalerList">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
         <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>

--- a/src/app/frontend/deploymentdetail/deploymentinfo.html
+++ b/src/app/frontend/deploymentdetail/deploymentinfo.html
@@ -2,8 +2,7 @@
   <kd-info-card-header>[[Details|Header in a detail view]]</kd-info-card-header>
   <kd-info-card-section>
     <kd-info-card-entry title="[[Name|Label 'Name' for the deployment name on the deployment details page.]]">
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.deployment.objectMeta.name}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.deployment.objectMeta.name}}">
       </kd-middle-ellipsis>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Namespace|Label 'Namespace' for the deployment namespace on the deployment details page.]]">
@@ -32,15 +31,14 @@
 
     <kd-info-card-entry title="[[Rolling update strategy|Label 'Rolling Update Strategy' for the deployment's rolling update strategy on the deployment details page.]]"
                         ng-if="$ctrl.rollingUpdateStrategy()">
-      [[Max surge: {{$ctrl.deployment.rollingUpdateStrategy.maxSurge}}|The message says how many replicas can be created above the desired number of replicas in a deployment (deployment details page).]],
-      [[Max unavailable: {{$ctrl.deployment.rollingUpdateStrategy.maxUnavailable}}|The message says how many replicas are allowed to be unavailable during an update in the deployment (deployment details page).]]
+      [[Max surge: {{$ctrl.deployment.rollingUpdateStrategy.maxSurge}}|The message says how many replicas can be created above the desired number of replicas in a deployment (deployment details page).]], [[Max unavailable: {{$ctrl.deployment.rollingUpdateStrategy.maxUnavailable}}|The
+      message says how many replicas are allowed to be unavailable during an update in the deployment (deployment details page).]]
     </kd-info-card-entry>
 
     <kd-info-card-entry title="[[Status|Label 'Status' for the deployment's status information on the deployment details page.]]">
-      [[{{$ctrl.deployment.statusInfo.updated}} updated|The message describes how many replicas were updated in the deployment (deployment details page).]],
-      [[{{$ctrl.deployment.statusInfo.replicas}} total|The message describes how many replicas (in total) are in the deployment (deployment details page).]],
-      [[{{$ctrl.deployment.statusInfo.available}} available|The message describes how many replicas are available in the deployment (deployment details page).]],
-      [[{{$ctrl.deployment.statusInfo.unavailable}} unavailable|The message says how many replicas are unavailable in the deployment (deployment details page).]]
+      [[{{$ctrl.deployment.statusInfo.updated}} updated|The message describes how many replicas were updated in the deployment (deployment details page).]], [[{{$ctrl.deployment.statusInfo.replicas}} total|The message describes how many replicas (in total)
+      are in the deployment (deployment details page).]], [[{{$ctrl.deployment.statusInfo.available}} available|The message describes how many replicas are available in the deployment (deployment details page).]], [[{{$ctrl.deployment.statusInfo.unavailable}}
+      unavailable|The message says how many replicas are unavailable in the deployment (deployment details page).]]
     </kd-info-card-entry>
   </kd-info-card-section>
 </kd-info-card>

--- a/src/app/frontend/deploymentlist/deploymentcard.html
+++ b/src/app/frontend/deploymentlist/deploymentcard.html
@@ -14,28 +14,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card type-meta="$ctrl.deployment.typeMeta" object-meta="$ctrl.deployment.objectMeta">
+<kd-resource-card type-meta="$ctrl.deployment.typeMeta"
+                  object-meta="$ctrl.deployment.objectMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.hasWarnings()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.hasWarnings()">
       error
       <md-tooltip md-direction="right">
         [[One or more pods have errors|Tooltip saying that some pods in a deployment have errors.]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">
         [[One or more pods are in pending state|Tooltip saying that some pods in a deployment are pending.]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getDeploymentDetailHref()}}" style="display: block;">
+        <a ng-href="{{::$ctrl.getDeploymentDetailHref()}}"
+           style="display: block;">
           <kd-middle-ellipsis display-string="{{$ctrl.deployment.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -77,8 +82,8 @@ limitations under the License.
     </kd-resource-card-column>
   </kd-resource-card-columns>
   <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
-      <div ng-repeat="warning in ::$ctrl.deployment.pods.warnings">
-        <span class="kd-error">{{::warning.message}}</span>
-      </div>
+    <div ng-repeat="warning in ::$ctrl.deployment.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
   </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/deploymentlist/deploymentcardlist.html
+++ b/src/app/frontend/deploymentlist/deploymentcardlist.html
@@ -14,43 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Deployments|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="deployments" list="$ctrl.deploymentList"
+  <kd-resource-card-list-pagination pagination-id="deployments"
+                                    list="$ctrl.deploymentList"
                                     list-resource="::$ctrl.deploymentListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Pods|Label 'Pods' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Images|Label 'Images' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-deployment-card ng-if="::$ctrl.deploymentListResource" deployment="deployment"
+  <kd-deployment-card ng-if="::$ctrl.deploymentListResource"
+                      deployment="deployment"
                       dir-paginate="deployment in $ctrl.deploymentList.deployments | itemsPerPage: default"
                       pagination-id="deployments"
                       total-items="$ctrl.deploymentList.listMeta.totalItems">
   </kd-deployment-card>
 
-  <kd-deployment-card ng-if="::!$ctrl.deploymentListResource" deployment="deployment"
+  <kd-deployment-card ng-if="::!$ctrl.deploymentListResource"
+                      deployment="deployment"
                       dir-paginate="deployment in $ctrl.deploymentList.deployments | itemsPerPage: default"
                       pagination-id="deployments">
   </kd-deployment-card>

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -15,18 +15,20 @@ limitations under the License.
 -->
 
 <div class="kd-error-center-fixed">
-  <div layout="column"  layout-align="center center">
-    <div flex="auto" class="kd-error-block">
+  <div layout="column"
+       layout-align="center center">
+    <div flex="auto"
+         class="kd-error-block">
       <h2 class="md-headline kd-error-view-header">
         <i class="material-icons kd-error-view-icon">error_outline</i>
         <span>{{ctrl.getErrorStatus()}}</span>
       </h2>
       <pre>{{ctrl.getErrorData()}}</pre>
-      <div layout="row" layout-align="end center">
+      <div layout="row"
+           layout-align="end center">
         <a ng-href="{{ctrl.getLinkToFeedbackPage()}}">
-          <md-button  class="kd-error-feedback-button">
-            [[Send feedback|This is a label for button displayed on error page used to send feedback
-            to GitHub new issue.]]
+          <md-button class="kd-error-feedback-button">
+            [[Send feedback|This is a label for button displayed on error page used to send feedback to GitHub new issue.]]
           </md-button>
         </a>
       </div>

--- a/src/app/frontend/events/eventcardlist.html
+++ b/src/app/frontend/events/eventcardlist.html
@@ -16,16 +16,19 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-resource-card-list selectable="false" with-statuses="true">
+    <kd-resource-card-list selectable="false"
+                           with-statuses="true">
       <kd-resource-card-list-header>
         [[Events|Label which appears above the list of such objects.]]
       </kd-resource-card-list-header>
-      <kd-resource-card-list-pagination pagination-id="events" list="$ctrl.eventList"
+      <kd-resource-card-list-pagination pagination-id="events"
+                                        list="$ctrl.eventList"
                                         list-resource="$ctrl.eventListResource">
       </kd-resource-card-list-pagination>
 
       <kd-resource-card-header-columns ng-show="$ctrl.hasEvents()">
-        <kd-resource-card-header-column size="medium" grow="4">
+        <kd-resource-card-header-column size="medium"
+                                        grow="4">
           [[Message|Label 'Message' for the event message column of the events table (events list page).]]
         </kd-resource-card-header-column>
         <kd-resource-card-header-column>
@@ -34,7 +37,8 @@ limitations under the License.
         <kd-resource-card-header-column>
           [[Sub-object|Label 'Sub-object' for the respective column of the events table (events list page).]]
         </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="nogrow">
+        <kd-resource-card-header-column size="small"
+                                        grow="nogrow">
           [[Count|Label 'Count' for event count column of the events table (events list page).]]
         </kd-resource-card-header-column>
         <kd-resource-card-header-column>
@@ -45,9 +49,11 @@ limitations under the License.
         </kd-resource-card-header-column>
       </kd-resource-card-header-columns>
 
-      <kd-resource-card
-              dir-paginate="event in $ctrl.eventList.events | itemsPerPage: default" total-items="::$ctrl.eventList.listMeta.totalItems"
-              object-meta="event.objectMeta" type-meta="event.typeMeta" pagination-id="events">
+      <kd-resource-card dir-paginate="event in $ctrl.eventList.events | itemsPerPage: default"
+                        total-items="::$ctrl.eventList.listMeta.totalItems"
+                        object-meta="event.objectMeta"
+                        type-meta="event.typeMeta"
+                        pagination-id="events">
         <kd-resource-card-status>
           <i ng-if="$ctrl.isEventWarning(event)"
              class="material-icons kd-replicationcontrollerevents-warning-icon">warning</i>
@@ -75,7 +81,8 @@ limitations under the License.
           </kd-resource-card-column>
         </kd-resource-card-columns>
       </kd-resource-card>
-      <kd-zerostate class="kd-zerostate-message" ng-if="!$ctrl.hasEvents()">
+      <kd-zerostate class="kd-zerostate-message"
+                    ng-if="!$ctrl.hasEvents()">
         <div class="kd-zerostate-title">[[There is nothing to display here|Title of section when there are no events.]]</div>
         <div class="kd-zerostate-text">[[It is possible that all events have expired.|User help on the events page when no events are to be displayed.]]</div>
       </kd-zerostate>

--- a/src/app/frontend/horizontalpodautoscalerdetail/actionbar.html
+++ b/src/app/frontend/horizontalpodautoscalerdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Horizontal Pod Autoscaler|Label 'Horizontal Pod Autoscaler' which appears at the top of the delete dialog, opened from a horizontal pod autoscaler details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Horizontal Pod Autoscaler|Label 'Horizontal Pod Autoscaler' which appears at the top of the delete dialog, opened from a horizontal pod autoscaler details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercard.html
+++ b/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercard.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.horizontalPodAutoscaler.objectMeta" type-meta="::$ctrl.horizontalPodAutoscaler.typeMeta">
+<kd-resource-card object-meta="::$ctrl.horizontalPodAutoscaler.objectMeta"
+                  type-meta="::$ctrl.horizontalPodAutoscaler.typeMeta">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <a ng-href="{{::$ctrl.getHorizontalPodAutoscalerDetailHref()}}">
@@ -64,12 +65,10 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>
-        <kd-resource-card-delete-menu-item
-                resource-kind-name="[[Horizontal Pod Autoscaler|Title 'Horizontal Pod Autoscaler' which is used as a title for the delete/update
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Horizontal Pod Autoscaler|Title 'Horizontal Pod Autoscaler' which is used as a title for the delete/update
    dialogs (that can be opened on the horizontal pod autoscaler list view).]]">
         </kd-resource-card-delete-menu-item>
-        <kd-resource-card-edit-menu-item
-                resource-kind-name="[[Horizontal Pod Autoscaler|Title 'Horizontal Pod Autoscaler' which is used as a title for the delete/update
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Horizontal Pod Autoscaler|Title 'Horizontal Pod Autoscaler' which is used as a title for the delete/update
    dialogs (that can be opened on the horizontal pod autoscaler list view).]]">
         </kd-resource-card-edit-menu-item>
       </kd-resource-card-menu>

--- a/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercardlist.html
+++ b/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalercardlist.html
@@ -18,55 +18,65 @@ limitations under the License.
   <kd-resource-card-list-header ng-transclude="header">
     [[Horizontal Pod Autoscalers|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="jobs" list="$ctrl.horizontalPodAutoscalerList"
+  <kd-resource-card-list-pagination pagination-id="jobs"
+                                    list="$ctrl.horizontalPodAutoscalerList"
                                     list-resource="::$ctrl.horizontalPodAutoscalerListResource">
   </kd-resource-card-list-pagination>
   <div ng-show="!$ctrl.horizontalPodAutoscalerList.listMeta.totalItems"
-      class="kd-zerostate-message" ng-transclude="zerostate"></div>
+       class="kd-zerostate-message"
+       ng-transclude="zerostate"></div>
 
   <kd-resource-card-header-columns ng-show="$ctrl.horizontalPodAutoscalerList.listMeta.totalItems">
-    <kd-resource-card-header-column size="small" grow="2">
-      [[Name|Label 'Name' which appears as a column label in the
-      table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Name|Label 'Name' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column ng-if="$ctrl.areMultipleNamespacesSelected()" size="small" grow="2">
-      [[Namespace|Label 'Namespace' which appears as a column label in the
-      table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column ng-if="$ctrl.areMultipleNamespacesSelected()"
+                                    size="small"
+                                    grow="2">
+      [[Namespace|Label 'Namespace' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showScaleTarget">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showScaleTarget">
       [[Target|Column header 'Target' on Horizontal Pod Autoscaler lists]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Target CPU Utilization|Label 'Target CPU Utilization' which appears as a column label in the table of
-      horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Target CPU Utilization|Label 'Target CPU Utilization' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Current CPU Utilization|Label 'Current CPU Utilization' which appears as a column label in the table of
-      horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Current CPU Utilization|Label 'Current CPU Utilization' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Min Replicas|Label 'Min Replicas' which appears as a column label in the table of
-      horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Min Replicas|Label 'Min Replicas' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Max Replicas|Label 'Max Replicas' which appears as a column label in the table of
-      horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Max Replicas|Label 'Max Replicas' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
-      [[Age|Label 'Age' which appears as a column label in the table of
-      horizontal pod autoscalers (horizontal pod autoscaler list view).]]
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Age|Label 'Age' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-horizontal-pod-autoscaler-card ng-if="::$ctrl.horizontalPodAutoscalerListResource" pagination-id="horizontalpodautoscalers"
-                      dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
-                      total-items="::$ctrl.horizontalPodAutoscalerList.listMeta.totalItems"
-                      horizontal-pod-autoscaler="horizontalPodAutoscaler" show-scale-target="::$ctrl.showScaleTarget">
+  <kd-horizontal-pod-autoscaler-card ng-if="::$ctrl.horizontalPodAutoscalerListResource"
+                                     pagination-id="horizontalpodautoscalers"
+                                     dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
+                                     total-items="::$ctrl.horizontalPodAutoscalerList.listMeta.totalItems"
+                                     horizontal-pod-autoscaler="horizontalPodAutoscaler"
+                                     show-scale-target="::$ctrl.showScaleTarget">
   </kd-horizontal-pod-autoscaler-card>
 
-  <kd-horizontal-pod-autoscaler-card ng-if="::!$ctrl.horizontalPodAutoscalerListResource" pagination-id="horizontalpodautoscalers"
-                      dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
-                      horizontal-pod-autoscaler="horizontalPodAutoscaler" show-scale-target="::$ctrl.showScaleTarget">
+  <kd-horizontal-pod-autoscaler-card ng-if="::!$ctrl.horizontalPodAutoscalerListResource"
+                                     pagination-id="horizontalpodautoscalers"
+                                     dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
+                                     horizontal-pod-autoscaler="horizontalPodAutoscaler"
+                                     show-scale-target="::$ctrl.showScaleTarget">
   </kd-horizontal-pod-autoscaler-card>
 </kd-resource-card-list>

--- a/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalerlist.html
+++ b/src/app/frontend/horizontalpodautoscalerlist/horizontalpodautoscalerlist.html
@@ -17,9 +17,8 @@ limitations under the License.
 <kd-content-card ng-if="!ctrl.shouldShowZeroState()">
   <kd-content>
     <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::ctrl.horizontalPodAutoscalerList"
-                             horizontal-pod-autoscaler-list-resource="::ctrl.horizontalPodAutoscalerListResource"
-                             show-scale-target="true"
-                             >
+                                            horizontal-pod-autoscaler-list-resource="::ctrl.horizontalPodAutoscalerListResource"
+                                            show-scale-target="true">
 
     </kd-horizontal-pod-autoscaler-card-list>
   </kd-content>

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -16,50 +16,60 @@ limitations under the License.
 
 <!doctype html>
 <html ng-app="kubernetesDashboard">
-  <!-- TODO(bryk): Add ng-strict-di setting for production builds. -->
-  <head>
-    <meta charset="utf-8">
-    <title ng-controller="kdTitle as $ctrl" ng-bind="$ctrl.title()"></title>
-    <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png"/>
-    <meta name="viewport" content="width=device-width">
+<!-- TODO(bryk): Add ng-strict-di setting for production builds. -->
 
-    <!-- build:css static/vendor.css -->
-    <!-- bower:css -->
-    <!-- Bower CSS dependencies are populated here (dev build) and compiled
+<head>
+  <meta charset="utf-8">
+  <title ng-controller="kdTitle as $ctrl"
+         ng-bind="$ctrl.title()"></title>
+  <link rel="icon"
+        type="image/png"
+        href="assets/images/kubernetes-logo.png" />
+  <meta name="viewport"
+        content="width=device-width">
+
+  <!-- build:css static/vendor.css -->
+  <!-- bower:css -->
+  <!-- Bower CSS dependencies are populated here (dev build) and compiled
          into vendor.css (prod build). -->
-    <!-- endbower -->
-    <!-- endbuild -->
+  <!-- endbower -->
+  <!-- endbuild -->
 
-    <!-- build:css static/app.css -->
-    <!-- inject:css -->
-    <!-- Application css files are populated here (dev build) and compiled
+  <!-- build:css static/app.css -->
+  <!-- inject:css -->
+  <!-- Application css files are populated here (dev build) and compiled
          into app.css (prod build). -->
-    <!-- endinject -->
-    <!-- endbuild -->
-  </head>
-  <body>
-    <!--[if lt IE 10]>
+  <!-- endinject -->
+  <!-- endbuild -->
+</head>
+
+<body>
+  <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser.
       Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your
       experience.</p>
     <![endif]-->
 
-    <kd-chrome layout="column" layout-fill> <!-- Application content is inserted here. --> </kd-chrome>
-    <!-- build:js static/vendor.js -->
-    <!-- bower:js -->
-    <!-- Bower JS dependencies are populated here (dev build) and compiled
+  <kd-chrome layout="column"
+             layout-fill>
+    <!-- Application content is inserted here. -->
+  </kd-chrome>
+  <!-- build:js static/vendor.js -->
+  <!-- bower:js -->
+  <!-- Bower JS dependencies are populated here (dev build) and compiled
          into vendor.js (prod build). -->
-    <!-- endbower -->
-    <!-- endbuild -->
+  <!-- endbower -->
+  <!-- endbuild -->
 
-    <!-- Script with configuration generated at backend. -->
-    <script src="api/appConfig.json"></script>
+  <!-- Script with configuration generated at backend. -->
+  <script src="api/appConfig.json"></script>
 
-    <!-- build:js static/app.js -->
-    <!-- inject:js -->
-    <!-- Application JS files are populated here. -->
-    <!-- endinject -->
-    <!-- endbuild -->
+  <!-- build:js static/app.js -->
+  <!-- inject:js -->
+  <!-- Application JS files are populated here. -->
+  <!-- endinject -->
+  <!-- endbuild -->
 
-  </body>
+</body>
+
 </html>

--- a/src/app/frontend/ingressdetail/actionbar.html
+++ b/src/app/frontend/ingressdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Ingress|Label 'Ingress' which appears at the top of the delete dialog, opened from an ingress details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Ingress|Label 'Ingress' which appears at the top of the delete dialog, opened from an ingress details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/ingressdetail/info.html
+++ b/src/app/frontend/ingressdetail/info.html
@@ -18,8 +18,7 @@ limitations under the License.
   <kd-info-card-header>[[Details|Header in a detail view]]</kd-info-card-header>
   <kd-info-card-section>
     <kd-info-card-entry title="[[Name|Resource info details section name entry.]]">
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.ingress.objectMeta.name}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.ingress.objectMeta.name}}">
       </kd-middle-ellipsis>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Namespace|Resource info details section namespace entry.]]">

--- a/src/app/frontend/ingresslist/card.html
+++ b/src/app/frontend/ingresslist/card.html
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card type-meta="::$ctrl.ingress.typeMeta" object-meta="::$ctrl.ingress.objectMeta">
+<kd-resource-card type-meta="::$ctrl.ingress.typeMeta"
+                  object-meta="::$ctrl.ingress.objectMeta">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getIngressDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getIngressDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{::$ctrl.ingress.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>

--- a/src/app/frontend/ingresslist/cardlist.html
+++ b/src/app/frontend/ingresslist/cardlist.html
@@ -18,24 +18,31 @@ limitations under the License.
   <kd-resource-card-list-header ng-transclude="header">
     [[Ingresses|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="ingresses" list="$ctrl.ingressList"
+  <kd-resource-card-list-pagination pagination-id="ingresses"
+                                    list="$ctrl.ingressList"
                                     list-resource="$ctrl.ingressListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-      <kd-resource-card-header-column size="small" grow="2">[[Name|Label 'Name' which appears as a column label in the table of ingresses (ingress list view).]]
-      </kd-resource-card-header-column>
-      <kd-resource-card-header-column size="small" grow="1" ng-if="$ctrl.areMultipleNamespacesSelected()">
-          [[Namespace|Label 'Namespace' which appears as a column label in the table of ingresses (ingress list view).]]
-      </kd-resource-card-header-column>
-      <kd-resource-card-header-column size="small" grow="1">
-          [[Endpoints|Label 'endpoints' which appears as a column label in the table of ingresses (ingress list view).]]
-      </kd-resource-card-header-column>
-      <kd-resource-card-header-column size="small" grow="1">[[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
-      </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">[[Name|Label 'Name' which appears as a column label in the table of ingresses (ingress list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
+      [[Namespace|Label 'Namespace' which appears as a column label in the table of ingresses (ingress list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Endpoints|Label 'endpoints' which appears as a column label in the table of ingresses (ingress list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">[[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
+    </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-ingress-card pagination-id="ingresses" ingress="ingress"
-                  dir-paginate="ingress in $ctrl.ingressList.items | itemsPerPage: default"
-                  total-items="::$ctrl.ingressList.listMeta.totalItems">
+  <kd-ingress-card pagination-id="ingresses"
+                   ingress="ingress"
+                   dir-paginate="ingress in $ctrl.ingressList.items | itemsPerPage: default"
+                   total-items="::$ctrl.ingressList.listMeta.totalItems">
   </kd-ingress-card>
 </kd-resource-card-list>

--- a/src/app/frontend/ingresslist/list.html
+++ b/src/app/frontend/ingresslist/list.html
@@ -15,10 +15,11 @@ limitations under the License.
 -->
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
-    <kd-content>
-        <kd-ingress-card-list ingress-list="$ctrl.ingressList" with-statuses="false"
-                             ingress-list-resource="$ctrl.ingressListResource">
-        </kd-ingress-card-list>
-    </kd-content>
+  <kd-content>
+    <kd-ingress-card-list ingress-list="$ctrl.ingressList"
+                          with-statuses="false"
+                          ingress-list-resource="$ctrl.ingressListResource">
+    </kd-ingress-card-list>
+  </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>

--- a/src/app/frontend/jobdetail/actionbar.html
+++ b/src/app/frontend/jobdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-        resource-kind-name="[[Job|Label 'Job' which appears at the top of the dialog, opened from a job details page.]]"
-        type-meta="$ctrl.details.typeMeta"
-        object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Job|Label 'Job' which appears at the top of the dialog, opened from a job details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/jobdetail/jobdetail.html
+++ b/src/app/frontend/jobdetail/jobdetail.html
@@ -30,7 +30,8 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-pod-card-list pod-list="::ctrl.jobDetail.podList" with-statuses="true"
+    <kd-pod-card-list pod-list="::ctrl.jobDetail.podList"
+                      with-statuses="true"
                       pod-list-resource="::ctrl.jobPodsResource">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for pods card zerostate in job details page.]]</div>
@@ -40,4 +41,5 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 
-<kd-event-card-list event-list="::ctrl.jobDetail.eventList" event-list-resource="::ctrl.eventListResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.jobDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/jobdetail/jobinfo.html
+++ b/src/app/frontend/jobdetail/jobinfo.html
@@ -18,8 +18,7 @@ limitations under the License.
   <kd-info-card-header>[[Details|Header in a detail view]]</kd-info-card-header>
   <kd-info-card-section name="[[Details|Details section header. Appears below main header.]]">
     <kd-info-card-entry title="[[Name|Job name. Appears in details section.]]">
-      <kd-middle-ellipsis
-              display-string="{{::$ctrl.job.objectMeta.name}}">
+      <kd-middle-ellipsis display-string="{{::$ctrl.job.objectMeta.name}}">
       </kd-middle-ellipsis>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Namespace|Job namespace. Appears in details section.]]">
@@ -44,13 +43,17 @@ limitations under the License.
     <kd-info-card-entry title="[[Pods|Pod status section header. Appears below main header.]]">
       <div>
         <div class="kd-comma-separated-item">
-          {{::$ctrl.job.podInfo.running}} [[active|Status of active pods. Appears next to number of active pods.]]<!-- Collapse
+          {{::$ctrl.job.podInfo.running}} [[active|Status of active pods. Appears next to number of active pods.]]
+          <!-- Collapse
           whitespace
-      --></div>
+      -->
+        </div>
         <div class="kd-comma-separated-item">
-          {{::$ctrl.job.podInfo.succeeded}} [[succeeded|Status of succeeded pods. Appears next to number of succeeded pods.]]<!-- Collapse
+          {{::$ctrl.job.podInfo.succeeded}} [[succeeded|Status of succeeded pods. Appears next to number of succeeded pods.]]
+          <!-- Collapse
           whitespace
-      --></div>
+      -->
+        </div>
         <div class="kd-comma-separated-item">
           {{::$ctrl.job.podInfo.failed}} [[failed|Status of failed pods. Appears next to number of failed pods.]]
         </div>

--- a/src/app/frontend/joblist/jobcard.html
+++ b/src/app/frontend/joblist/jobcard.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.job.objectMeta" type-meta="$ctrl.job.typeMeta">
+<kd-resource-card object-meta="$ctrl.job.objectMeta"
+                  type-meta="$ctrl.job.typeMeta">
   <kd-resource-card-status layout="row">
     <md-icon class="material-icons md-warn"
              ng-if="::$ctrl.hasWarnings()">
@@ -27,7 +28,9 @@ limitations under the License.
       <md-tooltip>One or more pods are in pending state</md-tooltip>
     </md-icon>
 
-    <md-icon class="material-icons" style="color: green";
+    <md-icon class="material-icons"
+             style="color: green"
+             ;
              ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
@@ -35,7 +38,8 @@ limitations under the License.
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getJobDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getJobDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{$ctrl.job.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -78,8 +82,8 @@ limitations under the License.
     </kd-resource-card-column>
   </kd-resource-card-columns>
   <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
-      <div ng-repeat="warning in ::$ctrl.job.pods.warnings">
-        <span class="kd-error">{{::warning.message}}</span>
-      </div>
+    <div ng-repeat="warning in ::$ctrl.job.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
   </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/joblist/jobcardlist.html
+++ b/src/app/frontend/joblist/jobcardlist.html
@@ -14,47 +14,63 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Jobs|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="jobs" list="$ctrl.jobList"
+  <kd-resource-card-list-pagination pagination-id="jobs"
+                                    list="$ctrl.jobList"
                                     list-resource="::$ctrl.jobListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of jobs (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if=::$ctrl.showResourceKind>
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if=::$ctrl.showResourceKind>
       [[Kind|Column header 'Kind' on a job list table]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of replication controllers (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of replication controllers (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Pods|Label 'Pods' which appears as a column label in the table of replication controllers (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of replication controllers (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Images|Label 'Images' which appears as a column label in the table of replication controllers (Job list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-job-card ng-if="::$ctrl.jobListResource" pagination-id="jobs"
-               dir-paginate="job in $ctrl.jobList.jobs | itemsPerPage: default" job="job"
+  <kd-job-card ng-if="::$ctrl.jobListResource"
+               pagination-id="jobs"
+               dir-paginate="job in $ctrl.jobList.jobs | itemsPerPage: default"
+               job="job"
                show-resource-kind="::$ctrl.showResourceKind"
                total-items="::$ctrl.jobList.listMeta.totalItems">
   </kd-job-card>
 
-  <kd-job-card ng-if="::!$ctrl.jobListResource" pagination-id="jobs"
-               dir-paginate="job in $ctrl.jobList.jobs | itemsPerPage: default" job="job"
+  <kd-job-card ng-if="::!$ctrl.jobListResource"
+               pagination-id="jobs"
+               dir-paginate="job in $ctrl.jobList.jobs | itemsPerPage: default"
+               job="job"
                show-resource-kind="::$ctrl.showResourceKind">
   </kd-job-card>
 </kd-resource-card-list>

--- a/src/app/frontend/joblist/joblist.html
+++ b/src/app/frontend/joblist/joblist.html
@@ -28,7 +28,8 @@ limitations under the License.
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
-    <kd-job-card-list job-list="$ctrl.jobList" job-list-resource="$ctrl.jobListResource">
+    <kd-job-card-list job-list="$ctrl.jobList"
+                      job-list-resource="$ctrl.jobListResource">
     </kd-job-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -17,37 +17,48 @@ limitations under the License.
 <kd-content-card class="kd-log-content-card">
   <kd-title class="kd-logs-title">
     [[Logs from|Title prefix for logs card.]]
-    <md-select class="kd-logs-toolbar-select" ng-model="ctrl.container"
-               md-on-close="ctrl.onContainerChange(ctrl.container)" required>
-      <md-option ng-repeat="item in ctrl.containers" ng-value="item">
+    <md-select class="kd-logs-toolbar-select"
+               ng-model="ctrl.container"
+               md-on-close="ctrl.onContainerChange(ctrl.container)"
+               required>
+      <md-option ng-repeat="item in ctrl.containers"
+                 ng-value="item">
         <span class="kd-logs-toolbar-text">{{::item}}</span>
       </md-option>
     </md-select>
     [[in|Title part for logs card.]] {{ctrl.podLogs.podId}}
     <div class="kd-logs-style-buttons">
-      <md-button class="kd-logs-toolbar-button" ng-click="ctrl.onTextColorChange()">
-        <md-icon md-font-library="material-icons" ng-class="ctrl.getColorIconClass()">
+      <md-button class="kd-logs-toolbar-button"
+                 ng-click="ctrl.onTextColorChange()">
+        <md-icon md-font-library="material-icons"
+                 ng-class="ctrl.getColorIconClass()">
           format_color_text
         </md-icon>
       </md-button>
-      <md-button class="kd-logs-toolbar-button" ng-click="ctrl.onFontSizeChange()">
-        <md-icon md-font-library="material-icons" ng-class="ctrl.getSizeIconClass()">
+      <md-button class="kd-logs-toolbar-button"
+                 ng-click="ctrl.onFontSizeChange()">
+        <md-icon md-font-library="material-icons"
+                 ng-class="ctrl.getSizeIconClass()">
           text_fields
         </md-icon>
       </md-button>
     </div>
   </kd-title>
   <kd-content>
-    <md-virtual-repeat-container class="kd-log-view" ng-class="ctrl.getStyleClass()"
+    <md-virtual-repeat-container class="kd-log-view"
+                                 ng-class="ctrl.getStyleClass()"
                                  md-top-index="ctrl.topIndex">
-      <div md-virtual-repeat="item in ctrl.logsSet" ng-class="ctrl.getLogsClass()">
-        <span ng-bind-html="item" class="kd-log-line">&nbsp;</span>
+      <div md-virtual-repeat="item in ctrl.logsSet"
+           ng-class="ctrl.getLogsClass()">
+        <span ng-bind-html="item"
+              class="kd-log-line">&nbsp;</span>
       </div>
     </md-virtual-repeat-container>
   </kd-content>
   <kd-footer>
     <div layout="row">
-      <span class="kd-logs-info" ng-show="ctrl.logsSet.length > 1">
+      <span class="kd-logs-info"
+            ng-show="ctrl.logsSet.length > 1">
         [[Logs from|Title prefix for logs card.]]
         {{ctrl.podLogs.firstLogLineReference.logTimestamp | date : "short"}}
         [[to|Footer part for logs card.]]

--- a/src/app/frontend/namespacedetail/namespacedetail.html
+++ b/src/app/frontend/namespacedetail/namespacedetail.html
@@ -16,15 +16,15 @@ limitations under the License.
 
 <kd-namespace-info namespace="::ctrl.namespaceDetail"></kd-namespace-info>
 <div ng-if="ctrl.namespaceDetail.resourceQuotaList.items">
-    <div ng-repeat="resourceQuota in ::ctrl.namespaceDetail.resourceQuotaList.items">
-        <kd-resource-quota-detail resource-quota-detail="::resourceQuota"></kd-resource-quota-detail>
-    </div>
+  <div ng-repeat="resourceQuota in ::ctrl.namespaceDetail.resourceQuotaList.items">
+    <kd-resource-quota-detail resource-quota-detail="::resourceQuota"></kd-resource-quota-detail>
+  </div>
 </div>
 
 <kd-content-card ng-if="ctrl.namespaceDetail.resourceLimits.length">
-    <kd-content>
-        <kd-resource-limits resource-limits="ctrl.namespaceDetail.resourceLimits"></kd-resource-limits>
-    </kd-content>
+  <kd-content>
+    <kd-resource-limits resource-limits="ctrl.namespaceDetail.resourceLimits"></kd-resource-limits>
+  </kd-content>
 </kd-content-card>
 <kd-event-card-list event-list="::ctrl.namespaceDetail.eventList"
                     event-list-resource="::ctrl.eventListResource">

--- a/src/app/frontend/namespacelist/namespacecard.html
+++ b/src/app/frontend/namespacelist/namespacecard.html
@@ -14,18 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.namespace.objectMeta" type-meta="$ctrl.namespace.typeMeta">
+<kd-resource-card object-meta="$ctrl.namespace.objectMeta"
+                  type-meta="$ctrl.namespace.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isTerminating()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.isTerminating()">
       error
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isActive()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isActive()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
-      <a ng-href="{{::$ctrl.getNamespaceDetailHref()}}" class="kd-middle-ellipsised-link">
+      <a ng-href="{{::$ctrl.getNamespaceDetailHref()}}"
+         class="kd-middle-ellipsised-link">
         <kd-middle-ellipsis display-string="{{$ctrl.namespace.objectMeta.name}}">
         </kd-middle-ellipsis>
       </a>

--- a/src/app/frontend/namespacelist/namespacecardlist.html
+++ b/src/app/frontend/namespacelist/namespacecardlist.html
@@ -14,36 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Namespaces|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="namespaces" list="$ctrl.namespaceList"
+  <kd-resource-card-list-pagination pagination-id="namespaces"
+                                    list="$ctrl.namespaceList"
                                     list-resource="$ctrl.namespaceListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Status|Label 'Status' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-namespace-card ng-if="::$ctrl.namespaceListResource"
                      dir-paginate="ns in $ctrl.namespaceList.namespaces | itemsPerPage: default"
-                     pagination-id="namespaces" namespace="ns"
+                     pagination-id="namespaces"
+                     namespace="ns"
                      total-items="::$ctrl.namespaceList.listMeta.totalItems">
   </kd-namespace-card>
 
   <kd-namespace-card ng-if="::!$ctrl.namespaceListResource"
                      dir-paginate="ns in $ctrl.namespaceList.namespaces | itemsPerPage: default"
-                     pagination-id="namespaces" namespace="ns">
+                     pagination-id="namespaces"
+                     namespace="ns">
   </kd-namespace-card>
 </kd-resource-card-list>

--- a/src/app/frontend/nodedetail/nodeallocatedresources.html
+++ b/src/app/frontend/nodedetail/nodeallocatedresources.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="false">
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
   <kd-resource-card-list-header>
     [[Allocated resources|Label 'Allocated resources' for the allocated resources section.]]
   </kd-resource-card-list-header>
@@ -43,41 +44,36 @@ limitations under the License.
   <kd-resource-card omit-meta="true">
     <kd-resource-card-columns>
       <kd-resource-card-column>
-        <div>{{$ctrl.allocatedResources.cpuRequests | kdCores}} /
-          {{$ctrl.allocatedResources.cpuCapacity | kdCores}}</div>
+        <div>{{$ctrl.allocatedResources.cpuRequests | kdCores}} / {{$ctrl.allocatedResources.cpuCapacity | kdCores}}</div>
       </kd-resource-card-column>
       <kd-resource-card-column>
         <div>{{$ctrl.allocatedResources.cpuRequestsFraction | number: 2}}</div>
       </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div>{{$ctrl.allocatedResources.cpuLimits | kdCores}} /
-        {{$ctrl.allocatedResources.cpuCapacity | kdCores}}</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div>{{$ctrl.allocatedResources.cpuLimitsFraction | number: 2}}</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div>{{$ctrl.allocatedResources.memoryRequests | kdMemory}} /
-        {{$ctrl.allocatedResources.memoryCapacity | kdMemory}}</div>
-    </kd-resource-card-column>
-    <kd-resource-card-column>
-      <div>{{$ctrl.allocatedResources.memoryRequestsFraction | number: 2}}</div>
-    </kd-resource-card-column>
       <kd-resource-card-column>
-        <div>{{$ctrl.allocatedResources.memoryLimits | kdMemory}} /
-          {{$ctrl.allocatedResources.memoryCapacity | kdMemory}}</div>
+        <div>{{$ctrl.allocatedResources.cpuLimits | kdCores}} / {{$ctrl.allocatedResources.cpuCapacity | kdCores}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{$ctrl.allocatedResources.cpuLimitsFraction | number: 2}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{$ctrl.allocatedResources.memoryRequests | kdMemory}} / {{$ctrl.allocatedResources.memoryCapacity | kdMemory}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{$ctrl.allocatedResources.memoryRequestsFraction | number: 2}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{$ctrl.allocatedResources.memoryLimits | kdMemory}} / {{$ctrl.allocatedResources.memoryCapacity | kdMemory}}</div>
       </kd-resource-card-column>
       <kd-resource-card-column>
         <div>{{$ctrl.allocatedResources.memoryLimitsFraction | number: 2}}</div>
       </kd-resource-card-column>
 
       <kd-resource-card-column>
-        <div>{{$ctrl.allocatedResources.allocatedPods}} /
-          {{$ctrl.allocatedResources.podCapacity}}</div>
+        <div>{{$ctrl.allocatedResources.allocatedPods}} / {{$ctrl.allocatedResources.podCapacity}}
+        </div>
       </kd-resource-card-column>
       <kd-resource-card-column>
-        <div>{{$ctrl.allocatedResources.allocatedPods / $ctrl.allocatedResources.podCapacity * 100
-          | number : 2}}</div>
+        <div>{{$ctrl.allocatedResources.allocatedPods / $ctrl.allocatedResources.podCapacity * 100 | number : 2}}</div>
       </kd-resource-card-column>
     </kd-resource-card-columns>
   </kd-resource-card>

--- a/src/app/frontend/nodedetail/nodedetail.html
+++ b/src/app/frontend/nodedetail/nodedetail.html
@@ -16,11 +16,13 @@ limitations under the License.
 
 <div layout="row">
   <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of one node.]]"
-                 metrics="::ctrl.nodeDetail.metrics" selected-metric-names="'cpu/usage_rate'">
+                 metrics="::ctrl.nodeDetail.metrics"
+                 selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one node.]]"
                  graph-info="[[The memory usage includes caches.|Help message detailing what is included in the memory usage]]"
-                 metrics="::ctrl.nodeDetail.metrics" selected-metric-names="'memory/usage'">
+                 metrics="::ctrl.nodeDetail.metrics"
+                 selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>
 
@@ -39,4 +41,5 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 
-<kd-event-card-list event-list="::ctrl.nodeDetail.eventList" event-list-resource="::ctrl.eventListResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.nodeDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/nodelist/nodecard.html
+++ b/src/app/frontend/nodelist/nodecard.html
@@ -14,22 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.node.objectMeta" type-meta="$ctrl.node.typeMeta">
+<kd-resource-card object-meta="$ctrl.node.objectMeta"
+                  type-meta="$ctrl.node.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isInNotReadyState()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.isInNotReadyState()">
       error
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isInUnknownState()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isInUnknownState()">
       help
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isInReadyState()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isInReadyState()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getNodeDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getNodeDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{$ctrl.node.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>

--- a/src/app/frontend/nodelist/nodecardlist.html
+++ b/src/app/frontend/nodelist/nodecardlist.html
@@ -14,36 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Nodes|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="nodes" list="$ctrl.nodeList"
+  <kd-resource-card-list-pagination pagination-id="nodes"
+                                    list="$ctrl.nodeList"
                                     list-resource="::$ctrl.nodeListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Ready|Label 'Ready' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-node-card ng-if="::$ctrl.nodeListResource"
                 dir-paginate="node in $ctrl.nodeList.nodes | itemsPerPage: default"
-                pagination-id="nodes" node="node"
+                pagination-id="nodes"
+                node="node"
                 total-items="::$ctrl.nodeList.listMeta.totalItems">
   </kd-node-card>
 
   <kd-node-card ng-if="::!$ctrl.nodeListResource"
                 dir-paginate="node in $ctrl.nodeList.nodes | itemsPerPage: default"
-                pagination-id="nodes" node="node">
+                pagination-id="nodes"
+                node="node">
   </kd-node-card>
 </kd-resource-card-list>

--- a/src/app/frontend/nodelist/nodelist.html
+++ b/src/app/frontend/nodelist/nodelist.html
@@ -16,17 +16,20 @@ limitations under the License.
 
 <div layout="row">
   <kd-graph-card graph-title="[[CPU usage|Title for graph card displaying CPU metric of nodes.]]"
-                 metrics="$ctrl.nodeList.cumulativeMetrics" selected-metric-names="'cpu/usage_rate'">
+                 metrics="$ctrl.nodeList.cumulativeMetrics"
+                 selected-metric-names="'cpu/usage_rate'">
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of nodes.]]"
                  graph-info="[[The memory usage includes caches.|Help message detailing what is included in the memory usage]]"
-                 metrics="$ctrl.nodeList.cumulativeMetrics" selected-metric-names="'memory/usage'">
+                 metrics="$ctrl.nodeList.cumulativeMetrics"
+                 selected-metric-names="'memory/usage'">
   </kd-graph-card>
 </div>
 
 <kd-content-card>
   <kd-content>
-    <kd-node-card-list node-list="$ctrl.nodeList" node-list-resource="$ctrl.nodeListResource">
+    <kd-node-card-list node-list="$ctrl.nodeList"
+                       node-list-resource="$ctrl.nodeListResource">
     </kd-node-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/persistentvolumeclaimdetail/actionbar.html
+++ b/src/app/frontend/persistentvolumeclaimdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Persistent Volume Claim|Label 'Persistent Volume Claim' which appears at the top of the delete dialog, opened from a persistent volume claim details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Persistent Volume Claim|Label 'Persistent Volume Claim' which appears at the top of the delete dialog, opened from a persistent volume claim details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcard.html
+++ b/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcard.html
@@ -14,24 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.persistentVolumeClaim.objectMeta" type-meta="::$ctrl.persistentVolumeClaim.typeMeta">
+<kd-resource-card object-meta="::$ctrl.persistentVolumeClaim.objectMeta"
+                  type-meta="::$ctrl.persistentVolumeClaim.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isLost()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.isLost()">
       error
       <md-tooltip md-direction="right">[[This claim is in lost state|Tooltip text which appears on error icon hover.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons kd-"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">[[This claim is in pending state|Tooltip text which appears on pending icon hover.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isBound()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isBound()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getPersistentVolumeClaimDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getPersistentVolumeClaimDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeClaim.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>

--- a/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcardlist.html
+++ b/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimcardlist.html
@@ -14,34 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Persistent Volume Claims|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="persistentvolumeclaims" list="$ctrl.persistentVolumeClaimList"
+  <kd-resource-card-list-pagination pagination-id="persistentvolumeclaims"
+                                    list="$ctrl.persistentVolumeClaimList"
                                     list-resource="$ctrl.persistentVolumeClaimListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Volume|Label 'Volume' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of persistent volume claim (persistent volume claim list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-persistent-volume-claim-card
-          dir-paginate="persistentVolumeClaim in $ctrl.persistentVolumeClaimList.items | itemsPerPage: default"
-          pagination-id="persistentvolumeclaims" persistent-volume-claim="persistentVolumeClaim"
-          total-items="$ctrl.persistentVolumeClaimList.listMeta.totalItems">
+  <kd-persistent-volume-claim-card dir-paginate="persistentVolumeClaim in $ctrl.persistentVolumeClaimList.items | itemsPerPage: default"
+                                   pagination-id="persistentvolumeclaims"
+                                   persistent-volume-claim="persistentVolumeClaim"
+                                   total-items="$ctrl.persistentVolumeClaimList.listMeta.totalItems">
   </kd-persistent-volume-claim-card>
 </kd-resource-card-list>

--- a/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimlist.html
+++ b/src/app/frontend/persistentvolumeclaimlist/persistentvolumeclaimlist.html
@@ -16,7 +16,7 @@ limitations under the License.
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
     <kd-persistent-volume-claim-card-list persistent-volume-claim-list="$ctrl.persistentVolumeClaimList"
-                       persistent-volume-claim-list-resource="$ctrl.persistentVolumeClaimListResource">
+                                          persistent-volume-claim-list-resource="$ctrl.persistentVolumeClaimListResource">
     </kd-persistent-volume-claim-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/persistentvolumedetail/actionbar.html
+++ b/src/app/frontend/persistentvolumedetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-        resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which appears at the top of the delete dialog, opened from a config map details page.]]"
-        type-meta="$ctrl.details.typeMeta"
-        object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which appears at the top of the delete dialog, opened from a config map details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/persistentvolumedetail/persistentvolumedetail.html
+++ b/src/app/frontend/persistentvolumedetail/persistentvolumedetail.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <div layout="column">
-    <kd-persistent-volume-info persistent-volume="::$ctrl.persistentVolumeDetail"></kd-persistent-volume-info>
-    <kd-persistent-volume-source-info persistent-volume-source="::$ctrl.persistentVolumeDetail.persistentVolumeSource"></kd-persistent-volume-source-info>
+  <kd-persistent-volume-info persistent-volume="::$ctrl.persistentVolumeDetail"></kd-persistent-volume-info>
+  <kd-persistent-volume-source-info persistent-volume-source="::$ctrl.persistentVolumeDetail.persistentVolumeSource"></kd-persistent-volume-source-info>
 </div>

--- a/src/app/frontend/persistentvolumedetail/persistentvolumeinfo.html
+++ b/src/app/frontend/persistentvolumedetail/persistentvolumeinfo.html
@@ -20,40 +20,36 @@ limitations under the License.
     <kd-object-meta-info-card object-meta="::$ctrl.persistentVolume.objectMeta">
     </kd-object-meta-info-card>
     <kd-info-card-entry title="[[Status|Persistent volume info details section status entry.]]">
-        <kd-middle-ellipsis
-                display-string="{{::$ctrl.persistentVolume.status}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.status">-</div>
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolume.status}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.status">-</div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Claim|Persistent volume info details section claim entry.]]">
-        <kd-middle-ellipsis
-                display-string="{{::$ctrl.persistentVolume.claim}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.claim">-</div>
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolume.claim}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.claim">-</div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Reclaim policy|Persistent volume info details section reclaim policy entry.]]">
-        <kd-middle-ellipsis
-                display-string="{{::$ctrl.persistentVolume.reclaimPolicy}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.reclaimPolicy">-</div>
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolume.reclaimPolicy}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.reclaimPolicy">-</div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Access modes|Persistent volume info details section access modes entry.]]">
-        <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.accessModes"
-                display-string="{{::value}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.accessModes">-</div>
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.accessModes"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.accessModes">-</div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Capacity|Persistent volume info details section capacity entry.]]">
-        <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.capacity"
-                            display-string="{{::value}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.capacity">-</div>
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.capacity"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.capacity">-</div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Message|Persistent volume info details section message entry.]]">
-        <kd-middle-ellipsis
-                display-string="{{::$ctrl.persistentVolume.message}}">
-        </kd-middle-ellipsis>
-        <div ng-hide="::$ctrl.persistentVolume.message">-</div>
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolume.message}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.message">-</div>
     </kd-info-card-entry>
   </kd-info-card-section>
 </kd-info-card>

--- a/src/app/frontend/persistentvolumedetail/persistentvolumesourceinfo.html
+++ b/src/app/frontend/persistentvolumedetail/persistentvolumesourceinfo.html
@@ -1,237 +1,216 @@
 <kd-info-card>
-    <kd-info-card-header>[[Persistent volume source|Persistent volume source info title.]]</kd-info-card-header>
-    <!--Host Path-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.hostPath" name="[[Host path|Persistent volume source info host path title.]]">
-        <kd-info-card-entry title="[[Path|Persistent volume source info host path section path entry.]]">
-            <kd-middle-ellipsis
-                display-string="{{::$ctrl.persistentVolumeSource.hostPath.path}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.hostPath.path">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--GCE Persistent Disk-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.gcePersistentDisk" name="[[GCE persistent disk|Persistent volume source info GCE persistent disk title.]]">
-        <kd-info-card-entry title="[[PD name|Persistent volume source info GCE persistent disk section PD name entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.pdName}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.pdName">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[FS type|Persistent volume source info GCE persistent disk section FS type entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.fsType}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.fsType">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Partition|Persistent volume source info GCE persistent disk section partition entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.partition}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.partition">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info GCE persistent disk section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--AWS Elastic Block Storage-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.awsElasticBlockStore" name="[[AWS block storage|Persistent volume source info AWS block storage title.]]">
-        <kd-info-card-entry title="[[Volume ID|Persistent volume source info AWS block storage section volume ID entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.volumeID}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.volumeID">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[FS type|Persistent volume source info AWS block storage section FS type entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.fsType}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.fsType">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Partition|Persistent volume source info AWS block storage section partition entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.partition}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.partition">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info AWS block storage section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--GLUSTER FS-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.glusterfs" name="[[GlusterFS|Persistent volume source info GlusterFS title.]]">
-        <kd-info-card-entry title="[[Endpoints|Persistent volume source info GlusterFS section endpoints entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.glusterfs.endpoints}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.endpoints">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Path|Persistent volume source info GlusterFS section path entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.glusterfs.path}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.path">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info GlusterFS section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.glusterfs.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--NFS-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.nfs" name="[[NFS|Persistent volume source info NFS title.]]">
-        <kd-info-card-entry title="[[Server|Persistent volume source info NFS section server entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.nfs.server}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.nfs.server">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Path|Persistent volume source info NFS section path entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.nfs.path}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.nfs.path">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info NFS section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.nfs.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.nfs.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--RBD-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.rbd" name="[[RBD|Persistent volume source info RBD title.]]">
-        <kd-info-card-entry title="[[Monitors|Persistent volume source info RBD section monitors entry.]]">
-            <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolumeSource.rbd.monitors"
-                                display-string="{{::value}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.monitors">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Image|Persistent volume source info RBD section image entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.rbd.image}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.image">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[User|Persistent volume source info RBD section user entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.rbd.user}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.user">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Keyring|Persistent volume source info RBD section keyring entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.rbd.keyring}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.keyring">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[SecretRef|Persistent volume source info RBD section secretRef entry.]]">
-            <kd-middle-ellipsis ng-if="::$ctrl.persistentVolumeSource.rbd.secretRef"
-                    display-string="{{::$ctrl.persistentVolumeSource.rbd.secretRef.name}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.secretRef.name">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info RBD section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.rbd.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.rbd.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--ISCSI-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.iscsi" name="[[ISCSI|Persistent volume source info ISCSI title.]]">
-        <kd-info-card-entry title="[[Target portal|Persistent volume source info ISCSI section target portal entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.iscsi.targetPortal}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.targetPortal">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[IQN|Persistent volume source info ISCSI section IQN entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.iscsi.iqn}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.iqnl">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Lun|Persistent volume source info ISCSI section lun entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.iscsi.lun}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.lun">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[FS type|Persistent volume source info ISCSI section FS type entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.iscsi.fsType}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.fsType">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info ISCSI section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.iscsi.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--Cinder-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.cinder" name="[[Cinder|Persistent volume source info cinder title.]]">
-        <kd-info-card-entry title="[[Volume ID|Persistent volume source info cinder section volume ID entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.cinder.volumeID}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.cinder.volumeID">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[FS Type|Persistent volume source info cinder section FS Type entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.cinder.fsType}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.cinder.fsType">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info cinder section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.cinder.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.cinder.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--FC-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.fc" name="[[FC|Persistent volume source info FC title.]]">
-        <kd-info-card-entry title="[[Target WWNs|Persistent volume source info FC section target WWNs entry.]]">
-            <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolumeSource.fc.targetWWNs"
-                                display-string="{{::value}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.fc.targetWWNs">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[FS type|Persistent volume source info FC section target FS type entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.fc.fsType}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.fc.fsType">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Lun|Persistent volume source info FC section lun entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.fc.lun}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.fc.lun">-</div>
-        </kd-info-card-entry>
-        <kd-info-card-entry title="[[Read only|Persistent volume source info FC section read only entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.fc.readOnly}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.fc.readOnly">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
-    <!--Flocker-->
-    <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.flocker" name="[[Flocker|Persistent volume source info flocker title.]]">
-        <kd-info-card-entry title="[[Dataset name|Persistent volume source info FC section dataset name entry.]]">
-            <kd-middle-ellipsis
-                    display-string="{{::$ctrl.persistentVolumeSource.flocker.datasetName}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolumeSource.flocker.datasetName">-</div>
-        </kd-info-card-entry>
-    </kd-info-card-section>
+  <kd-info-card-header>[[Persistent volume source|Persistent volume source info title.]]</kd-info-card-header>
+  <!--Host Path-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.hostPath"
+                        name="[[Host path|Persistent volume source info host path title.]]">
+    <kd-info-card-entry title="[[Path|Persistent volume source info host path section path entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.hostPath.path}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.hostPath.path">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--GCE Persistent Disk-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.gcePersistentDisk"
+                        name="[[GCE persistent disk|Persistent volume source info GCE persistent disk title.]]">
+    <kd-info-card-entry title="[[PD name|Persistent volume source info GCE persistent disk section PD name entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.pdName}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.pdName">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[FS type|Persistent volume source info GCE persistent disk section FS type entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.fsType}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.fsType">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Partition|Persistent volume source info GCE persistent disk section partition entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.partition}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.partition">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info GCE persistent disk section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.gcePersistentDisk.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.gcePersistentDisk.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--AWS Elastic Block Storage-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.awsElasticBlockStore"
+                        name="[[AWS block storage|Persistent volume source info AWS block storage title.]]">
+    <kd-info-card-entry title="[[Volume ID|Persistent volume source info AWS block storage section volume ID entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.volumeID}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.volumeID">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[FS type|Persistent volume source info AWS block storage section FS type entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.fsType}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.fsType">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Partition|Persistent volume source info AWS block storage section partition entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.partition}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.partition">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info AWS block storage section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.awsElasticBlockStore.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.awsElasticBlockStore.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--GLUSTER FS-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.glusterfs"
+                        name="[[GlusterFS|Persistent volume source info GlusterFS title.]]">
+    <kd-info-card-entry title="[[Endpoints|Persistent volume source info GlusterFS section endpoints entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.glusterfs.endpoints}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.endpoints">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Path|Persistent volume source info GlusterFS section path entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.glusterfs.path}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.path">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info GlusterFS section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.glusterfs.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.glusterfs.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--NFS-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.nfs"
+                        name="[[NFS|Persistent volume source info NFS title.]]">
+    <kd-info-card-entry title="[[Server|Persistent volume source info NFS section server entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.nfs.server}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.nfs.server">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Path|Persistent volume source info NFS section path entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.nfs.path}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.nfs.path">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info NFS section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.nfs.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.nfs.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--RBD-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.rbd"
+                        name="[[RBD|Persistent volume source info RBD title.]]">
+    <kd-info-card-entry title="[[Monitors|Persistent volume source info RBD section monitors entry.]]">
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolumeSource.rbd.monitors"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.monitors">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Image|Persistent volume source info RBD section image entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.rbd.image}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.image">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[User|Persistent volume source info RBD section user entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.rbd.user}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.user">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Keyring|Persistent volume source info RBD section keyring entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.rbd.keyring}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.keyring">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[SecretRef|Persistent volume source info RBD section secretRef entry.]]">
+      <kd-middle-ellipsis ng-if="::$ctrl.persistentVolumeSource.rbd.secretRef"
+                          display-string="{{::$ctrl.persistentVolumeSource.rbd.secretRef.name}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.secretRef.name">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info RBD section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.rbd.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.rbd.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--ISCSI-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.iscsi"
+                        name="[[ISCSI|Persistent volume source info ISCSI title.]]">
+    <kd-info-card-entry title="[[Target portal|Persistent volume source info ISCSI section target portal entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.iscsi.targetPortal}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.targetPortal">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[IQN|Persistent volume source info ISCSI section IQN entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.iscsi.iqn}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.iqnl">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Lun|Persistent volume source info ISCSI section lun entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.iscsi.lun}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.lun">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[FS type|Persistent volume source info ISCSI section FS type entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.iscsi.fsType}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.fsType">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info ISCSI section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.iscsi.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.iscsi.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--Cinder-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.cinder"
+                        name="[[Cinder|Persistent volume source info cinder title.]]">
+    <kd-info-card-entry title="[[Volume ID|Persistent volume source info cinder section volume ID entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.cinder.volumeID}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.cinder.volumeID">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[FS Type|Persistent volume source info cinder section FS Type entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.cinder.fsType}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.cinder.fsType">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info cinder section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.cinder.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.cinder.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--FC-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.fc"
+                        name="[[FC|Persistent volume source info FC title.]]">
+    <kd-info-card-entry title="[[Target WWNs|Persistent volume source info FC section target WWNs entry.]]">
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolumeSource.fc.targetWWNs"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.fc.targetWWNs">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[FS type|Persistent volume source info FC section target FS type entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.fc.fsType}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.fc.fsType">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Lun|Persistent volume source info FC section lun entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.fc.lun}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.fc.lun">-</div>
+    </kd-info-card-entry>
+    <kd-info-card-entry title="[[Read only|Persistent volume source info FC section read only entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.fc.readOnly}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.fc.readOnly">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
+  <!--Flocker-->
+  <kd-info-card-section ng-if="::$ctrl.persistentVolumeSource.flocker"
+                        name="[[Flocker|Persistent volume source info flocker title.]]">
+    <kd-info-card-entry title="[[Dataset name|Persistent volume source info FC section dataset name entry.]]">
+      <kd-middle-ellipsis display-string="{{::$ctrl.persistentVolumeSource.flocker.datasetName}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolumeSource.flocker.datasetName">-</div>
+    </kd-info-card-entry>
+  </kd-info-card-section>
 </kd-info-card>

--- a/src/app/frontend/persistentvolumelist/persistentvolumecard.html
+++ b/src/app/frontend/persistentvolumelist/persistentvolumecard.html
@@ -16,79 +16,86 @@ limitations under the License.
 
 <kd-resource-card object-meta="$ctrl.persistentVolume.objectMeta"
                   type-meta="$ctrl.persistentVolume.typeMeta">
-    <kd-resource-card-status layout="row" ng-switch="$ctrl.persistentVolume.status">
-        <md-icon class="material-icons kd-success" ng-switch-when="Available">
-            check_circle
-        </md-icon>
-        <md-icon class="material-icons" ng-switch-when="Pending">
-            update
-        </md-icon>
-        <md-icon class="material-icons kd-warning" ng-switch-when="Bound">
-            remove_circle
-        </md-icon>
-        <md-icon class="material-icons kd-warning" ng-switch-when="Released">
-            remove_circle
-        </md-icon>
-        <md-icon class="material-icons kd-error" ng-switch-when="Failed">
-            error
-        </md-icon>
-        <md-icon class="material-icons" ng-switch-default>
-            help
-        </md-icon>
-    </kd-resource-card-status>
-    <kd-resource-card-columns>
-        <kd-resource-card-column>
-            <div>
-                <a ng-href="{{::$ctrl.getPersistentVolumeDetailHref()}}"
-                   class="kd-middle-ellipsised-link">
-                    <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.objectMeta.name}}">
-                    </kd-middle-ellipsis>
-                </a>
-            </div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-labels labels="::$ctrl.persistentVolume.objectMeta.labels"></kd-labels>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.capacity"
-                                display-string="{{::value}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolume.capacity">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.accessModes"
-                                display-string="{{::value}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolume.accessModes">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.status}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolume.status">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.claim}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolume.claim">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.reason}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.persistentVolume.reason">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            {{::$ctrl.persistentVolume.objectMeta.creationTimestamp | relativeTime}}
-            <md-tooltip>
-                {{::$ctrl.getCreatedAtTooltip($ctrl.persistentVolume.objectMeta.creationTimestamp)}}
-            </md-tooltip>
-        </kd-resource-card-column>
-        <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
-            <kd-resource-card-menu>
-                <kd-resource-card-delete-menu-item resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.]]">
-                </kd-resource-card-delete-menu-item>
-                <kd-resource-card-edit-menu-item resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.]]">
-                </kd-resource-card-edit-menu-item>
-            </kd-resource-card-menu>
-        </kd-resource-card-column>
-    </kd-resource-card-columns>
+  <kd-resource-card-status layout="row"
+                           ng-switch="$ctrl.persistentVolume.status">
+    <md-icon class="material-icons kd-success"
+             ng-switch-when="Available">
+      check_circle
+    </md-icon>
+    <md-icon class="material-icons"
+             ng-switch-when="Pending">
+      update
+    </md-icon>
+    <md-icon class="material-icons kd-warning"
+             ng-switch-when="Bound">
+      remove_circle
+    </md-icon>
+    <md-icon class="material-icons kd-warning"
+             ng-switch-when="Released">
+      remove_circle
+    </md-icon>
+    <md-icon class="material-icons kd-error"
+             ng-switch-when="Failed">
+      error
+    </md-icon>
+    <md-icon class="material-icons"
+             ng-switch-default>
+      help
+    </md-icon>
+  </kd-resource-card-status>
+  <kd-resource-card-columns>
+    <kd-resource-card-column>
+      <div>
+        <a ng-href="{{::$ctrl.getPersistentVolumeDetailHref()}}"
+           class="kd-middle-ellipsised-link">
+          <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.objectMeta.name}}">
+          </kd-middle-ellipsis>
+        </a>
+      </div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-labels labels="::$ctrl.persistentVolume.objectMeta.labels"></kd-labels>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.capacity"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.capacity">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis ng-repeat="(key, value) in ::$ctrl.persistentVolume.accessModes"
+                          display-string="{{::value}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.accessModes">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.status}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.status">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.claim}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.claim">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis display-string="{{$ctrl.persistentVolume.reason}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.persistentVolume.reason">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.persistentVolume.objectMeta.creationTimestamp | relativeTime}}
+      <md-tooltip>
+        {{::$ctrl.getCreatedAtTooltip($ctrl.persistentVolume.objectMeta.creationTimestamp)}}
+      </md-tooltip>
+    </kd-resource-card-column>
+    <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
+      <kd-resource-card-menu>
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.]]">
+        </kd-resource-card-delete-menu-item>
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Persistent Volume|Label 'Persistent Volume' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.]]">
+        </kd-resource-card-edit-menu-item>
+      </kd-resource-card-menu>
+    </kd-resource-card-column>
+  </kd-resource-card-columns>
 </kd-resource-card>

--- a/src/app/frontend/persistentvolumelist/persistentvolumecardlist.html
+++ b/src/app/frontend/persistentvolumelist/persistentvolumecardlist.html
@@ -14,44 +14,56 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
-    <kd-resource-card-list-header ng-transclude="header">
-      [[Persistent Volumes|Label which appears above the list of such objects.]]
-    </kd-resource-card-list-header>
-    <kd-resource-card-list-pagination pagination-id="persistentvolumes" list="$ctrl.persistentVolumeList"
-                                      list-resource="$ctrl.persistentVolumeListResource">
-    </kd-resource-card-list-pagination>
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
+  <kd-resource-card-list-header ng-transclude="header">
+    [[Persistent Volumes|Label which appears above the list of such objects.]]
+  </kd-resource-card-list-header>
+  <kd-resource-card-list-pagination pagination-id="persistentvolumes"
+                                    list="$ctrl.persistentVolumeList"
+                                    list-resource="$ctrl.persistentVolumeListResource">
+  </kd-resource-card-list-pagination>
 
-    <kd-resource-card-header-columns>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Name|Persistent volume list header: name.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Labels|Persistent volume list header: labels.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Capacity|Persistent volume list header: capacity.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Access modes|Persistent volume list header: access modes.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Status|Persistent volume list header: status.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Claim|Persistent volume list header: claim.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Reason|Persistent volume list header: reason.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Age|Persistent volume list header: age.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="nogrow">
-        </kd-resource-card-header-column>
-    </kd-resource-card-header-columns>
-    <kd-persistent-volume-card dir-paginate="persistentVolume in $ctrl.persistentVolumeList.items | itemsPerPage: default"
-                               persistent-volume="persistentVolume" pagination-id="persistentvolumes"
-                               total-items="::$ctrl.persistentVolumeList.listMeta.totalItems">
-    </kd-persistent-volume-card>
+  <kd-resource-card-header-columns>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Name|Persistent volume list header: name.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Labels|Persistent volume list header: labels.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Capacity|Persistent volume list header: capacity.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Access modes|Persistent volume list header: access modes.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Status|Persistent volume list header: status.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Claim|Persistent volume list header: claim.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Reason|Persistent volume list header: reason.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Age|Persistent volume list header: age.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
+    </kd-resource-card-header-column>
+  </kd-resource-card-header-columns>
+  <kd-persistent-volume-card dir-paginate="persistentVolume in $ctrl.persistentVolumeList.items | itemsPerPage: default"
+                             persistent-volume="persistentVolume"
+                             pagination-id="persistentvolumes"
+                             total-items="::$ctrl.persistentVolumeList.listMeta.totalItems">
+  </kd-persistent-volume-card>
 </kd-resource-card-list>

--- a/src/app/frontend/persistentvolumelist/persistentvolumelist.html
+++ b/src/app/frontend/persistentvolumelist/persistentvolumelist.html
@@ -15,10 +15,10 @@ limitations under the License.
 -->
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
-    <kd-content>
-        <kd-persistent-volume-card-list persistent-volume-list="$ctrl.persistentVolumeList"
-                                        persistent-volume-list-resource="$ctrl.persistentVolumeListResource">
-        </kd-persistent-volume-card-list>
-    </kd-content>
+  <kd-content>
+    <kd-persistent-volume-card-list persistent-volume-list="$ctrl.persistentVolumeList"
+                                    persistent-volume-list-resource="$ctrl.persistentVolumeListResource">
+    </kd-persistent-volume-card-list>
+  </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>

--- a/src/app/frontend/poddetail/actionbar.html
+++ b/src/app/frontend/poddetail/actionbar.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <kd-actionbar-detail-buttons resource-kind-name="[[Pod|Label 'Pod' which appears at the top of the delete dialog, opened from a pod details page.]]"
-                        type-meta="$ctrl.details.typeMeta"
-                        object-meta="$ctrl.details.objectMeta">
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/poddetail/containerinfo.html
+++ b/src/app/frontend/poddetail/containerinfo.html
@@ -16,13 +16,15 @@ limitations under the License.
 
 <kd-info-card>
   <kd-info-card-header>[[Containers|Subtitle at the top of the container details.]]</kd-info-card-header>
-  <kd-info-card-section ng-repeat="container in ::$ctrl.containers" name="{{::container.name}}">
+  <kd-info-card-section ng-repeat="container in ::$ctrl.containers"
+                        name="{{::container.name}}">
     <kd-info-card-entry title="[[Image|Label for container image.]]">
       {{::container.image}}
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Environment variables|Label for container environment variables.]]">
       <div ng-if="::container.env.length">
-        <div ng-repeat="env in ::container.env" layout="row">
+        <div ng-repeat="env in ::container.env"
+             layout="row">
           <span>{{::env.name}}</span><span ng-if="env.valueFrom">
             <span ng-if="env.valueFrom.configMapKeyRef">
               (<a ng-href="{{::$ctrl.getEnvConfigMapHref(env.valueFrom.configMapKeyRef)}}">
@@ -30,7 +32,9 @@ limitations under the License.
               </a>)
             </span>
           </span><span>:&nbsp;</span>
-          <kd-middle-ellipsis display-string="{{::env.value}}" flex="shrink"><kd-middle-ellipsis>
+          <kd-middle-ellipsis display-string="{{::env.value}}"
+                              flex="shrink">
+            <kd-middle-ellipsis>
         </div>
       </div>
       <div ng-if="::!container.env.length">
@@ -39,8 +43,11 @@ limitations under the License.
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Commands|Label for container commands.]]">
       <div ng-if="::container.commands.length">
-        <div ng-repeat="(key, value) in ::container.commands" layout="row">
-          <kd-middle-ellipsis display-string="{{::value}}" flex="shrink"><kd-middle-ellipsis>
+        <div ng-repeat="(key, value) in ::container.commands"
+             layout="row">
+          <kd-middle-ellipsis display-string="{{::value}}"
+                              flex="shrink">
+            <kd-middle-ellipsis>
         </div>
       </div>
       <div ng-if="::!container.commands.length">
@@ -49,8 +56,11 @@ limitations under the License.
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Args|Label for container args.]]">
       <div ng-if="::container.args.length">
-        <div ng-repeat="(key, value) in ::container.args" layout="row">
-          <kd-middle-ellipsis display-string="{{::value}}" flex="shrink"><kd-middle-ellipsis>
+        <div ng-repeat="(key, value) in ::container.args"
+             layout="row">
+          <kd-middle-ellipsis display-string="{{::value}}"
+                              flex="shrink">
+            <kd-middle-ellipsis>
         </div>
       </div>
       <div ng-if="::!container.args.length">
@@ -58,10 +68,11 @@ limitations under the License.
       </div>
     </kd-info-card-entry>
     <kd-info-card-entry ng-if="::$ctrl.podName">
-          <a ng-href="{{::$ctrl.getLogsHref(container)}}" class="kd-middle-ellipsised-link">
-            <kd-middle-ellipsis display-string="[[View logs|Label for the container logs.]]">
-            </kd-middle-ellipsis>
-          </a>
+      <a ng-href="{{::$ctrl.getLogsHref(container)}}"
+         class="kd-middle-ellipsised-link">
+        <kd-middle-ellipsis display-string="[[View logs|Label for the container logs.]]">
+        </kd-middle-ellipsis>
+      </a>
     </kd-info-card-entry>
   </kd-info-card-section>
 </kd-info-card>

--- a/src/app/frontend/poddetail/creatorinfo.html
+++ b/src/app/frontend/poddetail/creatorinfo.html
@@ -18,33 +18,38 @@ limitations under the License.
   <kd-content>
     <div ng-switch="$ctrl.creator.kind">
       <div ng-switch-when="Job">
-        <kd-job-card-list job-list="$ctrl.creator.joblist" show-resource-kind="true">
+        <kd-job-card-list job-list="$ctrl.creator.joblist"
+                          show-resource-kind="true">
           <kd-header>[[Created by|Heading for Creator card on poddetail page]]</kd-header>
         </kd-job-card-list>
       </div>
       <div ng-switch-when="DaemonSet">
-        <kd-daemon-set-card-list daemon-set-list="$ctrl.creator.daemonsetlist" show-resource-kind="true">
+        <kd-daemon-set-card-list daemon-set-list="$ctrl.creator.daemonsetlist"
+                                 show-resource-kind="true">
           <kd-header>[[Created by|Heading for Creator card on poddetail page]]</kd-header>
         </kd-daemon-set-card-list>
       </div>
       <div ng-switch-when="ReplicationController">
-        <kd-replication-controller-card-list
-            replication-controller-list="$ctrl.creator.replicationcontrollerlist" show-resource-kind="true">
+        <kd-replication-controller-card-list replication-controller-list="$ctrl.creator.replicationcontrollerlist"
+                                             show-resource-kind="true">
           <kd-header>[[Created by|Heading for Creator card on poddetail page]]</kd-header>
         </kd-replication-controller-card-list>
       </div>
       <div ng-switch-when="ReplicaSet">
-        <kd-replica-set-card-list replica-set-list="$ctrl.creator.replicasetlist" show-resource-kind="true">
+        <kd-replica-set-card-list replica-set-list="$ctrl.creator.replicasetlist"
+                                  show-resource-kind="true">
           <kd-header>[[Created by|Heading for Creator card on poddetail page]]</kd-header>
         </kd-replica-set-card-list>
       </div>
       <div ng-switch-when="StatefulSet">
-        <kd-stateful-set-card-list stateful-set-list="$ctrl.creator.statefulsetlist" show-resource-kind="true">
+        <kd-stateful-set-card-list stateful-set-list="$ctrl.creator.statefulsetlist"
+                                   show-resource-kind="true">
           <kd-header>[[Created by|Heading for Creator card on poddetail page]]</kd-header>
         </kd-stateful-set-card-list>
       </div>
       <div ng-switch-default>
-        <kd-resource-card-list selectable="false" with-statuses="true">
+        <kd-resource-card-list selectable="false"
+                               with-statuses="true">
           <kd-resource-card-list-header>
             [[Created by|Heading for Creator card on poddetail page]]
           </kd-resource-card-list-header>

--- a/src/app/frontend/poddetail/poddetail.html
+++ b/src/app/frontend/poddetail/poddetail.html
@@ -28,7 +28,8 @@ limitations under the License.
 
 <kd-pod-info pod="::ctrl.podDetail"></kd-pod-info>
 <kd-container-info containers="::ctrl.podDetail.containers"
-    namespace="::ctrl.podDetail.objectMeta.namespace" pod-name="::ctrl.podDetail.objectMeta.name">
+                   namespace="::ctrl.podDetail.objectMeta.namespace"
+                   pod-name="::ctrl.podDetail.objectMeta.name">
 </kd-container-info>
 
 <kd-content-card ng-if="::ctrl.podDetail.conditions.length">
@@ -39,4 +40,5 @@ limitations under the License.
 
 <kd-creator-info creator="::ctrl.podDetail.controller"></kd-creator-info>
 
-<kd-event-card-list event-list="::ctrl.podDetail.eventList" event-list-resource="::ctrl.eventListResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.podDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/poddetail/podinfo.html
+++ b/src/app/frontend/poddetail/podinfo.html
@@ -23,7 +23,8 @@ limitations under the License.
       {{::$ctrl.pod.podPhase}}
     </kd-info-card-entry>
     <kd-info-card-entry>
-      <a ng-href="{{::$ctrl.getLogsHref()}}" class="kd-middle-ellipsised-link">
+      <a ng-href="{{::$ctrl.getLogsHref()}}"
+         class="kd-middle-ellipsised-link">
         <kd-middle-ellipsis display-string="[[View logs|Label for the pod logs in details part (left) of the pod details view.]]">
         </kd-middle-ellipsis>
       </a>

--- a/src/app/frontend/podlist/podcard.html
+++ b/src/app/frontend/podlist/podcard.html
@@ -14,28 +14,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.pod.objectMeta" type-meta="::$ctrl.pod.typeMeta">
+<kd-resource-card object-meta="::$ctrl.pod.objectMeta"
+                  type-meta="::$ctrl.pod.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isFailed()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.isFailed()">
       error
       <md-tooltip md-direction="right">
         [[This pod has errors.|Tooltip for failed pod card icon]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">
         [[This pod is in a pending state.|Tooltip for pending pod card icon]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getPodDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getPodDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{::$ctrl.pod.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -81,16 +86,16 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <md-button ng-if="::$ctrl.getPodLogsHref()"
-                 ng-href="{{::$ctrl.getPodLogsHref()}}" target="_blank" class="md-icon-button">
+                 ng-href="{{::$ctrl.getPodLogsHref()}}"
+                 target="_blank"
+                 class="md-icon-button">
         <md-icon md-font-library="material-icons">subject</md-icon>
         <md-tooltip>[[Logs|Label for logs tooltip]]</md-tooltip>
       </md-button>
       <kd-resource-card-menu>
-        <kd-resource-card-delete-menu-item
-                resource-kind-name="[[Pod|Name of the pod resource]]">
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Pod|Name of the pod resource]]">
         </kd-resource-card-delete-menu-item>
-        <kd-resource-card-edit-menu-item
-                resource-kind-name="[[Pod|Name of the pod resource]]">
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Pod|Name of the pod resource]]">
         </kd-resource-card-edit-menu-item>
       </kd-resource-card-menu>
     </kd-resource-card-column>

--- a/src/app/frontend/podlist/podcardlist.html
+++ b/src/app/frontend/podlist/podcardlist.html
@@ -14,49 +14,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="::$ctrl.selectable" with-statuses="::$ctrl.withStatuses"
+<kd-resource-card-list selectable="::$ctrl.selectable"
+                       with-statuses="::$ctrl.withStatuses"
                        ng-if="::$ctrl.podList.pods">
   <kd-resource-card-list-header ng-transclude="header">
     [[Pods|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="pods" list="$ctrl.podList"
+  <kd-resource-card-list-pagination pagination-id="pods"
+                                    list="$ctrl.podList"
                                     list-resource="$ctrl.podListResource">
   </kd-resource-card-list-pagination>
   <div ng-show="!$ctrl.podList.listMeta.totalItems"
-      class="kd-zerostate-message" ng-transclude="zerostate"></div>
+       class="kd-zerostate-message"
+       ng-transclude="zerostate"></div>
 
   <kd-resource-card-header-columns ng-show="::$ctrl.podList.listMeta.totalItems">
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Title of a column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Title of a column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Status|Title of a pod status column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
       [[Restarts|Title of a restarts column for a pod]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
       [[Age|Title of a column for the age of a pod]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showMetrics()">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showMetrics()">
       [[CPU (cores)|Title of a column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showMetrics()">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showMetrics()">
       [[Memory (bytes)|Title of a column]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-pod-card ng-if="::$ctrl.podListResource"
                dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default"
-               pagination-id="pods" pod="pod" show-metrics="::$ctrl.showMetrics()"
+               pagination-id="pods"
+               pod="pod"
+               show-metrics="::$ctrl.showMetrics()"
                total-items="::$ctrl.podList.listMeta.totalItems">
   </kd-pod-card>
-  <kd-pod-card ng-if="::!$ctrl.podListResource" show-metrics="::$ctrl.showMetrics()"
+  <kd-pod-card ng-if="::!$ctrl.podListResource"
+               show-metrics="::$ctrl.showMetrics()"
                dir-paginate="pod in $ctrl.podList.pods | itemsPerPage: default"
-               pagination-id="pods" pod="pod">
+               pagination-id="pods"
+               pod="pod">
   </kd-pod-card>
 </kd-resource-card-list>

--- a/src/app/frontend/podlist/podlist.html
+++ b/src/app/frontend/podlist/podlist.html
@@ -28,7 +28,8 @@ limitations under the License.
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
-    <kd-pod-card-list pod-list="$ctrl.podList" pod-list-resource="$ctrl.podListResource"
+    <kd-pod-card-list pod-list="$ctrl.podList"
+                      pod-list-resource="$ctrl.podListResource"
                       with-statuses="true">
     </kd-pod-card-list>
   </kd-content>

--- a/src/app/frontend/replicasetdetail/actionbar.html
+++ b/src/app/frontend/replicasetdetail/actionbar.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <kd-actionbar-detail-buttons resource-kind-name="[[Replica Set|Label 'Replica Set' which appears at the top of the delete dialog, opened from a replica set details page.]]"
-                        type-meta="$ctrl.details.typeMeta"
-                        object-meta="$ctrl.details.objectMeta">
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/replicasetdetail/replicasetdetail.html
+++ b/src/app/frontend/replicasetdetail/replicasetdetail.html
@@ -29,7 +29,8 @@ limitations under the License.
 <kd-replica-set-info replica-set="::ctrl.replicaSetDetail"></kd-replica-set-info>
 <kd-content-card>
   <kd-content>
-    <kd-pod-card-list pod-list="::ctrl.replicaSetDetail.podList" with-statuses="true"
+    <kd-pod-card-list pod-list="::ctrl.replicaSetDetail.podList"
+                      with-statuses="true"
                       pod-list-resource="::ctrl.replicaSetPodsResource">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for pods card zerostate in replica set details page.]]</div>
@@ -52,14 +53,14 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-horizontal-pod-autoscaler-card-list
-             horizontal-pod-autoscaler-list="::ctrl.replicaSetDetail.horizontalPodAutoscalerList">
-        <kd-zerostate>
-          <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
-          <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
-        </kd-zerostate>
+    <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::ctrl.replicaSetDetail.horizontalPodAutoscalerList">
+      <kd-zerostate>
+        <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
+        <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
+      </kd-zerostate>
     </kd-horizontal-pod-autoscaler-card-list>
   </kd-content>
 </kd-content-card>
 
-<kd-event-card-list event-list="::ctrl.replicaSetDetail.eventList" event-list-resource="::ctrl.eventListResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.replicaSetDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/replicasetdetail/replicasetinfo.html
+++ b/src/app/frontend/replicasetdetail/replicasetinfo.html
@@ -33,23 +33,25 @@ limitations under the License.
         on the replica set details page.]]">
     <kd-info-card-entry title="[[Pods|Label 'Pods' for the pods in a replica set on its details page.]]">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        [[{{::$ctrl.replicaSet.podInfo.current}} created|The message says how many pods were created (replica set details page).]],
-        [[{{::$ctrl.replicaSet.podInfo.desired}} desired|The message says how many pods are desired to run (replica set details page).]]
+        [[{{::$ctrl.replicaSet.podInfo.current}} created|The message says how many pods were created (replica set details page).]], [[{{::$ctrl.replicaSet.podInfo.desired}} desired|The message says how many pods are desired to run (replica set details page).]]
       </div>
       <div ng-if="$ctrl.areDesiredPodsRunning()">
         [[{{::$ctrl.replicaSet.podInfo.running}} running|How many pods are running (replica set details page).]]
       </div>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Pods status|Label 'Pods status' for the status of the pods in a replica set, on the replica set details page.]]"
-              ng-if="!$ctrl.areDesiredPodsRunning()">
+                        ng-if="!$ctrl.areDesiredPodsRunning()">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        <div ng-if="::$ctrl.replicaSet.podInfo.pending" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicaSet.podInfo.pending"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicaSet.podInfo.pending}} pending|The message says how many pods are pending (replica set details page).]]
         </div>
-        <div ng-if="::$ctrl.replicaSet.podInfo.failed" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicaSet.podInfo.failed"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicaSet.podInfo.failed}} failed|The message says how many pods have failed (replica set details page).]]
         </div>
-        <div ng-if="::$ctrl.replicaSet.podInfo.running" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicaSet.podInfo.running"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicaSet.podInfo.running}} running|The message says how many pods are running (replica set details page).]]
         </div>
       </div>

--- a/src/app/frontend/replicasetlist/replicasetcard.html
+++ b/src/app/frontend/replicasetlist/replicasetcard.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.replicaSet.objectMeta" type-meta="$ctrl.replicaSet.typeMeta">
+<kd-resource-card object-meta="$ctrl.replicaSet.objectMeta"
+                  type-meta="$ctrl.replicaSet.typeMeta">
   <kd-resource-card-status layout="row">
     <md-icon class="material-icons md-warn"
              ng-if="::$ctrl.hasWarnings()">
@@ -27,7 +28,9 @@ limitations under the License.
       <md-tooltip>[[One or more pods are in pending state|Tooltip saying that some pods in a replica set are pending.]]</md-tooltip>
     </md-icon>
 
-    <md-icon class="material-icons" style="color: green";
+    <md-icon class="material-icons"
+             style="color: green"
+             ;
              ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
@@ -35,7 +38,8 @@ limitations under the License.
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getReplicaSetDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getReplicaSetDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{$ctrl.replicaSet.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -82,8 +86,8 @@ limitations under the License.
     </kd-resource-card-column>
   </kd-resource-card-columns>
   <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
-      <div ng-repeat="warning in ::$ctrl.replicaSet.pods.warnings">
-        <span class="kd-error">{{::warning.message}}</span>
-      </div>
+    <div ng-repeat="warning in ::$ctrl.replicaSet.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
   </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/replicasetlist/replicasetcardlist.html
+++ b/src/app/frontend/replicasetlist/replicasetcardlist.html
@@ -14,48 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Replica Sets|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="replicasets" list="$ctrl.replicaSetList"
+  <kd-resource-card-list-pagination pagination-id="replicasets"
+                                    list="$ctrl.replicaSetList"
                                     list-resource="$ctrl.replicaSetListResource">
   </kd-resource-card-list-pagination>
   <kd-resource-card-header-columns ng-show="$ctrl.replicaSetList.listMeta.totalItems">
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showResourceKind">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showResourceKind">
       [[Kind|Column header 'Kind' for a Replica Set list]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Pods|Label 'Pods' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Images|Label 'Images' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-replica-set-card ng-if="::$ctrl.replicaSetListResource"
                        dir-paginate="rs in $ctrl.replicaSetList.replicaSets | itemsPerPage: default"
-                       pagination-id="replicasets" replica-set="rs" show-resource-kind="::$ctrl.showResourceKind"
+                       pagination-id="replicasets"
+                       replica-set="rs"
+                       show-resource-kind="::$ctrl.showResourceKind"
                        total-items="::$ctrl.replicaSetList.listMeta.totalItems">
   </kd-replica-set-card>
   <kd-replica-set-card ng-if="::!$ctrl.replicaSetListResource"
                        dir-paginate="rs in $ctrl.replicaSetList.replicaSets | itemsPerPage: default"
-                       pagination-id="replicasets" replica-set="rs" show-resource-kind="::$ctrl.showResourceKind">
+                       pagination-id="replicasets"
+                       replica-set="rs"
+                       show-resource-kind="::$ctrl.showResourceKind">
   </kd-replica-set-card>
   <div ng-show="!$ctrl.replicaSetList.listMeta.totalItems"
-      class="kd-zerostate-message" ng-transclude="zerostate"></div>
+       class="kd-zerostate-message"
+       ng-transclude="zerostate"></div>
 
 </kd-resource-card-list>

--- a/src/app/frontend/replicationcontrollerdetail/actionbar.html
+++ b/src/app/frontend/replicationcontrollerdetail/actionbar.html
@@ -21,8 +21,7 @@ limitations under the License.
   </md-tooltip>
   [[Scale|Tooltip for the 'scale' button on the action bar of a replication controller details view.]]
 </md-button>
-<kd-actionbar-detail-buttons
-    resource-kind-name="[[Replication Controller|Label 'Replication Controller' which appears at the top of the edit dialog, opened from a replication controller details page.]]"
-    type-meta="$ctrl.details.typeMeta"
-    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Replication Controller|Label 'Replication Controller' which appears at the top of the edit dialog, opened from a replication controller details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerdetail.html
@@ -56,8 +56,7 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-horizontal-pod-autoscaler-card-list
-             horizontal-pod-autoscaler-list="::$ctrl.replicationControllerDetail.horizontalPodAutoscalerList">
+    <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::$ctrl.replicationControllerDetail.horizontalPodAutoscalerList">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
         <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -32,22 +32,26 @@ limitations under the License.
   <kd-info-card-section name="[[Status|Subtitle 'Status' for the right section with pod status information on the replication controller details page.]]">
     <kd-info-card-entry title="[[Pods|Label 'Pods' for the pods in a replication controller on its details page.]]">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        [[{{::$ctrl.replicationController.podInfo.currentCount}} created|The message says how many pods were created (replication controller details page).]],
-        [[{{::$ctrl.replicationController.podInfo.desired}} desired|The message says how many pods are desired to run (replication controller details page).]]
+        [[{{::$ctrl.replicationController.podInfo.currentCount}} created|The message says how many pods were created (replication controller details page).]], [[{{::$ctrl.replicationController.podInfo.desired}} desired|The message says how many pods are desired
+        to run (replication controller details page).]]
       </div>
       <div ng-if="$ctrl.areDesiredPodsRunning()">
         [[{{::$ctrl.replicationController.podInfo.running}} running|The message says how many pods are running (replication controller details page).]]
       </div>
     </kd-info-card-entry>
-    <kd-info-card-entry title="[[Pods status|Label 'Pods status' for the status of the pods in a replication controller, on the replication controller details page.]]" ng-if="!$ctrl.areDesiredPodsRunning()">
+    <kd-info-card-entry title="[[Pods status|Label 'Pods status' for the status of the pods in a replication controller, on the replication controller details page.]]"
+                        ng-if="!$ctrl.areDesiredPodsRunning()">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        <div ng-if="::$ctrl.replicationController.podInfo.pending" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicationController.podInfo.pending"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicationController.podInfo.pending}} pending|The message says how many pods are pending (replication controller details page).]]
         </div>
-        <div ng-if="::$ctrl.replicationController.podInfo.failed" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicationController.podInfo.failed"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicationController.podInfo.failed}} failed|The message says how many pods have failed (replication controller details page).]]
         </div>
-        <div ng-if="::$ctrl.replicationController.podInfo.running" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.replicationController.podInfo.running"
+             class="kd-comma-separated-item">
           [[{{::$ctrl.replicationController.podInfo.running}} running|The message says how many pods are running (replication controller details page).]]
         </div>
       </div>

--- a/src/app/frontend/replicationcontrollerdetail/updatereplicas.html
+++ b/src/app/frontend/replicationcontrollerdetail/updatereplicas.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-dialog aria-label="Create a new namespace" layout="column">
+<md-dialog aria-label="Create a new namespace"
+           layout="column">
   <md-dialog-content layout-padding>
     <h4 class="md-title">[[Set desired number of pods|Title for the pod count update dialog (for a replication controller).]]</h4>
     <div>
@@ -23,22 +24,34 @@ limitations under the License.
         [[Current status: {{::$ctrl.createdPods}} created, {{::$ctrl.desiredPods}} desired|Status text for a replication controller, showing the number of created and desired pods.]]
       </span>
     </div>
-    <form name="ctrl.updateReplicasForm" ng-submit="ctrl.updateReplicas()" novalidate>
+    <form name="ctrl.updateReplicasForm"
+          ng-submit="ctrl.updateReplicas()"
+          novalidate>
       <md-input-container class="md-block">
         <label>[[Number of pods|Label 'Number of pods', which appears as a placeholder for the pods count input on the "update pods count" dialog (for a replication controller).]]</label>
-        <input name="podCount" type="number" kd-validate="integer" min="0" ng-model="ctrl.replicas"
-               required kd-warn-threshold="100" kd-warn-threshold-bind="showWarning">
-        <ng-messages for="ctrl.updateReplicasForm.podCount.$error" role="alert">
+        <input name="podCount"
+               type="number"
+               kd-validate="integer"
+               min="0"
+               ng-model="ctrl.replicas"
+               required
+               kd-warn-threshold="100"
+               kd-warn-threshold-bind="showWarning">
+        <ng-messages for="ctrl.updateReplicasForm.podCount.$error"
+                     role="alert">
           <ng-message when="required">[[Number of pods is required.|This warning appears when the user does not specify a pods count on the "update number of pods" dialog (for a replication controller).]]</ng-message>
           <ng-message when="number,kdValidInteger">[[Number of replicas must be equal to or greater than zero.|This warning appears when the specified pods count on the "update number of pods" dialog is not positive or non-integer.]]</ng-message>
         </ng-messages>
-        <span class="kd-warn-threshold" ng-show="showWarning">
+        <span class="kd-warn-threshold"
+              ng-show="showWarning">
           [[Setting high number of pods may cause performance issues of the cluster and Dashboard UI.|This warning appears when the specified pods count (on the "update number of pods" dialog) is very high.]]
         </span>
       </md-input-container>
       <md-dialog-actions layout="row">
-        <md-button class="md-primary" ng-click="ctrl.cancel()">[[Cancel|Action 'Cancel' for the cancel button on the "update number of pods" dialog.]]</md-button>
-        <md-button class="md-primary" type="submit">[[OK|Action 'OK' for the confirmation button on the "update number of pods dialog".]]</md-button>
+        <md-button class="md-primary"
+                   ng-click="ctrl.cancel()">[[Cancel|Action 'Cancel' for the cancel button on the "update number of pods" dialog.]]</md-button>
+        <md-button class="md-primary"
+                   type="submit">[[OK|Action 'OK' for the confirmation button on the "update number of pods dialog".]]</md-button>
       </md-dialog-actions>
     </form>
   </md-dialog-content>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercard.html
@@ -14,18 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card  object-meta="$ctrl.replicationController.objectMeta"
-    type-meta="$ctrl.replicationController.typeMeta">
+<kd-resource-card object-meta="$ctrl.replicationController.objectMeta"
+                  type-meta="$ctrl.replicationController.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.hasWarnings()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.hasWarnings()">
       error
       <md-tooltip md-direction="right">[[One or more pods have errors|Tooltip saying that some pods in a replication controller have errors.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">[[One or more pods are in pending state|Tooltip saying that some pods in a replication controller are pending.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
@@ -61,7 +64,7 @@ limitations under the License.
     <kd-resource-card-column>
       {{::$ctrl.replicationController.objectMeta.creationTimestamp | relativeTime}}
       <md-tooltip>
-      {{::$ctrl.getCreatedAtTooltip($ctrl.replicationController.objectMeta.creationTimestamp)}}
+        {{::$ctrl.getCreatedAtTooltip($ctrl.replicationController.objectMeta.creationTimestamp)}}
       </md-tooltip>
     </kd-resource-card-column>
     <kd-resource-card-column>
@@ -75,8 +78,8 @@ limitations under the License.
     </kd-resource-card-column>
   </kd-resource-card-columns>
   <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
-      <div ng-repeat="warning in ::$ctrl.replicationController.pods.warnings">
-        <span class="kd-error">{{::warning.message}}</span>
-      </div>
+    <div ng-repeat="warning in ::$ctrl.replicationController.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
   </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercardlist.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercardlist.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Replication Controllers|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
@@ -24,39 +25,52 @@ limitations under the License.
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.showResourceKind">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.showResourceKind">
       [[Kind|Column header 'Kind' of a Replication Controller list]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Pods|Label 'Pods' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="4">
+    <kd-resource-card-header-column size="small"
+                                    grow="4">
       [[Images|Label 'Images' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow" class="kd-row-layout-column">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow"
+                                    class="kd-row-layout-column">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-replication-controller-card ng-if="::$ctrl.replicationControllerListResource"
-                                  replication-controller="rc" pagination-id="replicationcontrollers"
+                                  replication-controller="rc"
+                                  pagination-id="replicationcontrollers"
                                   dir-paginate="rc in $ctrl.replicationControllerList.replicationControllers | itemsPerPage: default"
                                   show-resource-kind="::$ctrl.showResourceKind"
                                   total-items="$ctrl.replicationControllerList.listMeta.totalItems">
   </kd-replication-controller-card>
 
   <kd-replication-controller-card ng-if="::!$ctrl.replicationControllerListResource"
-                                  replication-controller="rc" pagination-id="replicationcontrollers"
+                                  replication-controller="rc"
+                                  pagination-id="replicationcontrollers"
                                   show-resource-kind="::$ctrl.showResourceKind"
                                   dir-paginate="rc in $ctrl.replicationControllerList.replicationControllers | itemsPerPage: default">
   </kd-replication-controller-card>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollercardmenu.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollercardmenu.html
@@ -29,4 +29,4 @@ limitations under the License.
   </kd-resource-card-edit-menu-item>
   <kd-resource-card-delete-menu-item resource-kind-name="[[Replication Controller|Label 'Replication Controller' which will appear in the replication Controller delete dialogm opened from a replication controller card on the list page.]]">
   </kd-resource-card-delete-menu-item>
-</md-menu>
+  </md-menu>

--- a/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
+++ b/src/app/frontend/replicationcontrollerlist/replicationcontrollerlist.html
@@ -28,9 +28,8 @@ limitations under the License.
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
-    <kd-replication-controller-card-list
-            replication-controller-list="$ctrl.replicationControllerList"
-            replication-controller-list-resource="$ctrl.rcListResource">
+    <kd-replication-controller-card-list replication-controller-list="$ctrl.replicationControllerList"
+                                         replication-controller-list-resource="$ctrl.rcListResource">
     </kd-replication-controller-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/resourcelimit/resourcelimits.html
+++ b/src/app/frontend/resourcelimit/resourcelimits.html
@@ -1,60 +1,69 @@
-<kd-resource-card-list selectable="false" with-statuses="false">
-    <kd-resource-card-list-header>
-        [[Resource limits|Title of resource limits card in the namespace details page.]]
-    </kd-resource-card-list-header>
-    <kd-resource-card-header-columns>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Type|Resource Limits name entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Resource|Resource Limits resource entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Min|]Resource Limits min entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Max|Resource Limits max entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Default Request|Resource Limits default request entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Default Limit|Resource Limits default limit entry.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Max Limit/Request Ratio|Resource Limits max limit/request ratio entry.]]
-        </kd-resource-card-header-column>
-    </kd-resource-card-header-columns>
-    <kd-resource-card ng-repeat="(key, limitRange) in ::$ctrl.resourceLimits" omit-meta="true">
-        <kd-resource-card-columns>
-            <kd-resource-card-column>
-                <div>{{::limitRange.resourceType}}</div>
-                <div ng-if="::!limitRange.resourceType.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.resourceName}}</div>
-                <div ng-if="::!limitRange.resourceName.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.min}}</div>
-                <div ng-if="::!limitRange.min.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.max}}</div>
-                <div ng-if="::!limitRange.max.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.defaultRequest}}</div>
-                <div ng-if="::!limitRange.defaultRequest.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.default}}</div>
-                <div ng-if="::!limitRange.default.length">-</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::limitRange.maxLimitRequestRatio}}</div>
-                <div ng-if="::!limitRange.maxLimitRequestRatio.length">-</div>
-            </kd-resource-card-column>
-        </kd-resource-card-columns>
-    </kd-resource-card>
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
+  <kd-resource-card-list-header>
+    [[Resource limits|Title of resource limits card in the namespace details page.]]
+  </kd-resource-card-list-header>
+  <kd-resource-card-header-columns>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Type|Resource Limits name entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Resource|Resource Limits resource entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Min|]Resource Limits min entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Max|Resource Limits max entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Default Request|Resource Limits default request entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Default Limit|Resource Limits default limit entry.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Max Limit/Request Ratio|Resource Limits max limit/request ratio entry.]]
+    </kd-resource-card-header-column>
+  </kd-resource-card-header-columns>
+  <kd-resource-card ng-repeat="(key, limitRange) in ::$ctrl.resourceLimits"
+                    omit-meta="true">
+    <kd-resource-card-columns>
+      <kd-resource-card-column>
+        <div>{{::limitRange.resourceType}}</div>
+        <div ng-if="::!limitRange.resourceType.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.resourceName}}</div>
+        <div ng-if="::!limitRange.resourceName.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.min}}</div>
+        <div ng-if="::!limitRange.min.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.max}}</div>
+        <div ng-if="::!limitRange.max.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.defaultRequest}}</div>
+        <div ng-if="::!limitRange.defaultRequest.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.default}}</div>
+        <div ng-if="::!limitRange.default.length">-</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::limitRange.maxLimitRequestRatio}}</div>
+        <div ng-if="::!limitRange.maxLimitRequestRatio.length">-</div>
+      </kd-resource-card-column>
+    </kd-resource-card-columns>
+  </kd-resource-card>
 </kd-resource-card-list>

--- a/src/app/frontend/resourcequotadetail/resourcequotadetail.html
+++ b/src/app/frontend/resourcequotadetail/resourcequotadetail.html
@@ -15,48 +15,55 @@ limitations under the License.
 -->
 
 <div layout="column">
-    <kd-content-card>
-        <kd-title>[[Resource Quotas|Resource quota info details section title.]]</kd-title>
-        <kd-content>
-            <div layout="column" class="layout-column">
-                <div class="kd-info-card-section layout-padding layout-row"
-                     layout="row" layout-padding="">
-                    <div layout="column"
-                         class="kd-info-card-section-container layout-column">
-                        <div flex="auto" class="flex-auto">
-                            <div layout="row"
-                                 class="kd-info-card-entry layout-row">
-                                <div flex="nogrow" class="ng-binding ng-scope flex-nogrow">
-                                    [[Name|Resource quota info details section name]]
-                                </div>
-                                <div flex="auto" class="kd-info-card-entry-content flex-auto">
-                                    <kd-middle-ellipsis display-string="{{::$ctrl.resourceQuotaDetail.objectMeta.name}}">
-                                    </kd-middle-ellipsis>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div layout="column"
-                         class="kd-info-card-section-container layout-column">
-                        <div flex="auto" class="flex-auto">
-                            <div layout="row"
-                                 class="kd-info-card-entry layout-row">
-                                <div flex="nogrow"
-                                     class="ng-binding flex-nogrow">
-                                    [[Scopes|Resource quota info details section scopes]]
-                                </div>
-                                <div flex="auto" class="kd-info-card-entry-content flex-auto">
-                                    <kd-middle-ellipsis ng-repeat="scope in ::$ctrl.resourceQuotaDetail.scopes"
-                                                        display-string="{{::scope}}">
-                                    </kd-middle-ellipsis>
-                                    <div ng-hide="::$ctrl.resourceQuotaDetail.scopes">-</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+  <kd-content-card>
+    <kd-title>[[Resource Quotas|Resource quota info details section title.]]</kd-title>
+    <kd-content>
+      <div layout="column"
+           class="layout-column">
+        <div class="kd-info-card-section layout-padding layout-row"
+             layout="row"
+             layout-padding="">
+          <div layout="column"
+               class="kd-info-card-section-container layout-column">
+            <div flex="auto"
+                 class="flex-auto">
+              <div layout="row"
+                   class="kd-info-card-entry layout-row">
+                <div flex="nogrow"
+                     class="ng-binding ng-scope flex-nogrow">
+                  [[Name|Resource quota info details section name]]
                 </div>
-                <kd-resource-quota-detail-status status-list="::$ctrl.resourceQuotaDetail.statusList"></kd-resource-quota-detail-status>
+                <div flex="auto"
+                     class="kd-info-card-entry-content flex-auto">
+                  <kd-middle-ellipsis display-string="{{::$ctrl.resourceQuotaDetail.objectMeta.name}}">
+                  </kd-middle-ellipsis>
+                </div>
+              </div>
             </div>
-        </kd-content>
-    </kd-content-card>
+          </div>
+          <div layout="column"
+               class="kd-info-card-section-container layout-column">
+            <div flex="auto"
+                 class="flex-auto">
+              <div layout="row"
+                   class="kd-info-card-entry layout-row">
+                <div flex="nogrow"
+                     class="ng-binding flex-nogrow">
+                  [[Scopes|Resource quota info details section scopes]]
+                </div>
+                <div flex="auto"
+                     class="kd-info-card-entry-content flex-auto">
+                  <kd-middle-ellipsis ng-repeat="scope in ::$ctrl.resourceQuotaDetail.scopes"
+                                      display-string="{{::scope}}">
+                  </kd-middle-ellipsis>
+                  <div ng-hide="::$ctrl.resourceQuotaDetail.scopes">-</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <kd-resource-quota-detail-status status-list="::$ctrl.resourceQuotaDetail.statusList"></kd-resource-quota-detail-status>
+      </div>
+    </kd-content>
+  </kd-content-card>
 </div>

--- a/src/app/frontend/resourcequotadetail/resourcequotadetailstatus.html
+++ b/src/app/frontend/resourcequotadetail/resourcequotadetailstatus.html
@@ -1,26 +1,31 @@
-<kd-resource-card-list selectable="false" with-statuses="false">
-    <kd-resource-card-header-columns>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Resource Name|Resource quota details status section resource name.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Hard|Resource quota details status section hard.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Used|Resource quota details status section used.]]
-        </kd-resource-card-header-column>
-    </kd-resource-card-header-columns>
-    <kd-resource-card ng-repeat="(key, value) in ::$ctrl.statusList" omit-meta="true">
-        <kd-resource-card-columns>
-            <kd-resource-card-column>
-                <div>{{::key}}</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::value.hard}}</div>
-            </kd-resource-card-column>
-            <kd-resource-card-column>
-                <div>{{::value.used}}</div>
-            </kd-resource-card-column>
-        </kd-resource-card-columns>
-    </kd-resource-card>
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
+  <kd-resource-card-header-columns>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Resource Name|Resource quota details status section resource name.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Hard|Resource quota details status section hard.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Used|Resource quota details status section used.]]
+    </kd-resource-card-header-column>
+  </kd-resource-card-header-columns>
+  <kd-resource-card ng-repeat="(key, value) in ::$ctrl.statusList"
+                    omit-meta="true">
+    <kd-resource-card-columns>
+      <kd-resource-card-column>
+        <div>{{::key}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::value.hard}}</div>
+      </kd-resource-card-column>
+      <kd-resource-card-column>
+        <div>{{::value.used}}</div>
+      </kd-resource-card-column>
+    </kd-resource-card-columns>
+  </kd-resource-card>
 </kd-resource-card-list>

--- a/src/app/frontend/secretdetail/actionbar.html
+++ b/src/app/frontend/secretdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Secret|Label 'Secret' which appears at the top of the delete dialog, opened from a secret details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Secret|Label 'Secret' which appears at the top of the delete dialog, opened from a secret details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/secretdetail/detail.html
+++ b/src/app/frontend/secretdetail/detail.html
@@ -19,13 +19,20 @@ limitations under the License.
   <kd-info-card>
     <kd-info-card-header>[[Data|Secrets info details section data.]]</kd-info-card-header>
     <kd-info-card-section>
-      <div layout="row" class="kd-info-card-entry kd-secret-detail-row" ng-repeat="(key, value) in ::$ctrl.secretDetail.data">
-        <div flex="nogrow" style="position: relative">
-          <md-button ng-click="isActive = !isActive" class="md-icon-button">
+      <div layout="row"
+           class="kd-info-card-entry kd-secret-detail-row"
+           ng-repeat="(key, value) in ::$ctrl.secretDetail.data">
+        <div flex="nogrow"
+             style="position: relative">
+          <md-button ng-click="isActive = !isActive"
+                     class="md-icon-button">
             <!-- SVG drawing to simulate crossed-eye icon.
                  This should be removed if possible. -->
-            <svg ng-if="isActive" width="40px" height="40px" viewBox="0 0 40 40"
-                      style="left: 0; top:0; position:absolute; bottom:0, right: 0;">
+            <svg ng-if="isActive"
+                 width="40px"
+                 height="40px"
+                 viewBox="0 0 40 40"
+                 style="left: 0; top:0; position:absolute; bottom:0, right: 0;">
               <line x1="10" y1="10" x2="30" y2="30"
                 style="stroke-width: 2; stroke: rgba(0,0,0,0.54);"/>
             </svg>
@@ -37,9 +44,9 @@ limitations under the License.
           {{::key}}:
         </div>
         <div class="kd-info-card-entry-content">
-          <kd-toggle-hidden-text  active="isActive"
-                                  placeholder="[[{{::$ctrl.formatDataValue(value).length}} bytes | Secrets info details section bytes.]]"
-                                  text="{{::$ctrl.formatDataValue(value)}}">
+          <kd-toggle-hidden-text active="isActive"
+                                 placeholder="[[{{::$ctrl.formatDataValue(value).length}} bytes | Secrets info details section bytes.]]"
+                                 text="{{::$ctrl.formatDataValue(value)}}">
           </kd-toggle-hidden-text>
         </div>
       </div>

--- a/src/app/frontend/secretlist/card.html
+++ b/src/app/frontend/secretlist/card.html
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card type-meta="::$ctrl.secret.typeMeta" object-meta="::$ctrl.secret.objectMeta">
+<kd-resource-card type-meta="::$ctrl.secret.typeMeta"
+                  object-meta="::$ctrl.secret.objectMeta">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getSecretDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getSecretDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{::$ctrl.secret.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>

--- a/src/app/frontend/secretlist/cardlist.html
+++ b/src/app/frontend/secretlist/cardlist.html
@@ -18,20 +18,26 @@ limitations under the License.
   <kd-resource-card-list-header ng-transclude="header">
     [[Secrets|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="secrets" list="$ctrl.secretList"
+  <kd-resource-card-list-pagination pagination-id="secrets"
+                                    list="$ctrl.secretList"
                                     list-resource="$ctrl.secretListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-      <kd-resource-card-header-column size="small" grow="4">[[Name|Label 'Name' which appears as a column label in the table of secrets (secret list view).]]
-      </kd-resource-card-header-column>
-      <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
-          [[Namespace|Label 'Namespace' which appears as a column label in the table of secrets (secret list view).]]
-      </kd-resource-card-header-column>
-      <kd-resource-card-header-column size="small" grow="1">[[Age|Label 'Age' which appears as a column label in the table of secrets (secret list view).]]
-      </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="4">[[Name|Label 'Name' which appears as a column label in the table of secrets (secret list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
+      [[Namespace|Label 'Namespace' which appears as a column label in the table of secrets (secret list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">[[Age|Label 'Age' which appears as a column label in the table of secrets (secret list view).]]
+    </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-secret-card pagination-id="secrets" secret="secret"
+  <kd-secret-card pagination-id="secrets"
+                  secret="secret"
                   dir-paginate="secret in $ctrl.secretList.secrets | itemsPerPage: default"
                   total-items="::$ctrl.secretList.listMeta.totalItems">
   </kd-secret-card>

--- a/src/app/frontend/secretlist/list.html
+++ b/src/app/frontend/secretlist/list.html
@@ -15,10 +15,11 @@ limitations under the License.
 -->
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
-    <kd-content>
-        <kd-secret-card-list secret-list="$ctrl.secretList" with-statuses="false"
-                             secret-list-resource="$ctrl.secretListResource">
-        </kd-secret-card-list>
-    </kd-content>
+  <kd-content>
+    <kd-secret-card-list secret-list="$ctrl.secretList"
+                         with-statuses="false"
+                         secret-list-resource="$ctrl.secretListResource">
+    </kd-secret-card-list>
+  </kd-content>
 </kd-content-card>
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>

--- a/src/app/frontend/servicedetail/actionbar.html
+++ b/src/app/frontend/servicedetail/actionbar.html
@@ -15,6 +15,6 @@ limitations under the License.
 -->
 
 <kd-actionbar-detail-buttons resource-kind-name="Service"
-                        type-meta="$ctrl.details.typeMeta"
-                        object-meta="$ctrl.details.objectMeta">
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/servicedetail/servicedetail.html
+++ b/src/app/frontend/servicedetail/servicedetail.html
@@ -18,7 +18,8 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-pod-card-list pod-list="ctrl.serviceDetail.podList" with-statuses="true"
+    <kd-pod-card-list pod-list="ctrl.serviceDetail.podList"
+                      with-statuses="true"
                       pod-list-resource="ctrl.servicePodsResource">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for pods card zerostate in stateful set details page.]]</div>

--- a/src/app/frontend/servicedetail/servicedetailinfo.html
+++ b/src/app/frontend/servicedetail/servicedetailinfo.html
@@ -36,7 +36,8 @@ limitations under the License.
     <kd-info-card-entry title="[[Cluster IP|Label 'Cluster IP' for the service IP in the cluster, appears in the connectivity part (right) of the service details view.]]">
       {{::$ctrl.service.clusterIP}}
     </kd-info-card-entry>
-    <kd-info-card-entry title="[[Internal endpoints|Label 'Internal endpoints' for the internal endpoints of the service, appears in the connectivity part (right) of the service details view.]]" ng-if="::$ctrl.service.internalEndpoint">
+    <kd-info-card-entry title="[[Internal endpoints|Label 'Internal endpoints' for the internal endpoints of the service, appears in the connectivity part (right) of the service details view.]]"
+                        ng-if="::$ctrl.service.internalEndpoint">
       <kd-internal-endpoint endpoint="::$ctrl.service.internalEndpoint"></kd-internal-endpoint>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[External endpoints|Label 'External endpoints' for the external endpoints of the service, appears in the connectivity part (right) of the service details view.]]"

--- a/src/app/frontend/servicelist/servicecard.html
+++ b/src/app/frontend/servicelist/servicecard.html
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.service.objectMeta" type-meta="::$ctrl.service.typeMeta">
+<kd-resource-card object-meta="::$ctrl.service.objectMeta"
+                  type-meta="::$ctrl.service.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">[[This service is in a pending state|tooltip for pending service card icon]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>

--- a/src/app/frontend/servicelist/servicecardlist.html
+++ b/src/app/frontend/servicelist/servicecardlist.html
@@ -14,45 +14,59 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="::$ctrl.selectable" with-statuses="true">
+<kd-resource-card-list selectable="::$ctrl.selectable"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Services|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="services" list="$ctrl.serviceList"
+  <kd-resource-card-list-pagination pagination-id="services"
+                                    list="$ctrl.serviceList"
                                     list-resource="::$ctrl.serviceListResource">
   </kd-resource-card-list-pagination>
   <div ng-show="!$ctrl.serviceList.listMeta.totalItems"
-      class="kd-zerostate-message" ng-transclude="zerostate"></div>
+       class="kd-zerostate-message"
+       ng-transclude="zerostate"></div>
 
   <kd-resource-card-header-columns ng-show="$ctrl.serviceList.listMeta.totalItems">
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Label 'Name' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Label 'Namespace' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Label 'Labels' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Cluster IP|Label 'Cluster IP' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Internal endpoints|Label 'Internal endpoints' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[External endpoints|Label 'External endpoints' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
 
-  <kd-service-card ng-if="::$ctrl.serviceListResource" service="service"
+  <kd-service-card ng-if="::$ctrl.serviceListResource"
+                   service="service"
                    dir-paginate="service in $ctrl.serviceList.services | itemsPerPage: default"
-                   total-items="::$ctrl.serviceList.listMeta.totalItems" pagination-id="services">
+                   total-items="::$ctrl.serviceList.listMeta.totalItems"
+                   pagination-id="services">
   </kd-service-card>
 
-  <kd-service-card ng-if="::!$ctrl.serviceListResource" pagination-id="services"
+  <kd-service-card ng-if="::!$ctrl.serviceListResource"
+                   pagination-id="services"
                    dir-paginate="service in $ctrl.serviceList.services | itemsPerPage: default"
                    service="service">
   </kd-service-card>

--- a/src/app/frontend/servicesanddiscovery/servicesanddiscovery.html
+++ b/src/app/frontend/servicesanddiscovery/servicesanddiscovery.html
@@ -17,15 +17,17 @@ limitations under the License.
 <div ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content-card ng-if="$ctrl.servicesAndDiscovery.serviceList.services.length">
     <kd-content>
-      <kd-service-card-list service-list="$ctrl.servicesAndDiscovery.serviceList" with-statuses="true"
-                               service-list-resource="$ctrl.kdServiceListResource">
+      <kd-service-card-list service-list="$ctrl.servicesAndDiscovery.serviceList"
+                            with-statuses="true"
+                            service-list-resource="$ctrl.kdServiceListResource">
       </kd-service-card-list>
     </kd-content>
   </kd-content-card>
   <kd-content-card ng-if="$ctrl.servicesAndDiscovery.ingressList.items.length">
     <kd-content>
-      <kd-ingress-card-list ingress-list="$ctrl.servicesAndDiscovery.ingressList" with-statuses="true"
-                               ingress-list-resource="$ctrl.kdIngressListResource">
+      <kd-ingress-card-list ingress-list="$ctrl.servicesAndDiscovery.ingressList"
+                            with-statuses="true"
+                            ingress-list-resource="$ctrl.kdIngressListResource">
       </kd-ingress-card-list>
     </kd-content>
   </kd-content-card>

--- a/src/app/frontend/statefulsetdetail/actionbar.html
+++ b/src/app/frontend/statefulsetdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-                    resource-kind-name="[[Stateful Set|Label 'Stateful Set' which appears at the top of the delete dialog, opened from a stateful set details page.]]"
-                    type-meta="$ctrl.details.typeMeta"
-                    object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Stateful Set|Label 'Stateful Set' which appears at the top of the delete dialog, opened from a stateful set details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/statefulsetdetail/statefulsetdetail.html
+++ b/src/app/frontend/statefulsetdetail/statefulsetdetail.html
@@ -41,4 +41,5 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 
-<kd-event-card-list event-list="::ctrl.statefulSetDetail.eventList" event-list-resource="::ctrl.eventListResource"></kd-event-card-list>
+<kd-event-card-list event-list="::ctrl.statefulSetDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/statefulsetdetail/statefulsetinfo.html
+++ b/src/app/frontend/statefulsetdetail/statefulsetinfo.html
@@ -32,8 +32,8 @@ limitations under the License.
   <kd-info-card-section name="[[Status|Stateful set info status section name.]]">
     <kd-info-card-entry title="[[Pods|Stateful set info status section pods entry.]]">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        [[{{$ctrl.statefulSet.podInfo.current}} created|The message says that that many pods were created (stateful set details page).]],
-        [[{{$ctrl.statefulSet.podInfo.desired}} desired|The message says that that many pods are desired to run (stateful set details page).]]
+        [[{{$ctrl.statefulSet.podInfo.current}} created|The message says that that many pods were created (stateful set details page).]], [[{{$ctrl.statefulSet.podInfo.desired}} desired|The message says that that many pods are desired to run (stateful set details
+        page).]]
       </div>
       <div ng-if="$ctrl.areDesiredPodsRunning()">
         [[{{$ctrl.statefulSet.podInfo.running}} running|The message says that that many pods are running (stateful set details page).]]
@@ -42,13 +42,16 @@ limitations under the License.
     <kd-info-card-entry title="[[Pods status|Stateful set info status section pods status entry.]]"
                         ng-if="!$ctrl.areDesiredPodsRunning()">
       <div ng-if="!$ctrl.areDesiredPodsRunning()">
-        <div ng-if="::$ctrl.statefulSet.podInfo.pending" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.statefulSet.podInfo.pending"
+             class="kd-comma-separated-item">
           [[{{$ctrl.statefulSet.podInfo.pending}} pending|The message says that that many pods are pending (stateful set details page).]]
         </div>
-        <div ng-if="::$ctrl.statefulSet.podInfo.failed" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.statefulSet.podInfo.failed"
+             class="kd-comma-separated-item">
           [[{{$ctrl.statefulSet.podInfo.failed}} failed|The message says that that many pods have failed (stateful set details page).]]
         </div>
-        <div ng-if="::$ctrl.statefulSet.podInfo.running" class="kd-comma-separated-item">
+        <div ng-if="::$ctrl.statefulSet.podInfo.running"
+             class="kd-comma-separated-item">
           [[{{$ctrl.statefulSet.podInfo.running}} running|The message says that that many pods are running (stateful set details page).]]
         </div>
       </div>

--- a/src/app/frontend/statefulsetlist/statefulsetcard.html
+++ b/src/app/frontend/statefulsetlist/statefulsetcard.html
@@ -14,26 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.statefulSet.objectMeta" type-meta="$ctrl.statefulSet.typeMeta">
+<kd-resource-card object-meta="$ctrl.statefulSet.objectMeta"
+                  type-meta="$ctrl.statefulSet.typeMeta">
   <kd-resource-card-status layout="row">
-    <md-icon class="material-icons kd-error" ng-if="::$ctrl.hasWarnings()">
+    <md-icon class="material-icons kd-error"
+             ng-if="::$ctrl.hasWarnings()">
       error
       <md-tooltip md-direction="right">[[One or more pods have errors|Tooltip text which appears on error icon hover.]]</md-tooltip>
     </md-icon>
-    <md-icon class="material-icons" ng-if="::$ctrl.isPending()">
+    <md-icon class="material-icons"
+             ng-if="::$ctrl.isPending()">
       timelapse
       <md-tooltip md-direction="right">
         [[One or more pods are in pending state|Tooltip text which appears on pending icon hover.]]
       </md-tooltip>
     </md-icon>
-    <md-icon class="material-icons kd-success" ng-if="::$ctrl.isSuccess()">
+    <md-icon class="material-icons kd-success"
+             ng-if="::$ctrl.isSuccess()">
       check_circle
     </md-icon>
   </kd-resource-card-status>
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getStatefulSetDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getStatefulSetDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{$ctrl.statefulSet.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>
@@ -70,18 +75,16 @@ limitations under the License.
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>
-        <kd-resource-card-delete-menu-item
-              resource-kind-name="[[Stateful Set|Label 'Stateful Set' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.]]">
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Stateful Set|Label 'Stateful Set' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.]]">
         </kd-resource-card-delete-menu-item>
-        <kd-resource-card-edit-menu-item
-              resource-kind-name="[[Stateful Set|Label 'Stateful Set' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.]]">
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Stateful Set|Label 'Stateful Set' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.]]">
         </kd-resource-card-edit-menu-item>
       </kd-resource-card-menu>
     </kd-resource-card-column>
   </kd-resource-card-columns>
   <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
-      <div ng-repeat="warning in ::$ctrl.statefulSet.pods.warnings">
-        <span class="kd-error">{{::warning.message}}</span>
-      </div>
+    <div ng-repeat="warning in ::$ctrl.statefulSet.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
   </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/statefulsetlist/statefulsetcardlist.html
+++ b/src/app/frontend/statefulsetlist/statefulsetcardlist.html
@@ -14,47 +14,63 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="true">
+<kd-resource-card-list selectable="false"
+                       with-statuses="true">
   <kd-resource-card-list-header ng-transclude="header">
     [[Stateful Sets|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="statefulsets" list="$ctrl.statefulSetList"
+  <kd-resource-card-list-pagination pagination-id="statefulsets"
+                                    list="$ctrl.statefulSetList"
                                     list-resource="$ctrl.statefulSetListResource">
   </kd-resource-card-list-pagination>
 
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Name|Stateful set list header: name.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1" ng-if="::$ctrl.showResourceKind">
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    ng-if="::$ctrl.showResourceKind">
       [[Kind|Column header 'Kind' of a Stateful Set List]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2" ng-if="$ctrl.areMultipleNamespacesSelected()">
+    <kd-resource-card-header-column size="small"
+                                    grow="2"
+                                    ng-if="$ctrl.areMultipleNamespacesSelected()">
       [[Namespace|Stateful set list header: namespace.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Labels|Stateful set list header: labels.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Pods|Stateful set list header: pods.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Stateful set list header: age.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="2">
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
       [[Images|Stateful set list header: images.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="nogrow">
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-stateful-set-card ng-if="::$ctrl.statefulSetListResource" pagination-id="statefulsets" stateful-set="statefulSet"
-                   dir-paginate="statefulSet in $ctrl.statefulSetList.statefulSets | itemsPerPage: default"
-                   show-resource-kind="::$ctrl.showResourceKind"
-                   total-items="::$ctrl.statefulSetList.listMeta.totalItems">
+  <kd-stateful-set-card ng-if="::$ctrl.statefulSetListResource"
+                        pagination-id="statefulsets"
+                        stateful-set="statefulSet"
+                        dir-paginate="statefulSet in $ctrl.statefulSetList.statefulSets | itemsPerPage: default"
+                        show-resource-kind="::$ctrl.showResourceKind"
+                        total-items="::$ctrl.statefulSetList.listMeta.totalItems">
   </kd-stateful-set-card>
 
-  <kd-stateful-set-card ng-if="::!$ctrl.statefulSetListResource" pagination-id="statefulsets" stateful-set="statefulSet"
-                   dir-paginate="statefulSet in $ctrl.statefulSetList.statefulSets | itemsPerPage: default"
-                   show-resource-kind="::$ctrl.showResourceKind">
+  <kd-stateful-set-card ng-if="::!$ctrl.statefulSetListResource"
+                        pagination-id="statefulsets"
+                        stateful-set="statefulSet"
+                        dir-paginate="statefulSet in $ctrl.statefulSetList.statefulSets | itemsPerPage: default"
+                        show-resource-kind="::$ctrl.showResourceKind">
   </kd-stateful-set-card>
 </kd-resource-card-list>

--- a/src/app/frontend/statefulsetlist/statefulsetlist.html
+++ b/src/app/frontend/statefulsetlist/statefulsetlist.html
@@ -29,7 +29,7 @@ limitations under the License.
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
   <kd-content>
     <kd-stateful-set-card-list stateful-set-list="$ctrl.statefulSetList"
-                          stateful-set-list-resource="$ctrl.statefulSetListResource">
+                               stateful-set-list-resource="$ctrl.statefulSetListResource">
     </kd-stateful-set-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/storageclassdetail/actionbar.html
+++ b/src/app/frontend/storageclassdetail/actionbar.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-actionbar-detail-buttons
-        resource-kind-name="[[Storage Class|Label 'Storage Class' which appears at the top of the delete dialog, opened from a config map details page.]]"
-        type-meta="$ctrl.details.typeMeta"
-        object-meta="$ctrl.details.objectMeta">
+<kd-actionbar-detail-buttons resource-kind-name="[[Storage Class|Label 'Storage Class' which appears at the top of the delete dialog, opened from a config map details page.]]"
+                             type-meta="$ctrl.details.typeMeta"
+                             object-meta="$ctrl.details.objectMeta">
 </kd-actionbar-detail-buttons>

--- a/src/app/frontend/storageclassdetail/storageclass.html
+++ b/src/app/frontend/storageclassdetail/storageclass.html
@@ -15,5 +15,5 @@ limitations under the License.
 -->
 
 <div layout="column">
-    <kd-storage-class-info storage-class="::$ctrl.storageClass"></kd-storage-class-info>
+  <kd-storage-class-info storage-class="::$ctrl.storageClass"></kd-storage-class-info>
 </div>

--- a/src/app/frontend/storageclasslist/card.html
+++ b/src/app/frontend/storageclasslist/card.html
@@ -14,42 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="$ctrl.storageClass.objectMeta" type-meta="$ctrl.storageClass.typeMeta">
-    <kd-resource-card-columns>
-        <kd-resource-card-column>
-            <div>
-                <a ng-href="{{::$ctrl.getStorageClassDetailHref()}}" class="kd-middle-ellipsised-link">
-                    <kd-middle-ellipsis display-string="{{$ctrl.storageClass.objectMeta.name}}">
-                    </kd-middle-ellipsis>
-                </a>
-            </div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-labels labels="::$ctrl.storageClass.objectMeta.labels"></kd-labels>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-middle-ellipsis display-string="{{$ctrl.storageClass.provisioner}}">
-            </kd-middle-ellipsis>
-            <div ng-hide="::$ctrl.storageClass.provisioner">-</div>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            <kd-labels labels="::$ctrl.storageClass.parameters"></kd-labels>
-        </kd-resource-card-column>
-        <kd-resource-card-column>
-            {{::$ctrl.storageClass.objectMeta.creationTimestamp | relativeTime}}
-            <md-tooltip>
-                {{::$ctrl.getCreatedAtTooltip($ctrl.storageClass.objectMeta.creationTimestamp)}}
-            </md-tooltip>
-        </kd-resource-card-column>
-        <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
-            <kd-resource-card-menu>
-                <kd-resource-card-delete-menu-item
-                        resource-kind-name="[[Storage Class|Label 'Storage Class' which will appear in the storage class delete dialog opened from a storageclass card on the list page.]]">
-                </kd-resource-card-delete-menu-item>
-                <kd-resource-card-edit-menu-item
-                        resource-kind-name="[[Storage Class|Label 'Storage Class' which will appear in the storage class delete dialog opened from a storageclass card on the list page.]]">
-                </kd-resource-card-edit-menu-item>
-            </kd-resource-card-menu>
-        </kd-resource-card-column>
-    </kd-resource-card-columns>
+<kd-resource-card object-meta="$ctrl.storageClass.objectMeta"
+                  type-meta="$ctrl.storageClass.typeMeta">
+  <kd-resource-card-columns>
+    <kd-resource-card-column>
+      <div>
+        <a ng-href="{{::$ctrl.getStorageClassDetailHref()}}"
+           class="kd-middle-ellipsised-link">
+          <kd-middle-ellipsis display-string="{{$ctrl.storageClass.objectMeta.name}}">
+          </kd-middle-ellipsis>
+        </a>
+      </div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-labels labels="::$ctrl.storageClass.objectMeta.labels"></kd-labels>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-middle-ellipsis display-string="{{$ctrl.storageClass.provisioner}}">
+      </kd-middle-ellipsis>
+      <div ng-hide="::$ctrl.storageClass.provisioner">-</div>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      <kd-labels labels="::$ctrl.storageClass.parameters"></kd-labels>
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.storageClass.objectMeta.creationTimestamp | relativeTime}}
+      <md-tooltip>
+        {{::$ctrl.getCreatedAtTooltip($ctrl.storageClass.objectMeta.creationTimestamp)}}
+      </md-tooltip>
+    </kd-resource-card-column>
+    <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
+      <kd-resource-card-menu>
+        <kd-resource-card-delete-menu-item resource-kind-name="[[Storage Class|Label 'Storage Class' which will appear in the storage class delete dialog opened from a storageclass card on the list page.]]">
+        </kd-resource-card-delete-menu-item>
+        <kd-resource-card-edit-menu-item resource-kind-name="[[Storage Class|Label 'Storage Class' which will appear in the storage class delete dialog opened from a storageclass card on the list page.]]">
+        </kd-resource-card-edit-menu-item>
+      </kd-resource-card-menu>
+    </kd-resource-card-column>
+  </kd-resource-card-columns>
 </kd-resource-card>

--- a/src/app/frontend/storageclasslist/cardlist.html
+++ b/src/app/frontend/storageclasslist/cardlist.html
@@ -14,36 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list selectable="false" with-statuses="false">
-    <kd-resource-card-list-header ng-transclude="header">
-      [[Storage Classes|Label which appears above the list of such objects.]]
-    </kd-resource-card-list-header>
-    <kd-resource-card-list-pagination pagination-id="storageclasses" list="$ctrl.storageClassList"
-                                      list-resource="$ctrl.storageClassListResource">
-    </kd-resource-card-list-pagination>
+<kd-resource-card-list selectable="false"
+                       with-statuses="false">
+  <kd-resource-card-list-header ng-transclude="header">
+    [[Storage Classes|Label which appears above the list of such objects.]]
+  </kd-resource-card-list-header>
+  <kd-resource-card-list-pagination pagination-id="storageclasses"
+                                    list="$ctrl.storageClassList"
+                                    list-resource="$ctrl.storageClassListResource">
+  </kd-resource-card-list-pagination>
 
-    <kd-resource-card-header-columns>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Name|Storage class list header: name.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Labels|Storage class list header: labels.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Provisioner|Storage class list header: provisioner.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="2">
-            [[Parameters|Storage class list header: parameters.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="1">
-            [[Age|Storage class list header: age.]]
-        </kd-resource-card-header-column>
-        <kd-resource-card-header-column size="small" grow="nogrow">
-        </kd-resource-card-header-column>
-    </kd-resource-card-header-columns>
-    <kd-storage-class-card dir-paginate="storageClass in $ctrl.storageClassList.storageClasses | itemsPerPage: default"
-                           total-items="::$ctrl.storageClassList.listMeta.totalItems"
-                           storage-class="storageClass"
-                           pagination-id="storageclasses">
-    </kd-storage-class-card>
+  <kd-resource-card-header-columns>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Name|Storage class list header: name.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Labels|Storage class list header: labels.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Provisioner|Storage class list header: provisioner.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="2">
+      [[Parameters|Storage class list header: parameters.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Age|Storage class list header: age.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="nogrow">
+    </kd-resource-card-header-column>
+  </kd-resource-card-header-columns>
+  <kd-storage-class-card dir-paginate="storageClass in $ctrl.storageClassList.storageClasses | itemsPerPage: default"
+                         total-items="::$ctrl.storageClassList.listMeta.totalItems"
+                         storage-class="storageClass"
+                         pagination-id="storageclasses">
+  </kd-storage-class-card>
 </kd-resource-card-list>

--- a/src/app/frontend/storageclasslist/storageclasslist.html
+++ b/src/app/frontend/storageclasslist/storageclasslist.html
@@ -15,11 +15,11 @@ limitations under the License.
 -->
 
 <kd-content-card ng-if="!$ctrl.shouldShowZeroState()">
-    <kd-content>
-        <kd-storage-class-card-list storage-class-list="$ctrl.storageClassList"
-                                    storage-class-list-resource="$ctrl.storageClassListResource">
-        </kd-storage-class-card-list>
-    </kd-content>
+  <kd-content>
+    <kd-storage-class-card-list storage-class-list="$ctrl.storageClassList"
+                                storage-class-list-resource="$ctrl.storageClassListResource">
+    </kd-storage-class-card-list>
+  </kd-content>
 </kd-content-card>
 
 <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>

--- a/src/app/frontend/thirdpartyresourcedetail/detail.html
+++ b/src/app/frontend/thirdpartyresourcedetail/detail.html
@@ -17,18 +17,18 @@ limitations under the License.
 <kd-third-party-resource-info tpr-detail="$ctrl.tprDetail"></kd-third-party-resource-info>
 
 <kd-content-card>
-    <kd-content>
-        <kd-third-party-resource-objects object-list="$ctrl.tprDetail.objects"
-                                         object-list-resource="$ctrl.tprObjectsResource"
-                                         with-statuses="false">
-            <kd-zerostate>
-              <div class="kd-zerostate-title">
-                  [[There is nothing to display here|Title for objects card zerostate in third party resource details page.]]
-              </div>
-              <div class="kd-zerostate-text">
-                  [[There are currently no instances of Third Party Resource.|Text for objects card zerostate in third party resource details page.]]
-              </div>
-            </kd-zerostate>
-        </kd-third-party-resource-objects>
-    </kd-content>
+  <kd-content>
+    <kd-third-party-resource-objects object-list="$ctrl.tprDetail.objects"
+                                     object-list-resource="$ctrl.tprObjectsResource"
+                                     with-statuses="false">
+      <kd-zerostate>
+        <div class="kd-zerostate-title">
+          [[There is nothing to display here|Title for objects card zerostate in third party resource details page.]]
+        </div>
+        <div class="kd-zerostate-text">
+          [[There are currently no instances of Third Party Resource.|Text for objects card zerostate in third party resource details page.]]
+        </div>
+      </kd-zerostate>
+    </kd-third-party-resource-objects>
+  </kd-content>
 </kd-content-card>

--- a/src/app/frontend/thirdpartyresourcedetail/objectcard.html
+++ b/src/app/frontend/thirdpartyresourcedetail/objectcard.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card object-meta="::$ctrl.object.metadata" type-meta="::$ctrl.object">
+<kd-resource-card object-meta="::$ctrl.object.metadata"
+                  type-meta="::$ctrl.object">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <kd-middle-ellipsis display-string="{{::$ctrl.object.metadata.name}}">

--- a/src/app/frontend/thirdpartyresourcedetail/objectlist.html
+++ b/src/app/frontend/thirdpartyresourcedetail/objectlist.html
@@ -29,17 +29,19 @@ limitations under the License.
        ng-transclude="zerostate">
   </div>
   <kd-resource-card-header-columns ng-show="::$ctrl.objectList.listMeta.totalItems">
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Name|Title of a column for the name of a third party resource instance.]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Title of a column for the age of a third party resource instance.]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-object-card ng-if="::$ctrl.objectListResource"
-               dir-paginate="object in $ctrl.objectList.items | itemsPerPage: default"
-               pagination-id="objects"
-               object="object"
-               total-items="::$ctrl.objectList.listMeta.totalItems">
+                  dir-paginate="object in $ctrl.objectList.items | itemsPerPage: default"
+                  pagination-id="objects"
+                  object="object"
+                  total-items="::$ctrl.objectList.listMeta.totalItems">
   </kd-object-card>
 </kd-resource-card-list>

--- a/src/app/frontend/thirdpartyresourcelist/card.html
+++ b/src/app/frontend/thirdpartyresourcelist/card.html
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card type-meta="::$ctrl.thirdPartyResource.typeMeta" object-meta="::$ctrl.thirdPartyResource.objectMeta">
+<kd-resource-card type-meta="::$ctrl.thirdPartyResource.typeMeta"
+                  object-meta="::$ctrl.thirdPartyResource.objectMeta">
   <kd-resource-card-columns>
     <kd-resource-card-column>
       <div>
-        <a ng-href="{{::$ctrl.getThirdPartyResourceDetailHref()}}" class="kd-middle-ellipsised-link">
+        <a ng-href="{{::$ctrl.getThirdPartyResourceDetailHref()}}"
+           class="kd-middle-ellipsised-link">
           <kd-middle-ellipsis display-string="{{::$ctrl.thirdPartyResource.objectMeta.name}}">
           </kd-middle-ellipsis>
         </a>

--- a/src/app/frontend/thirdpartyresourcelist/cardlist.html
+++ b/src/app/frontend/thirdpartyresourcelist/cardlist.html
@@ -23,14 +23,17 @@ limitations under the License.
                                     list-resource="$ctrl.thirdPartyResourceListResource">
   </kd-resource-card-list-pagination>
   <kd-resource-card-header-columns>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Name|Label 'Name' which appears as a column label in the table of third party resources (thirdpartyresource listview).]]
     </kd-resource-card-header-column>
-    <kd-resource-card-header-column size="small" grow="1">
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
       [[Age|Label 'Age' which appears as a column label in the table of third party resources (thirdpartyresource list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-third-party-resource-card pagination-id="thirdpartyresources" third-party-resource="tpr"
+  <kd-third-party-resource-card pagination-id="thirdpartyresources"
+                                third-party-resource="tpr"
                                 dir-paginate="tpr in $ctrl.thirdPartyResourceList.thirdPartyResources | itemsPerPage: default"
                                 total-items="::$ctrl.thirdPartyResourceList.listMeta.totalItems">
   </kd-third-party-resource-card>

--- a/src/app/frontend/thirdpartyresourcelist/list.html
+++ b/src/app/frontend/thirdpartyresourcelist/list.html
@@ -16,10 +16,9 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-third-party-resource-card-list
-            third-party-resource-list="$ctrl.thirdPartyResourceList"
-            third-party-resource-list-resource="$ctrl.thirdPartyResourceListResource"
-            with-statuses="false">
+    <kd-third-party-resource-card-list third-party-resource-list="$ctrl.thirdPartyResourceList"
+                                       third-party-resource-list-resource="$ctrl.thirdPartyResourceListResource"
+                                       with-statuses="false">
     </kd-third-party-resource-card-list>
   </kd-content>
 </kd-content-card>

--- a/src/app/frontend/workloads/workloads.html
+++ b/src/app/frontend/workloads/workloads.html
@@ -21,6 +21,7 @@ limitations under the License.
   </kd-graph-card>
   <kd-graph-card graph-title="[[Memory usage|Title for graph card displaying memory metric of one all resources.]]"
                  graph-info="[[The memory usage includes the caches in the pods managed by these resources. (Does not count pods double because it is mentioned both in the pod list and its controller is mentioned in e.g. a replica set.)|Help message detailing what is included in the memory usage]]"
+
                  metrics="::$ctrl.workloads.podList.cumulativeMetrics"
                  selected-metric-names="'memory/usage'">
   </kd-graph-card>
@@ -45,16 +46,16 @@ limitations under the License.
 
   <kd-content-card ng-if="$ctrl.workloads.replicationControllerList.replicationControllers.length">
     <kd-content>
-      <kd-replication-controller-card-list
-              replication-controller-list="$ctrl.workloads.replicationControllerList"
-              replication-controller-list-resource="$ctrl.rcListResource">
+      <kd-replication-controller-card-list replication-controller-list="$ctrl.workloads.replicationControllerList"
+                                           replication-controller-list-resource="$ctrl.rcListResource">
       </kd-replication-controller-card-list>
     </kd-content>
   </kd-content-card>
 
   <kd-content-card ng-if="$ctrl.workloads.daemonSetList.daemonSets.length">
     <kd-content>
-      <kd-daemon-set-card-list daemon-set-list="$ctrl.workloads.daemonSetList" with-statuses="true"
+      <kd-daemon-set-card-list daemon-set-list="$ctrl.workloads.daemonSetList"
+                               with-statuses="true"
                                daemon-set-list-resource="$ctrl.daemonSetListResource">
       </kd-daemon-set-card-list>
     </kd-content>
@@ -78,7 +79,8 @@ limitations under the License.
 
   <kd-content-card ng-if="$ctrl.workloads.podList.pods.length">
     <kd-content>
-      <kd-pod-card-list pod-list="$ctrl.workloads.podList" pod-list-resource="$ctrl.podListResource"
+      <kd-pod-card-list pod-list="$ctrl.workloads.podList"
+                        pod-list-resource="$ctrl.podListResource"
                         with-statuses="true">
       </kd-pod-card-list>
     </kd-content>


### PR DESCRIPTION
Added go/html formatting. HTML formatter will preserve bigger part of the code. It will only split and keep all tag attributes aligned in new lines, keep line indentation set to 2, and try to preserve max line length which is now 120. Additionally it will add new lines on end of each file so we don't have to worry about that anymore.

I've also added task for go formatting (`gulp format-go`) and exposed one common `gulp format` task to format JS, HTML and Go code at once.