### PR TITLE
fix server crashed when upload yaml in 1.6

### DIFF
--- a/src/app/backend/resource/deployment/deploy.go
+++ b/src/app/backend/resource/deployment/deploy.go
@@ -25,6 +25,7 @@ import (
 	client "k8s.io/client-go/kubernetes"
 	api "k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kubectlResource "k8s.io/kubernetes/pkg/kubectl/resource"
 )
@@ -290,11 +291,12 @@ func CreateObjectFromInfoFn(info *kubectlResource.Info) (bool, error) {
 
 // DeployAppFromFile deploys an app based on the given yaml or json file.
 func DeployAppFromFile(spec *AppDeploymentFromFileSpec,
-	createObjectFromInfoFn createObjectFromInfo) (bool, error) {
+	createObjectFromInfoFn createObjectFromInfo,
+	clientConfig clientcmd.ClientConfig) (bool, error) {
 	const emptyCacheDir = ""
 	validate := spec.Validate
 
-	factory := cmdutil.NewFactory(nil)
+	factory := cmdutil.NewFactory(clientConfig)
 	schema, err := factory.Validator(validate, emptyCacheDir)
 	if err != nil {
 		return false, err

--- a/src/app/backend/resource/deployment/deploy_test.go
+++ b/src/app/backend/resource/deployment/deploy_test.go
@@ -199,7 +199,7 @@ func TestDeployAppFromFileWithValidContent(t *testing.T) {
 	}
 	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
 
-	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo)
+	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
 	if err != nil {
 		t.Errorf("Expected err to be %#v but got %#v", nil, err)
 	}
@@ -218,7 +218,7 @@ func TestDeployAppFromFileWithInvalidContent(t *testing.T) {
 	// return is set to true to check if the validation prior to this function really works
 	fakeCreateObjectFromInfo := func(info *kubectlResource.Info) (bool, error) { return true, nil }
 
-	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo)
+	isDeployed, err := DeployAppFromFile(spec, fakeCreateObjectFromInfo, nil)
 	if err == nil {
 		t.Errorf("Expected return value to have an error but got %#v", nil)
 	}


### PR DESCRIPTION
## how to present problem
1. start container:
`docker run --rm -ti -p 9090:9090 gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.0 --apiserver-host=http://192.168.0.10:8080 `

2. click "Create" and upload a yaml.

3. the server crashed, and error like below:
```
Using apiserver-host location: http://localhost:8080
Creating API server client for http://localhost:8080
Error while initializing connection to Kubernetes apiserver. This most likely means that the cluster is misconfigured (e.g., it has invalid apiserver certificates or service accounts configuration) or the
 --apiserver-host param points to a server that does not exist. Reason: Get http://localhost:8080/version: dial tcp [::1]:8080: getsockopt: connection refused
```

## what I do
according to https://github.com/kubernetes/dashboard/pull/1739 , I just modify the deploy part.

## how to check
`gulp serve` to check first, and then `gulp docker-image:release:cross` build image and run container to check again.

Signed-off-by: wefine <wang.xiaoren@zte.com.cn>
