### PR TITLE
Replace the app label in deploy yaml to k8s-app

### DIFF
--- a/src/deploy/kubernetes-dashboard-arm-head-no-rbac.yaml
+++ b/src/deploy/kubernetes-dashboard-arm-head-no-rbac.yaml
@@ -20,18 +20,18 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kubernetes-dashboard-head
+      k8s-app: kubernetes-dashboard-head
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard-head
+        k8s-app: kubernetes-dashboard-head
       # Comment the following annotation if Dashboard must not be deployed on master
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -67,7 +67,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -76,4 +76,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head

--- a/src/deploy/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/kubernetes-dashboard-arm-head.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 ---
@@ -30,7 +30,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-head
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -44,18 +44,18 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kubernetes-dashboard-head
+      k8s-app: kubernetes-dashboard-head
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard-head
+        k8s-app: kubernetes-dashboard-head
     spec:
       containers:
       - name: kubernetes-dashboard-head
@@ -85,7 +85,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -94,4 +94,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head

--- a/src/deploy/kubernetes-dashboard-arm-no-rbac.yaml
+++ b/src/deploy/kubernetes-dashboard-arm-no-rbac.yaml
@@ -20,18 +20,18 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kubernetes-dashboard
+      k8s-app: kubernetes-dashboard
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard
+        k8s-app: kubernetes-dashboard
       # Comment the following annotation if Dashboard must not be deployed on master
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -67,7 +67,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -76,4 +76,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard

--- a/src/deploy/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/kubernetes-dashboard-arm.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 ---
@@ -30,7 +30,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -44,18 +44,18 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kubernetes-dashboard
+      k8s-app: kubernetes-dashboard
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard
+        k8s-app: kubernetes-dashboard
     spec:
       containers:
       - name: kubernetes-dashboard
@@ -85,7 +85,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -94,4 +94,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard

--- a/src/deploy/kubernetes-dashboard-head-no-rbac.yaml
+++ b/src/deploy/kubernetes-dashboard-head-no-rbac.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -28,11 +28,11 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kubernetes-dashboard-head
+      k8s-app: kubernetes-dashboard-head
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard-head
+        k8s-app: kubernetes-dashboard-head
       # Comment the following annotation if Dashboard must not be deployed on master
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -68,7 +68,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -77,4 +77,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head

--- a/src/deploy/kubernetes-dashboard-head.yaml
+++ b/src/deploy/kubernetes-dashboard-head.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 ---
@@ -30,7 +30,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-head
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -44,7 +44,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -52,11 +52,11 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kubernetes-dashboard-head
+      k8s-app: kubernetes-dashboard-head
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard-head
+        k8s-app: kubernetes-dashboard-head
     spec:
       containers:
       - name: kubernetes-dashboard-head
@@ -86,7 +86,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-head
   namespace: kube-system
 spec:
@@ -95,4 +95,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard-head
+    k8s-app: kubernetes-dashboard-head

--- a/src/deploy/kubernetes-dashboard-no-rbac.yaml
+++ b/src/deploy/kubernetes-dashboard-no-rbac.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -28,11 +28,11 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kubernetes-dashboard
+      k8s-app: kubernetes-dashboard
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard
+        k8s-app: kubernetes-dashboard
       # Comment the following annotation if Dashboard must not be deployed on master
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -68,7 +68,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -77,4 +77,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard

--- a/src/deploy/kubernetes-dashboard.yaml
+++ b/src/deploy/kubernetes-dashboard.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 ---
@@ -30,7 +30,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -44,7 +44,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -52,11 +52,11 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kubernetes-dashboard
+      k8s-app: kubernetes-dashboard
   template:
     metadata:
       labels:
-        app: kubernetes-dashboard
+        k8s-app: kubernetes-dashboard
     spec:
       containers:
       - name: kubernetes-dashboard
@@ -86,7 +86,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
@@ -95,4 +95,4 @@ spec:
   - port: 80
     targetPort: 9090
   selector:
-    app: kubernetes-dashboard
+    k8s-app: kubernetes-dashboard


### PR DESCRIPTION
replace app label to k8s-app, to keep it uniform with other k8s components app label format,and let dashboard e2e test passed