### PR TITLE
Deprecated :modify core to CoreV1

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -183,9 +183,9 @@ func formatResponseLog(response *restful.Response, request *restful.Request) str
 func CreateHTTPAPIHandler(client *clientK8s.Clientset, heapsterClient client.HeapsterClient,
 	clientConfig *restclient.Config) (http.Handler, error) {
 
-	verber := common.NewResourceVerber(client.Core().RESTClient(),
-		client.Extensions().RESTClient(), client.Apps().RESTClient(),
-		client.Batch().RESTClient(), client.Autoscaling().RESTClient(), client.Storage().RESTClient())
+	verber := common.NewResourceVerber(client.CoreV1().RESTClient(),
+		client.ExtensionsV1beta1().RESTClient(), client.AppsV1beta1().RESTClient(),
+		client.BatchV1().RESTClient(), client.AutoscalingV1().RESTClient(), client.StorageV1beta1().RESTClient())
 
 	var csrfKey string
 	inClusterConfig, err := restclient.InClusterConfig()

--- a/src/app/backend/resource/common/resourcechannels.go
+++ b/src/app/backend/resource/common/resourcechannels.go
@@ -136,7 +136,7 @@ func GetServiceListChannel(client client.Interface,
 		Error: make(chan error, numReads),
 	}
 	go func() {
-		list, err := client.Core().Services(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().Services(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []api.Service
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -169,7 +169,7 @@ func GetIngressListChannel(client client.Interface, nsQuery *NamespaceQuery,
 		Error: make(chan error, numReads),
 	}
 	go func() {
-		list, err := client.Extensions().Ingresses(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.ExtensionsV1beta1().Ingresses(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []extensions.Ingress
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -203,7 +203,7 @@ func GetLimitRangeListChannel(client client.Interface, nsQuery *NamespaceQuery,
 	}
 
 	go func() {
-		list, err := client.Core().LimitRanges(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().LimitRanges(nsQuery.ToRequestParam()).List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -228,7 +228,7 @@ func GetNodeListChannel(client client.Interface, numReads int) NodeListChannel {
 	}
 
 	go func() {
-		list, err := client.Core().Nodes().List(listEverything)
+		list, err := client.CoreV1().Nodes().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -253,7 +253,7 @@ func GetNamespaceListChannel(client client.Interface, numReads int) NamespaceLis
 	}
 
 	go func() {
-		list, err := client.Core().Namespaces().List(listEverything)
+		list, err := client.CoreV1().Namespaces().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -285,7 +285,7 @@ func GetEventListChannelWithOptions(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Core().Events(nsQuery.ToRequestParam()).List(options)
+		list, err := client.CoreV1().Events(nsQuery.ToRequestParam()).List(options)
 		var filteredItems []api.Event
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -325,7 +325,7 @@ func GetPodListChannelWithOptions(client client.Interface, nsQuery *NamespaceQue
 	}
 
 	go func() {
-		list, err := client.Core().Pods(nsQuery.ToRequestParam()).List(options)
+		list, err := client.CoreV1().Pods(nsQuery.ToRequestParam()).List(options)
 		var filteredItems []api.Pod
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -360,7 +360,7 @@ func GetReplicationControllerListChannel(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Core().ReplicationControllers(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().ReplicationControllers(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []api.ReplicationController
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -394,7 +394,7 @@ func GetDeploymentListChannel(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Extensions().Deployments(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.ExtensionsV1beta1().Deployments(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []extensions.Deployment
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -434,7 +434,7 @@ func GetReplicaSetListChannelWithOptions(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Extensions().ReplicaSets(nsQuery.ToRequestParam()).List(options)
+		list, err := client.ExtensionsV1beta1().ReplicaSets(nsQuery.ToRequestParam()).List(options)
 		var filteredItems []extensions.ReplicaSet
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -467,7 +467,7 @@ func GetDaemonSetListChannel(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Extensions().DaemonSets(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.ExtensionsV1beta1().DaemonSets(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []extensions.DaemonSet
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -500,7 +500,7 @@ func GetJobListChannel(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.Batch().Jobs(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.BatchV1().Jobs(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []batch.Job
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -533,7 +533,7 @@ func GetStatefulSetListChannel(client client.Interface,
 	}
 
 	go func() {
-		statefulSets, err := client.Apps().StatefulSets(nsQuery.ToRequestParam()).List(listEverything)
+		statefulSets, err := client.AppsV1beta1().StatefulSets(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []apps.StatefulSet
 		for _, item := range statefulSets.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -566,7 +566,7 @@ func GetConfigMapListChannel(client client.Interface, nsQuery *NamespaceQuery, n
 	}
 
 	go func() {
-		list, err := client.Core().ConfigMaps(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().ConfigMaps(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []api.ConfigMap
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -599,7 +599,7 @@ func GetSecretListChannel(client client.Interface, nsQuery *NamespaceQuery, numR
 	}
 
 	go func() {
-		list, err := client.Core().Secrets(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().Secrets(nsQuery.ToRequestParam()).List(listEverything)
 		var filteredItems []api.Secret
 		for _, item := range list.Items {
 			if nsQuery.Matches(item.ObjectMeta.Namespace) {
@@ -731,7 +731,7 @@ func GetPersistentVolumeListChannel(client client.Interface, numReads int) Persi
 	}
 
 	go func() {
-		list, err := client.Core().PersistentVolumes().List(listEverything)
+		list, err := client.CoreV1().PersistentVolumes().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -758,7 +758,7 @@ func GetPersistentVolumeClaimListChannel(client client.Interface, nsQuery *Names
 	}
 
 	go func() {
-		list, err := client.Core().PersistentVolumeClaims(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().PersistentVolumeClaims(nsQuery.ToRequestParam()).List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -785,7 +785,7 @@ func GetResourceQuotaListChannel(client client.Interface, nsQuery *NamespaceQuer
 	}
 
 	go func() {
-		list, err := client.Core().ResourceQuotas(nsQuery.ToRequestParam()).List(listEverything)
+		list, err := client.CoreV1().ResourceQuotas(nsQuery.ToRequestParam()).List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -844,7 +844,7 @@ func GetPodMetricsChannel(heapsterClient kdClient.HeapsterClient, name string, n
 	return channel
 }
 
-// PodMetricsChannel is a list and error channels to MetricsByPod.
+// HorizontalPodAutoscalerListChannel is a list and error channels.
 type HorizontalPodAutoscalerListChannel struct {
 	List  chan *autoscaling.HorizontalPodAutoscalerList
 	Error chan error
@@ -884,7 +884,7 @@ func GetThirdPartyResourceListChannel(client client.Interface, numReads int) Thi
 	}
 
 	go func() {
-		list, err := client.Extensions().ThirdPartyResources().List(listEverything)
+		list, err := client.ExtensionsV1beta1().ThirdPartyResources().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -909,7 +909,7 @@ func GetStorageClassListChannel(client client.Interface, numReads int) StorageCl
 	}
 
 	go func() {
-		list, err := client.Storage().StorageClasses().List(listEverything)
+		list, err := client.StorageV1beta1().StorageClasses().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err

--- a/src/app/backend/resource/daemonset/detail.go
+++ b/src/app/backend/resource/daemonset/detail.go
@@ -59,7 +59,7 @@ func GetDaemonSetDetail(client k8sClient.Interface, heapsterClient client.Heapst
 	namespace, name string) (*DaemonSetDetail, error) {
 	log.Printf("Getting details of %s daemon set in %s namespace", name, namespace)
 
-	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name, metaV1.GetOptions{})
+	daemonSet, err := client.ExtensionsV1beta1().DaemonSets(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/daemonset/events.go
+++ b/src/app/backend/resource/daemonset/events.go
@@ -64,7 +64,7 @@ func GetDaemonSetEvents(client client.Interface, dsQuery *dataselect.DataSelectQ
 func GetDaemonSetPodsEvents(client client.Interface, namespace, daemonSetName string) (
 	[]api.Event, error) {
 
-	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(daemonSetName, metaV1.GetOptions{})
+	daemonSet, err := client.ExtensionsV1beta1().DaemonSets(namespace).Get(daemonSetName, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/daemonset/pods.go
+++ b/src/app/backend/resource/daemonset/pods.go
@@ -45,7 +45,7 @@ func GetDaemonSetPods(client k8sClient.Interface, heapsterClient client.Heapster
 func getRawDaemonSetPods(client k8sClient.Interface, daemonSetName, namespace string) (
 	[]api.Pod, error) {
 
-	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(daemonSetName, metaV1.GetOptions{})
+	daemonSet, err := client.ExtensionsV1beta1().DaemonSets(namespace).Get(daemonSetName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/daemonset/services.go
+++ b/src/app/backend/resource/daemonset/services.go
@@ -27,7 +27,7 @@ import (
 func GetDaemonSetServices(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	namespace, name string) (*service.ServiceList, error) {
 
-	daemonSet, err := client.Extensions().DaemonSets(namespace).Get(name, metaV1.GetOptions{})
+	daemonSet, err := client.ExtensionsV1beta1().DaemonSets(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/deployment/deploy.go
+++ b/src/app/backend/resource/deployment/deploy.go
@@ -205,7 +205,7 @@ func DeployApp(spec *AppDeploymentSpec, client client.Interface) error {
 			Template: podTemplate,
 		},
 	}
-	_, err := client.Extensions().Deployments(spec.Namespace).Create(deployment)
+	_, err := client.ExtensionsV1beta1().Deployments(spec.Namespace).Create(deployment)
 
 	if err != nil {
 		// TODO(bryk): Roll back created resources in case of error.
@@ -240,7 +240,7 @@ func DeployApp(spec *AppDeploymentSpec, client client.Interface) error {
 			service.Spec.Ports = append(service.Spec.Ports, servicePort)
 		}
 
-		_, err = client.Core().Services(spec.Namespace).Create(service)
+		_, err = client.CoreV1().Services(spec.Namespace).Create(service)
 
 		// TODO(bryk): Roll back created resources in case of error.
 		return err

--- a/src/app/backend/resource/deployment/detail.go
+++ b/src/app/backend/resource/deployment/detail.go
@@ -96,7 +96,7 @@ func GetDeploymentDetail(client client.Interface, heapsterClient heapster.Heapst
 
 	log.Printf("Getting details of %s deployment in %s namespace", deploymentName, namespace)
 
-	deployment, err := client.Extensions().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
+	deployment, err := client.ExtensionsV1beta1().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/deployment/events.go
+++ b/src/app/backend/resource/deployment/events.go
@@ -27,7 +27,7 @@ import (
 func GetDeploymentEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace string, deploymentName string) (
 	*common.EventList, error) {
 
-	deployment, err := client.Extensions().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
+	deployment, err := client.ExtensionsV1beta1().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/deployment/oldreplicasets.go
+++ b/src/app/backend/resource/deployment/oldreplicasets.go
@@ -14,7 +14,7 @@ import (
 func GetDeploymentOldReplicaSets(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	namespace string, deploymentName string) (*replicaset.ReplicaSetList, error) {
 
-	deployment, err := client.Extensions().Deployments(namespace).Get(deploymentName,
+	deployment, err := client.ExtensionsV1beta1().Deployments(namespace).Get(deploymentName,
 		metaV1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/deployment/pods.go
+++ b/src/app/backend/resource/deployment/pods.go
@@ -28,7 +28,7 @@ import (
 func GetDeploymentPods(client client.Interface, heapsterClient heapster.HeapsterClient,
 	dsQuery *dataselect.DataSelectQuery, namespace string, deploymentName string) (*pod.PodList, error) {
 
-	deployment, err := client.Extensions().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
+	deployment, err := client.ExtensionsV1beta1().Deployments(namespace).Get(deploymentName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/event/common.go
+++ b/src/app/backend/resource/event/common.go
@@ -144,7 +144,7 @@ func GetNodeEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 
 // GetNodeEvents gets events associated to node with given name.
 func GetNamespaceEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace string) (common.EventList, error) {
-	events, _ := client.CoreV1().Events(namespace).List(metaV1.ListOptions{
+	events, _ := client.Core().Events(namespace).List(metaV1.ListOptions{
 		LabelSelector: labels.Everything().String(),
 		FieldSelector: fields.Everything().String(),
 	})

--- a/src/app/backend/resource/event/common.go
+++ b/src/app/backend/resource/event/common.go
@@ -127,13 +127,13 @@ func GetNodeEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	groupVersion := schema.GroupVersion{Group: "", Version: "v1"}
 	scheme.AddKnownTypes(groupVersion, &api.Node{})
 
-	mc := client.Core().Nodes()
+	mc := client.CoreV1().Nodes()
 	node, err := mc.Get(nodeName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	events, err := client.Core().Events(api.NamespaceAll).Search(scheme, node)
+	events, err := client.CoreV1().Events(api.NamespaceAll).Search(scheme, node)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func GetNodeEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 
 // GetNodeEvents gets events associated to node with given name.
 func GetNamespaceEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace string) (common.EventList, error) {
-	events, _ := client.Core().Events(namespace).List(metaV1.ListOptions{
+	events, _ := client.CoreV1().Events(namespace).List(metaV1.ListOptions{
 		LabelSelector: labels.Everything().String(),
 		FieldSelector: fields.Everything().String(),
 	})

--- a/src/app/backend/resource/event/common_test.go
+++ b/src/app/backend/resource/event/common_test.go
@@ -157,11 +157,15 @@ func TestToEventList(t *testing.T) {
 				Events: []common.Event{
 					{
 						ObjectMeta: common.ObjectMeta{Name: "event-1"},
-						TypeMeta:   common.TypeMeta{common.ResourceKindEvent},
+						TypeMeta: common.TypeMeta{
+							Kind: common.ResourceKindEvent,
+						},
 					},
 					{
 						ObjectMeta: common.ObjectMeta{Name: "event-2"},
-						TypeMeta:   common.TypeMeta{common.ResourceKindEvent},
+						TypeMeta: common.TypeMeta{
+							Kind: common.ResourceKindEvent,
+						},
 					},
 				},
 			},

--- a/src/app/backend/resource/horizontalpodautoscaler/detail.go
+++ b/src/app/backend/resource/horizontalpodautoscaler/detail.go
@@ -47,7 +47,7 @@ type HorizontalPodAutoscalerDetail struct {
 func GetHorizontalPodAutoscalerDetail(client client.Interface, namespace string, name string) (*HorizontalPodAutoscalerDetail, error) {
 	log.Printf("Getting details of %s horizontal pod autoscaler", name)
 
-	rawHorizontalPodAutoscaler, err := client.Autoscaling().HorizontalPodAutoscalers(namespace).Get(name, v1.GetOptions{})
+	rawHorizontalPodAutoscaler, err := client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, v1.GetOptions{})
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/job/detail.go
+++ b/src/app/backend/resource/job/detail.go
@@ -57,7 +57,7 @@ func GetJobDetail(client k8sClient.Interface, heapsterClient client.HeapsterClie
 	namespace, name string) (*JobDetail, error) {
 
 	// TODO(floreks): Use channels.
-	jobData, err := client.Batch().Jobs(namespace).Get(name, metaV1.GetOptions{})
+	jobData, err := client.BatchV1().Jobs(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/namespace/detail.go
+++ b/src/app/backend/resource/namespace/detail.go
@@ -36,7 +36,7 @@ type NamespaceDetail struct {
 	ObjectMeta common.ObjectMeta `json:"objectMeta"`
 	TypeMeta   common.TypeMeta   `json:"typeMeta"`
 
-	// NamespacePhase is the current lifecycle phase of the namespace.
+	// Phase is the current lifecycle phase of the namespace.
 	Phase api.NamespacePhase `json:"phase"`
 
 	// Events is list of events associated to the namespace.
@@ -54,7 +54,7 @@ func GetNamespaceDetail(client k8sClient.Interface, heapsterClient client.Heapst
 	*NamespaceDetail, error) {
 	log.Printf("Getting details of %s namespace", name)
 
-	namespace, err := client.Core().Namespaces().Get(name, metaV1.GetOptions{})
+	namespace, err := client.CoreV1().Namespaces().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ var listEverything = metaV1.ListOptions{
 }
 
 func getResourceQuotas(client k8sClient.Interface, namespace api.Namespace) (*resourcequota.ResourceQuotaDetailList, error) {
-	list, err := client.Core().ResourceQuotas(namespace.Name).List(listEverything)
+	list, err := client.CoreV1().ResourceQuotas(namespace.Name).List(listEverything)
 
 	result := &resourcequota.ResourceQuotaDetailList{
 		Items:    make([]resourcequota.ResourceQuotaDetail, 0),
@@ -113,7 +113,7 @@ func getResourceQuotas(client k8sClient.Interface, namespace api.Namespace) (*re
 }
 
 func getLimitRanges(client k8sClient.Interface, namespace api.Namespace) ([]limitrange.LimitRangeItem, error) {
-	list, err := client.Core().LimitRanges(namespace.Name).List(listEverything)
+	list, err := client.CoreV1().LimitRanges(namespace.Name).List(listEverything)
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/node/detail.go
+++ b/src/app/backend/resource/node/detail.go
@@ -118,7 +118,7 @@ type NodeDetail struct {
 func GetNodeDetail(client k8sClient.Interface, heapsterClient client.HeapsterClient, name string) (*NodeDetail, error) {
 	log.Printf("Getting details of %s node", name)
 
-	node, err := client.Core().Nodes().Get(name, metaV1.GetOptions{})
+	node, err := client.CoreV1().Nodes().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +208,9 @@ func getNodeAllocatedResources(node api.Node, podList *api.PodList) (NodeAllocat
 	}, nil
 }
 
+// GetNodePods return pods list in given named node
 func GetNodePods(client k8sClient.Interface, heapsterClient client.HeapsterClient, dsQuery *dataselect.DataSelectQuery, name string) (*pod.PodList, error) {
-	node, err := client.Core().Nodes().Get(name, metaV1.GetOptions{})
+	node, err := client.CoreV1().Nodes().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +224,7 @@ func GetNodePods(client k8sClient.Interface, heapsterClient client.HeapsterClien
 	return &podList, nil
 }
 
+// getNodePods return pods list
 func getNodePods(client k8sClient.Interface, node api.Node) (*api.PodList, error) {
 	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name +
 		",status.phase!=" + string(api.PodSucceeded) +
@@ -232,7 +234,7 @@ func getNodePods(client k8sClient.Interface, node api.Node) (*api.PodList, error
 		return nil, err
 	}
 
-	return client.Core().Pods(api.NamespaceAll).List(metaV1.ListOptions{
+	return client.CoreV1().Pods(api.NamespaceAll).List(metaV1.ListOptions{
 		FieldSelector: fieldSelector.String(),
 	})
 }

--- a/src/app/backend/resource/node/list.go
+++ b/src/app/backend/resource/node/list.go
@@ -64,7 +64,7 @@ func GetNodeListFromChannels(channels *common.ResourceChannels, dsQuery *datasel
 func GetNodeList(client client.Interface, dsQuery *dataselect.DataSelectQuery, heapsterClient *heapster.HeapsterClient) (*NodeList, error) {
 	log.Print("Getting list of all nodes in the cluster")
 
-	nodes, err := client.Core().Nodes().List(metaV1.ListOptions{
+	nodes, err := client.CoreV1().Nodes().List(metaV1.ListOptions{
 		LabelSelector: labels.Everything().String(),
 		FieldSelector: fields.Everything().String(),
 	})

--- a/src/app/backend/resource/owner/owner.go
+++ b/src/app/backend/resource/owner/owner.go
@@ -50,35 +50,35 @@ func NewResourceController(reference api.ObjectReference, client kubernetes.Inte
 	ResourceController, error) {
 	switch reference.Kind {
 	case "Job":
-		job, err := client.Batch().Jobs(reference.Namespace).Get(reference.Name,
+		job, err := client.BatchV1().Jobs(reference.Namespace).Get(reference.Name,
 			meta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 		return JobController(*job), nil
 	case "ReplicaSet":
-		rs, err := client.Extensions().ReplicaSets(reference.Namespace).Get(reference.Name,
+		rs, err := client.ExtensionsV1beta1().ReplicaSets(reference.Namespace).Get(reference.Name,
 			meta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 		return ReplicaSetController(*rs), nil
 	case "ReplicationController":
-		rc, err := client.Core().ReplicationControllers(reference.Namespace).Get(
+		rc, err := client.CoreV1().ReplicationControllers(reference.Namespace).Get(
 			reference.Name, meta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 		return ReplicationControllerController(*rc), nil
 	case "DaemonSet":
-		ds, err := client.Extensions().DaemonSets(reference.Namespace).Get(reference.Name,
+		ds, err := client.ExtensionsV1beta1().DaemonSets(reference.Namespace).Get(reference.Name,
 			meta.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 		return DaemonSetController(*ds), nil
 	case "StatefulSet":
-		ss, err := client.Apps().StatefulSets(reference.Namespace).Get(reference.Name,
+		ss, err := client.AppsV1beta1().StatefulSets(reference.Namespace).Get(reference.Name,
 			meta.GetOptions{})
 		if err != nil {
 			return nil, err

--- a/src/app/backend/resource/persistentvolume/detail.go
+++ b/src/app/backend/resource/persistentvolume/detail.go
@@ -41,7 +41,7 @@ type PersistentVolumeDetail struct {
 func GetPersistentVolumeDetail(client client.Interface, name string) (*PersistentVolumeDetail, error) {
 	log.Printf("Getting details of %s persistent volume", name)
 
-	rawPersistentVolume, err := client.Core().PersistentVolumes().Get(name, metaV1.GetOptions{})
+	rawPersistentVolume, err := client.CoreV1().PersistentVolumes().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/replicaset/detail.go
+++ b/src/app/backend/resource/replicaset/detail.go
@@ -63,7 +63,7 @@ func GetReplicaSetDetail(client k8sClient.Interface, heapsterClient client.Heaps
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
 	// TODO(floreks): Use channels.
-	replicaSetData, err := client.Extensions().ReplicaSets(namespace).Get(name, metaV1.GetOptions{})
+	replicaSetData, err := client.ExtensionsV1beta1().ReplicaSets(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/replicaset/events.go
+++ b/src/app/backend/resource/replicaset/events.go
@@ -65,7 +65,7 @@ func GetReplicaSetEvents(client client.Interface, dsQuery *dataselect.DataSelect
 func GetReplicaSetPodsEvents(client client.Interface, namespace, replicaSetName string) (
 	[]api.Event, error) {
 
-	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(replicaSetName, metaV1.GetOptions{})
+	replicaSet, err := client.ExtensionsV1beta1().ReplicaSets(namespace).Get(replicaSetName, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/replicaset/pods.go
+++ b/src/app/backend/resource/replicaset/pods.go
@@ -47,7 +47,7 @@ func GetReplicaSetPods(client k8sClient.Interface, heapsterClient client.Heapste
 func getRawReplicaSetPods(client k8sClient.Interface, petSetName, namespace string) (
 	[]api.Pod, error) {
 
-	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(petSetName, metaV1.GetOptions{})
+	replicaSet, err := client.ExtensionsV1beta1().ReplicaSets(namespace).Get(petSetName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func getRawReplicaSetPods(client k8sClient.Interface, petSetName, namespace stri
 	return podList.Items, nil
 }
 
-// Returns simple info about pods(running, desired, failing, etc.) related to given replica set.
+// getReplicaSetPodInfo returns simple info about pods(running, desired, failing, etc.) related to given replica set.
 func getReplicaSetPodInfo(client k8sClient.Interface, replicaSet *extensions.ReplicaSet) (
 	*common.PodInfo, error) {
 

--- a/src/app/backend/resource/replicaset/services.go
+++ b/src/app/backend/resource/replicaset/services.go
@@ -27,7 +27,7 @@ import (
 func GetReplicaSetServices(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	namespace, name string) (*service.ServiceList, error) {
 
-	replicaSet, err := client.Extensions().ReplicaSets(namespace).Get(name, metaV1.GetOptions{})
+	replicaSet, err := client.ExtensionsV1beta1().ReplicaSets(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/replicationcontroller/detail.go
+++ b/src/app/backend/resource/replicationcontroller/detail.go
@@ -70,7 +70,7 @@ func GetReplicationControllerDetail(client k8sClient.Interface, heapsterClient c
 	namespace, name string) (*ReplicationControllerDetail, error) {
 	log.Printf("Getting details of %s replication controller in %s namespace", name, namespace)
 
-	replicationController, err := client.Core().ReplicationControllers(namespace).Get(name, metaV1.GetOptions{})
+	replicationController, err := client.CoreV1().ReplicationControllers(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func UpdateReplicasCount(client k8sClient.Interface, namespace, name string,
 	log.Printf("Updating replicas count to %d for %s replication controller from %s namespace",
 		replicationControllerSpec.Replicas, name, namespace)
 
-	replicationController, err := client.Core().ReplicationControllers(namespace).Get(name, metaV1.GetOptions{})
+	replicationController, err := client.CoreV1().ReplicationControllers(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/src/app/backend/resource/replicationcontroller/events.go
+++ b/src/app/backend/resource/replicationcontroller/events.go
@@ -65,7 +65,7 @@ func GetReplicationControllerEvents(client client.Interface, dsQuery *dataselect
 func getReplicationControllerPodsEvents(client client.Interface, namespace,
 	replicationControllerName string) ([]api.Event, error) {
 
-	replicationController, err := client.Core().ReplicationControllers(namespace).Get(replicationControllerName, metaV1.GetOptions{})
+	replicationController, err := client.CoreV1().ReplicationControllers(namespace).Get(replicationControllerName, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/replicationcontroller/pods.go
+++ b/src/app/backend/resource/replicationcontroller/pods.go
@@ -43,11 +43,11 @@ func GetReplicationControllerPods(client k8sClient.Interface, heapsterClient cli
 	return &podList, nil
 }
 
-// Returns array of api pods targeting replication controller associated to given name.
+// getRawReplicationControllerPods returns array of api pods targeting replication controller associated to given name.
 func getRawReplicationControllerPods(client k8sClient.Interface, rcName, namespace string) (
 	[]api.Pod, error) {
 
-	replicationController, err := client.Core().ReplicationControllers(namespace).Get(rcName, metaV1.GetOptions{})
+	replicationController, err := client.CoreV1().ReplicationControllers(namespace).Get(rcName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func getRawReplicationControllerPods(client k8sClient.Interface, rcName, namespa
 	return podList.Items, nil
 }
 
-// Returns simple info about pods(running, desired, failing, etc.) related to given replication
+// getReplicationControllerPodInfo returns simple info about pods(running, desired, failing, etc.) related to given replication
 // controller.
 func getReplicationControllerPodInfo(client k8sClient.Interface, rc *api.ReplicationController,
 	namespace string) (*common.PodInfo, error) {

--- a/src/app/backend/resource/replicationcontroller/services.go
+++ b/src/app/backend/resource/replicationcontroller/services.go
@@ -27,7 +27,7 @@ import (
 func GetReplicationControllerServices(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	namespace, rcName string) (*service.ServiceList, error) {
 
-	replicationController, err := client.Core().ReplicationControllers(namespace).Get(rcName, metaV1.GetOptions{})
+	replicationController, err := client.CoreV1().ReplicationControllers(namespace).Get(rcName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/statefulset/detail.go
+++ b/src/app/backend/resource/statefulset/detail.go
@@ -53,7 +53,7 @@ func GetStatefulSetDetail(client *k8sClient.Clientset, heapsterClient client.Hea
 	log.Printf("Getting details of %s service in %s namespace", name, namespace)
 
 	// TODO(floreks): Use channels.
-	statefulSetData, err := client.Apps().StatefulSets(namespace).Get(name, metaV1.GetOptions{})
+	statefulSetData, err := client.AppsV1beta1().StatefulSets(namespace).Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/statefulset/events.go
+++ b/src/app/backend/resource/statefulset/events.go
@@ -64,7 +64,7 @@ func GetStatefulSetEvents(client *client.Clientset, dsQuery *dataselect.DataSele
 func GetStatefulSetPodsEvents(client *client.Clientset, namespace, statefulSetName string) (
 	[]api.Event, error) {
 
-	statefulSet, err := client.Apps().StatefulSets(namespace).Get(statefulSetName, metaV1.GetOptions{})
+	statefulSet, err := client.AppsV1beta1().StatefulSets(namespace).Get(statefulSetName, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/statefulset/pods.go
+++ b/src/app/backend/resource/statefulset/pods.go
@@ -41,11 +41,11 @@ func GetStatefulSetPods(client *k8sClient.Clientset, heapsterClient client.Heaps
 	return &podList, nil
 }
 
-// Returns array of api pods targeting pet set with given name.
+// getRawStatefulSetPods return array of api pods targeting pet set with given name.
 func getRawStatefulSetPods(client *k8sClient.Clientset, statefulSetName, namespace string) (
 	[]api.Pod, error) {
 
-	statefulSet, err := client.Apps().StatefulSets(namespace).Get(statefulSetName, metaV1.GetOptions{})
+	statefulSet, err := client.AppsV1beta1().StatefulSets(namespace).Get(statefulSetName, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/storageclass/detail.go
+++ b/src/app/backend/resource/storageclass/detail.go
@@ -47,7 +47,7 @@ func GetStorageClass(client kubernetes.Interface, name string) (*StorageClass, e
 	log.Printf("Getting details of %s storage class", name)
 
 	// TODO(maciaszczykm): Use channels.
-	storage, err := client.Storage().StorageClasses().Get(name, metaV1.GetOptions{})
+	storage, err := client.StorageV1beta1().StorageClasses().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/thirdpartyresource/detail.go
+++ b/src/app/backend/resource/thirdpartyresource/detail.go
@@ -38,7 +38,7 @@ type ThirdPartyResourceDetail struct {
 func GetThirdPartyResourceDetail(client k8sClient.Interface, config *rest.Config, name string) (*ThirdPartyResourceDetail, error) {
 	log.Printf("Getting details of %s third party resource", name)
 
-	thirdPartyResource, err := client.Extensions().ThirdPartyResources().Get(name, metaV1.GetOptions{})
+	thirdPartyResource, err := client.ExtensionsV1beta1().ThirdPartyResources().Get(name, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/backend/resource/thirdpartyresource/objects.go
+++ b/src/app/backend/resource/thirdpartyresource/objects.go
@@ -37,7 +37,7 @@ func GetThirdPartyResourceObjects(client k8sClient.Interface, config *rest.Confi
 	log.Printf("Getting third party resource %s objects", tprName)
 	var list ThirdPartyResourceObjectList
 
-	thirdPartyResource, err := client.Extensions().ThirdPartyResources().Get(tprName, metaV1.GetOptions{})
+	thirdPartyResource, err := client.ExtensionsV1beta1().ThirdPartyResources().Get(tprName, metaV1.GetOptions{})
 	if err != nil {
 		return list, err
 	}

--- a/src/app/backend/validation/validateappname.go
+++ b/src/app/backend/validation/validateappname.go
@@ -45,7 +45,7 @@ func ValidateAppName(spec *AppNameValiditySpec, client client.Interface) (*AppNa
 	isValidRc := false
 	isValidService := false
 
-	_, err := client.Core().ReplicationControllers(spec.Namespace).Get(spec.Name, metaV1.GetOptions{})
+	_, err := client.CoreV1().ReplicationControllers(spec.Namespace).Get(spec.Name, metaV1.GetOptions{})
 	if err != nil {
 		if isNotFoundError(err) {
 			isValidRc = true
@@ -54,7 +54,7 @@ func ValidateAppName(spec *AppNameValiditySpec, client client.Interface) (*AppNa
 		}
 	}
 
-	_, err = client.Core().Services(spec.Namespace).Get(spec.Name, metaV1.GetOptions{})
+	_, err = client.CoreV1().Services(spec.Namespace).Get(spec.Name, metaV1.GetOptions{})
 	if err != nil {
 		if isNotFoundError(err) {
 			isValidService = true


### PR DESCRIPTION
gentle ping @maciaszczykm 
[Core](https://github.com/kubernetes/client-go/blob/master/kubernetes/clientset.go#L47) deprecated,so we need modify `Core` to `CoreV1` in the file [`resource/event/common`](https://github.com/kubernetes/dashboard/blob/master/src/app/backend/resource/event/common.go#L147)