### PR TITLE
Use a github owned domain for install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ kubectl get pods --all-namespaces | grep dashboard
 
 If it is missing, you can install the latest stable release by running the following command:
 ```shell
-$ kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+$ kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
 ```
 
 You can also install unstable HEAD builds with the newest features that the team works on by

--- a/docs/devel/head-releases.md
+++ b/docs/devel/head-releases.md
@@ -6,7 +6,7 @@ This document describes how to install and discover development releases of the 
 
 To install latest HEAD release, execute the following command.
 ```bash
-kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard-head.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard-head.yaml
 ```
 
 Once installed, the release of the UI is not automatically updated. In order to update it, delete


### PR DESCRIPTION
`whois rawgit.com` uses `contactprivacy.email` which means there is no
visible accountability for that domain.

`ping rawgit.com` shows it terminates in CloudFlare, which means there
is TLS decapsulation outside of the github.com trust domain. This makes
it not possible to verify end-to-end encryption to github.com content.

Running `kubectl apply -f <url>` assumes a trusted source and no
tampering.

`rawgit.com` leaves the trust of github.com and opens the possibility
for man-in-the-middle attacks.

Github can serve raw content from a domain under their control at
`raw.githubusercontent.com`. By using this domain, whois shows the
owner, and provides end-to-end encryption to github.com content.