### PR TITLE
Fix head image

### DIFF
--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE translationbundle><translationbundle lang="zh">
+  <translation id="961242340990264399" key="MSG_ABOUT_ABOUT_0" desc="This is a label for button displayed on about page used to open documentaion in browser">Documentation</translation>
+  <translation id="5634646746226609179" key="MSG_ABOUT_ABOUT_1" desc="Label \'Dashboard Version\' for the about page.">Dashboard Version</translation>
+  <translation id="4718120324314749596" key="MSG_ABOUT_ABOUT_2" desc="Label \'Git Commit\' for the about page.">Git Commit</translation>
+  <translation id="5788105450172886273" key="MSG_ABOUT_ABOUT_3" desc="This is a label for button displayed on about page used to send feedback to GitHub new issue.">Send feedback</translation>
+  <translation id="4249662097435421699" key="MSG_ABOUT_ABOUT_4" desc="This is the copyright statement displayed on the about page">Copyright 2015-{{ $ctrl.latestCopyrightYear}} The Kubernetes Authors.</translation>
+  <translation id="4171916442768740608" key="MSG_ABOUT_ABOUT_5" desc="This is the creator reference on the footer of the about page"> Kubernetes Dashboard is made possible by the Dashboard &lt;a href="https://github.com/kubernetes/dashboard/graphs/contributors"&gt;community&lt;/a&gt; as an &lt;a href="https://github.com/kubernetes/dashboard"&gt;open source project&lt;/a&gt;. </translation>
+  <translation id="4426231252111230009" key="MSG_ABOUT_ABOUT_6" desc="Dashbord moto on the about page, just below the header">General-Purpose Web UI for Kubernetes Clusters</translation>
   <translation id="6783150167357318030" key="MSG_ACTION_BAR_DELETE_TOOLTIP" desc="Generic &quot;Delete some resource&quot; tooltip text which appears over the delete icon on the global action bar.">删除<ph name="RESOURCE_NAME"/></translation>
   <translation id="1421031463694814701" key="MSG_ACTION_BAR_EDIT_TOOLTIP" desc="Generic &quot;Edit some resource&quot; tooltip text which appears over the edit icon on the global action bar.">编辑<ph name="RESOURCE_NAME"/></translation>
   <translation id="1024358167652076581" key="MSG_ALL_NAMESPACES" desc="Text for dropdown item that indicates that no namespace was selected">包括所有名字空间(All namespaces)</translation>
+  <translation id="6614117428496734699" key="MSG_BREADCRUMBS_ABOUT_LABEL" desc="Label 'About' that appears as a breadcrumbs on the action bar.">About</translation>
   <translation id="4466763630197200161" key="MSG_BREADCRUMBS_ADMIN_LABEL" desc="Label 'Admin' that appears as a breadcrumbs on the action bar.">管理(Admin)</translation>
+  <translation id="1153397682574555638" key="MSG_BREADCRUMBS_CLUSTER_LABEL" desc="Label 'Cluster' that appears as a breadcrumbs on the action bar.">Cluster</translation>
+  <translation id="5346529710805392125" key="MSG_BREADCRUMBS_CONFIG_AND_STORAGE_LABEL" desc="Label 'Config and storage' that appears as a breadcrumbs on the action bar.">Config and storage</translation>
   <translation id="954605561178153927" key="MSG_BREADCRUMBS_CONFIG_LABEL" desc="Label 'Config' that appears as a breadcrumbs on the action bar.">配置字典(Config)</translation>
   <translation id="3212328899649855136" key="MSG_BREADCRUMBS_CONFIG_MAPS_LABEL" desc="Label 'Config Maps' that appears as a breadcrumbs on the action bar.">配置式字典(Config Maps)</translation>
   <translation id="3217932097841975938" key="MSG_BREADCRUMBS_DAEMON_SETS_LABEL" desc="Label 'Daemon Sets' that appears as a breadcrumbs on the action bar.">守护式Pod集(Daemon Sets)</translation>
   <translation id="1744394420157932960" key="MSG_BREADCRUMBS_DEPLOYMENTS_LABEL" desc="Label 'Deployments' that appears as a breadcrumbs on the action bar.">部署(Deployments)</translation>
   <translation id="9213553703311647006" key="MSG_BREADCRUMBS_DEPLOY_APP_LABEL" desc="Breadcrum label for the deploy containerized app form view.">创建应用</translation>
   <translation id="3098067826555563293" key="MSG_BREADCRUMBS_DEPLOY_FILE_LABEL" desc="Breadcrum label for the YAML upload form">上传(Upload)</translation>
+  <translation id="8693076889249273053" key="MSG_BREADCRUMBS_DISCOVERY_AND_LOAD_BALANCING_LABEL" desc="Label 'Discovery and load balancing' that appears as a breadcrumbs on the action bar.">Discovery and load balancing</translation>
   <translation id="2248903848244811172" key="MSG_BREADCRUMBS_HORIZONTAL_POD_AUTOSCALERS_LABEL" desc="Label 'Horizontal Pod Autoscalers' that appears as a breadcrumbs on the action bar.">Pod水平自动伸缩</translation>
   <translation id="5747298115200147575" key="MSG_BREADCRUMBS_INGRESSS_LABEL" desc="Label 'Ingress' that appears as a breadcrumbs on the action bar.">入口地址(Ingress)</translation>
+  <translation id="8885204956315323333" key="MSG_BREADCRUMBS_INGRESSS_LABEL" desc="Label 'Ingresses' that appears as a breadcrumbs on the action bar.">Ingresses</translation>
   <translation id="2741276106482217695" key="MSG_BREADCRUMBS_INTERNALERROR_LABEL" desc="Label for internal error page for breadcrumbs on the action bar.">内部错误(Internal error)</translation>
   <translation id="2024511088483477440" key="MSG_BREADCRUMBS_JOBS_LABEL" desc="Label 'Jobs' that appears as a breadcrumbs on the action bar.">批量任务(Jobs)</translation>
   <translation id="1050029015813261838" key="MSG_BREADCRUMBS_LOGS_LABEL" desc="Breadcrum label for the logs view.">日志</translation>
@@ -22,32 +34,58 @@
   <translation id="64391241316684157" key="MSG_BREADCRUMBS_PODS_LABEL" desc="Label 'Pods' that appears as a breadcrumbs on the action bar.">容器组(Pods)</translation>
   <translation id="7569244915796303702" key="MSG_BREADCRUMBS_RC_LABEL" desc="Label 'Replication Controllers' that appears as a breadcrumbs on the action bar.">复制控制(Replication Controllers)</translation>
   <translation id="837518421741773666" key="MSG_BREADCRUMBS_REPLICA_SETS_LABEL" desc="Label 'Replica Sets' that appears as a breadcrumbs on the action bar.">复制集(Replica Sets)</translation>
+  <translation id="5794147661362074597" key="MSG_BREADCRUMBS_ROLES_LABEL" desc="Label 'Roles' that appears as a breadcrumbs on the action bar.">Roles</translation>
   <translation id="391192137756114804" key="MSG_BREADCRUMBS_SECRETS_LABEL" desc="Label 'Secrets' that appears as a breadcrumbs on the action bar.">保密式字典(Secrets)</translation>
   <translation id="5207082267245498149" key="MSG_BREADCRUMBS_SERVICES_AND_DISCOVERY_LABEL" desc="Label 'Services and discovery' that appears as a breadcrumbs on the action bar.">服务和发现(Services and discovery)</translation>
   <translation id="2218294864744563724" key="MSG_BREADCRUMBS_SERVICES_LABEL" desc="Label 'Services' that appears as a breadcrumbs on the action bar.">服务(Services)</translation>
   <translation id="7318741060898365517" key="MSG_BREADCRUMBS_STATEFUL_SETS_LABEL" desc="Label 'Stateful Sets' that appears as a breadcrumbs on the action bar.">有状态POD集(Stateful Sets)</translation>
+  <translation id="1427200251427963672" key="MSG_BREADCRUMBS_STORAGE_CLASSES_LABEL" desc="Label 'Storage Classes' that appears as a breadcrumbs on the action bar.">Storage Classes</translation>
+  <translation id="6132384114487014259" key="MSG_BREADCRUMBS_THIRD_PARTY_RESOURCES_LABEL" desc="Label 'Third Party Resources' that appears as a breadcrumbs on the action bar.">Third Party Resources</translation>
   <translation id="1656728804447365846" key="MSG_BREADCRUMBS_WORKLOADS_LABEL" desc="Label 'Workloads' that appears as a breadcrumbs on the action bar.">载荷(Workloads)</translation>
+  <translation id="5023828914132135944" key="MSG_CHROME_NAV_NAV_0" desc="Cluster group menu entry.">Cluster</translation>
   <translation id="9218333053624016665" key="MSG_CHROME_NAV_NAV_0" desc="Admin menu item in the nav.">管理(Admin)</translation>
   <translation id="6343362656986122693" key="MSG_CHROME_NAV_NAV_1" desc="Namespaces menu item in the nav.">名字空间(Namespaces)</translation>
+  <translation id="716443703088219571" key="MSG_CHROME_NAV_NAV_10" desc="Pods menu entry.">Pods</translation>
   <translation id="8628118612810849429" key="MSG_CHROME_NAV_NAV_10" desc="Jobs menu item in the nav.">批量任务(Jobs)</translation>
+  <translation id="5165405066720776929" key="MSG_CHROME_NAV_NAV_11" desc="Replica Sets entry.">Replica Sets</translation>
   <translation id="5330416203049826616" key="MSG_CHROME_NAV_NAV_11" desc="Pods menu item in the nav.">容器组(Pods)</translation>
+  <translation id="1368029980670062566" key="MSG_CHROME_NAV_NAV_12" desc="Replication Controllers menu entry.">Replication Controllers</translation>
   <translation id="2093749467777012107" key="MSG_CHROME_NAV_NAV_12" desc="Services and discovery menu item in the nav.">服务和发现(Services and discovery)</translation>
+  <translation id="727510939665067635" key="MSG_CHROME_NAV_NAV_13" desc="Stateful Sets menu entry.">Stateful Sets</translation>
   <translation id="7231060462716768345" key="MSG_CHROME_NAV_NAV_13" desc="Services menu item in the nav.">服务(Services)</translation>
+  <translation id="3750547428998043153" key="MSG_CHROME_NAV_NAV_14" desc="Discovery and Load Balancing group menu entry.">Discovery and Load Balancing</translation>
   <translation id="4709315173311947609" key="MSG_CHROME_NAV_NAV_14" desc="Ingress item in the nav.">入口地址(Ingress)</translation>
   <translation id="7847222014427123367" key="MSG_CHROME_NAV_NAV_14" desc="Ingresses item in the nav.">入口地址(Ingresses)</translation>
   <translation id="3039957839920471408" key="MSG_CHROME_NAV_NAV_15" desc="Storage item in the nav.">存储(Storage)</translation>
+  <translation id="5657472840568954752" key="MSG_CHROME_NAV_NAV_15" desc="Ingresses menu entry.">Ingresses</translation>
+  <translation id="6209183557961833624" key="MSG_CHROME_NAV_NAV_16" desc="Services menu entry.">Services</translation>
   <translation id="8015161624640032228" key="MSG_CHROME_NAV_NAV_16" desc="Persistent Volume Claims item in the nav.">持久性存储卷索取(Persistent Volume Claims)</translation>
   <translation id="6873247849362907014" key="MSG_CHROME_NAV_NAV_17" desc="Config item in the nav.">配置字典(Config)</translation>
+  <translation id="9193587195994732985" key="MSG_CHROME_NAV_NAV_17" desc="Config and Storage group menu entryv.">Config and Storage</translation>
+  <translation id="5112568842026217488" key="MSG_CHROME_NAV_NAV_18" desc="Config Maps menu entry.">Config Maps</translation>
   <translation id="7499906935876891155" key="MSG_CHROME_NAV_NAV_18" desc="Secrets item in the nav.">保密式字典(Secrets)</translation>
   <translation id="8736839163304985332" key="MSG_CHROME_NAV_NAV_19" desc="Config Maps item in the nav.">配置式字典(Config Maps)</translation>
+  <translation id="8817168805652183378" key="MSG_CHROME_NAV_NAV_19" desc="Persistent Volume Claims menu entry.">Persistent Volume Claims</translation>
   <translation id="1743316598408730775" key="MSG_CHROME_NAV_NAV_2" desc="Nodes menu item in the nav.">工作节点(Nodes)</translation>
+  <translation id="1040732924028857594" key="MSG_CHROME_NAV_NAV_20" desc="Secrets menu entry.">Secrets</translation>
+  <translation id="8368599117962865229" key="MSG_CHROME_NAV_NAV_21" desc="About page menu entry.">About</translation>
   <translation id="4957526140740745953" key="MSG_CHROME_NAV_NAV_3" desc="Persistent Volumes menu item in the nav.">持久性存储卷(Persistent Volumes)</translation>
   <translation id="4398523516847444868" key="MSG_CHROME_NAV_NAV_4" desc="Workloads menu item in the nav.">载荷(Workloads)</translation>
+  <translation id="8596594035523566698" key="MSG_CHROME_NAV_NAV_4" desc="Roles menu entry.">Roles</translation>
+  <translation id="874273813471860738" key="MSG_CHROME_NAV_NAV_5" desc="Storage Classes menu entry.">Storage Classes</translation>
   <translation id="6003139668988832289" key="MSG_CHROME_NAV_NAV_5" desc="Deployments menu item in the nav.">部署(Deployments)</translation>
+  <translation id="4285258567654567328" key="MSG_CHROME_NAV_NAV_6" desc="Workloads group menu entry.">Workloads</translation>
   <translation id="5274052053251499355" key="MSG_CHROME_NAV_NAV_6" desc="Replica Sets menu item in the nav.">复制集(Replica Sets)</translation>
   <translation id="723915224801093587" key="MSG_CHROME_NAV_NAV_7" desc="Replication Controllers menu item in the nav.">复制控制(Replication Controllers)</translation>
+  <translation id="5016929559748268107" key="MSG_CHROME_NAV_NAV_7" desc="Daemon Sets menu entry.">Daemon Sets</translation>
+  <translation id="3185730728792936775" key="MSG_CHROME_NAV_NAV_8" desc="Deployments menu entry.">Deployments</translation>
   <translation id="7243740857154177059" key="MSG_CHROME_NAV_NAV_8" desc="Daemon Sets menu item in the nav.">守护式Pod集(Daemon Sets)</translation>
+  <translation id="1017990697544914862" key="MSG_CHROME_NAV_NAV_9" desc="Jobs menu entry.">Jobs</translation>
   <translation id="2342408690900978106" key="MSG_CHROME_NAV_NAV_9" desc="Stateful Sets menu item in the nav.">有状态POD集(Stateful Sets)</translation>
+  <translation id="5512331139275482810" key="MSG_CHROME_NAV_THIRDPARTYRESOURCENAV_0" desc="Third Party Resources menu item in the nav.">Third Party Resources</translation>
+  <translation id="4777782265247414366" key="MSG_CLUSTER_CLUSTER_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU usage</translation>
+  <translation id="836326363584870134" key="MSG_CLUSTER_CLUSTER_1" desc="Title for graph card displaying memory metric of one all resources.">Memory usage</translation>
+  <translation id="6503182982225697463" key="MSG_CLUSTER_CLUSTER_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these resources. (Does not count pods double because it is mentioned both in the pod list and its controller is mentioned in e.g. a replica set.)</translation>
   <translation id="6660248664655766122" key="MSG_COMMON_COMPONENTS_ACTIONBAR_ACTIONBARDELETEITEM_0" desc="Action \'Delete\', which is a button on the actionbar and is there for every resource type.">删除</translation>
   <translation id="8227118065394270046" key="MSG_COMMON_COMPONENTS_ACTIONBAR_ACTIONBAREDITITEM_0" desc="Action \'Edit\' for the edit button on the global action bar.">编辑</translation>
   <translation id="6890205203402149061" key="MSG_COMMON_COMPONENTS_ACTIONBAR_ACTIONBARLISTBUTTONS_0" desc="Label for deploy app button.">部署应用</translation>
@@ -92,10 +130,12 @@
   <translation id="4882763297660106258" key="MSG_COMMON_RESOURCE_DELETERESOURCE_2" desc="Confirmation question, appears before any dashboard resource will be deleted.">确实要删除{{::$ctrl.resourceKindName}} &lt;i&gt;{{::$ctrl.objectMeta.name}}&lt;/i&gt;在名字空间&lt;i&gt;{{::$ctrl.objectMeta.namespace}}&lt;/i&gt;？</translation>
   <translation id="4128050333493885311" key="MSG_COMMON_RESOURCE_DELETERESOURCE_3" desc="Label for cancel button.">取消</translation>
   <translation id="896694419951320432" key="MSG_COMMON_RESOURCE_DELETERESOURCE_4" desc="Label for delete button.">删除</translation>
+  <translation id="4968436708987569734" key="MSG_COMMON_RESOURCE_DELETERESOURCE_5" desc="Confirmation question, appears before any dashboard resource will be deleted. (unnamespaced resources)">Are you sure you want to delete {{::$ctrl.resourceKindName}} &lt;i&gt;{{::$ctrl.objectMeta.name}}&lt;/i&gt;?</translation>
   <translation id="5788637878898196013" key="MSG_COMMON_RESOURCE_EDITRESOURCE_0" desc="Title for a delete resource dialog.">修改{{::$ctrl.resourceKindName}}</translation>
   <translation id="6030718757273830989" key="MSG_COMMON_RESOURCE_EDITRESOURCE_1" desc="Title for a delete resource dialog.">修改{{::$ctrl.resourceKindName}}</translation>
   <translation id="7280957759518658382" key="MSG_COMMON_RESOURCE_EDITRESOURCE_2" desc="Label for cancel button.">取消</translation>
   <translation id="874103626505058314" key="MSG_COMMON_RESOURCE_EDITRESOURCE_3" desc="Label for update button.">更新</translation>
+  <translation id="2484996950399771862" key="MSG_COMMON_RESOURCE_EDITRESOURCE_4" desc="Label for copy button.">Copy</translation>
   <translation id="5535184846025660010" key="MSG_CONFIGMAPDETAIL_ACTIONBAR_0" desc="Label \'Config Map\' which appears at the top of the\n      delete dialog, opened from a config map details page.">配置项字典(Config Map)</translation>
   <translation id="8136474798646965010" key="MSG_CONFIGMAPDETAIL_CONFIGMAPDETAIL_0" desc="Config map info details section name.">数据(Data)</translation>
   <translation id="1352871513810336119" key="MSG_CONFIGMAPDETAIL_CONFIGMAPINFO_0" desc="Config map info details section name.">详情(Details)</translation>
@@ -109,9 +149,24 @@
   <translation id="8188034795115917545" key="MSG_CONFIGMAPLIST_CONFIGMAPCARDLIST_4" desc="Config map list header: age.">生存(Age)</translation>
   <translation id="9099377478659685689" key="MSG_CONFIGMAPLIST_CONFIGMAPCARD_0" desc="Label \'Config Map\' which will appear in the config map\n      delete dialog opened from a config map card on the list page.">配置项字典(Config Map)</translation>
   <translation id="6007981365208604989" key="MSG_CONFIGMAPLIST_CONFIGMAPCARD_1" desc="Label \'Config Map\' which will appear in the config map\n      delete dialog opened from a config map card on the list page.">配置项字典(Config Map)</translation>
+  <translation id="2290466353199139171" key="MSG_CONFIGMAP_DETAIL_ACTIONBAR_0" desc="Label \'Config Map\' which appears at the top of the\n      delete dialog, opened from a config map details page.">Config Map</translation>
+  <translation id="1345195277871602727" key="MSG_CONFIGMAP_DETAIL_DETAIL_0" desc="Header in a detail view of config map deta">Data</translation>
+  <translation id="998665058731826460" key="MSG_CONFIGMAP_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="4380163225141081319" key="MSG_CONFIGMAP_DETAIL_INFO_1" desc="Config map info details section name entry.">Name</translation>
+  <translation id="6748979229650497011" key="MSG_CONFIGMAP_DETAIL_INFO_2" desc="Config map info details section namespace entry.">Namespace</translation>
+  <translation id="397339215031139526" key="MSG_CONFIGMAP_DETAIL_INFO_3" desc="Config map info details section labels entry.">Labels</translation>
+  <translation id="9090261468074115569" key="MSG_CONFIGMAP_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Config Maps</translation>
+  <translation id="5434719528055235183" key="MSG_CONFIGMAP_LIST_CARDLIST_1" desc="Config map list header: name.">Name</translation>
+  <translation id="4172472290353802354" key="MSG_CONFIGMAP_LIST_CARDLIST_2" desc="Config map list header: namespace.">Namespace</translation>
+  <translation id="2010918488451009803" key="MSG_CONFIGMAP_LIST_CARDLIST_3" desc="Config map list header: labels.">Labels</translation>
+  <translation id="5490277101487527964" key="MSG_CONFIGMAP_LIST_CARDLIST_4" desc="Config map list header: age.">Age</translation>
+  <translation id="5461266186409477738" key="MSG_CONFIGMAP_LIST_CARDLIST_5" desc="Text for config map card list zerostate.">There are no Config Maps to display.</translation>
+  <translation id="6220776078337852001" key="MSG_CONFIGMAP_LIST_CARD_0" desc="Label \'Config Map\' which will appear in the config map\n      delete dialog opened from a config map card on the list page.">Config Map</translation>
+  <translation id="1762365164654423553" key="MSG_CONFIGMAP_LIST_CARD_1" desc="Label \'Config Map\' which will appear in the config map\n      delete dialog opened from a config map card on the list page.">Config Map</translation>
   <translation id="8072030721088093841" key="MSG_CONFIG_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; on a dialog.">关闭</translation>
   <translation id="6503474189903659041" key="MSG_CONFIG_DIALOG_TITLE" desc="Label for the kubectl.kubernetes.io/last-applied-configuration annotation.">当前有效配置</translation>
   <translation id="9181886817358182792" key="MSG_CONFIG_MAP_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of config map.">创建于<ph name="CREATION_DATE"/></translation>
+  <translation id="6508331633234837511" key="MSG_COPIED_TOAST" desc="Toast message appears when copied to clipboard.">Copied to clipboard</translation>
   <translation id="1503342925011598787" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU使用</translation>
   <translation id="2835520423599206338" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">内存使用</translation>
   <translation id="7319143768148352243" key="MSG_DAEMONSETDETAIL_DAEMONSETDETAIL_2" desc="Title for services card zerostate in daemon set details page.">无内容显示</translation>
@@ -149,6 +204,42 @@
   <translation id="5303615337793440206" key="MSG_DAEMONSETLIST_DAEMONSETLIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU使用</translation>
   <translation id="140376028532845180" key="MSG_DAEMONSETLIST_DAEMONSETLIST_1" desc="Title for graph card displaying memory metric of daemon sets.">内存使用</translation>
   <translation id="7975175396227169314" key="MSG_DAEMONSETLIST_DAEMONSETLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these daemon sets.</translation>
+  <translation id="3159284180115253445" key="MSG_DAEMONSET_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one daemon set.">CPU usage</translation>
+  <translation id="3656189643804804472" key="MSG_DAEMONSET_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one daemon set.">Memory usage</translation>
+  <translation id="2830742900079405655" key="MSG_DAEMONSET_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this daemon set.</translation>
+  <translation id="5813652713612060929" key="MSG_DAEMONSET_DETAIL_DETAIL_4" desc="Text for services card zerostate in daemon set details page.">There are currently no Services with the same label selector as this Daemon Set.</translation>
+  <translation id="2603922476358928027" key="MSG_DAEMONSET_DETAIL_DETAIL_6" desc="Text for pods card zerostate in daemon set details page.">There are currently no Pods scheduled on this Daemon Set.</translation>
+  <translation id="4390902408757290154" key="MSG_DAEMONSET_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="4420147250432171295" key="MSG_DAEMONSET_DETAIL_INFO_1" desc="Label \'Name\' for the daemon set name on the details page.">Name</translation>
+  <translation id="6360476314472751831" key="MSG_DAEMONSET_DETAIL_INFO_10" desc="Label \'Pods status\' for the status of the pods in a daemon set, on the daemon set details page.">Pods status</translation>
+  <translation id="3771546490015192323" key="MSG_DAEMONSET_DETAIL_INFO_11" desc="The message says how many pods are pending (daemon set details page).">{{::$ctrl.daemonSet.podInfo.pending}} pending</translation>
+  <translation id="6989004320544423836" key="MSG_DAEMONSET_DETAIL_INFO_12" desc="The message says how many pods have failed (daemon set details page).">{{::$ctrl.daemonSet.podInfo.failed}} failed</translation>
+  <translation id="7121920513850122580" key="MSG_DAEMONSET_DETAIL_INFO_13" desc="The message describes how many pods are running (daemon set details page).">{{::$ctrl.daemonSet.podInfo.running}} running</translation>
+  <translation id="1915762576763304293" key="MSG_DAEMONSET_DETAIL_INFO_2" desc="Label \'Namespace\' for the daemon set namespace on the details page">Namespace</translation>
+  <translation id="3087018613949976492" key="MSG_DAEMONSET_DETAIL_INFO_3" desc="Label \'Labels\' for the daemon set\'s labels list on the daemon set details page.">Labels</translation>
+  <translation id="5529663386929562771" key="MSG_DAEMONSET_DETAIL_INFO_4" desc="Label \'Images\' for the list of images used in a daemon set, on its details page.">Images</translation>
+  <translation id="8207927853231587262" key="MSG_DAEMONSET_DETAIL_INFO_5" desc="Subtitle \'Status\' for the right section with pod status information on the daemon set details page.">Status</translation>
+  <translation id="3195556158142781226" key="MSG_DAEMONSET_DETAIL_INFO_6" desc="Label \'Pods\' for the pods in a daemon set on its details page.">Pods</translation>
+  <translation id="1832136994003570020" key="MSG_DAEMONSET_DETAIL_INFO_7" desc="The message describes how many pods were created (daemon set details page).">{{::$ctrl.daemonSet.podInfo.current}} created</translation>
+  <translation id="5651976668507530367" key="MSG_DAEMONSET_DETAIL_INFO_8" desc="The message describes how many pods are desired to run (daemon set details page).">{{::$ctrl.daemonSet.podInfo.desired}} desired</translation>
+  <translation id="5550367961828357134" key="MSG_DAEMONSET_DETAIL_INFO_9" desc="The message describes how many pods are running (daemon set details page).">{{::$ctrl.daemonSet.podInfo.running}} running</translation>
+  <translation id="5631725742223773299" key="MSG_DAEMONSET_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Daemon Sets</translation>
+  <translation id="3304895041101053745" key="MSG_DAEMONSET_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of daemon sets (daemon set list view).">Name</translation>
+  <translation id="7715674186436282027" key="MSG_DAEMONSET_LIST_CARDLIST_2" desc="Column header \'Kind\' on Daemon Set lists">Kind</translation>
+  <translation id="1198220912632063457" key="MSG_DAEMONSET_LIST_CARDLIST_3" desc="Label \'Namespace\' which appears as a column label in the table of daemon sets (daemon set list view).">Namespace</translation>
+  <translation id="4316139792239592855" key="MSG_DAEMONSET_LIST_CARDLIST_4" desc="Label \'Labels\' which appears as a column label in the table of daemon sets (daemon set list view).">Labels</translation>
+  <translation id="315233313099478215" key="MSG_DAEMONSET_LIST_CARDLIST_5" desc="Label \'Pods\' which appears as a column label in the table of daemon sets (daemon set list view).">Pods</translation>
+  <translation id="5238998686445297660" key="MSG_DAEMONSET_LIST_CARDLIST_6" desc="Label \'Age\' which appears as a column label in the table of daemon sets (daemon set list view).">Age</translation>
+  <translation id="2598397233464322530" key="MSG_DAEMONSET_LIST_CARDLIST_7" desc="Label \'Images\' which appears as a column label in the table of daemon sets (daemon set list view).">Images</translation>
+  <translation id="4980932810318302398" key="MSG_DAEMONSET_LIST_CARDLIST_8" desc="Text for daemon set card list zerostate.">There are no Daemon Sets to display.</translation>
+  <translation id="6325130526007284501" key="MSG_DAEMONSET_LIST_CARD_0" desc="Tooltip for failed pod card icon.">One or more pods have errors.</translation>
+  <translation id="7994511127932765314" key="MSG_DAEMONSET_LIST_CARD_1" desc="Tooltip for pending pod card icon.">One or more pods are in pending state.</translation>
+  <translation id="141161203909207679" key="MSG_DAEMONSET_LIST_CARD_2" desc="Column \'Daemon Set\' in a Daemon Set List">Daemon Set</translation>
+  <translation id="422238456212619456" key="MSG_DAEMONSET_LIST_CARD_3" desc="Title \'Daemon Set\' which is used as a title for the delete/update\n   dialogs (that can be opened on the daemon set list view).">Daemon Set</translation>
+  <translation id="583742092710968694" key="MSG_DAEMONSET_LIST_CARD_4" desc="Title \'Daemon Set\' which is used as a title for the delete/update\n   dialogs (that can be opened on the daemon set list view).">Daemon Set</translation>
+  <translation id="7320728056398668491" key="MSG_DAEMONSET_LIST_LIST_0" desc="Title for graph card displaying CPU metric of daemon sets.">CPU usage</translation>
+  <translation id="8788831308012182190" key="MSG_DAEMONSET_LIST_LIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage</translation>
+  <translation id="2452514894533620787" key="MSG_DAEMONSET_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these daemon sets.</translation>
   <translation id="1183334493862832095" key="MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the daemon set.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="4053635060615677386" key="MSG_DEPLOYMENTDETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">部署(Deployment)</translation>
   <translation id="1190053946078776500" key="MSG_DEPLOYMENTDETAIL_DEPLOYMENTDETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU使用</translation>
@@ -193,7 +284,48 @@
   <translation id="3596671845051866336" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU使用</translation>
   <translation id="6520027878530985690" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_1" desc="Title for graph card displaying memory metric of deployments.">内存使用</translation>
   <translation id="5720117868467044726" key="MSG_DEPLOYMENTLIST_DEPLOYMENTLIST_2" desc="Help message detailing what is included in the memory usage">内存使用上包括Deployment下Pod的缓存。</translation>
+  <translation id="8731452969115857295" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
+  <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
+  <translation id="8453931805104629005" key="MSG_DEPLOYMENT_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one deployment.">Memory usage</translation>
+  <translation id="620255252783687720" key="MSG_DEPLOYMENT_DETAIL_DETAIL_10" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Deployment.</translation>
+  <translation id="7206451673196119468" key="MSG_DEPLOYMENT_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this deployment.</translation>
+  <translation id="4293182903162394917" key="MSG_DEPLOYMENT_DETAIL_DETAIL_3" desc="Title \'New Replica Set\' for the newly created replica set view, on the deployment details page.">New Replica Set</translation>
+  <translation id="5406429395386793842" key="MSG_DEPLOYMENT_DETAIL_DETAIL_5" desc="Text for new replica sets card zero-state in deployment details page.">There are currently no new Replica Sets on this Deployment.</translation>
+  <translation id="1547411698211271610" key="MSG_DEPLOYMENT_DETAIL_DETAIL_6" desc="Title \'Old Replica Sets\' for the old replica sets view, on the deployment details page.">Old Replica Sets</translation>
+  <translation id="7774850522073185051" key="MSG_DEPLOYMENT_DETAIL_DETAIL_8" desc="Text for old replica sets card zero-state in deployment details page.">This Deployment does not have any old replica sets</translation>
+  <translation id="6611756545608338379" key="MSG_DEPLOYMENT_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="6535447767822430239" key="MSG_DEPLOYMENT_DETAIL_INFO_1" desc="Label \'Name\' for the deployment name on the deployment details page.">Name</translation>
+  <translation id="4052405407765242541" key="MSG_DEPLOYMENT_DETAIL_INFO_10" desc="The message says how many replicas can be created above the desired number of replicas in a deployment (deployment details page).">Max surge: {{ $ctrl.deployment.rollingUpdateStrategy.maxSurge}}</translation>
+  <translation id="978278245821528339" key="MSG_DEPLOYMENT_DETAIL_INFO_11" desc="The message says how many replicas are allowed to be unavailable during an update in the deployment (deployment details page).">Max unavailable: {{ $ctrl.deployment.rollingUpdateStrategy.maxUnavailable}}</translation>
+  <translation id="1006526299552096694" key="MSG_DEPLOYMENT_DETAIL_INFO_12" desc="Label \'Status\' for the deployment\'s status information on the deployment details page.">Status</translation>
+  <translation id="4141792758328458887" key="MSG_DEPLOYMENT_DETAIL_INFO_13" desc="The message describes how many replicas were updated in the deployment (deployment details page).">{{ $ctrl.deployment.statusInfo.updated}} updated</translation>
+  <translation id="2896056679280503985" key="MSG_DEPLOYMENT_DETAIL_INFO_14" desc="The message describes how many replicas (in total) are in the deployment (deployment details page).">{{ $ctrl.deployment.statusInfo.replicas}} total</translation>
+  <translation id="1768519246344146437" key="MSG_DEPLOYMENT_DETAIL_INFO_15" desc="The message describes how many replicas are available in the deployment (deployment details page).">{{ $ctrl.deployment.statusInfo.available}} available</translation>
+  <translation id="3113137197415192324" key="MSG_DEPLOYMENT_DETAIL_INFO_16" desc="The message says how many replicas are unavailable in the deployment (deployment details page).">{{ $ctrl.deployment.statusInfo.unavailable}} unavailable</translation>
+  <translation id="638037533109128765" key="MSG_DEPLOYMENT_DETAIL_INFO_2" desc="Label \'Namespace\' for the deployment namespace on the deployment details page.">Namespace</translation>
+  <translation id="5010967792828441755" key="MSG_DEPLOYMENT_DETAIL_INFO_3" desc="Label \'Labels\' for the deployment\'s labels list on the deployment details page.">Labels</translation>
+  <translation id="4852965799360700062" key="MSG_DEPLOYMENT_DETAIL_INFO_4" desc="Label \'Selector\' for the deployment\'s labels list on the deployment details page.">Selector</translation>
+  <translation id="7842815268569286123" key="MSG_DEPLOYMENT_DETAIL_INFO_5" desc="Label \'Min Ready Seconds\' for the deployment on the deployment details page.">Strategy</translation>
+  <translation id="120947107266620923" key="MSG_DEPLOYMENT_DETAIL_INFO_6" desc="Label \'Min Ready Seconds\' for the deployment on the deployment details page.">Min ready seconds</translation>
+  <translation id="2320949909785930806" key="MSG_DEPLOYMENT_DETAIL_INFO_7" desc="Label \'Revision history limit\' for the deployment property on the deployment details page.">Revision history limit</translation>
+  <translation id="4394284536277128064" key="MSG_DEPLOYMENT_DETAIL_INFO_8" desc="Label for the when revision history limit is not set.">Not set</translation>
+  <translation id="8285539345236486139" key="MSG_DEPLOYMENT_DETAIL_INFO_9" desc="Label \'Rolling Update Strategy\' for the deployment\'s rolling update strategy on the deployment details page.">Rolling update strategy</translation>
+  <translation id="6649720579304216997" key="MSG_DEPLOYMENT_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Deployments</translation>
+  <translation id="4397343821685483589" key="MSG_DEPLOYMENT_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of deployments (deployment list view).">Name</translation>
+  <translation id="6493674795356876555" key="MSG_DEPLOYMENT_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of deployments (deployment list view).">Namespace</translation>
+  <translation id="4423617422088109346" key="MSG_DEPLOYMENT_LIST_CARDLIST_3" desc="Label \'Labels\' which appears as a column label in the table of deployments (deployment list view).">Labels</translation>
+  <translation id="7758788285438806394" key="MSG_DEPLOYMENT_LIST_CARDLIST_4" desc="Label \'Pods\' which appears as a column label in the table of deployments (deployment list view).">Pods</translation>
+  <translation id="7541857931830669966" key="MSG_DEPLOYMENT_LIST_CARDLIST_5" desc="Label \'Age\' which appears as a column label in the table of deployments (deployment list view).">Age</translation>
+  <translation id="3825241451049418242" key="MSG_DEPLOYMENT_LIST_CARDLIST_6" desc="Label \'Images\' which appears as a column label in the table of deployments (deployment list view).">Images</translation>
+  <translation id="2954809258563901091" key="MSG_DEPLOYMENT_LIST_CARDLIST_7" desc="Text for deployment card list zerostate.">There are no Deployment to display.</translation>
+  <translation id="2943455083749849727" key="MSG_DEPLOYMENT_LIST_CARD_0" desc="Tooltip saying that some pods in a deployment have errors.">One or more pods have errors</translation>
+  <translation id="5603340787019545076" key="MSG_DEPLOYMENT_LIST_CARD_1" desc="Tooltip saying that some pods in a deployment are pending.">One or more pods are in pending state</translation>
+  <translation id="5335487391687545375" key="MSG_DEPLOYMENT_LIST_CARD_2" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
+  <translation id="5009335850870865346" key="MSG_DEPLOYMENT_LIST_CARD_3" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from a deployment card on the list page.">Deployment</translation>
   <translation id="8652993905127268587" key="MSG_DEPLOYMENT_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of a deployment.">创建于<ph name="CREATION_DATE"/></translation>
+  <translation id="7895969081606283904" key="MSG_DEPLOYMENT_LIST_LIST_0" desc="Title for graph card displaying CPU metric of deployments.">CPU usage</translation>
+  <translation id="3670753449040819695" key="MSG_DEPLOYMENT_LIST_LIST_1" desc="Title for graph card displaying memory metric of deployments.">Memory usage</translation>
+  <translation id="5284074846571684536" key="MSG_DEPLOYMENT_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these deployments.</translation>
   <translation id="8097230988371724477" key="MSG_DEPLOY_ANYWAY_DIALOG_CANCEL" desc="Cancellation text for the dialog shown on deploy validation error.">否</translation>
   <translation id="7984990840791623021" key="MSG_DEPLOY_ANYWAY_DIALOG_CONTENT" desc="Content for the dialog shown on deploy validation error.">你现在要部署吗？</translation>
   <translation id="4208506908994292909" key="MSG_DEPLOY_ANYWAY_DIALOG_OK" desc="Confirmation text for the dialog shown on deploy validation error.">是</translation>
@@ -313,6 +445,14 @@
   <translation id="7320935166128929457" key="MSG_ERROR_UKNOWN_WARNING" desc="This message appears in an error dialog when the returned error code is not recognized.">未知的服务错误(Unknown Server Error)</translation>
   <translation id="7527074982331141078" key="MSG_EVENTS_ALL_LABEL" desc="Label 'All' for the event selection drop-down.">全部</translation>
   <translation id="9183905402242013542" key="MSG_EVENTS_CARD" desc="Label for the events card.">事件</translation>
+  <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">Events</translation>
+  <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">Message</translation>
+  <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">Source</translation>
+  <translation id="4598322482281808115" key="MSG_EVENTS_CARDLIST_3" desc="Label \'Sub-object\' for the respective column of the events table (events list page).">Sub-object</translation>
+  <translation id="4243993147460207456" key="MSG_EVENTS_CARDLIST_4" desc="Label \'Count\' for event count column of the events table (events list page).">Count</translation>
+  <translation id="2318056046996927961" key="MSG_EVENTS_CARDLIST_5" desc="Label \'First seen\' for the respective column of the events table (events list page).">First seen</translation>
+  <translation id="8546806166673222480" key="MSG_EVENTS_CARDLIST_6" desc="Label \'Last seen\' for the respective column of the events table (events list page).">Last seen</translation>
+  <translation id="8384910280515978185" key="MSG_EVENTS_CARDLIST_8" desc="User help on the events page when no events are to be displayed.">It is possible that all events have expired.</translation>
   <translation id="6413199566846581831" key="MSG_EVENTS_COUNT_LABEL" desc="Label 'Count' for event count column of the events table (events list page).">数量</translation>
   <translation id="4179338997362096957" key="MSG_EVENTS_EVENTCARDLIST_0" desc="Label for the events card.">事件</translation>
   <translation id="4179338997362096957" key="MSG_EVENTS_EVENTCARDLIST_0" desc="Label which appears above the list of such objects.">事件</translation>
@@ -360,6 +500,33 @@
   <translation id="4151977615417356292" key="MSG_HORIZONTALPODAUTOSCALERLIST_HORIZONTALPODAUTOSCALERCARD_3" desc="Show the current CPU utilization percentage of a the pods of the targetted resource of a HPA">{{::$ctrl.horizontalPodAutoscaler.currentCPUUtilizationPercentage}}%</translation>
   <translation id="3565335137919292331" key="MSG_HORIZONTALPODAUTOSCALERLIST_HORIZONTALPODAUTOSCALERLIST_0" desc="Title for graph card displaying CPU metric of horizontal pod autoscalers.">CPU usage history</translation>
   <translation id="5614176435246042613" key="MSG_HORIZONTALPODAUTOSCALERLIST_HORIZONTALPODAUTOSCALERLIST_1" desc="Title for graph card displaying memory metric of horizontal pod autoscalers.">Memory usage history</translation>
+  <translation id="3116131023784654870" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_ACTIONBAR_0" desc="Label \'Horizontal Pod Autoscaler\' which appears at the top of the delete dialog, opened from a horizontal pod autoscaler details page.">Horizontal Pod Autoscaler</translation>
+  <translation id="4234217286162701029" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_0" desc="Horizontal pod autoscaler info details section name.">Details</translation>
+  <translation id="8852238167226878780" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_1" desc="Horizontal pod autoscaler info details section target entry.">Target</translation>
+  <translation id="3801305643617716507" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_10" desc="Show the current CPU utilization percentage of a the pods of the targetted resource of a HPA">{{::$ctrl.horizontalPodAutoscaler.currentCPUUtilizationPercentage}}%</translation>
+  <translation id="497992149326036535" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_11" desc="Horizontal pod autoscaler info status section lastScaleTime entry.">Last Scaled</translation>
+  <translation id="8730855784576965122" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_2" desc="Horizontal pod autoscaler info details section minReplicas entry.">Min Replicas</translation>
+  <translation id="3022079345770588418" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_3" desc="Horizontal pod autoscaler info details section maxReplicas entry.">Max Replicas</translation>
+  <translation id="4199855790520636602" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_4" desc="Horizontal pod autoscaler info details section targetCPUUtilizationPercentage entry.">Target CPU Utilization</translation>
+  <translation id="8718543337819526846" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_5" desc="Show the target CPU utilization percentage of a the pods of the targetted resource of a HPA">{{::$ctrl.horizontalPodAutoscaler.targetCPUUtilizationPercentage}}%</translation>
+  <translation id="8954426675014032405" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_6" desc="Horizontal pod autoscaler info status section">Status</translation>
+  <translation id="3808910683344466681" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_7" desc="Horizontal pod autoscaler info status section currentReplicas entry.">Current Replicas</translation>
+  <translation id="564448650580373807" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_8" desc="Horizontal pod autoscaler info status section desiredReplicas entry.">Desired Replicas</translation>
+  <translation id="3389156809898904124" key="MSG_HORIZONTALPODAUTOSCALER_DETAIL_INFO_9" desc="Horizontal pod autoscaler info status section currentCPUUtilizationPercentage entry.">Current CPU Utilization</translation>
+  <translation id="2401546852640381854" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Horizontal Pod Autoscalers</translation>
+  <translation id="6229449628982316627" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Name</translation>
+  <translation id="2615165549137360373" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Namespace</translation>
+  <translation id="2649209286132146798" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_3" desc="Column header \'Target\' on Horizontal Pod Autoscaler lists">Target</translation>
+  <translation id="6390261292837099398" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_4" desc="Label \'Target CPU Utilization\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Target CPU Utilization</translation>
+  <translation id="1138380808295885535" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_5" desc="Label \'Current CPU Utilization\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Current CPU Utilization</translation>
+  <translation id="2631385607889091074" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_6" desc="Label \'Min Replicas\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Min Replicas</translation>
+  <translation id="8088373128320107261" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_7" desc="Label \'Max Replicas\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Max Replicas</translation>
+  <translation id="4787729230562636049" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_8" desc="Label \'Age\' which appears as a column label in the table of horizontal pod autoscalers (horizontal pod autoscaler list view).">Age</translation>
+  <translation id="1108386405397731039" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARDLIST_9" desc="Text for horizontal pod autoscaler card list zerostate.">There are no Horizontal Pod Autoscalers to display.</translation>
+  <translation id="7169021054679689074" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARD_0" desc="Show the target CPU utilization percentage of a the pods of the targetted resource of a HPA">{{::$ctrl.horizontalPodAutoscaler.targetCPUUtilizationPercentage}}%</translation>
+  <translation id="2749124983305767530" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARD_1" desc="Show the current CPU utilization percentage of a the pods of the targetted resource of a HPA">{{::$ctrl.horizontalPodAutoscaler.currentCPUUtilizationPercentage}}%</translation>
+  <translation id="8805456014928287136" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARD_2" desc="Title \'Horizontal Pod Autoscaler\' which is used as a title for the delete/update\n   dialogs (that can be opened on the horizontal pod autoscaler list view).">Horizontal Pod Autoscaler</translation>
+  <translation id="8880232300868913858" key="MSG_HORIZONTALPODAUTOSCALER_LIST_CARD_3" desc="Title \'Horizontal Pod Autoscaler\' which is used as a title for the delete/update\n   dialogs (that can be opened on the horizontal pod autoscaler list view).">Horizontal Pod Autoscaler</translation>
   <translation id="6040027076420887056" key="MSG_HORIZONTAL_POD_AUTOSCALER_DETAIL_LAST_SCALED_TOOLTIP" desc="Tooltip 'Last scaled at [some date]' showing the exact time of the last time the horizontal pod autoscaler was scaled.">Last scaled at <ph name="SCALE_DATE"/></translation>
   <translation id="9182587734524448852" key="MSG_HORIZONTAL_POD_AUTOSCALER_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the horizontal pod autoscaler.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="919509716730095946" key="MSG_IMAGE_PULL_SECRET_CANCEL_ACTION" desc="The text is put on the 'Cancel' button in the image pull secret creation dialog.">取消</translation>
@@ -387,6 +554,18 @@
   <translation id="1103411838151096703" key="MSG_INGRESSLIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of ingresses (ingress list view).">名字空间(Namespace)</translation>
   <translation id="6970100075274497061" key="MSG_INGRESSLIST_CARDLIST_3" desc="Label \'endpoints\' which appears as a column label in the table of ingresses (ingress list view).">Endpoints</translation>
   <translation id="8202258406797150740" key="MSG_INGRESSLIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">生存(Age)</translation>
+  <translation id="8095485922114238358" key="MSG_INGRESS_DETAIL_ACTIONBAR_0" desc="Label \'Ingress\' which appears at the top of the delete dialog, opened from an ingress details page.">Ingress</translation>
+  <translation id="7647290016989598143" key="MSG_INGRESS_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="6047464944743303851" key="MSG_INGRESS_DETAIL_INFO_1" desc="Resource info details section name entry.">Name</translation>
+  <translation id="5740003858384112864" key="MSG_INGRESS_DETAIL_INFO_2" desc="Resource info details section namespace entry.">Namespace</translation>
+  <translation id="5275379574716211763" key="MSG_INGRESS_DETAIL_INFO_3" desc="Resource info details section labels entry.">Labels</translation>
+  <translation id="7691713819120999107" key="MSG_INGRESS_DETAIL_INFO_4" desc="Resource info details section annotations entry.">Annotations</translation>
+  <translation id="1439690942149691720" key="MSG_INGRESS_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Ingresses</translation>
+  <translation id="4939251984111923775" key="MSG_INGRESS_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of ingresses (ingress list view).">Name</translation>
+  <translation id="2888039058521136770" key="MSG_INGRESS_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of ingresses (ingress list view).">Namespace</translation>
+  <translation id="6177082876544143675" key="MSG_INGRESS_LIST_CARDLIST_3" desc="Label \'endpoints\' which appears as a column label in the table of ingresses (ingress list view).">Endpoints</translation>
+  <translation id="5470067088066957568" key="MSG_INGRESS_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
+  <translation id="6006534028215971090" key="MSG_INGRESS_LIST_CARDLIST_5" desc="Text for ingress card list zerostate.">There are no Ingresses to display.</translation>
   <translation id="6014322650743882966" key="MSG_INGRESS_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the ingress.">创建于<ph name="START_DATE"/> UTC</translation>
   <translation id="6315518507776012285" key="MSG_JOBDETAIL_ACTIONBAR_0" desc="Label \'Job\' which appears at the top of the dialog, opened from a job details page.">Job</translation>
   <translation id="3137266053437967990" key="MSG_JOBDETAIL_JOBDETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU使用</translation>
@@ -419,6 +598,37 @@
   <translation id="357262544660295674" key="MSG_JOBLIST_JOBLIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU使用</translation>
   <translation id="6787661994791732767" key="MSG_JOBLIST_JOBLIST_1" desc="Title for graph card displaying memory metric of jobs.">内存使用</translation>
   <translation id="8660427171549456209" key="MSG_JOBLIST_JOBLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these jobs.</translation>
+  <translation id="3490469769225638472" key="MSG_JOB_DETAIL_ACTIONBAR_0" desc="Label \'Job\' which appears at the top of the dialog, opened from a job details page.">Job</translation>
+  <translation id="9158321222252952956" key="MSG_JOB_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one job.">CPU usage</translation>
+  <translation id="5829638785096512195" key="MSG_JOB_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one job.">Memory usage</translation>
+  <translation id="91452791679953853" key="MSG_JOB_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this job.</translation>
+  <translation id="4839874577559134292" key="MSG_JOB_DETAIL_DETAIL_4" desc="Text for pods card zerostate in job details page.">There are currently no Pods managed by this Job.</translation>
+  <translation id="6354233284482895196" key="MSG_JOB_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="4213335429121543625" key="MSG_JOB_DETAIL_INFO_1" desc="Details section header. Appears below main header.">Details</translation>
+  <translation id="359304148729162860" key="MSG_JOB_DETAIL_INFO_10" desc="Status of active pods. Appears next to number of active pods.">active</translation>
+  <translation id="7527180372211997328" key="MSG_JOB_DETAIL_INFO_11" desc="Status of succeeded pods. Appears next to number of succeeded pods.">succeeded</translation>
+  <translation id="8898056515542811638" key="MSG_JOB_DETAIL_INFO_12" desc="Status of failed pods. Appears next to number of failed pods.">failed</translation>
+  <translation id="3440502962034639890" key="MSG_JOB_DETAIL_INFO_2" desc="Job name. Appears in details section.">Name</translation>
+  <translation id="7757613850626055375" key="MSG_JOB_DETAIL_INFO_3" desc="Job namespace. Appears in details section.">Namespace</translation>
+  <translation id="3677864800975797430" key="MSG_JOB_DETAIL_INFO_4" desc="Job labels. Appears in details section.">Labels</translation>
+  <translation id="4960487631004379061" key="MSG_JOB_DETAIL_INFO_5" desc="Job images. Appears in details section.">Images</translation>
+  <translation id="7440600544272586624" key="MSG_JOB_DETAIL_INFO_6" desc="Job completions. Appears in details section.">Completions</translation>
+  <translation id="3932529820663589356" key="MSG_JOB_DETAIL_INFO_7" desc="Job parallelism. Appears in details section.">Parallelism</translation>
+  <translation id="5087019331139352594" key="MSG_JOB_DETAIL_INFO_8" desc="Job status. Appears in details section.">Status</translation>
+  <translation id="7217243907189605640" key="MSG_JOB_DETAIL_INFO_9" desc="Pod status section header. Appears below main header.">Pods</translation>
+  <translation id="8899423721882867038" key="MSG_JOB_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Jobs</translation>
+  <translation id="2221793663625201923" key="MSG_JOB_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of jobs (Job list view).">Name</translation>
+  <translation id="9149766952814193905" key="MSG_JOB_LIST_CARDLIST_2" desc="Column header \'Kind\' on a job list table">Kind</translation>
+  <translation id="8590813179543551101" key="MSG_JOB_LIST_CARDLIST_3" desc="Label \'Namespace\' which appears as a column label in the table of replication controllers (Job list view).">Namespace</translation>
+  <translation id="7500297282568394709" key="MSG_JOB_LIST_CARDLIST_4" desc="Label \'Labels\' which appears as a column label in the table of replication controllers (Job list view).">Labels</translation>
+  <translation id="8618481285106862901" key="MSG_JOB_LIST_CARDLIST_5" desc="Label \'Pods\' which appears as a column label in the table of replication controllers (Job list view).">Pods</translation>
+  <translation id="2422035758692427914" key="MSG_JOB_LIST_CARDLIST_6" desc="Label \'Age\' which appears as a column label in the table of replication controllers (Job list view).">Age</translation>
+  <translation id="8162859503142023792" key="MSG_JOB_LIST_CARDLIST_7" desc="Label \'Images\' which appears as a column label in the table of replication controllers (Job list view).">Images</translation>
+  <translation id="3716747253637312807" key="MSG_JOB_LIST_CARDLIST_8" desc="Text for job card list zerostate.">There are no Jobs to display.</translation>
+  <translation id="122753681203495181" key="MSG_JOB_LIST_CARD_0" desc="Column \'Job\' that shows if the resource kind should be shown in a Job List">Job</translation>
+  <translation id="3055363125961915665" key="MSG_JOB_LIST_LIST_0" desc="Title for graph card displaying CPU metric of jobs.">CPU usage</translation>
+  <translation id="5794425570699478727" key="MSG_JOB_LIST_LIST_1" desc="Title for graph card displaying memory metric of jobs.">Memory usage</translation>
+  <translation id="6300164314930034252" key="MSG_JOB_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these jobs.</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">日志来自</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">在</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">日志来自</translation>
@@ -431,6 +641,14 @@
   <translation id="5732001205743518035" key="MSG_NAMESPACELIST_NAMESPACECARDLIST_2" desc="Label \'Labels\' which appears as a column label in the table of namespaces (namespace list view).">标签(Labels)</translation>
   <translation id="6617082814971547346" key="MSG_NAMESPACELIST_NAMESPACECARDLIST_3" desc="Label \'Status\' which appears as a column label in the table of namespaces (namespace list view).">状态(Status)</translation>
   <translation id="2470377857712331671" key="MSG_NAMESPACELIST_NAMESPACECARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of namespaces (namespace list view).">生存(Age)</translation>
+  <translation id="8066049814492652432" key="MSG_NAMESPACE_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="6352041840775187168" key="MSG_NAMESPACE_DETAIL_INFO_1" desc="Label \'Status\' for the namespace namespace on the namespace details page.">Status</translation>
+  <translation id="2794451768196559104" key="MSG_NAMESPACE_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Namespaces</translation>
+  <translation id="5403498579453928243" key="MSG_NAMESPACE_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of namespaces (namespace list view).">Name</translation>
+  <translation id="1576456781675309581" key="MSG_NAMESPACE_LIST_CARDLIST_2" desc="Label \'Labels\' which appears as a column label in the table of namespaces (namespace list view).">Labels</translation>
+  <translation id="3598200911441557553" key="MSG_NAMESPACE_LIST_CARDLIST_3" desc="Label \'Status\' which appears as a column label in the table of namespaces (namespace list view).">Status</translation>
+  <translation id="2325476578537884124" key="MSG_NAMESPACE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of namespaces (namespace list view).">Age</translation>
+  <translation id="2075541801746082922" key="MSG_NAMESPACE_LIST_CARDLIST_5" desc="Text for namespace card list zerostate.">There are no Namespaces to display.</translation>
   <translation id="2940798370079834880" key="MSG_NAMESPACE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of namespace.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="5143266087600531180" key="MSG_NAMESPACE_SELECT_ARIA_LABEL" desc="Text describing what namespace selector is">所选的名字空间标签</translation>
   <translation id="7797522188510592984" key="MSG_NODEDETAIL_NODEALLOCATEDRESOURCES_0" desc="Label \'Allocated resources\' for the allocated resources section.">Allocated resources</translation>
@@ -469,7 +687,43 @@
   <translation id="1139931975436155591" key="MSG_NODELIST_NODELIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU使用</translation>
   <translation id="4611353673808918004" key="MSG_NODELIST_NODELIST_1" desc="Title for graph card displaying memory metric of nodes.">内存使用</translation>
   <translation id="1508766902785018036" key="MSG_NODELIST_NODELIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes caches.</translation>
+  <translation id="5644753445531072726" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_0" desc="Label \'Allocated resources\' for the allocated resources section.">Allocated resources</translation>
+  <translation id="5653584408656823407" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_1" desc="Label \'CPU requests (cores)\' for the allocated resources table header on the node details page.">CPU requests (cores)</translation>
+  <translation id="776419576895892458" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_2" desc="Label \'CPU limits (cores)\' for the allocated resources table header on the node details page.">CPU limits (cores)</translation>
+  <translation id="2364634598145731752" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_3" desc="Label \'Memory requests (bytes)\' for the allocated resources table header on the node details page.">Memory requests (bytes)</translation>
+  <translation id="4803828848895485340" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_4" desc="Label \'Memory limits (bytes)\' for the allocated resources table header on the node details page.">Memory limits (bytes)</translation>
+  <translation id="2898321976840844764" key="MSG_NODE_DETAIL_ALLOCATEDRESOURCES_5" desc="Label \'Pods\' for the allocated resources table header on the node details page.">Pods</translation>
+  <translation id="8825218677764515340" key="MSG_NODE_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one node.">CPU usage</translation>
+  <translation id="1397958944434227282" key="MSG_NODE_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one node.">Memory usage</translation>
+  <translation id="1964687474867368783" key="MSG_NODE_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes caches.</translation>
+  <translation id="7278964988916967478" key="MSG_NODE_DETAIL_DETAIL_4" desc="Text for pods card zerostate in node details page.">There are currently no Pods scheduled on this Node.</translation>
+  <translation id="2128002365715974283" key="MSG_NODE_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="1545993044656301071" key="MSG_NODE_DETAIL_INFO_1" desc="Label \'Phase\' for the node namespace on the node details page.">Phase</translation>
+  <translation id="7199224922769170090" key="MSG_NODE_DETAIL_INFO_10" desc="Label \'Kernel Version\' for the node kernel version displayed on its details page.">Kernel Version</translation>
+  <translation id="9150708343514384042" key="MSG_NODE_DETAIL_INFO_11" desc="Label \'OS Image\' for the node OS image displayed on its details page.">OS Image</translation>
+  <translation id="5435737724872052823" key="MSG_NODE_DETAIL_INFO_12" desc="Label \'Container Runtime Version\' for the node container runtime version displayed on its details page.">Container Runtime Version</translation>
+  <translation id="4342372933200360270" key="MSG_NODE_DETAIL_INFO_13" desc="Label \'Kubelet Version\' for the node Kubelet version displayed on its details page.">Kubelet Version</translation>
+  <translation id="104208579964546346" key="MSG_NODE_DETAIL_INFO_14" desc="Label \'Kube-Proxy Version\' for the node Kube-Proxy version displayed on its details page.">Kube-Proxy Version</translation>
+  <translation id="6424547851609840629" key="MSG_NODE_DETAIL_INFO_15" desc="Label \'Operating system\' for the node operating system displayed on its details page.">Operating system</translation>
+  <translation id="6375391815927008544" key="MSG_NODE_DETAIL_INFO_16" desc="Label \'Architecture\' for the node architecture displayed on its details page.">Architecture</translation>
+  <translation id="6713664714270681129" key="MSG_NODE_DETAIL_INFO_2" desc="Label \'External ID\' for the node external ID displayed on its details page.">External ID</translation>
+  <translation id="684407257893900868" key="MSG_NODE_DETAIL_INFO_3" desc="Label \'Pod CIDR\' for the node external ID displayed on its details page.">Pod CIDR</translation>
+  <translation id="3412686708492919268" key="MSG_NODE_DETAIL_INFO_4" desc="Label \'Provider ID\' for the node external ID displayed on its details page.">Provider ID</translation>
+  <translation id="4308082913059054249" key="MSG_NODE_DETAIL_INFO_5" desc="Label \'Unschedulable\' for the node external ID displayed on its details page.">Unschedulable</translation>
+  <translation id="2600858180408528492" key="MSG_NODE_DETAIL_INFO_6" desc="Subtitle \'System info\' for the right section with general information about node system on the node details page.">System info</translation>
+  <translation id="4872640972002083253" key="MSG_NODE_DETAIL_INFO_7" desc="Label \'Machine ID\' for the node machine ID displayed on its details page.">Machine ID</translation>
+  <translation id="8031159424504518385" key="MSG_NODE_DETAIL_INFO_8" desc="Label \'System UUID\' for the node system UUID displayed on its details page.">System UUID</translation>
+  <translation id="2870803363346147220" key="MSG_NODE_DETAIL_INFO_9" desc="Label \'Boot ID\' for the node boot ID displayed on its details page.">Boot ID</translation>
+  <translation id="7623646557609839039" key="MSG_NODE_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Nodes</translation>
+  <translation id="4079495084138822779" key="MSG_NODE_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of nodes (node list view).">Name</translation>
+  <translation id="666977111261221823" key="MSG_NODE_LIST_CARDLIST_2" desc="Label \'Labels\' which appears as a column label in the table of nodes (node list view).">Labels</translation>
+  <translation id="5568169056290988879" key="MSG_NODE_LIST_CARDLIST_3" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
+  <translation id="7563356541739732697" key="MSG_NODE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
+  <translation id="2936243005887118324" key="MSG_NODE_LIST_CARDLIST_5" desc="Text for node card list zerostate.">There are no Nodes to display.</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node.">创建于<ph name="CREATION_DATE"/></translation>
+  <translation id="7165645741606687474" key="MSG_NODE_LIST_LIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
+  <translation id="7938673888851238901" key="MSG_NODE_LIST_LIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
+  <translation id="1363994976459428521" key="MSG_NODE_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes caches.</translation>
   <translation id="2230058550547139309" key="MSG_NO_ERROR_DATA" desc="String to display when error object has no data.">无错误</translation>
   <translation id="6997507737763635005" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume Claim\' which appears at the top of the delete dialog, opened from a persistent volume claim details page.">Persistent Volume Claim</translation>
   <translation id="1297935396913654466" key="MSG_PERSISTENTVOLUMECLAIMDETAIL_PERSISTENTVOLUMECLAIMINFO_0" desc="Header in a detail view">详情(Details)</translation>
@@ -485,6 +739,21 @@
   <translation id="4669931994584774261" key="MSG_PERSISTENTVOLUMECLAIMLIST_PERSISTENTVOLUMECLAIMCARDLIST_5" desc="Label \'Age\' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).">生存(Age)</translation>
   <translation id="5605513756759404025" key="MSG_PERSISTENTVOLUMECLAIMLIST_PERSISTENTVOLUMECLAIMCARD_0" desc="Tooltip text which appears on error icon hover.">This claim is in lost state</translation>
   <translation id="7813004235196632560" key="MSG_PERSISTENTVOLUMECLAIMLIST_PERSISTENTVOLUMECLAIMCARD_1" desc="Tooltip text which appears on pending icon hover.">This claim is in pending state</translation>
+  <translation id="486388281806331038" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume Claim\' which appears at the top of the delete dialog, opened from a persistent volume claim details page.">Persistent Volume Claim</translation>
+  <translation id="1482471968556330090" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="6385503627780441862" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_INFO_1" desc="Persistent volume claim info details section status entry.">Status</translation>
+  <translation id="2412371468817393973" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_INFO_2" desc="Persistent volume claim info details section volume entry.">Volume</translation>
+  <translation id="6740597941261077457" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_INFO_3" desc="Persistent volume claim info details section capacity entry.">Capacity</translation>
+  <translation id="297809042910539610" key="MSG_PERSISTENTVOLUMECLAIM_DETAIL_INFO_4" desc="Persistent volume claim info details section access modes entry.">Access modes</translation>
+  <translation id="29404782164326270" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Persistent Volume Claims</translation>
+  <translation id="5483797855700474826" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).">Name</translation>
+  <translation id="1258689958046107203" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).">Namespace</translation>
+  <translation id="1790149424209494199" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_3" desc="Label \'Volume\' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).">Volume</translation>
+  <translation id="5942271040555588136" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_4" desc="Label \'Labels\' which appears as a column label in the table of persistent volume claim (persistent volume claim list view).">Labels</translation>
+  <translation id="5458993660911534244" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_5" desc="Label \'Age\' which appears as a column label in the table of persistent volume claims (persistent volume claim list view).">Age</translation>
+  <translation id="5623491181214143081" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARDLIST_6" desc="Text for persistent volume claim card list zerostate.">There are no Persistent Volume Claims to display.</translation>
+  <translation id="445776331089273321" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARD_0" desc="Tooltip text which appears on error icon hover.">This claim is in lost state</translation>
+  <translation id="2307976094948542528" key="MSG_PERSISTENTVOLUMECLAIM_LIST_CARD_1" desc="Tooltip text which appears on pending icon hover.">This claim is in pending state</translation>
   <translation id="5690741977032012793" key="MSG_PERSISTENTVOLUMEDETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume\' which appears at the top of the delete dialog, opened from a config map details page.">Persistent Volume</translation>
   <translation id="531832117748275245" key="MSG_PERSISTENTVOLUMEDETAIL_PERSISTENTVOLUMEINFO_0" desc="Header in a detail view">详情(Details)</translation>
   <translation id="1042932866818648035" key="MSG_PERSISTENTVOLUMEDETAIL_PERSISTENTVOLUMEINFO_1" desc="Persistent volume info details section status entry.">状态(Status)</translation>
@@ -549,6 +818,71 @@
   <translation id="2604157972664563506" key="MSG_PERSISTENTVOLUMELIST_PERSISTENTVOLUMECARDLIST_8" desc="Persistent volume list header: age.">生存(Age)</translation>
   <translation id="4506741016926991795" key="MSG_PERSISTENTVOLUMELIST_PERSISTENTVOLUMECARD_0" desc="Label \'Persistent Volume\' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">Persistent Volume</translation>
   <translation id="6677838767738117816" key="MSG_PERSISTENTVOLUMELIST_PERSISTENTVOLUMECARD_1" desc="Label \'Persistent Volume\' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">Persistent Volume</translation>
+  <translation id="6410423382942434423" key="MSG_PERSISTENTVOLUME_DETAIL_ACTIONBAR_0" desc="Label \'Persistent Volume\' which appears at the top of the delete dialog, opened from a config map details page.">Persistent Volume</translation>
+  <translation id="6875466029803342193" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="5670456105080780751" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_1" desc="Persistent volume info details section status entry.">Status</translation>
+  <translation id="1183014090355571191" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_2" desc="Persistent volume info details section claim entry.">Claim</translation>
+  <translation id="8253469971637153606" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_3" desc="Persistent volume info details section reclaim policy entry.">Reclaim policy</translation>
+  <translation id="1048037683065603923" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_4" desc="Persistent volume info details section access modes entry.">Access modes</translation>
+  <translation id="489198110526224081" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_5" desc="Persistent volume info details section capacity entry.">Capacity</translation>
+  <translation id="7193098873360233228" key="MSG_PERSISTENTVOLUME_DETAIL_INFO_6" desc="Persistent volume info details section message entry.">Message</translation>
+  <translation id="3344267084925697004" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_0" desc="Persistent volume source info title.">Persistent volume source</translation>
+  <translation id="4229851576634547217" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_1" desc="Persistent volume source info host path title.">Host path</translation>
+  <translation id="2012274989896397034" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_10" desc="Persistent volume source info AWS block storage section FS type entry.">FS type</translation>
+  <translation id="1159922307397938960" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_11" desc="Persistent volume source info AWS block storage section partition entry.">Partition</translation>
+  <translation id="4179916509768425352" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_12" desc="Persistent volume source info AWS block storage section read only entry.">Read only</translation>
+  <translation id="7238343147110343511" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_13" desc="Persistent volume source info GlusterFS title.">GlusterFS</translation>
+  <translation id="1354033677473902339" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_14" desc="Persistent volume source info GlusterFS section endpoints entry.">Endpoints</translation>
+  <translation id="375828333102036934" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_15" desc="Persistent volume source info GlusterFS section path entry.">Path</translation>
+  <translation id="3510098912106931945" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_16" desc="Persistent volume source info GlusterFS section read only entry.">Read only</translation>
+  <translation id="3276696203563418711" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_17" desc="Persistent volume source info NFS title.">NFS</translation>
+  <translation id="129895814498011422" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_18" desc="Persistent volume source info NFS section server entry.">Server</translation>
+  <translation id="5829629031113012465" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_19" desc="Persistent volume source info NFS section path entry.">Path</translation>
+  <translation id="8315534477825179327" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_2" desc="Persistent volume source info host path section path entry.">Path</translation>
+  <translation id="8795208928592673628" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_20" desc="Persistent volume source info NFS section read only entry.">Read only</translation>
+  <translation id="5496246456166850695" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_21" desc="Persistent volume source info RBD title.">RBD</translation>
+  <translation id="5687418530859459612" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_22" desc="Persistent volume source info RBD section monitors entry.">Monitors</translation>
+  <translation id="8871994344367210584" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_23" desc="Persistent volume source info RBD section image entry.">Image</translation>
+  <translation id="6182877524861275895" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_24" desc="Persistent volume source info RBD section user entry.">User</translation>
+  <translation id="3506078183497376960" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_25" desc="Persistent volume source info RBD section keyring entry.">Keyring</translation>
+  <translation id="7440034293387101951" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_26" desc="Persistent volume source info RBD section secretRef entry.">SecretRef</translation>
+  <translation id="5166862124480598854" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_27" desc="Persistent volume source info RBD section read only entry.">Read only</translation>
+  <translation id="3033202154295339450" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_28" desc="Persistent volume source info ISCSI title.">ISCSI</translation>
+  <translation id="8618333463598695585" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_29" desc="Persistent volume source info ISCSI section target portal entry.">Target portal</translation>
+  <translation id="6125773785592861251" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_3" desc="Persistent volume source info GCE persistent disk title.">GCE persistent disk</translation>
+  <translation id="3150214227551452858" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_30" desc="Persistent volume source info ISCSI section IQN entry.">IQN</translation>
+  <translation id="9020043228751440021" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_31" desc="Persistent volume source info ISCSI section lun entry.">Lun</translation>
+  <translation id="7456243076382885514" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_32" desc="Persistent volume source info ISCSI section FS type entry.">FS type</translation>
+  <translation id="6745988707391969135" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_33" desc="Persistent volume source info ISCSI section read only entry.">Read only</translation>
+  <translation id="2995342957043632456" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_34" desc="Persistent volume source info cinder title.">Cinder</translation>
+  <translation id="6376034190324400343" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_35" desc="Persistent volume source info cinder section volume ID entry.">Volume ID</translation>
+  <translation id="7830413820255512859" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_36" desc="Persistent volume source info cinder section FS Type entry.">FS Type</translation>
+  <translation id="6420301831828714554" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_37" desc="Persistent volume source info cinder section read only entry.">Read only</translation>
+  <translation id="147942501041597135" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_38" desc="Persistent volume source info FC title.">FC</translation>
+  <translation id="3477305325473430932" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_39" desc="Persistent volume source info FC section target WWNs entry.">Target WWNs</translation>
+  <translation id="5593004702745409068" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_4" desc="Persistent volume source info GCE persistent disk section PD name entry.">PD name</translation>
+  <translation id="5770021054145618993" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_40" desc="Persistent volume source info FC section target FS type entry.">FS type</translation>
+  <translation id="6989685862216675322" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_41" desc="Persistent volume source info FC section lun entry.">Lun</translation>
+  <translation id="6455200962901000045" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_42" desc="Persistent volume source info FC section read only entry.">Read only</translation>
+  <translation id="3973978788850461107" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_43" desc="Persistent volume source info flocker title.">Flocker</translation>
+  <translation id="3542351005726885065" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_44" desc="Persistent volume source info FC section dataset name entry.">Dataset name</translation>
+  <translation id="6663983114121853218" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_5" desc="Persistent volume source info GCE persistent disk section FS type entry.">FS type</translation>
+  <translation id="6570825756735916995" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_6" desc="Persistent volume source info GCE persistent disk section partition entry.">Partition</translation>
+  <translation id="713683902153120640" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_7" desc="Persistent volume source info GCE persistent disk section read only entry.">Read only</translation>
+  <translation id="1527957761443744838" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_8" desc="Persistent volume source info AWS block storage title.">AWS block storage</translation>
+  <translation id="2543608444657856177" key="MSG_PERSISTENTVOLUME_DETAIL_SOURCEINFO_9" desc="Persistent volume source info AWS block storage section volume ID entry.">Volume ID</translation>
+  <translation id="7944617415298542080" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Persistent Volumes</translation>
+  <translation id="132041398851471554" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_1" desc="Persistent volume list header: name.">Name</translation>
+  <translation id="5516067660249261426" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_2" desc="Persistent volume list header: labels.">Labels</translation>
+  <translation id="401484757289437256" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_3" desc="Persistent volume list header: capacity.">Capacity</translation>
+  <translation id="119943904947653278" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_4" desc="Persistent volume list header: access modes.">Access modes</translation>
+  <translation id="384445450481051056" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_5" desc="Persistent volume list header: status.">Status</translation>
+  <translation id="6387315119675278668" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_6" desc="Persistent volume list header: claim.">Claim</translation>
+  <translation id="1737383119058892029" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_7" desc="Persistent volume list header: reason.">Reason</translation>
+  <translation id="6418120519158013412" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_8" desc="Persistent volume list header: age.">Age</translation>
+  <translation id="6613585718528767524" key="MSG_PERSISTENTVOLUME_LIST_CARDLIST_9" desc="Text for persistent volume card list zerostate.">There are no Persistent Volumes to display.</translation>
+  <translation id="4551076669296579967" key="MSG_PERSISTENTVOLUME_LIST_CARD_0" desc="Label \'Persistent Volume\' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">Persistent Volume</translation>
+  <translation id="7476369653916486566" key="MSG_PERSISTENTVOLUME_LIST_CARD_1" desc="Label \'Persistent Volume\' which will appear in the persistent volume delete dialog opened from a persistentvolume card on the list page.">Persistent Volume</translation>
   <translation id="6860347532246002287" key="MSG_PERSISTENT_VOLUME_CLAIM_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of persistent volume claim.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="7869718532150162176" key="MSG_PERSISTENT_VOLUME_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of persistent volume.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="2274539880532747000" key="MSG_PODDETAIL_ACTIONBAR_0" desc="Label \'Pod\' which appears at the top of the delete dialog, opened from a pod details page.">Pod</translation>
@@ -599,6 +933,52 @@
   <translation id="4624949365521774090" key="MSG_PODLIST_PODLIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU使用</translation>
   <translation id="1774454191311054495" key="MSG_PODLIST_PODLIST_1" desc="Title for graph card displaying memory metric of pods.">内存使用</translation>
   <translation id="7210994576558913771" key="MSG_PODLIST_PODLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in these pods.</translation>
+  <translation id="4867553232280640900" key="MSG_POD_DETAIL_ACTIONBAR_0" desc="Label \'Pod\' which appears at the top of the delete dialog, opened from a pod details page.">Pod</translation>
+  <translation id="3190654996078973226" key="MSG_POD_DETAIL_CONTAINERINFO_0" desc="Subtitle at the top of the container details.">Containers</translation>
+  <translation id="1970650270984178962" key="MSG_POD_DETAIL_CONTAINERINFO_1" desc="Label for container image.">Image</translation>
+  <translation id="1360847805196042023" key="MSG_POD_DETAIL_CONTAINERINFO_2" desc="Label for container environment variables.">Environment variables</translation>
+  <translation id="3109447894831467677" key="MSG_POD_DETAIL_CONTAINERINFO_3" desc="Label for environment variable that comes from a Config Map">value from ConfigMap {{env.valueFrom.configMapKeyRef.Name}}/{{env.valueFrom.configMapKeyRef.key}}</translation>
+  <translation id="7982652991565550562" key="MSG_POD_DETAIL_CONTAINERINFO_4" desc="Label when there is no container environment variables.">-</translation>
+  <translation id="7884138906305492767" key="MSG_POD_DETAIL_CONTAINERINFO_5" desc="Label for container commands.">Commands</translation>
+  <translation id="6310781543090479387" key="MSG_POD_DETAIL_CONTAINERINFO_6" desc="Label when there is no container commands.">-</translation>
+  <translation id="3742802452775193525" key="MSG_POD_DETAIL_CONTAINERINFO_7" desc="Label for container args.">Args</translation>
+  <translation id="3712176760429571617" key="MSG_POD_DETAIL_CONTAINERINFO_8" desc="Label when there is no container arguments.">-</translation>
+  <translation id="6103596689592690772" key="MSG_POD_DETAIL_CONTAINERINFO_9" desc="Label for the container logs.">View logs</translation>
+  <translation id="3675899736876134447" key="MSG_POD_DETAIL_CREATORINFO_0" desc="Heading for Creator card on pod detail page.">Created by</translation>
+  <translation id="9199113045758849849" key="MSG_POD_DETAIL_CREATORINFO_1" desc="Label \'Name\' which appears as a column label in the creator card.">Name</translation>
+  <translation id="6242760697176997170" key="MSG_POD_DETAIL_CREATORINFO_2" desc="Label \'Kind\' which appears as a column label in the creator card.">Kind</translation>
+  <translation id="859169969272492339" key="MSG_POD_DETAIL_CREATORINFO_3" desc="Label \'Namespace\' which appears as a column label in the creator card.">Namespace</translation>
+  <translation id="5639894053861673852" key="MSG_POD_DETAIL_CREATORINFO_4" desc="Label \'Labels\' which appears as a column label in the creator card.">Labels</translation>
+  <translation id="1299427439266004356" key="MSG_POD_DETAIL_CREATORINFO_5" desc="Label \'Pods\' which appears as a column label in the creator card.">Pods</translation>
+  <translation id="2344179924431390658" key="MSG_POD_DETAIL_CREATORINFO_6" desc="Label \'Age\' which appears as a column label in the creator card.">Age</translation>
+  <translation id="347463114068534057" key="MSG_POD_DETAIL_CREATORINFO_7" desc="Label \'Images\' which appears as a column label in the creator card.">Images</translation>
+  <translation id="2652259329893477150" key="MSG_POD_DETAIL_CREATORINFO_9" desc="Text for pod creator zero state in pod details page.">This Pod does not have a creator.</translation>
+  <translation id="7254693136643899288" key="MSG_POD_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
+  <translation id="9048608003178144260" key="MSG_POD_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
+  <translation id="5738415577560264420" key="MSG_POD_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in this pod.</translation>
+  <translation id="855512770998820017" key="MSG_POD_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="1457675883548195036" key="MSG_POD_DETAIL_INFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
+  <translation id="8753288911649190943" key="MSG_POD_DETAIL_INFO_2" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>
+  <translation id="694126564552626450" key="MSG_POD_DETAIL_INFO_3" desc="Subtitle \'Network\' at the top of the column about network connectivity (right) at the pod detail view.">Network</translation>
+  <translation id="7855013997463493128" key="MSG_POD_DETAIL_INFO_4" desc="Label \'Node\' for the node a pods is running on, appears in the connectivity part (right) of the pod details view.">Node</translation>
+  <translation id="7683783814970718475" key="MSG_POD_DETAIL_INFO_5" desc="Label \'IP\' for the pod internal IP, appears in the connectivity part (right) of the pod details view.">IP</translation>
+  <translation id="7869212130089500561" key="MSG_POD_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Pods</translation>
+  <translation id="1984772040767431754" key="MSG_POD_LIST_CARDLIST_1" desc="Title of a column">Name</translation>
+  <translation id="7443881172620941594" key="MSG_POD_LIST_CARDLIST_2" desc="Title of a column">Namespace</translation>
+  <translation id="6983001768279857619" key="MSG_POD_LIST_CARDLIST_3" desc="Title of a pod status column">Status</translation>
+  <translation id="9188256196176968844" key="MSG_POD_LIST_CARDLIST_4" desc="Title of a restarts column for a pod">Restarts</translation>
+  <translation id="6713259838973606526" key="MSG_POD_LIST_CARDLIST_5" desc="Title of a column for the age of a pod">Age</translation>
+  <translation id="2353613362278824556" key="MSG_POD_LIST_CARDLIST_6" desc="Title of a column">CPU (cores)</translation>
+  <translation id="6472029030033782169" key="MSG_POD_LIST_CARDLIST_7" desc="Title of a column">Memory (bytes)</translation>
+  <translation id="8463106700747317382" key="MSG_POD_LIST_CARDLIST_8" desc="Text for pods card list zerostate.">There are no Pods to display.</translation>
+  <translation id="5608535302521220986" key="MSG_POD_LIST_CARD_0" desc="Tooltip for failed pod card icon">This pod has errors.</translation>
+  <translation id="7889427465656547627" key="MSG_POD_LIST_CARD_1" desc="Tooltip for pending pod card icon">This pod is in a pending state.</translation>
+  <translation id="6227114160090429637" key="MSG_POD_LIST_CARD_2" desc="Label for logs tooltip">Logs</translation>
+  <translation id="1278633357095866885" key="MSG_POD_LIST_CARD_3" desc="Name of the pod resource">Pod</translation>
+  <translation id="1053078836410141563" key="MSG_POD_LIST_CARD_4" desc="Name of the pod resource">Pod</translation>
+  <translation id="4686932628263410864" key="MSG_POD_LIST_LIST_0" desc="Title for graph card displaying CPU metric of pods.">CPU usage</translation>
+  <translation id="6787006912063616508" key="MSG_POD_LIST_LIST_1" desc="Title for graph card displaying memory metric of pods.">Memory usage</translation>
+  <translation id="2972892229238972501" key="MSG_POD_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in these pods.</translation>
   <translation id="1014088790164786434" key="MSG_POD_LIST_POD_TERMINATED_STATUS" desc="Status message showing a terminated status with [reason].">Terminated: <ph name="REASON"/></translation>
   <translation id="3724043031520273690" key="MSG_POD_LIST_POD_WAITING_STATUS" desc="Status message showing a waiting status with [reason].">Waiting: <ph name="REASON"/></translation>
   <translation id="240453070925206277" key="MSG_POD_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the pod.">Started at <ph name="START_DATE"/> UTC</translation>
@@ -646,6 +1026,42 @@
   <translation id="4060565009520367123" key="MSG_REPLICASETLIST_REPLICASETLIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU使用</translation>
   <translation id="4492539501833209064" key="MSG_REPLICASETLIST_REPLICASETLIST_1" desc="Title for graph card displaying memory metric of replica sets.">内存使用</translation>
   <translation id="5987073561559829067" key="MSG_REPLICASETLIST_REPLICASETLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replica sets.</translation>
+  <translation id="1260262098898397299" key="MSG_REPLICASET_DETAIL_ACTIONBAR_0" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set details page.">Replica Set</translation>
+  <translation id="4400871969398726978" key="MSG_REPLICASET_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one replica set.">CPU usage</translation>
+  <translation id="4704389000141025902" key="MSG_REPLICASET_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one replica set.">Memory usage</translation>
+  <translation id="8906155885743398611" key="MSG_REPLICASET_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this replica set.</translation>
+  <translation id="4572191373237361392" key="MSG_REPLICASET_DETAIL_DETAIL_4" desc="Text for pods card zerostate in replica set details page.">There are currently no Pods managed by this Replica Set</translation>
+  <translation id="4073087810541869774" key="MSG_REPLICASET_DETAIL_DETAIL_6" desc="Text for services card zerostate in replica set details page.">There are currently no Services with the same label selector as this Replica Set.</translation>
+  <translation id="866751517478629490" key="MSG_REPLICASET_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replica Set.</translation>
+  <translation id="55301176526383580" key="MSG_REPLICASET_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="4263408774070199925" key="MSG_REPLICASET_DETAIL_INFO_1" desc="Label \'selector\' for replica sets.">Selector</translation>
+  <translation id="3760168929569923839" key="MSG_REPLICASET_DETAIL_INFO_10" desc="The message says how many pods have failed (replica set details page).">{{::$ctrl.replicaSet.podInfo.failed}} failed</translation>
+  <translation id="7492629527868215674" key="MSG_REPLICASET_DETAIL_INFO_11" desc="The message says how many pods are running (replica set details page).">{{::$ctrl.replicaSet.podInfo.running}} running</translation>
+  <translation id="3911353918422532139" key="MSG_REPLICASET_DETAIL_INFO_2" desc="Label \'Images\' for the list of images used in a replica set, on its details page.">Images</translation>
+  <translation id="8102227019794353148" key="MSG_REPLICASET_DETAIL_INFO_3" desc="Subtitle \'Status\' for the right section with pod status information\n        on the replica set details page.">Status</translation>
+  <translation id="875157097607992319" key="MSG_REPLICASET_DETAIL_INFO_4" desc="Label \'Pods\' for the pods in a replica set on its details page.">Pods</translation>
+  <translation id="2767096077990855253" key="MSG_REPLICASET_DETAIL_INFO_5" desc="The message says how many pods were created (replica set details page).">{{::$ctrl.replicaSet.podInfo.current}} created</translation>
+  <translation id="111482360301352967" key="MSG_REPLICASET_DETAIL_INFO_6" desc="The message says how many pods are desired to run (replica set details page).">{{::$ctrl.replicaSet.podInfo.desired}} desired</translation>
+  <translation id="1490872208453690790" key="MSG_REPLICASET_DETAIL_INFO_7" desc="How many pods are running (replica set details page).">{{::$ctrl.replicaSet.podInfo.running}} running</translation>
+  <translation id="6003817598627470456" key="MSG_REPLICASET_DETAIL_INFO_8" desc="Label \'Pods status\' for the status of the pods in a replica set, on the replica set details page.">Pods status</translation>
+  <translation id="4170684647118324267" key="MSG_REPLICASET_DETAIL_INFO_9" desc="The message says how many pods are pending (replica set details page).">{{::$ctrl.replicaSet.podInfo.pending}} pending</translation>
+  <translation id="3006509380820850241" key="MSG_REPLICASET_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Replica Sets</translation>
+  <translation id="2550445470731407296" key="MSG_REPLICASET_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of replica sets (replica set list view).">Name</translation>
+  <translation id="7363658059896561467" key="MSG_REPLICASET_LIST_CARDLIST_2" desc="Column header \'Kind\' for a Replica Set list">Kind</translation>
+  <translation id="5504242566546487357" key="MSG_REPLICASET_LIST_CARDLIST_3" desc="Label \'Namespace\' which appears as a column label in the table of replication controllers (RC list view).">Namespace</translation>
+  <translation id="8675343797885354425" key="MSG_REPLICASET_LIST_CARDLIST_4" desc="Label \'Labels\' which appears as a column label in the table of replica sets (replica set list view).">Labels</translation>
+  <translation id="2654175592807957242" key="MSG_REPLICASET_LIST_CARDLIST_5" desc="Label \'Pods\' which appears as a column label in the table of replica sets (replica set list view).">Pods</translation>
+  <translation id="5432873809831530051" key="MSG_REPLICASET_LIST_CARDLIST_6" desc="Label \'Age\' which appears as a column label in the table of replica sets (replica set list view).">Age</translation>
+  <translation id="7205864905890564062" key="MSG_REPLICASET_LIST_CARDLIST_7" desc="Label \'Images\' which appears as a column label in the table of replica sets (replica set list view).">Images</translation>
+  <translation id="7039160728674777775" key="MSG_REPLICASET_LIST_CARDLIST_8" desc="Text for replica set card list zerostate.">There are no Replica Sets to display.</translation>
+  <translation id="1049026925963989324" key="MSG_REPLICASET_LIST_CARD_0" desc="Tooltip saying that some pods in a replica set have errors.">One or more pods have errors</translation>
+  <translation id="8962209911077753915" key="MSG_REPLICASET_LIST_CARD_1" desc="Tooltip saying that some pods in a replica set are pending.">One or more pods are in pending state</translation>
+  <translation id="8737661932051185312" key="MSG_REPLICASET_LIST_CARD_2" desc="Column \'Replica Set\' that shows if the resource kind should be shown in a Replica Set List">Replica Set</translation>
+  <translation id="7581599441949506500" key="MSG_REPLICASET_LIST_CARD_3" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set list page.">Replica Set</translation>
+  <translation id="4577636652353595689" key="MSG_REPLICASET_LIST_CARD_4" desc="Label \'Replica Set\' which appears at the top of the delete dialog, opened from a replica set list page.">Replica Set</translation>
+  <translation id="1953836789676016853" key="MSG_REPLICASET_LIST_LIST_0" desc="Title for graph card displaying CPU metric of replica sets.">CPU usage</translation>
+  <translation id="110700328163812848" key="MSG_REPLICASET_LIST_LIST_1" desc="Title for graph card displaying memory metric of replica sets.">Memory usage</translation>
+  <translation id="8124993050775257685" key="MSG_REPLICASET_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replica sets.</translation>
   <translation id="6194638567193104531" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_0" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Edit number of pods</translation>
   <translation id="1117778161103271395" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_1" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Scale</translation>
   <translation id="1073944984422921935" key="MSG_REPLICATIONCONTROLLERDETAIL_ACTIONBAR_2" desc="Label \'Replication Controller\' which appears at the top of the edit dialog, opened from a replication controller details page.">Replication Controller</translation>
@@ -703,6 +1119,55 @@
   <translation id="4795577034077745296" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU使用</translation>
   <translation id="259439258646686772" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_1" desc="Title for graph card displaying memory metric of replication controllers.">内存使用</translation>
   <translation id="3837527568365892343" key="MSG_REPLICATIONCONTROLLERLIST_REPLICATIONCONTROLLERLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replication controllers.</translation>
+  <translation id="1878569263371070678" key="MSG_REPLICATIONCONTROLLER_DETAIL_ACTIONBAR_0" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Edit number of pods</translation>
+  <translation id="3406595776017844770" key="MSG_REPLICATIONCONTROLLER_DETAIL_ACTIONBAR_1" desc="Tooltip for the \'scale\' button on the action bar of a replication controller details view.">Scale</translation>
+  <translation id="5668789506232173619" key="MSG_REPLICATIONCONTROLLER_DETAIL_ACTIONBAR_2" desc="Label \'Replication Controller\' which appears at the top of the edit dialog, opened from a replication controller details page.">Replication Controller</translation>
+  <translation id="540465365371246326" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one replication controller.">CPU usage</translation>
+  <translation id="5679990989824450360" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one replication controller.">Memory usage</translation>
+  <translation id="811005294829243195" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this replication controller.</translation>
+  <translation id="5205445021979184107" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_4" desc="Text for services card zerostate in replication controller details page.">There are currently no Services with the same label selector as this Replication Controller.</translation>
+  <translation id="3131127524918345503" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_6" desc="Text for pods card zerostate in replication controller details page.">There are currently no Pods managed by this Replication Controller.</translation>
+  <translation id="6774788258232499089" key="MSG_REPLICATIONCONTROLLER_DETAIL_DETAIL_8" desc="Text for horizontal pod autoscalers card zerostate in replica set details page.">There are currently no Horizontal Pod Autoscalers targeting this Replication Controller.</translation>
+  <translation id="226817742496907856" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="2966352401153803656" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_1" desc="Label \'Selector\' for the replication controller\'s selector on the replication controller details page.">Selector</translation>
+  <translation id="4612002136140637630" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_10" desc="The message says how many pods have failed (replication controller details page).">{{::$ctrl.replicationController.podInfo.failed}} failed</translation>
+  <translation id="6124228678804559019" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_11" desc="The message says how many pods are running (replication controller details page).">{{::$ctrl.replicationController.podInfo.running}} running</translation>
+  <translation id="8187351409255724077" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_2" desc="Label \'Images\' for the list of images used in a replication controller, on its details page.">Images</translation>
+  <translation id="5182546327040956779" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_3" desc="Subtitle \'Status\' for the right section with pod status information on the replication controller details page.">Status</translation>
+  <translation id="1084410744399884216" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_4" desc="Label \'Pods\' for the pods in a replication controller on its details page.">Pods</translation>
+  <translation id="5269025916970350208" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_5" desc="The message says how many pods were created (replication controller details page).">{{::$ctrl.replicationController.podInfo.currentCount}} created</translation>
+  <translation id="2486312277918544072" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_6" desc="The message says how many pods are desired to run (replication controller details page).">{{::$ctrl.replicationController.podInfo.desired}} desired</translation>
+  <translation id="6816738060650305426" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_7" desc="The message says how many pods are running (replication controller details page).">{{::$ctrl.replicationController.podInfo.running}} running</translation>
+  <translation id="2996817668812553434" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_8" desc="Label \'Pods status\' for the status of the pods in a replication controller, on the replication controller details page.">Pods status</translation>
+  <translation id="1894294583521271782" key="MSG_REPLICATIONCONTROLLER_DETAIL_INFO_9" desc="The message says how many pods are pending (replication controller details page).">{{::$ctrl.replicationController.podInfo.pending}} pending</translation>
+  <translation id="896527128088271476" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_0" desc="Title for the pod count update dialog (for a replication controller).">Set desired number of pods</translation>
+  <translation id="312578428600091178" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_1" desc="User help for the pod count update dialog (on the replication controllers detail page).">Replication controller {{::$ctrl.replicationController}} will be updated to reflect the desired count.</translation>
+  <translation id="191594115181420708" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_2" desc="Status text for a replication controller, showing the number of created and desired pods.">Current status: {{::$ctrl.createdPods}} created, {{::$ctrl.desiredPods}} desired</translation>
+  <translation id="6410992033611109786" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_3" desc="Label \'Number of pods\', which appears as a placeholder for the pods count input on the &quot;update pods count&quot; dialog (for a replication controller).">Number of pods</translation>
+  <translation id="8389132044085623804" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_4" desc="This warning appears when the user does not specify a pods count on the &quot;update number of pods&quot; dialog (for a replication controller).">Number of pods is required.</translation>
+  <translation id="1088411438311223666" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_5" desc="This warning appears when the specified pods count on the &quot;update number of pods&quot; dialog is not positive or non-integer.">Number of replicas must be equal to or greater than zero.</translation>
+  <translation id="4749346717776383469" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_6" desc="This warning appears when the specified pods count (on the &quot;update number of pods&quot; dialog) is very high.">Setting high number of pods may cause performance issues of the cluster and Dashboard UI.</translation>
+  <translation id="6267424688704647935" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_7" desc="Action \'Cancel\' for the cancel button on the &quot;update number of pods&quot; dialog.">Cancel</translation>
+  <translation id="2703075926259904665" key="MSG_REPLICATIONCONTROLLER_DETAIL_UPDATEREPLICAS_8" desc="Action \'OK\' for the confirmation button on the &quot;update number of pods dialog&quot;.">OK</translation>
+  <translation id="4434451626308089157" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Replication Controllers</translation>
+  <translation id="4241490788014176188" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of replication controllers (RC list view).">Name</translation>
+  <translation id="8687785566574889286" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_2" desc="Column header \'Kind\' of a Replication Controller list">Kind</translation>
+  <translation id="2769002056868132125" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_3" desc="Label \'Namespace\' which appears as a column label in the table of replication controllers (RC list view).">Namespace</translation>
+  <translation id="5486561933775656760" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_4" desc="Label \'Labels\' which appears as a column label in the table of replication controllers (RC list view).">Labels</translation>
+  <translation id="4938088632137667978" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_5" desc="Label \'Pods\' which appears as a column label in the table of replication controllers (RC list view).">Pods</translation>
+  <translation id="3957484052069652608" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_6" desc="Label \'Age\' which appears as a column label in the table of replication controllers (RC list view).">Age</translation>
+  <translation id="6698419478883321763" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_7" desc="Label \'Images\' which appears as a column label in the table of replication controllers (RC list view).">Images</translation>
+  <translation id="3909279990084178026" key="MSG_REPLICATIONCONTROLLER_LIST_CARDLIST_8" desc="Text for replication controller card list zerostate.">There are no Replication Controllers to display.</translation>
+  <translation id="8284947559459883225" key="MSG_REPLICATIONCONTROLLER_LIST_CARDMENU_0" desc="Action \'View details\' on the drop down menu for a single replication controller (replication controller list page).">View details</translation>
+  <translation id="3333225559692017548" key="MSG_REPLICATIONCONTROLLER_LIST_CARDMENU_1" desc="Action \'Edit Pod Count\' on the drop down menu for a single replication controller (replication controller list page).">Scale</translation>
+  <translation id="1225563863938274391" key="MSG_REPLICATIONCONTROLLER_LIST_CARDMENU_2" desc="Label \'Replication Controller\' which will appear in the replication Controller delete dialogm opened from a replication controller card on the list page.">Replication Controller</translation>
+  <translation id="538474906418277358" key="MSG_REPLICATIONCONTROLLER_LIST_CARDMENU_3" desc="Label \'Replication Controller\' which will appear in the replication Controller delete dialogm opened from a replication controller card on the list page.">Replication Controller</translation>
+  <translation id="3633473974060235402" key="MSG_REPLICATIONCONTROLLER_LIST_CARD_0" desc="Tooltip saying that some pods in a replication controller have errors.">One or more pods have errors</translation>
+  <translation id="6705215400440462224" key="MSG_REPLICATIONCONTROLLER_LIST_CARD_1" desc="Tooltip saying that some pods in a replication controller are pending.">One or more pods are in pending state</translation>
+  <translation id="8826822240745100509" key="MSG_REPLICATIONCONTROLLER_LIST_CARD_2" desc="Column \'Replication Controller\' in a Replication Controller list">Replication Controller</translation>
+  <translation id="2152773077822216333" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_0" desc="Title for graph card displaying CPU metric of replication controllers.">CPU usage</translation>
+  <translation id="6842269165977804217" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage</translation>
+  <translation id="8345903533746337382" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replication controllers.</translation>
   <translation id="8299490700020675585" key="MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of replica set.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="8622510329837879978" key="MSG_RESOURCELIMIT_RESOURCELIMITS_0" desc="Title of resource limits card in the namespace details page.">Resource limits</translation>
   <translation id="6879936491586186000" key="MSG_RESOURCELIMIT_RESOURCELIMITS_1" desc="Resource Limits name entry.">类型(Type)</translation>
@@ -718,7 +1183,24 @@
   <translation id="2713001911479470584" key="MSG_RESOURCEQUOTADETAIL_RESOURCEQUOTADETAIL_0" desc="Resource quota info details section title.">Resource Quotas</translation>
   <translation id="4707374810025494648" key="MSG_RESOURCEQUOTADETAIL_RESOURCEQUOTADETAIL_1" desc="Resource quota info details section name">名称(Name)</translation>
   <translation id="6441862772940625742" key="MSG_RESOURCEQUOTADETAIL_RESOURCEQUOTADETAIL_2" desc="Resource quota info details section scopes">Scopes</translation>
+  <translation id="7531862076213500526" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_0" desc="Resource quota info details section title.">Resource Quotas</translation>
+  <translation id="2839859779657386369" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_1" desc="Resource quota info details section name">Name</translation>
+  <translation id="4649467264578406553" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_2" desc="Resource quota info details section scopes">Scopes</translation>
+  <translation id="2324096734502898237" key="MSG_RESOURCEQUOTA_DETAIL_STATUS_0" desc="Resource quota details status section resource name.">Resource Name</translation>
+  <translation id="1028467341074968941" key="MSG_RESOURCEQUOTA_DETAIL_STATUS_1" desc="Resource quota details status section hard.">Hard</translation>
+  <translation id="1101311215261110165" key="MSG_RESOURCEQUOTA_DETAIL_STATUS_2" desc="Resource quota details status section used.">Used</translation>
+  <translation id="5666870883139874190" key="MSG_RESOURCE_CARD_LIST_FILTERING_ERROR" desc="Message shown to the user when there is a filtering error.">Filtering error</translation>
+  <translation id="5352740626481015314" key="MSG_RESOURCE_CARD_LIST_FILTER_ICON_TOOLTIP" desc="Tooltip on resource card list filter icon.">Filter objects by name</translation>
+  <translation id="6139977749663403568" key="MSG_RESOURCE_CARD_LIST_FILTER_PLACEHOLDER_TEXT" desc="Tooltip on resource card list filter icon.">Search</translation>
   <translation id="3641265385665997534" key="MSG_RESOURCE_CARD_LIST_PAGINATION_ERROR" desc="Message shown to the user when there is a pagination error.">Pagination error</translation>
+  <translation id="8315383091892527627" key="MSG_RESOURCE_CARD_LIST_SORT_ERROR" desc="Message shown to the user when there is a sort error.">Sort error</translation>
+  <translation id="3279648086091797093" key="MSG_ROLE_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Roles</translation>
+  <translation id="4180591456756847095" key="MSG_ROLE_LIST_CARDLIST_1" desc="Role list header: name.">Name</translation>
+  <translation id="7494857132807181920" key="MSG_ROLE_LIST_CARDLIST_2" desc="Role list header: role type.">Role Type</translation>
+  <translation id="3561280019877192219" key="MSG_ROLE_LIST_CARDLIST_3" desc="Role list header: namespace.">Namespace</translation>
+  <translation id="3197213955933923965" key="MSG_ROLE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
+  <translation id="8108259204772140609" key="MSG_ROLE_LIST_CARDLIST_5" desc="Text for role card list zerostate.">There are no Roles to display.</translation>
+  <translation id="2864599603034607510" key="MSG_ROLE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the role.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="1320482404001625698" key="MSG_SECRETDETAIL_ACTIONBAR_0" desc="Label \'Secret\' which appears at the top of the delete dialog, opened from a secret details page.">Secret</translation>
   <translation id="1561742373508692276" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">数据(Data)</translation>
   <translation id="7988357395949564443" key="MSG_SECRETDETAIL_DETAIL_0" desc="Secrets info details section data.">数据(Data)</translation>
@@ -732,6 +1214,17 @@
   <translation id="5153024833276909612" key="MSG_SECRETLIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of secrets (secret list view).">名称(Name)</translation>
   <translation id="3968263046960145971" key="MSG_SECRETLIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of secrets (secret list view).">名字空间(Namespace)</translation>
   <translation id="6328422207560999836" key="MSG_SECRETLIST_CARDLIST_3" desc="Label \'Age\' which appears as a column label in the table of secrets (secret list view).">生存(Age)</translation>
+  <translation id="6072176334759614767" key="MSG_SECRET_DETAIL_ACTIONBAR_0" desc="Label \'Secret\' which appears at the top of the delete dialog, opened from a secret details page.">Secret</translation>
+  <translation id="2720871506693211747" key="MSG_SECRET_DETAIL_DETAIL_0" desc="Secrets info details section data.">Data</translation>
+  <translation id="5212791345913891342" key="MSG_SECRET_DETAIL_DETAIL_1" desc="Tooltip label for showing secret content">Show secret content</translation>
+  <translation id="4846548664493416435" key="MSG_SECRET_DETAIL_DETAIL_2" desc="Tooltip label for hiding secret content">Hide secret content</translation>
+  <translation id="3077755770695564562" key="MSG_SECRET_DETAIL_DETAIL_3" desc="Secrets info details section bytes.">{{::$ctrl.formatDataValue(value).length}} bytes </translation>
+  <translation id="7738406856610373390" key="MSG_SECRET_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="482275567627182819" key="MSG_SECRET_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Secrets</translation>
+  <translation id="2133941155168166972" key="MSG_SECRET_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of secrets (secret list view).">Name</translation>
+  <translation id="7478420130341878455" key="MSG_SECRET_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of secrets (secret list view).">Namespace</translation>
+  <translation id="4493598488188566434" key="MSG_SECRET_LIST_CARDLIST_3" desc="Label \'Age\' which appears as a column label in the table of secrets (secret list view).">Age</translation>
+  <translation id="5636111591527461304" key="MSG_SECRET_LIST_CARDLIST_4" desc="Text for secret card list zerostate.">There are no Secrets to display.</translation>
   <translation id="2799384691872397176" key="MSG_SECRET_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the secret.">创建于<ph name="START_DATE"/> UTC</translation>
   <translation id="7259128300465442626" key="MSG_SERVICEDETAIL_SERVICEDETAILINFO_0" desc="Header in a detail view">详情(Details)</translation>
   <translation id="1436736742516221745" key="MSG_SERVICEDETAIL_SERVICEDETAILINFO_1" desc="Label \'Label selector\' for the service\'s label selector in the details part (left) of the service details view.">所选的标签</translation>
@@ -750,6 +1243,25 @@
   <translation id="8943299193201683733" key="MSG_SERVICELIST_SERVICECARDLIST_5" desc="Label \'Internal endpoints\' which appears as a column label in the table of services (service list view).">Internal endpoints（容器地址及端口）</translation>
   <translation id="2444115344683141265" key="MSG_SERVICELIST_SERVICECARDLIST_6" desc="Label \'External endpoints\' which appears as a column label in the table of services (service list view).">External endpoints（对外地址及端口）</translation>
   <translation id="6527658776236691367" key="MSG_SERVICELIST_SERVICECARD_0" desc="tooltip for pending service card icon">This service is in a pending state</translation>
+  <translation id="2095406541360162780" key="MSG_SERVICE_DETAIL_DETAIL_1" desc="Text for pods card zerostate in stateful set details page.">There are currently no Pods selected by this Service.</translation>
+  <translation id="8542374982013786209" key="MSG_SERVICE_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="7974388484711199446" key="MSG_SERVICE_DETAIL_INFO_1" desc="Label \'Label selector\' for the service\'s label selector in the details part (left) of the service details view.">Label selector</translation>
+  <translation id="7808412066758701485" key="MSG_SERVICE_DETAIL_INFO_2" desc="Label \'Type\' for the service type in the details part (left) of the service details view.">Type</translation>
+  <translation id="1680894004419513394" key="MSG_SERVICE_DETAIL_INFO_3" desc="Subtitle \'Connection\' at the top of the column about network connectivity (right) at the service detail view.">Connection</translation>
+  <translation id="2067516562928424611" key="MSG_SERVICE_DETAIL_INFO_4" desc="Label \'Cluster IP\' for the service IP in the cluster, appears in the connectivity part (right) of the service details view.">Cluster IP</translation>
+  <translation id="4993540105836483919" key="MSG_SERVICE_DETAIL_INFO_5" desc="Label \'Internal endpoints\' for the internal endpoints of the service, appears in the connectivity part (right) of the service details view.">Internal endpoints</translation>
+  <translation id="314633649096123526" key="MSG_SERVICE_DETAIL_INFO_6" desc="Label \'External endpoints\' for the external endpoints of the service, appears in the connectivity part (right) of the service details view.">External endpoints</translation>
+  <translation id="1726750954635562524" key="MSG_SERVICE_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Services</translation>
+  <translation id="5124961947121108258" key="MSG_SERVICE_LIST_CARDLIST_1" desc="Label \'Name\' which appears as a column label in the table of services (service list view).">Name</translation>
+  <translation id="520133206236868567" key="MSG_SERVICE_LIST_CARDLIST_2" desc="Label \'Namespace\' which appears as a column label in the table of services (service list view).">Namespace</translation>
+  <translation id="4071419935719305601" key="MSG_SERVICE_LIST_CARDLIST_3" desc="Label \'Labels\' which appears as a column label in the table of services (service list view).">Labels</translation>
+  <translation id="6401528393336695678" key="MSG_SERVICE_LIST_CARDLIST_4" desc="Label \'Cluster IP\' which appears as a column label in the table of services (service list view).">Cluster IP</translation>
+  <translation id="5768650563576253785" key="MSG_SERVICE_LIST_CARDLIST_5" desc="Label \'Internal endpoints\' which appears as a column label in the table of services (service list view).">Internal endpoints</translation>
+  <translation id="8610616614395595684" key="MSG_SERVICE_LIST_CARDLIST_6" desc="Label \'External endpoints\' which appears as a column label in the table of services (service list view).">External endpoints</translation>
+  <translation id="9019769847701593849" key="MSG_SERVICE_LIST_CARDLIST_7" desc="Label \'Age\' which appears as a column label in the table of ingresses (ingress list view).">Age</translation>
+  <translation id="7871952624539430064" key="MSG_SERVICE_LIST_CARDLIST_8" desc="Text for service card list zerostate.">There are no Services to display.</translation>
+  <translation id="3019719082217228018" key="MSG_SERVICE_LIST_CARD_0" desc="tooltip for pending service card icon">This service is in a pending state</translation>
+  <translation id="5528801080901607886" key="MSG_SERVICE_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact start time of the service.">Created at <ph name="START_DATE"/> UTC</translation>
   <translation id="6466948840454457439" key="MSG_STATEFULSETDETAIL_ACTIONBAR_0" desc="Label \'Stateful Set\' which appears at the top of the delete dialog, opened from a stateful set details page.">Stateful Set（有状态POD集）</translation>
   <translation id="8560431905058366716" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_0" desc="Title for graph card displaying CPU metric of one stateful set.">CPU使用</translation>
   <translation id="4602699404115016650" key="MSG_STATEFULSETDETAIL_STATEFULSETDETAIL_1" desc="Title for graph card displaying memory metric of one stateful set.">内存使用</translation>
@@ -784,7 +1296,69 @@
   <translation id="5496057141257652512" key="MSG_STATEFULSETLIST_STATEFULSETLIST_0" desc="Title for graph card displaying CPU metric of stateful sets.">CPU使用</translation>
   <translation id="5949487857481253373" key="MSG_STATEFULSETLIST_STATEFULSETLIST_1" desc="Title for graph card displaying memory metric of stateful sets.">内存使用</translation>
   <translation id="4453952610053429376" key="MSG_STATEFULSETLIST_STATEFULSETLIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these stateful sets.</translation>
+  <translation id="2232943352979399383" key="MSG_STATEFULSET_DETAIL_ACTIONBAR_0" desc="Label \'Stateful Set\' which appears at the top of the delete dialog, opened from a stateful set details page.">Stateful Set</translation>
+  <translation id="7161753444048215428" key="MSG_STATEFULSET_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one stateful set.">CPU usage</translation>
+  <translation id="8249817415205260138" key="MSG_STATEFULSET_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one stateful set.">Memory usage</translation>
+  <translation id="5166179618558114310" key="MSG_STATEFULSET_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by this stateful set.</translation>
+  <translation id="8863896898922148088" key="MSG_STATEFULSET_DETAIL_DETAIL_4" desc="Text for pods card zerostate in stateful set details page.">There are currently no Pods managed by this Stateful Set.</translation>
+  <translation id="3348024993164925047" key="MSG_STATEFULSET_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="3442372861347610857" key="MSG_STATEFULSET_DETAIL_INFO_1" desc="Stateful set info details section images entry.">Images</translation>
+  <translation id="638418405338120294" key="MSG_STATEFULSET_DETAIL_INFO_10" desc="The message says that that many pods are running (stateful set details page).">{{ $ctrl.statefulSet.podInfo.running}} running</translation>
+  <translation id="6022511979639323705" key="MSG_STATEFULSET_DETAIL_INFO_2" desc="Stateful set info status section name.">Status</translation>
+  <translation id="4333163254678014871" key="MSG_STATEFULSET_DETAIL_INFO_3" desc="Stateful set info status section pods entry.">Pods</translation>
+  <translation id="2225505653570116356" key="MSG_STATEFULSET_DETAIL_INFO_4" desc="The message says that that many pods were created (stateful set details page).">{{ $ctrl.statefulSet.podInfo.current}} created</translation>
+  <translation id="1716379563650440954" key="MSG_STATEFULSET_DETAIL_INFO_5" desc="The message says that that many pods are desired to run (stateful set details page).">{{ $ctrl.statefulSet.podInfo.desired}} desired</translation>
+  <translation id="7816002201100319166" key="MSG_STATEFULSET_DETAIL_INFO_6" desc="The message says that that many pods are running (stateful set details page).">{{ $ctrl.statefulSet.podInfo.running}} running</translation>
+  <translation id="5917392867555318609" key="MSG_STATEFULSET_DETAIL_INFO_7" desc="Stateful set info status section pods status entry.">Pods status</translation>
+  <translation id="4705118863872693508" key="MSG_STATEFULSET_DETAIL_INFO_8" desc="The message says that that many pods are pending (stateful set details page).">{{ $ctrl.statefulSet.podInfo.pending}} pending</translation>
+  <translation id="3990693047066216292" key="MSG_STATEFULSET_DETAIL_INFO_9" desc="The message says that that many pods have failed (stateful set details page).">{{ $ctrl.statefulSet.podInfo.failed}} failed</translation>
+  <translation id="5793511256137993991" key="MSG_STATEFULSET_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Stateful Sets</translation>
+  <translation id="1171712742904097783" key="MSG_STATEFULSET_LIST_CARDLIST_1" desc="Stateful set list header: name.">Name</translation>
+  <translation id="3541355470656139746" key="MSG_STATEFULSET_LIST_CARDLIST_2" desc="Column header \'Kind\' of a Stateful Set List">Kind</translation>
+  <translation id="1489012022186096853" key="MSG_STATEFULSET_LIST_CARDLIST_3" desc="Stateful set list header: namespace.">Namespace</translation>
+  <translation id="8078172220093810587" key="MSG_STATEFULSET_LIST_CARDLIST_4" desc="Stateful set list header: labels.">Labels</translation>
+  <translation id="6154663102883314004" key="MSG_STATEFULSET_LIST_CARDLIST_5" desc="Stateful set list header: pods.">Pods</translation>
+  <translation id="2017309324677252198" key="MSG_STATEFULSET_LIST_CARDLIST_6" desc="Stateful set list header: age.">Age</translation>
+  <translation id="6924436875491034923" key="MSG_STATEFULSET_LIST_CARDLIST_7" desc="Stateful set list header: images.">Images</translation>
+  <translation id="8940586773655259683" key="MSG_STATEFULSET_LIST_CARDLIST_8" desc="Text for stateful set card list zerostate.">There are no Stateful Sets to display.</translation>
+  <translation id="8013469692840013975" key="MSG_STATEFULSET_LIST_CARD_0" desc="Tooltip text which appears on error icon hover.">One or more pods have errors</translation>
+  <translation id="8182116240528269169" key="MSG_STATEFULSET_LIST_CARD_1" desc="Tooltip text which appears on pending icon hover.">One or more pods are in pending state</translation>
+  <translation id="8536391692904195793" key="MSG_STATEFULSET_LIST_CARD_2" desc="Column \'Stateful Set\' of a Stateful Set List">Stateful Set</translation>
+  <translation id="8303350341808463069" key="MSG_STATEFULSET_LIST_CARD_3" desc="Label \'Stateful Set\' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.">Stateful Set</translation>
+  <translation id="7265964616399472549" key="MSG_STATEFULSET_LIST_CARD_4" desc="Label \'Stateful Set\' which will appear in the stateful set delete dialog opened from a stateful set card on the list page.">Stateful Set</translation>
+  <translation id="8198362727821894618" key="MSG_STATEFULSET_LIST_LIST_0" desc="Title for graph card displaying CPU metric of stateful sets.">CPU usage</translation>
+  <translation id="7302052672443322476" key="MSG_STATEFULSET_LIST_LIST_1" desc="Title for graph card displaying memory metric of stateful sets.">Memory usage</translation>
+  <translation id="725937525862708224" key="MSG_STATEFULSET_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these stateful sets.</translation>
   <translation id="6868140200572137421" key="MSG_STATEFUL_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of stateful set.">创建于<ph name="CREATION_DATE"/></translation>
+  <translation id="5285354056155654849" key="MSG_STORAGECLASS_DETAIL_ACTIONBAR_0" desc="Label \'Storage Class\' which appears at the top of the delete dialog, opened from a config map details page.">Storage Class</translation>
+  <translation id="6786610737142795668" key="MSG_STORAGECLASS_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="6633055939482604965" key="MSG_STORAGECLASS_DETAIL_INFO_1" desc="Label \'Labels\' for the storage class\'s labels list on the storage class details page.">Labels</translation>
+  <translation id="3807082804567161957" key="MSG_STORAGECLASS_DETAIL_INFO_2" desc="Storage Class info details section provisioner entry.">Provisioner</translation>
+  <translation id="8091843399508345711" key="MSG_STORAGECLASS_DETAIL_INFO_3" desc="Storage Class info details section parameters entry.">Parameters</translation>
+  <translation id="2250081047141795057" key="MSG_STORAGECLASS_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Storage Classes</translation>
+  <translation id="1878670581745731263" key="MSG_STORAGECLASS_LIST_CARDLIST_1" desc="Storage class list header: name.">Name</translation>
+  <translation id="7270752644289752116" key="MSG_STORAGECLASS_LIST_CARDLIST_2" desc="Storage class list header: labels.">Labels</translation>
+  <translation id="1137741577335174033" key="MSG_STORAGECLASS_LIST_CARDLIST_3" desc="Storage class list header: provisioner.">Provisioner</translation>
+  <translation id="4317180536835761343" key="MSG_STORAGECLASS_LIST_CARDLIST_4" desc="Storage class list header: parameters.">Parameters</translation>
+  <translation id="1567288620608447744" key="MSG_STORAGECLASS_LIST_CARDLIST_5" desc="Storage class list header: age.">Age</translation>
+  <translation id="544730200378378586" key="MSG_STORAGECLASS_LIST_CARDLIST_6" desc="Text for storage class card list zerostate.">There are no Storage Classes to display.</translation>
+  <translation id="8108461949496336520" key="MSG_STORAGECLASS_LIST_CARD_0" desc="Label \'Storage Class\' which will appear in the storage class delete dialog opened from a storageclass card on the list page.">Storage Class</translation>
+  <translation id="3154139817057931405" key="MSG_STORAGECLASS_LIST_CARD_1" desc="Label \'Storage Class\' which will appear in the storage class delete dialog opened from a storageclass card on the list page.">Storage Class</translation>
+  <translation id="2857396329294182623" key="MSG_STORAGE_CLASS_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of storage class.">Created at <ph name="CREATION_DATE"/></translation>
+  <translation id="8144868515522892950" key="MSG_THIRDPARTYRESOURCE_DETAIL_DETAIL_1" desc="Text for objects card zerostate in third party resource details page.">There are currently no instances of Third Party Resource.</translation>
+  <translation id="1645019540162911830" key="MSG_THIRDPARTYRESOURCE_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
+  <translation id="5988964246734196216" key="MSG_THIRDPARTYRESOURCE_DETAIL_INFO_1" desc="Third party resource info details section labels entry.">Labels</translation>
+  <translation id="7342744654411379319" key="MSG_THIRDPARTYRESOURCE_DETAIL_INFO_2" desc="Third party resource details description entry.">Description</translation>
+  <translation id="7580548521958733766" key="MSG_THIRDPARTYRESOURCE_DETAIL_INFO_3" desc="Third party resource details version entries.">Versions</translation>
+  <translation id="5179027765873903398" key="MSG_THIRDPARTYRESOURCE_DETAIL_OBJECTLIST_0" desc="Label which appears above the list of such objects.">Objects</translation>
+  <translation id="8485751285614915949" key="MSG_THIRDPARTYRESOURCE_DETAIL_OBJECTLIST_1" desc="Title of a column for the name of a third party resource instance.">Name</translation>
+  <translation id="3982141959710379486" key="MSG_THIRDPARTYRESOURCE_DETAIL_OBJECTLIST_2" desc="Title of a column for the age of a third party resource instance.">Age</translation>
+  <translation id="1437843514019946359" key="MSG_THIRDPARTYRESOURCE_DETAIL_OBJECTLIST_3" desc="Text for third party resource object card list zerostate.">There are no Third Party Resource Objects to display.</translation>
+  <translation id="30183360808931965" key="MSG_THIRDPARTYRESOURCE_LIST_CARDLIST_0" desc="Label which appears above the list of such objects.">Third Party Resources</translation>
+  <translation id="5740863454207335284" key="MSG_THIRDPARTYRESOURCE_LIST_CARDLIST_1" desc="Text for third party resource card list zerostate.">There are no Third Party Resources to display.</translation>
+  <translation id="8791753450494828145" key="MSG_THIRDPARTYRESOURCE_LIST_CARDLIST_2" desc="Label \'Age\' which appears as a column label in the table of third party resources (thirdpartyresource list view).">Age</translation>
+  <translation id="3992016852662821711" key="MSG_THIRDPARTYRESOURCE_LIST_CARDLIST_3" desc="Label \'Name\' which appears as a column label in the table of third party resources (thirdpartyresource list view).">Name</translation>
+  <translation id="8199201262548259491" key="MSG_THIRD_PARTY_RESOURCE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of third party resource.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="6463616657349920914" key="MSG_TIME_NOT_YET_LABEL" desc="Label for relative time that did not happened yet.">-</translation>
   <translation id="3921240742330478356" key="MSG_TIME_UNIT_DAYS_LABEL" desc="Time units label, many days (plural).">天</translation>
   <translation id="3980015737897416585" key="MSG_TIME_UNIT_DAY_LABEL" desc="Time units label, a single day.">1天</translation>
@@ -798,8 +1372,11 @@
   <translation id="3967360362065546967" key="MSG_TIME_UNIT_SECOND_LABEL" desc="Time units label, a single second.">1秒</translation>
   <translation id="270964281826728358" key="MSG_TIME_UNIT_YEARS_LABEL" desc="Time units label, many years (plural).">年</translation>
   <translation id="58035047264145239" key="MSG_TIME_UNIT_YEAR_LABEL" desc="Time units label, a single year.">1年</translation>
+  <translation id="7831482692212754207" key="MSG_TPR_LIST_STARTED_AT_TOOLTIP" desc="Tooltip 'Started at [some date]' showing the exact creation time of third party resource object.">Started at <ph name="START_DATE"/> UTC</translation>
   <translation id="4037658160328783864" key="MSG_UNKNOWN_SERVER_ERROR" desc="String to display when error object has invalid structure.">未知的服务错误(Unknown Server Error)</translation>
+  <translation id="5877596609986036290" key="MSG_UNSUPPORTED_TOAST" desc="Toast message appears when browser does not support clipboard">Unsupported browser</translation>
   <translation id="4302564966959880468" key="MSG_WORKLOADS_WORKLOADS_0" desc="Title for graph card displaying CPU metric of one all resources.">CPU使用</translation>
   <translation id="1036433586363793837" key="MSG_WORKLOADS_WORKLOADS_1" desc="Title for graph card displaying memory metric of one all resources.">内存使用</translation>
   <translation id="5680064618107855853" key="MSG_WORKLOADS_WORKLOADS_2" desc="Help message detailing what is included in the memory usage">内存使用上包括相关Pod的缓存（不要重复计算Pod使用，在PodList及控制如ReplicaSet上）</translation>
+  <translation id="6487218483864052953" key="MSG_serviceS_LABEL" desc="Label 'Services' that appears as a breadcrumbs on the action bar.">Services</translation>
 </translationbundle>

--- a/src/deploy/Dockerfile
+++ b/src/deploy/Dockerfile
@@ -27,4 +27,4 @@ ADD . /
 # The port that the application listens on.
 # TODO(bryk): Parametrize this argument so that other build tools are aware of the exposed port.
 EXPOSE 9090
-ENTRYPOINT ["/dashboard", "--port=9090"]
+ENTRYPOINT ["/dashboard", "--port=9090", "--insecure-bind-address=0.0.0.0"]


### PR DESCRIPTION
Translations updated during the build.

Fixes #1929. Due to introduced recently https support for dashboard docker image stopped working. It was caused by default binding for insecure address to `127.0.0.1`. Inside docker container we have to bind to `0.0.0.0` in order to access dashboard.