### PR TITLE
Make timestamp toggable 

### DIFF
--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -21,6 +21,32 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/logs"
 )
 
+
+var log1 = logs.LogLine{
+	Timestamp: "1",
+	Content: "log1",
+}
+
+var log2 = logs.LogLine{
+	Timestamp: "2",
+	Content: "log2",
+}
+
+var log3 = logs.LogLine{
+	Timestamp: "3",
+	Content: "log3",
+}
+
+var log4 = logs.LogLine{
+	Timestamp: "4",
+	Content: "log4",
+}
+
+var log5 = logs.LogLine{
+	Timestamp: "5",
+	Content: "log5",
+}
+
 func TestGetLogs(t *testing.T) {
 
 	cases := []struct {
@@ -51,7 +77,7 @@ func TestGetLogs(t *testing.T) {
 			logs.AllLogViewSelector,
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"1 log1", "2 log2", "3 log3", "4 log4", "5 log5"},
+				LogLines:  logs.LogLines{log1, log2 ,log3, log4, log5},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "1",
@@ -82,7 +108,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"2 log2", "3 log3"},
+				LogLines:  logs.LogLines{log2,log3},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "2",
@@ -113,7 +139,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"2 log2", "3 log3"},
+				LogLines:  logs.LogLines{log2, log3},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "2",
@@ -147,7 +173,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"2 log2", "3 log3"},
+				LogLines:  logs.LogLines{log2, log3},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "2",
@@ -181,7 +207,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"4 log4", "5 log5"},
+				LogLines:  logs.LogLines{log4, log5},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "4",
@@ -215,7 +241,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"1 log1", "2 log2"},
+				LogLines:  logs.LogLines{log1, log2},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "1",
@@ -249,7 +275,13 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{"1 log2", "1 log3"},
+				LogLines:  logs.LogLines{logs.LogLine{
+					Timestamp: "1",
+					Content: "log2",
+				}, logs.LogLine{
+					Timestamp: "1",
+					Content: "log3",
+				}},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "1",

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -901,7 +901,7 @@ backendApi.ReplicationControllerPods;
 /**
  * @typedef {{
  *   podId: string,
- *   logs: !Array<string>,
+ *   logs: !Array<backendApi.LogLine>,
  *   container: string,
  *   firstLogLineReference: !backendApi.LogLineReference,
  *   lastLogLineReference: !backendApi.LogLineReference,
@@ -912,11 +912,19 @@ backendApi.Logs;
 
 /**
  * @typedef {{
- *   logTimestamp: string,
+ *   timestamp: string,
  *   lineNum: number,
  * }}
  */
 backendApi.LogLineReference;
+
+/**
+ * @typedef {{
+ *   timestamp: string,
+ *   content: string,
+ * }}
+ */
+backendApi.LogLine;
 
 /**
  * @typedef {{

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -42,6 +42,13 @@ limitations under the License.
           text_fields
         </md-icon>
       </md-button>
+      <md-button class="kd-logs-toolbar-button"
+                 ng-click="ctrl.onShowTimestamp()">
+        <md-icon md-font-library="material-icons"
+                 class="kd-logs-timer-icon">
+          {{ctrl.getTimestampIcon()}}
+        </md-icon>
+      </md-button>
     </div>
   </kd-title>
   <kd-content>
@@ -60,9 +67,9 @@ limitations under the License.
       <span class="kd-logs-info"
             ng-show="ctrl.logsSet.length > 1">
         [[Logs from|Title prefix for logs card.]]
-        {{ctrl.podLogs.firstLogLineReference.logTimestamp | date : "short"}}
+        {{ctrl.podLogs.firstLogLineReference.timestamp | date : "short"}}
         [[to|Footer part for logs card.]]
-        {{ctrl.podLogs.lastLogLineReference.logTimestamp | date : "short" }}
+        {{ctrl.podLogs.lastLogLineReference.timestamp | date : "short" }}
       </span>
       <span flex></span>
       <div class="kd-list-pagination-buttons">

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -130,6 +130,10 @@ kd-content-card {
   transform: scale(-1, 1);
 }
 
+.kd-logs-timer-icon {
+  color: $logs-color-black;
+}
+
 .kd-logs-info {
   padding: 1.5 * $baseline-grid;
 }

--- a/src/app/frontend/logs/service.js
+++ b/src/app/frontend/logs/service.js
@@ -26,6 +26,9 @@ export class LogsService {
 
     /** @private {boolean} */
     this.compact_ = false;
+
+    /** @private {boolean} */
+    this.showTimestamp_ = false;
   }
 
   /**
@@ -56,5 +59,20 @@ export class LogsService {
    */
   getCompact() {
     return this.compact_;
+  }
+
+  /**
+   * Switches the show timestamp flag
+   */
+  setShowTimestamp() {
+    this.showTimestamp_ = !this.showTimestamp_;
+  }
+
+  /**
+   * Getter for the show timestamp flag
+   * @returns {boolean}
+   */
+  getShowTimestamp() {
+    return this.showTimestamp_;
   }
 }

--- a/src/test/frontend/logs/controller_test.js
+++ b/src/test/frontend/logs/controller_test.js
@@ -46,22 +46,26 @@ describe('Logs controller', () => {
   const podContainers = {containers: [mockContainer]};
 
   let podLogs = {
-    logs: ['1 a', '2 b', '3 c'],
-    firstLogLineReference: {'logTimestamp': '1', 'lineNum': -1},
-    lastLogLineReference: {logTimestamp: '3', lineNum: -1},
+    logs: [
+      {timestamp: '1', content: 'a'},
+      {timestamp: '2', content: 'b'},
+      {timestamp: '3', content: 'c'},
+    ],
+    firstLogLineReference: {'timestamp': '1', 'lineNum': -1},
+    lastLogLineReference: {timestamp: '3', lineNum: -1},
     logViewInfo: {
-      referenceLogLineId: {'logTimestamp': 'X', 'lineNum': 11},
+      referenceLogLineId: {'timestamp': 'X', 'lineNum': 11},
       'relativeFrom': 22,
       'relativeTo': 25,
     },
   };
 
   let otherLogs = {
-    logs: ['7 x', '8 y'],
-    firstLogLineReference: {'logTimestamp': '7', 'lineNum': -1},
-    lastLogLineReference: {logTimestamp: '8', lineNum: -1},
+    logs: [{timestamp: '7', content: 'x'}, {timestamp: '8', content: 'y'}],
+    firstLogLineReference: {'timestamp': '7', 'lineNum': -1},
+    lastLogLineReference: {timestamp: '8', lineNum: -1},
     logViewInfo: {
-      referenceLogLineId: {'logTimestamp': 'Y', 'lineNum': 12},
+      referenceLogLineId: {'timestamp': 'Y', 'lineNum': 12},
       'relativeFrom': 33,
       'relativeTo': 35,
     },
@@ -99,6 +103,19 @@ describe('Logs controller', () => {
   it('should display logs', () => {
     ctrl.$onInit();
     expect(ctrl.logsSet.length).toEqual(3);
+  });
+
+  it('should not contain timestamp by default', () => {
+    ctrl.$onInit();
+    expect(ctrl.logsSet[0].toString()).toEqual('a');
+    expect(ctrl.logsSet[1].toString()).toEqual('b');
+  });
+
+  it('should contain timestamp when enabling', () => {
+    ctrl.logsService.setShowTimestamp();
+    ctrl.$onInit();
+    expect(ctrl.logsSet[0].toString()).toEqual('1 a');
+    expect(ctrl.logsSet[1].toString()).toEqual('2 b');
   });
 
   it('should load newer logs on loadNewer call', () => {


### PR DESCRIPTION
In Dashboard Logs-View we currently show the timestamp, always. In kubectl the timestamp is not shown by default, but can be enabled (--timestamp=true)

The timestamp is required in the backend for pagination. I refactored the code to be able to strip off the timestamp. Seems to work. Maybe I should do some more refactoring for beautification, because there a several similar objects. I will check. 

The toggle button in the UI is also missing

Will fix: https://github.com/kubernetes/dashboard/issues/1546 