### PR TITLE
Revert "Use a github owned domain for install documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ kubectl get pods --all-namespaces | grep dashboard
 
 If it is missing, you can install the latest stable release by running the following command:
 ```shell
-$ kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+$ kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
 ```
 
 You can also install unstable HEAD builds with the newest features that the team works on by

--- a/docs/devel/head-releases.md
+++ b/docs/devel/head-releases.md
@@ -6,7 +6,7 @@ This document describes how to install and discover development releases of the 
 
 To install latest HEAD release, execute the following command.
 ```bash
-kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard-head.yaml
+kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard-head.yaml
 ```
 
 Once installed, the release of the UI is not automatically updated. In order to update it, delete


### PR DESCRIPTION
Reverts kubernetes/dashboard#1843