### PR TITLE
Fix build process not failing when compiler error occurs

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -234,6 +234,13 @@ gulp.task('scripts:prod', ['angular-templates', 'generate-xtbs'], function(doneF
   // add a default compilation task (no localization)
   streams = streams.concat(createCompileTask());
 
+  // Handle unhandled rejections and fail immediately if any error occurs.
+  process.on('unhandledRejection', (reason) => {
+    if (reason.message.toLowerCase().includes('error')) {
+      doneFn(reason);
+    }
+  });
+
   // TODO (taimir) : do not run the tasks sequentially once
   // gulp-closure-compiler can be run in parallel
   async.series(streams, doneFn);


### PR DESCRIPTION
Unfortunately official gulp plugin for google-closure-compiler does not handle correctly compilation errors and build proceeds. One way to handle them without modifying third party plugin is to handle all unhandled rejections and fail in case any error is found.