### PR TITLE
Increase items per page in list views

### DIFF
--- a/src/app/frontend/common/dataselect/builder.js
+++ b/src/app/frontend/common/dataselect/builder.js
@@ -23,7 +23,7 @@ export const SortableProperties = {
 };
 
 /** @const {number} **/
-export const ItemsPerPage = 10;
+export const ItemsPerPage = 30;
 
 /**
  * @final

--- a/src/app/frontend/common/dataselect/builder.js
+++ b/src/app/frontend/common/dataselect/builder.js
@@ -23,7 +23,7 @@ export const SortableProperties = {
 };
 
 /** @const {number} **/
-export const ItemsPerPage = 30;
+export const ItemsPerPage = 15;
 
 /**
  * @final


### PR DESCRIPTION
Using the dashboard for quite a while now and it has become very annoying that the list views are only showing 10 items per page. I think we should increase the default.

If someone is able to, it would be even more awesome if you could have a drop down selector for each list view and change between some default values like 10, 20, 30, 40, 50, 100 etc.