### PR TITLE
Minor fixes

### DIFF
--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -45,7 +45,7 @@ func FilterPodsByControllerResource(resourceNamespace string, resourceUID types.
 	for _, pod := range allPods {
 		if pod.Namespace == resourceNamespace {
 			for _, ownerRef := range pod.OwnerReferences {
-				if *ownerRef.Controller == true && ownerRef.UID == resourceUID {
+				if ownerRef.Controller != nil && *ownerRef.Controller == true && ownerRef.UID == resourceUID {
 					pods = append(pods, pod)
 				}
 			}

--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	api "k8s.io/client-go/pkg/api/v1"
 )
 
@@ -33,6 +34,24 @@ func FilterNamespacedPodsBySelector(pods []api.Pod, namespace string,
 	}
 
 	return matchingPods
+}
+
+// FilterPodsByControllerResource returns set of pods controlled by given resource.
+// Please note, that OwnerReference is still in development phase:
+// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md.
+// Currently works for given resources: Replication Controllers.
+func FilterPodsByControllerResource(resourceNamespace string, resourceUID types.UID, allPods []api.Pod) []api.Pod {
+	var pods []api.Pod
+	for _, pod := range allPods {
+		if pod.Namespace == resourceNamespace {
+			for _, ownerRef := range pod.OwnerReferences {
+				if *ownerRef.Controller == true && ownerRef.UID == resourceUID {
+					pods = append(pods, pod)
+				}
+			}
+		}
+	}
+	return pods
 }
 
 // FilterPodsBySelector returns pods targeted by given resource selector.

--- a/src/app/backend/resource/persistentvolume/detail_test.go
+++ b/src/app/backend/resource/persistentvolume/detail_test.go
@@ -20,15 +20,15 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	api "k8s.io/client-go/pkg/api/v1"
 )
 
 func TestGetPersistentVolumeDetail(t *testing.T) {
 	cases := []struct {
-		name string
+		name             string
 		persistentVolume *api.PersistentVolume
-		expected          *PersistentVolumeDetail
+		expected         *PersistentVolumeDetail
 	}{
 		{
 			"foo",

--- a/src/app/backend/resource/replicationcontroller/list/list.go
+++ b/src/app/backend/resource/replicationcontroller/list/list.go
@@ -89,8 +89,8 @@ func CreateReplicationControllerList(replicationControllers []api.ReplicationCon
 	replicationControllers = replicationcontroller.FromCells(replicationControllerCells)
 
 	for _, rc := range replicationControllers {
-		matchingPods := common.FilterNamespacedPodsBySelector(pods, rc.ObjectMeta.Namespace,
-			rc.Spec.Selector)
+		matchingPods := common.FilterPodsByControllerResource(rc.Namespace, rc.UID, pods)
+
 		podInfo := common.GetPodInfo(rc.Status.Replicas, *rc.Spec.Replicas, matchingPods)
 		podInfo.Warnings = event.GetPodsEventWarnings(events, matchingPods)
 

--- a/src/app/backend/resource/replicationcontroller/list/list_test.go
+++ b/src/app/backend/resource/replicationcontroller/list/list_test.go
@@ -29,6 +29,13 @@ import (
 func TestGetReplicationControllerList(t *testing.T) {
 	replicas := int32(0)
 	events := []api.Event{}
+	controller := true;
+	firstAppOwnerRef := []metaV1.OwnerReference{{
+		Kind:  "ReplicationController",
+		Name: "my-name-1",
+		UID: "uid-1",
+		Controller: &controller,
+	}}
 
 	cases := []struct {
 		replicationControllers []api.ReplicationController
@@ -49,6 +56,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-1",
 						Namespace: "namespace-1",
+						UID: "uid-1",
 					},
 					Spec: api.ReplicationControllerSpec{
 						Replicas: &replicas,
@@ -62,6 +70,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-2",
 						Namespace: "namespace-2",
+						UID: "uid-2",
 					},
 					Spec: api.ReplicationControllerSpec{
 						Replicas: &replicas,
@@ -78,6 +87,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-1",
 						Namespace: "namespace-1",
+						UID: "uid-1",
 					},
 				},
 				{
@@ -85,6 +95,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-2",
 						Namespace: "namespace-2",
+						UID: "uid-1",
 					},
 				},
 			},
@@ -92,7 +103,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodFailed,
@@ -101,7 +112,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodFailed,
@@ -110,7 +121,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodPending,
@@ -119,7 +130,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-2",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodPending,
@@ -128,7 +139,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodRunning,
@@ -137,7 +148,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodSucceeded,
@@ -146,7 +157,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				{
 					ObjectMeta: metaV1.ObjectMeta{
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"app": "my-name-1"},
+						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
 						Phase: api.PodUnknown,

--- a/src/app/backend/resource/replicationcontroller/list/list_test.go
+++ b/src/app/backend/resource/replicationcontroller/list/list_test.go
@@ -29,11 +29,11 @@ import (
 func TestGetReplicationControllerList(t *testing.T) {
 	replicas := int32(0)
 	events := []api.Event{}
-	controller := true;
+	controller := true
 	firstAppOwnerRef := []metaV1.OwnerReference{{
-		Kind:  "ReplicationController",
-		Name: "my-name-1",
-		UID: "uid-1",
+		Kind:       "ReplicationController",
+		Name:       "my-name-1",
+		UID:        "uid-1",
 		Controller: &controller,
 	}}
 
@@ -56,7 +56,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-1",
 						Namespace: "namespace-1",
-						UID: "uid-1",
+						UID:       "uid-1",
 					},
 					Spec: api.ReplicationControllerSpec{
 						Replicas: &replicas,
@@ -70,7 +70,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-2",
 						Namespace: "namespace-2",
-						UID: "uid-2",
+						UID:       "uid-2",
 					},
 					Spec: api.ReplicationControllerSpec{
 						Replicas: &replicas,
@@ -87,7 +87,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-1",
 						Namespace: "namespace-1",
-						UID: "uid-1",
+						UID:       "uid-1",
 					},
 				},
 				{
@@ -95,14 +95,14 @@ func TestGetReplicationControllerList(t *testing.T) {
 					ObjectMeta: metaV1.ObjectMeta{
 						Name:      "my-app-2",
 						Namespace: "namespace-2",
-						UID: "uid-1",
+						UID:       "uid-1",
 					},
 				},
 			},
 			[]api.Pod{
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -111,7 +111,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -120,7 +120,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -129,7 +129,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-2",
+						Namespace:       "namespace-2",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -138,7 +138,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -147,7 +147,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{
@@ -156,7 +156,7 @@ func TestGetReplicationControllerList(t *testing.T) {
 				},
 				{
 					ObjectMeta: metaV1.ObjectMeta{
-						Namespace: "namespace-1",
+						Namespace:       "namespace-1",
 						OwnerReferences: firstAppOwnerRef,
 					},
 					Status: api.PodStatus{

--- a/src/app/frontend/deploymentdetail/deploymentinfo.html
+++ b/src/app/frontend/deploymentdetail/deploymentinfo.html
@@ -11,7 +11,7 @@
     <kd-info-card-entry title="[[Labels|Label 'Labels' for the deployment's labels list on the deployment details page.]]">
       <kd-labels labels="::$ctrl.deployment.objectMeta.labels"></kd-labels>
     </kd-info-card-entry>
-    <kd-info-card-entry title="[[Label selector|Label 'Label selector' for the deployment's labels list on the deployment details page.]]">
+    <kd-info-card-entry title="[[Selector|Label 'Selector' for the deployment's labels list on the deployment details page.]]">
       <kd-labels labels="::$ctrl.deployment.selector"></kd-labels>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Strategy|Label 'Min Ready Seconds' for the deployment on the deployment details page.]]">

--- a/src/app/frontend/persistentvolumelist/persistentvolumecard.html
+++ b/src/app/frontend/persistentvolumelist/persistentvolumecard.html
@@ -26,9 +26,9 @@ limitations under the License.
              ng-switch-when="Pending">
       update
     </md-icon>
-    <md-icon class="material-icons kd-warning"
+    <md-icon class="material-icons kd-success"
              ng-switch-when="Bound">
-      remove_circle
+      check_circle
     </md-icon>
     <md-icon class="material-icons kd-warning"
              ng-switch-when="Released">

--- a/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
+++ b/src/app/frontend/replicationcontrollerdetail/replicationcontrollerinfo.html
@@ -19,7 +19,7 @@ limitations under the License.
   <kd-info-card-section>
     <kd-object-meta-info-card object-meta="::$ctrl.replicationController.objectMeta">
     </kd-object-meta-info-card>
-    <kd-info-card-entry title="[[Label selector|Label 'Label selector' for the replication controller's selector on the replication controller details page.]]">
+    <kd-info-card-entry title="[[Selector|Label 'Selector' for the replication controller's selector on the replication controller details page.]]">
       <kd-labels labels="::$ctrl.replicationController.labelSelector"></kd-labels>
     </kd-info-card-entry>
     <kd-info-card-entry title="[[Images|Label 'Images' for the list of images used in a replication controller, on its details page.]]">

--- a/src/app/frontend/statefulsetdetail/statefulsetinfo.html
+++ b/src/app/frontend/statefulsetdetail/statefulsetinfo.html
@@ -19,9 +19,6 @@ limitations under the License.
   <kd-info-card-section>
     <kd-object-meta-info-card object-meta="::$ctrl.statefulSet.objectMeta">
     </kd-object-meta-info-card>
-    <kd-info-card-entry title="[[Labels|Stateful set info details section labels entry.]]">
-      <kd-labels labels="::$ctrl.statefulSet.objectMeta.labels"></kd-labels>
-    </kd-info-card-entry>
     <kd-info-card-entry title="[[Images|Stateful set info details section images entry.]]">
       <div ng-repeat="image in $ctrl.statefulSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>


### PR DESCRIPTION
- Removed duplicated labels section from stateful set details.
- s/`Label selector`/`Selector` to be consistent
- Added `FilterPodsByControllerResource()` method to find pods owned by given controller.
- Update PV status icon (Bound is a "green" state)