### PR TITLE
confighandler: remove the redundant http.Error call

### DIFF
--- a/src/app/backend/handler/confighandler.go
+++ b/src/app/backend/handler/confighandler.go
@@ -63,7 +63,6 @@ func ConfigHandler(w http.ResponseWriter, r *http.Request) (int, error) {
 	template, err := template.New(ConfigTemplateName).Parse(ConfigTemplate)
 	w.Header().Set("Content-Type", "application/javascript")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return http.StatusInternalServerError, err
 	}
 	return http.StatusOK, template.Execute(w, getAppConfigJSON())


### PR DESCRIPTION
The removed line is actually duplicated with https://github.com/kubernetes/dashboard/blob/master/src/app/backend/handler/confighandler.go#L44.