### PR TITLE
Allow default setttings override for serve and serve:prod

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -101,11 +101,24 @@ export default {
      */
     apiServerHost: 'http://localhost:8080',
     /**
+     * Env variable with address for the Kubernetes API server.
+     */
+    envApiServerHost: process.env.KUBE_DASHBOARD_APISERVER_HOST,
+    /**
+     * Env variable with path to kubeconfig file.
+     */
+    envKubeconfig: process.env.KUBE_DASHBOARD_KUBECONFIG,
+    /**
      * Address for the Heapster API server. If blank, the dashboard
      * will attempt to connect to Heapster via a service proxy.
      */
     heapsterServerHost:
         gulpUtil.env.heapsterServerHost !== undefined ? gulpUtil.env.heapsterServerHost : '',
+    /**
+     * Variables used to differentiate between prod and dev build.
+     */
+    production: 'prod',
+    development: 'dev',
   },
 
   /**

--- a/build/serve.js
+++ b/build/serve.js
@@ -24,33 +24,10 @@ import proxyMiddleware from 'proxy-middleware';
 import url from 'url';
 import conf from './conf';
 
-
 /**
  * Browser sync instance that serves the application.
  */
 export const browserSyncInstance = browserSync.create();
-
-/**
- * Dashboard backend arguments used for development mode.
- *
- * @type {!Array<string>}
- */
-const backendDevArgs = [
-  `--apiserver-host=${conf.backend.apiServerHost}`,
-  `--port=${conf.backend.devServerPort}`,
-  `--heapster-host=${conf.backend.heapsterServerHost}`,
-];
-
-/**
- * Dashboard backend arguments used for production mode.
- *
- * @type {!Array<string>}
- */
-const backendArgs = [
-  `--apiserver-host=${conf.backend.apiServerHost}`,
-  `--port=${conf.frontend.serverPort}`,
-  `--heapster-host=${conf.backend.heapsterServerHost}`,
-];
 
 /**
  * Currently running backend process object. Null if the backend is not running.
@@ -58,6 +35,32 @@ const backendArgs = [
  * @type {?child.ChildProcess}
  */
 let runningBackendProcess = null;
+
+/**
+ * Builds array of arguments for backend process based on env variables and prod/dev mode.
+ *
+ * @param {string} mode
+ * @return {!Array<string>}
+ */
+function getBackendArgs(mode) {
+  let args = [`--heapster-host=${conf.backend.heapsterServerHost}`];
+
+  if (mode === conf.backend.production) {
+    args.push(`--port=${conf.frontend.serverPort}`);
+  }
+
+  if (mode === conf.backend.development) {
+    args.push(`--port=${conf.backend.devServerPort}`)
+  }
+
+  if (conf.backend.envKubeconfig) {
+    args.push(`--kubeconfig=${conf.backend.envKubeconfig}`)
+  } else {
+    args.push(`--apiserver-host=${conf.backend.envApiServerHost || conf.backend.apiServerHost}`)
+  }
+
+  return args;
+}
 
 /**
  * Initializes BrowserSync tool. Files are served from baseDir directory list and all API calls
@@ -134,8 +137,8 @@ gulp.task('serve:prod', ['spawn-backend:prod']);
  */
 gulp.task('spawn-backend', ['backend', 'kill-backend', 'locales-for-backend:dev'], function() {
   runningBackendProcess = child.spawn(
-      path.join(conf.paths.serve, conf.backend.binaryName), backendDevArgs,
-      {stdio: 'inherit', cwd: conf.paths.serve});
+      path.join(conf.paths.serve, conf.backend.binaryName),
+      getBackendArgs(conf.backend.development), {stdio: 'inherit', cwd: conf.paths.serve});
 
   runningBackendProcess.on('exit', function() {
     // Mark that there is no backend process running anymore.
@@ -150,7 +153,7 @@ gulp.task('spawn-backend', ['backend', 'kill-backend', 'locales-for-backend:dev'
  */
 gulp.task('spawn-backend:prod', ['build-frontend', 'backend:prod', 'kill-backend'], function() {
   runningBackendProcess = child.spawn(
-      path.join(conf.paths.dist, conf.backend.binaryName), backendArgs,
+      path.join(conf.paths.dist, conf.backend.binaryName), getBackendArgs(conf.backend.production),
       {stdio: 'inherit', cwd: conf.paths.dist});
 
   runningBackendProcess.on('exit', function() {

--- a/build/serve.js
+++ b/build/serve.js
@@ -50,13 +50,13 @@ function getBackendArgs(mode) {
   }
 
   if (mode === conf.backend.development) {
-    args.push(`--port=${conf.backend.devServerPort}`)
+    args.push(`--port=${conf.backend.devServerPort}`);
   }
 
   if (conf.backend.envKubeconfig) {
-    args.push(`--kubeconfig=${conf.backend.envKubeconfig}`)
+    args.push(`--kubeconfig=${conf.backend.envKubeconfig}`);
   } else {
-    args.push(`--apiserver-host=${conf.backend.envApiServerHost || conf.backend.apiServerHost}`)
+    args.push(`--apiserver-host=${conf.backend.envApiServerHost || conf.backend.apiServerHost}`);
   }
 
   return args;

--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -64,6 +64,19 @@ $ kubectl proxy --port=8080
 kubectl will handle authentication with Kubernetes and create an API proxy with the address
 `localhost:8080`. Therefore, no changes in the configuration are required.
 
+Another way to connect to real cluster while developing dashboard is to override default values used 
+by our build pipeline. In order to do that we have introduced two environment variables
+`KUBE_DASHBOARD_APISERVER_HOST` and `KUBE_DASHBOARD_KUBECONFIG` that will be used over default ones when
+defined. Before running our gulp tasks just do:
+
+```shell
+$ export KUBE_DASHBOARD_APISERVER_HOST="http://<APISERVER_IP>:<APISERVER_PORT>"
+# or
+$ export KUBE_DASHBOARD_KUBECONFIG="<KUBECONFIG_FILE_PATH>"
+```
+
+**NOTE: Environment variable `KUBE_DASHBOARD_KUBECONFIG` has higher priority than `KUBE_DASHBOARD_APISERVER_HOST`.**
+
 ## Serving Dashboard for Development
 
 It is easy to compile and run Dashboard. Open a new tab in your terminal and type:


### PR DESCRIPTION
Currently when using `serve` or `serve:prod` dashboard could only connect to local cluster. In order to change that we've had to change build files. I have changed that to first check environment variables, then use predefined ones.

This allows to easily configure build pipeline to use external cluster for `serve` and `serve:prod`, i.e. I'm using kubeconfig env variable to connect to minikube cluster that by default is secured and does not expose insecure api server port.

Environment variables:
 - `KUBE_DASHBOARD_APISERVER_HOST` - do `export KUBE_DASHBOARD_APISERVER_HOST=<HOST>` to override default api server url
 - `KUBE_DASHBOARD_KUBECONFIG` - do `export KUBE_DASHBOARD_KUBECONFIG=<PATH>` to use kubeconfig file instead of api server host param. Kubeconfig env variable has higher priority than apiserver host.

~I will also adjust the documentation.~ Done.