### PR TITLE
Add sorting support to remaining list resources

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -296,6 +296,7 @@
   <translation id="8731452969115857295" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
   <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
   <translation id="8453931805104629005" key="MSG_DEPLOYMENT_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage</translation>
+  <translation id="620255252783687720" key="MSG_DEPLOYMENT_DETAIL_DETAIL_10" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Deployment.</translation>
   <translation id="4236751308157834550" key="MSG_DEPLOYMENT_DETAIL_DETAIL_10" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replica Set.</translation>
   <translation id="7206451673196119468" key="MSG_DEPLOYMENT_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this deployment.</translation>
   <translation id="4293182903162394917" key="MSG_DEPLOYMENT_DETAIL_DETAIL_3" desc="Title \'New Replica Set\' for the newly created replica set view, on the deployment details page.">New Replica Set</translation>
@@ -1155,6 +1156,7 @@
   <translation id="3131127524918345503" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_6" desc="Text for pods card zerostate in replication controller details page.">There are currently no Pods managed by this Replication Controller.</translation>
   <translation id="8500914651917232176" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_7" desc="Title for horizontal pod autoscalers card zerostate in replica set details page.">There is nothing to display here</translation>
   <translation id="4489091683101765622" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replica Set.</translation>
+  <translation id="6774788258232499089" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replication Controller.</translation>
   <translation id="226817742496907856" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="2966352401153803656" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_1" desc="Label \'Selector\' for the replication controller\'s selector on the replication controller details page.">Selector</translation>
   <translation id="4612002136140637630" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_10" desc="The message says how many pods have failed (replication controller details page).">{{::$ctrl.replicationController.podInfo.failed}} failed</translation>
@@ -1225,6 +1227,8 @@
   <translation id="4180591456756847095" key="MSG_ROLE_LIST_CARDLIST_1" desc="Role list header: name.">Name</translation>
   <translation id="7494857132807181920" key="MSG_ROLE_LIST_CARDLIST_2" desc="Role list header: role type.">Role Type</translation>
   <translation id="3561280019877192219" key="MSG_ROLE_LIST_CARDLIST_3" desc="Role list header: namespace.">Namespace</translation>
+  <translation id="3197213955933923965" key="MSG_ROLE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
+  <translation id="2864599603034607510" key="MSG_ROLE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the role.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="1320482404001625698" key="MSG_SECRETDETAIL_ACTIONBAR_0" desc="Label \'Secret\' which appears at the top of the delete dialog, opened from a secret details page.">Secret</translation>
   <translation id="1561742373508692276" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">Data </translation>
   <translation id="7988357395949564443" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">Data</translation>
@@ -1282,7 +1286,9 @@
   <translation id="6401528393336695678" key="MSG_SERVICE_LIST_CARDLIST_4" desc="Label \'Cluster IP\' which appears as a column label in the table of services (service list view).">Cluster IP</translation>
   <translation id="5768650563576253785" key="MSG_SERVICE_LIST_CARDLIST_5" desc="Label \'Internal endpoints\' which appears as a column label in the table of services (service list view).">Internal endpoints</translation>
   <translation id="8610616614395595684" key="MSG_SERVICE_LIST_CARDLIST_6" desc="Label \'External endpoints\' which appears as a column label in the table of services (service list view).">External endpoints</translation>
+  <translation id="9019769847701593849" key="MSG_SERVICE_LIST_CARDLIST_7" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
   <translation id="3019719082217228018" key="MSG_SERVICE_LIST_CARD_0" desc="tooltip for pending service card icon">This service is in a pending state</translation>
+  <translation id="5528801080901607886" key="MSG_SERVICE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the service.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="6466948840454457439" key="MSG_STATEFULSETDETAIL_ACTIONBAR_0" desc="Label \'Stateful Set\' which appears at the top of the delete dialog, opened from a stateful set details page.">Stateful Set</translation>
   <translation id="8560431905058366716" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_0" desc="Title for graph card displaying CPU metric of one stateful set.">CPU usage</translation>
   <translation id="4602699404115016650" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_1" desc="Title for graph card displaying memory metric of one stateful set.">Memory usage</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -413,6 +413,7 @@
   <translation id="7624038583322136825" key="MSG_DEPLOYMENT_DETAIL_DETAILS_SUBTITLE" desc="Subtitle 'Details' for the left section with general information about a deployment on the deployment details page.">詳細</translation>
   <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
   <translation id="8453931805104629005" key="MSG_DEPLOYMENT_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage</translation>
+  <translation id="620255252783687720" key="MSG_DEPLOYMENT_DETAIL_DETAIL_10" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Deployment.</translation>
   <translation id="4236751308157834550" key="MSG_DEPLOYMENT_DETAIL_DETAIL_10" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replica Set.</translation>
   <translation id="7206451673196119468" key="MSG_DEPLOYMENT_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this deployment.</translation>
   <translation id="4293182903162394917" key="MSG_DEPLOYMENT_DETAIL_DETAIL_3" desc="Title \'New Replica Set\' for the newly created replica set view, on the deployment details page.">New Replica Set</translation>
@@ -1833,6 +1834,7 @@
   <translation id="3131127524918345503" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_6" desc="Text for pods card zerostate in replication controller details page.">There are currently no Pods managed by this Replication Controller.</translation>
   <translation id="8500914651917232176" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_7" desc="Title for horizontal pod autoscalers card zerostate in replica set details page.">There is nothing to display here</translation>
   <translation id="4489091683101765622" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replica Set.</translation>
+  <translation id="6774788258232499089" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replication Controller.</translation>
   <translation id="226817742496907856" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="2966352401153803656" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_1" desc="Label \'Selector\' for the replication controller\'s selector on the replication controller details page.">Selector</translation>
   <translation id="4612002136140637630" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_10" desc="The message says how many pods have failed (replication controller details page).">{{::$ctrl.replicationController.podInfo.failed}} failed</translation>
@@ -1956,6 +1958,8 @@
   <translation id="4180591456756847095" key="MSG_ROLE_LIST_CARDLIST_1" desc="Role list header: name.">Name</translation>
   <translation id="7494857132807181920" key="MSG_ROLE_LIST_CARDLIST_2" desc="Role list header: role type.">Role Type</translation>
   <translation id="3561280019877192219" key="MSG_ROLE_LIST_CARDLIST_3" desc="Role list header: namespace.">Namespace</translation>
+  <translation id="3197213955933923965" key="MSG_ROLE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
+  <translation id="2864599603034607510" key="MSG_ROLE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the role.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="1320482404001625698" key="MSG_SECRETDETAIL_ACTIONBAR_0" desc="Label \'Secret\' which appears at the top of the delete dialog, opened from a secret details page.">シークレット</translation>
   <translation id="1561742373508692276" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">データ </translation>
   <translation id="7988357395949564443" key="MSG_SECRETDETAIL_DETAIL_0" desc="Config map info details section name.">データ</translation>
@@ -2053,6 +2057,7 @@
   <translation id="6401528393336695678" key="MSG_SERVICE_LIST_CARDLIST_4" desc="Label \'Cluster IP\' which appears as a column label in the table of services (service list view).">Cluster IP</translation>
   <translation id="5768650563576253785" key="MSG_SERVICE_LIST_CARDLIST_5" desc="Label \'Internal endpoints\' which appears as a column label in the table of services (service list view).">Internal endpoints</translation>
   <translation id="8610616614395595684" key="MSG_SERVICE_LIST_CARDLIST_6" desc="Label \'External endpoints\' which appears as a column label in the table of services (service list view).">External endpoints</translation>
+  <translation id="9019769847701593849" key="MSG_SERVICE_LIST_CARDLIST_7" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
   <translation id="3019719082217228018" key="MSG_SERVICE_LIST_CARD_0" desc="tooltip for pending service card icon">This service is in a pending state</translation>
   <translation id="3377429311985946324" key="MSG_SERVICE_LIST_CLUSTER_IP_LABEL" desc="Label 'Cluster IP' which appears as a column label in the table of services (service list view).">クラスター IP</translation>
   <translation id="1737784623295570501" key="MSG_SERVICE_LIST_EXTERNAL_ENDPOINTS_LABEL" desc="Label 'External endpoints' which appears as a column label in the table of services (service list view).">外部エンドポイント</translation>
@@ -2060,6 +2065,7 @@
   <translation id="4510746585636758800" key="MSG_SERVICE_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of services (service list view).">ラベル</translation>
   <translation id="6859808734310490214" key="MSG_SERVICE_LIST_NAMESPACE_LABEL" desc="Label 'Namespace' which appears as a column label in the table of services (service list view).">ネームスペース</translation>
   <translation id="4581297925702163661" key="MSG_SERVICE_LIST_NAME_LABEL" desc="Label 'Name' which appears as a column label in the table of services (service list view).">名前</translation>
+  <translation id="5528801080901607886" key="MSG_SERVICE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the service.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="6466948840454457439" key="MSG_STATEFULSETDETAIL_ACTIONBAR_0" desc="Label \'Stateful Set\' which appears at the top of the delete dialog, opened from a stateful set details page.">ステートフルセット</translation>
   <translation id="4919296013189797225" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_0" desc="Title for graph card displaying CPU metric of one stateful set.">CPU使用量の履歴</translation>
   <translation id="8560431905058366716" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_0" desc="Title for graph card displaying CPU metric of one stateful set.">CPU使用量</translation>

--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -21,30 +21,29 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/logs"
 )
 
-
 var log1 = logs.LogLine{
 	Timestamp: "1",
-	Content: "log1",
+	Content:   "log1",
 }
 
 var log2 = logs.LogLine{
 	Timestamp: "2",
-	Content: "log2",
+	Content:   "log2",
 }
 
 var log3 = logs.LogLine{
 	Timestamp: "3",
-	Content: "log3",
+	Content:   "log3",
 }
 
 var log4 = logs.LogLine{
 	Timestamp: "4",
-	Content: "log4",
+	Content:   "log4",
 }
 
 var log5 = logs.LogLine{
 	Timestamp: "5",
-	Content: "log5",
+	Content:   "log5",
 }
 
 func TestGetLogs(t *testing.T) {
@@ -77,7 +76,7 @@ func TestGetLogs(t *testing.T) {
 			logs.AllLogViewSelector,
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{log1, log2 ,log3, log4, log5},
+				LogLines:  logs.LogLines{log1, log2, log3, log4, log5},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "1",
@@ -108,7 +107,7 @@ func TestGetLogs(t *testing.T) {
 			},
 			&logs.Logs{
 				PodId:     "pod-1",
-				LogLines:  logs.LogLines{log2,log3},
+				LogLines:  logs.LogLines{log2, log3},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{
 					LogTimestamp: "2",
@@ -274,13 +273,13 @@ func TestGetLogs(t *testing.T) {
 				RelativeTo:   2, // request indices 1, 2
 			},
 			&logs.Logs{
-				PodId:     "pod-1",
-				LogLines:  logs.LogLines{logs.LogLine{
+				PodId: "pod-1",
+				LogLines: logs.LogLines{logs.LogLine{
 					Timestamp: "1",
-					Content: "log2",
+					Content:   "log2",
 				}, logs.LogLine{
 					Timestamp: "1",
-					Content: "log3",
+					Content:   "log3",
 				}},
 				Container: "test",
 				FirstLogLineReference: logs.LogLineId{

--- a/src/app/backend/resource/deployment/list.go
+++ b/src/app/backend/resource/deployment/list.go
@@ -110,8 +110,8 @@ func CreateDeploymentList(deployments []extensions.Deployment, pods []api.Pod,
 	cachedResources := &dataselect.CachedResources{
 		Pods: pods,
 	}
-	replicationControllerCells, metricPromises := dataselect.GenericDataSelectWithMetrics(toCells(deployments), dsQuery, cachedResources, heapsterClient)
-	deployments = fromCells(replicationControllerCells)
+	deploymentCells, metricPromises := dataselect.GenericDataSelectWithMetrics(toCells(deployments), dsQuery, cachedResources, heapsterClient)
+	deployments = fromCells(deploymentCells)
 
 	for _, deployment := range deployments {
 

--- a/src/app/backend/resource/deployment/oldreplicasets.go
+++ b/src/app/backend/resource/deployment/oldreplicasets.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployment
 
 import (
@@ -9,8 +23,7 @@ import (
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
-//GetDeploymentEvents returns model events for a deployment with the given name in the given
-//namespace
+//GetDeploymentOldReplicaSets returns old replica sets targeting Deployment with given name
 func GetDeploymentOldReplicaSets(client client.Interface, dsQuery *dataselect.DataSelectQuery,
 	namespace string, deploymentName string) (*replicaset.ReplicaSetList, error) {
 

--- a/src/app/backend/resource/logs/logs.go
+++ b/src/app/backend/resource/logs/logs.go
@@ -29,12 +29,10 @@ var DefaultDisplayNumLogLines = 100
 // number of log lines than we can handle.
 var MaxLogLines int = 2000000000
 
-
 const (
 	NewestTimestamp = "newest"
 	OldestTimestamp = "oldest"
 )
-
 
 // NewestLogLineId is the reference Id of the newest line.
 var NewestLogLineId = LogLineId{
@@ -45,7 +43,6 @@ var NewestLogLineId = LogLineId{
 var OldestLogLineId = LogLineId{
 	LogTimestamp: OldestTimestamp,
 }
-
 
 // Default log view selector that is used in case of invalid request
 // Downloads newest DefaultDisplayNumLogLines lines.
@@ -76,8 +73,6 @@ type LogViewSelector struct {
 	RelativeTo int
 }
 
-
-
 // Logs is a representation of logs response structure.
 type Logs struct {
 	// Pod name.
@@ -99,7 +94,6 @@ type Logs struct {
 	LogLines `json:"logs"`
 }
 
-
 // LogViewInfo provides information on the current log view.
 // Fields have the same meaning as in LogViewSelector.
 type LogViewInfo struct {
@@ -107,7 +101,6 @@ type LogViewInfo struct {
 	RelativeFrom       int       `json:"relativeFrom"`
 	RelativeTo         int       `json:"relativeTo"`
 }
-
 
 // LogLines provides means of selecting log views.
 // Problem with logs is that old logs are being deleted and new logs are constantly added.
@@ -120,13 +113,11 @@ type LogViewInfo struct {
 // slice of logs relatively to certain reference line ID.
 type LogLines []LogLine
 
-
 // A single log line. Split into timestamp and and the actual content
 type LogLine struct {
 	Timestamp LogTimestamp `json:"timestamp"`
-	Content string `json:"content"`
+	Content   string       `json:"content"`
 }
-
 
 // LogLineId uniquely identifies a line in logs - immune to log addition/deletion.
 type LogLineId struct {
@@ -141,7 +132,6 @@ type LogLineId struct {
 
 // LogTimestamp is a timestamp that appears on the beginning of each log line.
 type LogTimestamp string
-
 
 // GetLogLineId returns ID of the line with provided lineIndex.
 func (self LogLines) GetLogLineId(lineIndex int) *LogLineId {
@@ -168,7 +158,6 @@ func (self LogLines) GetLogLineId(lineIndex int) *LogLineId {
 		LineNum:      offset,
 	}
 }
-
 
 // SelectLogs returns selected part of LogLines as required by logSelector, moreover it returns IDs of first and last
 // of returned lines and the information of the resulting logView.
@@ -199,8 +188,6 @@ func (self LogLines) SelectLogs(logSelector *LogViewSelector) (LogLines, LogLine
 	}
 	return self[fromIndex:toIndex], *self.GetLogLineId(fromIndex), *self.GetLogLineId(toIndex - 1), logViewInfo
 }
-
-
 
 // GetLineIndex returns the index of the line (referenced from beginning of log array) with provided logLineId.
 func (self LogLines) GetLineIndex(logLineId *LogLineId) int {
@@ -235,7 +222,6 @@ func (self LogLines) GetLineIndex(logLineId *LogLineId) int {
 		return LINE_INDEX_NOT_FOUND
 	}
 }
-
 
 // ToLogLines converts rawLogs (string) to LogLines. This might be slow as we have to split ALL logs by \n.
 // The solution could be to split only required part of logs. To find reference line - do smart binary search on raw string -

--- a/src/app/frontend/common/components/resourcecard/resourcecardheadercolumn_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardheadercolumn_component.js
@@ -63,10 +63,11 @@ export class ResourceCardHeaderColumnController {
     this.selectId = this.resourceCardListCtrl.selectId;
     this.resourceCardHeaderColumnsCtrl.addAndSizeHeaderColumn(this, this.element_);
 
+    // If column is sortable but required resources are not provided then disable sorting support
     if (this.isSortable() &&
         (this.resourceCardListCtrl.list === undefined ||
          this.resourceCardListCtrl.listResource === undefined)) {
-      throw new Error('List and list resource have to be set on list card.');
+      this.sortable = false;
     }
 
     // Initialize default sort for AGE column

--- a/src/app/frontend/configmap/list/cardlist.html
+++ b/src/app/frontend/configmap/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Config map list header: name.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -39,7 +41,9 @@ limitations under the License.
       [[Labels|Config map list header: labels.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="nogrow">
+                                    grow="nogrow"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Config map list header: age.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/daemonset/list/cardlist.html
+++ b/src/app/frontend/daemonset/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -48,7 +50,9 @@ limitations under the License.
       [[Pods|Label 'Pods' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of daemon sets (daemon set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/deployment/detail/detail.html
+++ b/src/app/frontend/deployment/detail/detail.html
@@ -66,7 +66,7 @@ limitations under the License.
     <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::ctrl.deploymentDetail.horizontalPodAutoscalerList">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
-        <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
+        <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Deployment.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
       </kd-zerostate>
     </kd-horizontal-pod-autoscaler-card-list>
   </kd-content>

--- a/src/app/frontend/deployment/list/cardlist.html
+++ b/src/app/frontend/deployment/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -43,7 +45,9 @@ limitations under the License.
       [[Pods|Label 'Pods' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of deployments (deployment list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/horizontalpodautoscaler/list/cardlist.html
+++ b/src/app/frontend/horizontalpodautoscaler/list/cardlist.html
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-resource-card-list>
+{{$ctrl.horizontalPodAutoscalerListResource}}
+<kd-resource-card-list select-id="{{::$ctrl.getSelectId()}}"
+                       list="$ctrl.horizontalPodAutoscalerList"
+                       list-resource="$ctrl.horizontalPodAutoscalerListResource">
   <kd-resource-card-list-header ng-transclude="header">
     [[Horizontal Pod Autoscalers|Label which appears above the list of such objects.]]
   </kd-resource-card-list-header>
-  <kd-resource-card-list-pagination pagination-id="jobs"
-                                    list="$ctrl.horizontalPodAutoscalerList"
-                                    list-resource="::$ctrl.horizontalPodAutoscalerListResource">
-  </kd-resource-card-list-pagination>
+  <kd-resource-card-list-pagination></kd-resource-card-list-pagination>
   <div ng-show="!$ctrl.horizontalPodAutoscalerList.listMeta.totalItems"
        class="kd-zerostate-message"
        ng-transclude="zerostate"></div>
@@ -65,17 +65,9 @@ limitations under the License.
                                     grow="nogrow">
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
-  <kd-horizontal-pod-autoscaler-card ng-if="::$ctrl.horizontalPodAutoscalerListResource"
-                                     pagination-id="horizontalpodautoscalers"
+  <kd-horizontal-pod-autoscaler-card pagination-id="{{::$ctrl.getSelectId()}}"
                                      dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
                                      total-items="::$ctrl.horizontalPodAutoscalerList.listMeta.totalItems"
-                                     horizontal-pod-autoscaler="horizontalPodAutoscaler"
-                                     show-scale-target="::$ctrl.showScaleTarget">
-  </kd-horizontal-pod-autoscaler-card>
-
-  <kd-horizontal-pod-autoscaler-card ng-if="::!$ctrl.horizontalPodAutoscalerListResource"
-                                     pagination-id="horizontalpodautoscalers"
-                                     dir-paginate="horizontalPodAutoscaler in $ctrl.horizontalPodAutoscalerList.horizontalpodautoscalers | itemsPerPage: default"
                                      horizontal-pod-autoscaler="horizontalPodAutoscaler"
                                      show-scale-target="::$ctrl.showScaleTarget">
   </kd-horizontal-pod-autoscaler-card>

--- a/src/app/frontend/horizontalpodautoscaler/list/list.html
+++ b/src/app/frontend/horizontalpodautoscaler/list/list.html
@@ -16,8 +16,8 @@ limitations under the License.
 
 <kd-content-card ng-if="!ctrl.shouldShowZeroState()">
   <kd-content>
-    <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::ctrl.horizontalPodAutoscalerList"
-                                            horizontal-pod-autoscaler-list-resource="::ctrl.horizontalPodAutoscalerListResource"
+    <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="ctrl.horizontalPodAutoscalerList"
+                                            horizontal-pod-autoscaler-list-resource="ctrl.horizontalPodAutoscalerListResource"
                                             show-scale-target="true">
 
     </kd-horizontal-pod-autoscaler-card-list>

--- a/src/app/frontend/ingress/list/cardlist.html
+++ b/src/app/frontend/ingress/list/cardlist.html
@@ -25,7 +25,10 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">[[Name|Label 'Name' which appears as a column label in the table of ingresses (ingress list view).]]
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
+      [[Name|Label 'Name' which appears as a column label in the table of ingresses (ingress list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
                                     grow="1"
@@ -37,7 +40,10 @@ limitations under the License.
       [[Endpoints|Label 'endpoints' which appears as a column label in the table of ingresses (ingress list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">[[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
+      [[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-ingress-card pagination-id="{{::$ctrl.getSelectId()}}"

--- a/src/app/frontend/namespace/list/cardlist.html
+++ b/src/app/frontend/namespace/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -38,7 +40,9 @@ limitations under the License.
       [[Status|Label 'Status' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of namespaces (namespace list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>

--- a/src/app/frontend/node/list/cardlist.html
+++ b/src/app/frontend/node/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -38,7 +40,9 @@ limitations under the License.
       [[Ready|Label 'Ready' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>

--- a/src/app/frontend/persistentvolume/list/cardlist.html
+++ b/src/app/frontend/persistentvolume/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Persistent volume list header: name.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -54,7 +56,9 @@ limitations under the License.
       [[Reason|Persistent volume list header: reason.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Persistent volume list header: age.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/persistentvolumeclaim/list/cardlist.html
+++ b/src/app/frontend/persistentvolumeclaim/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -43,7 +45,9 @@ limitations under the License.
       [[Labels|Label 'Labels' which appears as a column label in the table of persistent volume claim (persistent volume claim list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>

--- a/src/app/frontend/replicaset/list/cardlist.html
+++ b/src/app/frontend/replicaset/list/cardlist.html
@@ -25,7 +25,9 @@ limitations under the License.
   <kd-resource-card-list-pagination></kd-resource-card-list-pagination>
   <kd-resource-card-header-columns ng-show="$ctrl.replicaSetList.listMeta.totalItems">
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -47,7 +49,9 @@ limitations under the License.
       [[Pods|Label 'Pods' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of replica sets (replica set list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/replicationcontroller/detail/detail.html
+++ b/src/app/frontend/replicationcontroller/detail/detail.html
@@ -59,7 +59,7 @@ limitations under the License.
     <kd-horizontal-pod-autoscaler-card-list horizontal-pod-autoscaler-list="::$ctrl.replicationControllerDetail.horizontalPodAutoscalerList">
       <kd-zerostate>
         <div class="kd-zerostate-title">[[There is nothing to display here|Title for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
-        <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replica Set.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
+        <div class="kd-zerostate-text">[[There are currently no Horizontal Pod Autoscalers targeting this Replication Controller.|Text for horizontal pod autoscalers card zerostate in replica set details page.]]</div>
       </kd-zerostate>
     </kd-horizontal-pod-autoscaler-card-list>
   </kd-content>

--- a/src/app/frontend/replicationcontroller/list/cardlist.html
+++ b/src/app/frontend/replicationcontroller/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -48,7 +50,9 @@ limitations under the License.
       [[Pods|Label 'Pods' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Label 'Age' which appears as a column label in the table of replication controllers (RC list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/role/list/card.html
+++ b/src/app/frontend/role/list/card.html
@@ -38,5 +38,14 @@ limitations under the License.
       </kd-middle-ellipsis>
       <div ng-switch-default>{{::$ctrl.role.objectMeta.namespace}}</div>
     </kd-resource-card-column>
+    <kd-resource-card-column>
+      <div ng-if="::$ctrl.role.objectMeta.creationTimestamp">
+        {{::$ctrl.role.objectMeta.creationTimestamp | relativeTime}}
+        <md-tooltip>
+          {{::$ctrl.getStartedAtTooltip($ctrl.role.objectMeta.creationTimestamp)}}
+        </md-tooltip>
+      </div>
+      <div ng-if="::!$ctrl.role.objectMeta.creationTimestamp">-</div>
+    </kd-resource-card-column>
   </kd-resource-card-columns>
 </kd-resource-card>

--- a/src/app/frontend/role/list/card_component.js
+++ b/src/app/frontend/role/list/card_component.js
@@ -36,6 +36,20 @@ export default class RoleCardController {
     /** @private */
     this.interpolate_ = $interpolate;
   }
+
+  /**
+   * @export
+   * @param  {string} startDate - start date of the role
+   * @return {string} localized tooltip with the formatted start date
+   */
+  getStartedAtTooltip(startDate) {
+    let filter = this.interpolate_(`{{date | date}}`);
+    /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
+     * the role.*/
+    let MSG_ROLE_LIST_STARTED_AT_TOOLTIP =
+        goog.getMsg('Created at {$startDate} UTC', {'startDate': filter({'date': startDate})});
+    return MSG_ROLE_LIST_STARTED_AT_TOOLTIP;
+  }
 }
 
 /**

--- a/src/app/frontend/role/list/cardlist.html
+++ b/src/app/frontend/role/list/cardlist.html
@@ -25,7 +25,9 @@ limitations under the License.
   <kd-resource-card-list-pagination></kd-resource-card-list-pagination>
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Role list header: name.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -35,6 +37,12 @@ limitations under the License.
     <kd-resource-card-header-column size="small"
                                     grow="2">
       [[Namespace|Role list header: namespace.]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
+      [[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-role-card dir-paginate="role in $ctrl.roleList.items | itemsPerPage: default"

--- a/src/app/frontend/secret/list/cardlist.html
+++ b/src/app/frontend/secret/list/cardlist.html
@@ -25,7 +25,10 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="4">[[Name|Label 'Name' which appears as a column label in the table of secrets (secret list view).]]
+                                    grow="4"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
+      [[Name|Label 'Name' which appears as a column label in the table of secrets (secret list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
                                     grow="2"
@@ -33,7 +36,10 @@ limitations under the License.
       [[Namespace|Label 'Namespace' which appears as a column label in the table of secrets (secret list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">[[Age|Label 'Age' which appears as a column label in the table of secrets (secret list view).]]
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
+      [[Age|Label 'Age' which appears as a column label in the table of secrets (secret list view).]]
     </kd-resource-card-header-column>
   </kd-resource-card-header-columns>
   <kd-secret-card dir-paginate="secret in $ctrl.secretList.secrets | itemsPerPage: default"

--- a/src/app/frontend/service/list/card.html
+++ b/src/app/frontend/service/list/card.html
@@ -59,6 +59,15 @@ limitations under the License.
       </div>
       <div ng-hide="::$ctrl.service.externalEndpoints">-</div>
     </kd-resource-card-column>
+    <kd-resource-card-column>
+      <div ng-if="::$ctrl.service.objectMeta.creationTimestamp">
+        {{::$ctrl.service.objectMeta.creationTimestamp | relativeTime}}
+        <md-tooltip>
+          {{::$ctrl.getStartedAtTooltip($ctrl.service.objectMeta.creationTimestamp)}}
+        </md-tooltip>
+      </div>
+      <div ng-if="::!$ctrl.service.objectMeta.creationTimestamp">-</div>
+    </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>
         <kd-resource-card-delete-menu-item resource-kind-name="Service">

--- a/src/app/frontend/service/list/card_component.js
+++ b/src/app/frontend/service/list/card_component.js
@@ -21,10 +21,11 @@ import {stateName} from 'service/detail/state';
 export class ServiceCardController {
   /**
    * @param {!ui.router.$state} $state
+   * @param {!angular.$interpolate} $interpolate
    * @param {!./../../common/namespace/service.NamespaceService} kdNamespaceService
    * @ngInject
    */
-  constructor($state, kdNamespaceService) {
+  constructor($state, $interpolate, kdNamespaceService) {
     /** @private {!./../../common/namespace/service.NamespaceService} */
     this.kdNamespaceService_ = kdNamespaceService;
 
@@ -33,6 +34,9 @@ export class ServiceCardController {
 
     /** @private {!ui.router.$state} */
     this.state_ = $state;
+
+    /** @private {!angular.$interpolate} */
+    this.interpolate_ = $interpolate;
   }
 
   /**
@@ -82,6 +86,20 @@ export class ServiceCardController {
    */
   getServiceClusterIP() {
     return this.service.clusterIP ? this.service.clusterIP : '-';
+  }
+
+  /**
+   * @export
+   * @param  {string} startDate - start date of the service
+   * @return {string} localized tooltip with the formatted start date
+   */
+  getStartedAtTooltip(startDate) {
+    let filter = this.interpolate_(`{{date | date}}`);
+    /** @type {string} @desc Tooltip 'Started at [some date]' showing the exact start time of
+     * the service.*/
+    let MSG_SERVICE_LIST_STARTED_AT_TOOLTIP =
+        goog.getMsg('Created at {$startDate} UTC', {'startDate': filter({'date': startDate})});
+    return MSG_SERVICE_LIST_STARTED_AT_TOOLTIP;
   }
 }
 

--- a/src/app/frontend/service/list/cardlist.html
+++ b/src/app/frontend/service/list/cardlist.html
@@ -29,7 +29,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns ng-show="$ctrl.serviceList.listMeta.totalItems">
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Label 'Name' which appears as a column label in the table of services (service list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -52,6 +54,12 @@ limitations under the License.
     <kd-resource-card-header-column size="small"
                                     grow="2">
       [[External endpoints|Label 'External endpoints' which appears as a column label in the table of services (service list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
+      [[Age|Label 'Age' which appears as a column label in the table of ingresses (ingress list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
                                     grow="nogrow">

--- a/src/app/frontend/statefulset/list/cardlist.html
+++ b/src/app/frontend/statefulset/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Stateful set list header: name.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -48,7 +50,9 @@ limitations under the License.
       [[Pods|Stateful set list header: pods.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Stateful set list header: age.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/app/frontend/storageclass/list/cardlist.html
+++ b/src/app/frontend/storageclass/list/cardlist.html
@@ -26,7 +26,9 @@ limitations under the License.
 
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
-                                    grow="2">
+                                    grow="2"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.NAME">
       [[Name|Storage class list header: name.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
@@ -42,7 +44,9 @@ limitations under the License.
       [[Parameters|Storage class list header: parameters.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
-                                    grow="1">
+                                    grow="1"
+                                    sortable="true"
+                                    sort-id="$root.SortableProperties.AGE">
       [[Age|Storage class list header: age.]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"

--- a/src/test/frontend/common/components/resourcecard/resourcecardheadercolumn_components_test.js
+++ b/src/test/frontend/common/components/resourcecard/resourcecardheadercolumn_components_test.js
@@ -65,15 +65,17 @@ describe('Resource card header column', () => {
     expect(ctrl).toBeDefined();
   });
 
-  it('should throw an error when sortable and list or list resource not defined', () => {
-    // given
-    ctrl.sortable = true;
+  it('should disable sorting when sortable is true and list or list resource is not defined',
+     () => {
+       // given
+       ctrl.sortable = true;
 
-    // then
-    expect(() => {
-      ctrl.$onInit();
-    }).toThrow(new Error('List and list resource have to be set on list card.'));
-  });
+       // when
+       ctrl.$onInit();
+
+       // then
+       expect(ctrl.sortable).toBeFalsy();
+     });
 
   it('should init ascending sorting on age column by default', () => {
     // given


### PR DESCRIPTION
## Additional changes
 - Add age column to all resources as by default we are sorting by age
 - Update backend documentation
 - `gofmt` backend
 - Clean up horizontal pod autoscalers frontend code to correctly support sorting
 - Disable sorting in case list resource is not provided instead of throwing an error

Last change is done due to i.e. deployment's new replica sets not having it's own endpoint for updates. As there is always only one new replica set and we are using list to display it I am not sure if having separate endpoint is good. We don't need sorting nor paging on such lists so we can disable it instead of throwing an error.

Closes #1677.