### PR TITLE
Add support for s390x platform

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -40,7 +40,7 @@ const arch = {
   /**
    * List of all supported architectures by this project.
    */
-  list: ['amd64', 'arm', 'arm64', 'ppc64le'],
+  list: ['amd64', 'arm', 'arm64', 'ppc64le', 's390x'],
 };
 
 /**

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -35,7 +35,7 @@ const env = lodash.merge(process.env, {GOPATH: sourceGopath, PATH: devPath});
 /**
  * Minimum required Go Version
  */
-const minGoVersion = '1.6.1';
+const minGoVersion = '1.7.1';
 
 /**
  * Spawns a Go process after making sure all Go prerequisites are


### PR DESCRIPTION
Closes #1668.

Updated min. required go version to 1.7.1 as cross compilation for s390x platform was introduced in go 1.7.

@XiLongZheng