### PR TITLE
Fix of misusing bindToController instead of bindings

### DIFF
--- a/src/app/frontend/deploy/environmentvariables_component.js
+++ b/src/app/frontend/deploy/environmentvariables_component.js
@@ -94,7 +94,7 @@ export const environmentVariablesComponent = {
   controller: EnvironmentVariablesController,
   controllerAs: 'ctrl',
   templateUrl: 'deploy/environmentvariables.html',
-  bindToController: {
+  bindings: {
     'variables': '=',
   },
 };

--- a/src/app/frontend/deploy/portmappings_component.js
+++ b/src/app/frontend/deploy/portmappings_component.js
@@ -191,7 +191,7 @@ export const portMappingsComponent = {
   controller: PortMappingsController,
   controllerAs: 'ctrl',
   templateUrl: 'deploy/portmappings.html',
-  bindToController: {
+  bindings: {
     'portMappings': '=',
     'protocols': '=',
     'isExternal': '=',


### PR DESCRIPTION
"Deploy a Containerized App" doesn't work properly.

![image](https://cloud.githubusercontent.com/assets/1693027/25416794/5eec7e24-2a72-11e7-8e86-70dedf010c8d.png)

Since the `environmentvariables_component.js` and `portmappings_component.js` have been migrated from `directive` to `component` which should actually  use `bindings` instead of `bindToController `
