### PR TITLE
Pod attach/exec proto

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,9 @@
     "ng-jsoneditor": "angular-tools/ng-jsoneditor#~1.0.0",
     "angularUtils-pagination": "angular-utils-pagination#~0.11.1",
     "easyfont-roboto-mono": "easyfont/roboto-mono#fa7971ea56f68bfdb2771f9cb560c99aca0164c1",
-    "angular-clipboard": "^1.5.0"
+    "angular-clipboard": "^1.5.0",
+    "hterm": "~1.0.0",
+    "sockjs-client": "^1.1.4"
   },
   "overrides": {
     "material-design-icons": {

--- a/build/script.js
+++ b/build/script.js
@@ -163,6 +163,9 @@ function compileES6(translation) {
     path.join(conf.paths.externs, 'dataselect.js'),
     path.join(conf.paths.externs, 'dirPagination.js'),
     path.join(conf.paths.externs, 'searchapi.js'),
+    path.join(conf.paths.externs, 'shell.js'),
+    path.join(conf.paths.externs, 'hterm.js'),
+    path.join(conf.paths.externs, 'sockjs.js'),
   ];
 
   let closureCompilerConfig = {

--- a/build/serve.js
+++ b/build/serve.js
@@ -19,9 +19,8 @@ import browserSync from 'browser-sync';
 import browserSyncSpa from 'browser-sync-spa';
 import child from 'child_process';
 import gulp from 'gulp';
+import proxyMiddleware from 'http-proxy-middleware';
 import path from 'path';
-import proxyMiddleware from 'proxy-middleware';
-import url from 'url';
 import conf from './conf';
 
 /**
@@ -77,9 +76,11 @@ function browserSyncInit(baseDir, includeBowerComponents) {
   }));
 
   let apiRoute = '/api';
-  let proxyMiddlewareOptions =
-      url.parse(`http://localhost:${conf.backend.devServerPort}${apiRoute}`);
-  proxyMiddlewareOptions.route = apiRoute;
+  let proxyMiddlewareOptions = {
+    target: `http://localhost:${conf.backend.devServerPort}`,
+    // proxy websockets
+    ws: true,
+  };
 
   let config = {
     browser: [],       // Needed so that the browser does not auto-launch.
@@ -87,7 +88,7 @@ function browserSyncInit(baseDir, includeBowerComponents) {
     // TODO(bryk): Add proxy to the backend here.
     server: {
       baseDir: baseDir,
-      middleware: proxyMiddleware(proxyMiddlewareOptions),
+      middleware: proxyMiddleware(apiRoute, proxyMiddlewareOptions),
     },
     port: conf.frontend.serverPort,
     startPath: '/',

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -95,6 +95,7 @@ func main() {
 	http.Handle("/api/", apiHandler)
 	// TODO(maciaszczykm): Move to /appConfig.json as it was discussed in #640.
 	http.Handle("/api/appConfig.json", handler.AppHandler(handler.ConfigHandler))
+	http.Handle("/api/sockjs/", handler.CreateAttachHandler("/api/sockjs"))
 	http.Handle("/metrics", prometheus.Handler())
 
 	// Listen for http and https

--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	restful "github.com/emicklei/go-restful"
+	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
+)
+
+// PtyHandler is what remotecommand expects from a pty
+type PtyHandler interface {
+	io.Reader
+	io.Writer
+	remotecommand.TerminalSizeQueue
+}
+
+// TerminalSession implements PtyHandler (using a SockJS connection)
+type TerminalSession struct {
+	id            string
+	bound         chan error
+	sockJSSession sockjs.Session
+	sizeChan      chan remotecommand.TerminalSize
+}
+
+// TerminalMessage is the messaging protocol between ShellController and TerminalSession.
+//
+// OP      DIRECTION  FIELD(S) USED  DESCRIPTION
+// ---------------------------------------------------------------------
+// bind    fe->be     SessionID      Id sent back from TerminalReponse
+// stdin   fe->be     Data           Keystrokes/paste buffer
+// resize  fe->be     Rows, Cols     New terminal size
+// stdout  be->fe     Data           Output from the process
+// toast   be->fe     Data           OOB message to be shown to the user
+type TerminalMessage struct {
+	Op, Data, SessionID string
+	Rows, Cols          uint16
+}
+
+// TerminalSize handles pty->process resize events
+// Called in a loop from remotecommand as long as the process is running
+func (t TerminalSession) Next() *remotecommand.TerminalSize {
+	select {
+	case size := <-t.sizeChan:
+		return &size
+	}
+	return nil
+}
+
+// Read handles pty->process messages (stdin, resize)
+// Called in a loop from remotecommand as long as the process is running
+func (t TerminalSession) Read(p []byte) (int, error) {
+	m, err := t.sockJSSession.Recv()
+	if err != nil {
+		return 0, err
+	}
+
+	var msg TerminalMessage
+	if err := json.Unmarshal([]byte(m), &msg); err != nil {
+		return 0, err
+	}
+
+	switch msg.Op {
+	case "stdin":
+		return copy(p, msg.Data), nil
+	case "resize":
+		t.sizeChan <- remotecommand.TerminalSize{msg.Cols, msg.Rows}
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unknown message type '%s'", msg.Op)
+	}
+}
+
+// Write handles process->pty stdout
+// Called from remotecommand whenever there is any output
+func (t TerminalSession) Write(p []byte) (int, error) {
+	msg, err := json.Marshal(TerminalMessage{
+		Op:   "stdout",
+		Data: string(p),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	if err = t.sockJSSession.Send(string(msg)); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// Toast can be used to send the user any OOB messages
+// hterm puts these in the center of the terminal
+func (t TerminalSession) Toast(p string) error {
+	msg, err := json.Marshal(TerminalMessage{
+		Op:   "toast",
+		Data: p,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = t.sockJSSession.Send(string(msg)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close shuts down the SockJS connection and sends the status code and reason to the client
+// Can happen if the process exits or if there is an error starting up the process
+// For now the status code is unused and reason is shown to the user (unless "")
+func (t TerminalSession) Close(status uint32, reason string) {
+	t.sockJSSession.Close(status, reason)
+}
+
+// terminalSessions stores a map of all TerminalSession objects
+// FIXME: this structure needs locking
+var terminalSessions = make(map[string]TerminalSession)
+
+// handleTerminalSession is Called by net/http for any new /api/sockjs connections
+func handleTerminalSession(session sockjs.Session) {
+	var (
+		buf             string
+		err             error
+		msg             TerminalMessage
+		terminalSession TerminalSession
+		ok              bool
+	)
+
+	if buf, err = session.Recv(); err != nil {
+		log.Printf("handleTerminalSession: can't Recv: %v", err)
+		return
+	}
+
+	if err = json.Unmarshal([]byte(buf), &msg); err != nil {
+		log.Printf("handleTerminalSession: can't UnMarshal (%v): %s", err, buf)
+		return
+	}
+
+	if msg.Op != "bind" {
+		log.Printf("handleTerminalSession: expected 'bind' message, got: %s", buf)
+		return
+	}
+
+	if terminalSession, ok = terminalSessions[msg.SessionID]; !ok {
+		log.Printf("handleTerminalSession: can't find session '%s'", msg.SessionID)
+		return
+	}
+
+	terminalSession.sockJSSession = session
+	terminalSession.bound <- nil
+	terminalSessions[msg.SessionID] = terminalSession
+}
+
+// CreateAttachHandler is called from main for /api/sockjs
+func CreateAttachHandler(path string) http.Handler {
+	return sockjs.NewHandler(path, sockjs.DefaultOptions, handleTerminalSession)
+}
+
+// startProcess is called by handleAttach
+// Executed cmd in the container specified in request and connects it up with the ptyHandler (a session)
+func startProcess(k8sClient *kubernetes.Clientset, cfg *rest.Config, request *restful.Request, cmd []string, ptyHandler PtyHandler) error {
+	namespace := request.PathParameter("namespace")
+	podName := request.PathParameter("pod")
+	containerName := request.PathParameter("container")
+
+	req := k8sClient.Core().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	req.VersionedParams(&api.PodExecOptions{
+		Container: containerName,
+		Command:   cmd,
+		Stdin:     true,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       true,
+	}, api.ParameterCodec)
+
+	exec, err := remotecommand.NewExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		SupportedProtocols: remotecommandconsts.SupportedStreamingProtocols,
+		Stdin:              ptyHandler,
+		Stdout:             ptyHandler,
+		Stderr:             ptyHandler,
+		TerminalSizeQueue:  ptyHandler,
+		Tty:                true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// genTerminalSessionId generates a random session ID string. The format is not really interesting.
+// This ID is used to identify the session when the client opens the SockJS connection.
+// Not the same as the SockJS session id! We can't use that as that is generated
+// on the client side and we don't have it yet at this point.
+func genTerminalSessionId() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	id := make([]byte, hex.EncodedLen(len(bytes)))
+	hex.Encode(id, bytes)
+	return string(id), nil
+}
+
+// isValidShell checks if the shell is an allowed one
+func isValidShell(validShells []string, shell string) bool {
+	for _, validShell := range validShells {
+		if validShell == shell {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitForTerminal is called from apihandler.handleAttach as a goroutine
+// Waits for the SockJS connection to be opened by the client the session to be bound in handleTerminalSession
+func WaitForTerminal(k8sClient *kubernetes.Clientset, cfg *rest.Config, request *restful.Request, sessionId string) {
+	shell := request.QueryParameter("shell")
+
+	select {
+	case <-terminalSessions[sessionId].bound:
+		close(terminalSessions[sessionId].bound)
+
+		var err error
+		validShells := []string{"bash", "sh"}
+
+		if isValidShell(validShells, shell) {
+			cmd := []string{shell}
+			err = startProcess(k8sClient, cfg, request, cmd, terminalSessions[sessionId])
+		} else {
+			// No shell given or it was not valid: try some shells until one succeeds or all fail
+			// FIXME: if the first shell fails then the first keyboard event is lost
+			for _, testShell := range validShells {
+				cmd := []string{testShell}
+				if err = startProcess(k8sClient, cfg, request, cmd, terminalSessions[sessionId]); err == nil {
+					break
+				}
+			}
+		}
+
+		if err != nil {
+			terminalSessions[sessionId].Close(2, err.Error())
+			return
+		}
+
+		terminalSessions[sessionId].Close(1, "Process exited")
+	}
+}

--- a/src/app/externs/hterm.js
+++ b/src/app/externs/hterm.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Externs for hterm
+ *
+ * @externs
+ */
+
+const hterm = {};
+hterm.defaultStorage;
+hterm.Terminal;
+hterm.Terminal.prototype.decorate;
+hterm.Terminal.prototype.installKeyboard;
+hterm.Terminal.prototype.io;
+hterm.Terminal.prototype.io.prototype.onTerminalResize;
+hterm.Terminal.prototype.io.prototype.onVTKeystroke;
+hterm.Terminal.prototype.io.prototype.print;
+hterm.Terminal.prototype.io.prototype.push;
+hterm.Terminal.prototype.io.prototype.sendString;
+hterm.Terminal.prototype.io.prototype.showOverlay;
+hterm.Terminal.prototype.onTerminalReady;
+hterm.Terminal.prototype.screenSize;
+hterm.Terminal.prototype.uninstallKeyboard;
+
+const lib = {};
+lib.Storage;
+lib.Storage.Memory;

--- a/src/app/externs/shell.js
+++ b/src/app/externs/shell.js
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Externs for the shell/termopen_directive
+ *
+ * @externs
+ */
+
+const TermOpen = {};
+
+/**
+ * @typedef {{
+ *    termOpen: string,
+ * }}
+ */
+TermOpen.attrs;

--- a/src/app/externs/sockjs.js
+++ b/src/app/externs/sockjs.js
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Externs for sockjs
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ */
+const SockJS = function(url) {};
+SockJS.prototype.close;
+SockJS.prototype.onopen;
+SockJS.prototype.onmessage;
+SockJS.prototype.onclose;
+SockJS.prototype.onerror;
+SockJS.prototype.send;

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -45,6 +45,7 @@ import roleModule from './role/module';
 import searchModule from './search/module';
 import secretModule from './secret/module';
 import serviceModule from './service/module';
+import shellModule from './shell/module';
 import statefulSetModule from './statefulset/module';
 import storageClassModule from './storageclass/module';
 import thirdPartyResourceModule from './thirdpartyresource/module';
@@ -69,6 +70,7 @@ export default angular
           errorModule.name,
           jobModule.name,
           logsModule.name,
+          shellModule.name,
           replicationControllerModule.name,
           replicaSetModule.name,
           namespaceModule.name,

--- a/src/app/frontend/pod/detail/containerinfo.html
+++ b/src/app/frontend/pod/detail/containerinfo.html
@@ -75,6 +75,11 @@ limitations under the License.
         <kd-middle-ellipsis display-string="[[View logs|Label for the container logs.]]">
         </kd-middle-ellipsis>
       </a>
+      <a ng-href="{{::$ctrl.getShellHref(container)}}"
+         class="kd-middle-ellipsised-link">
+        <kd-middle-ellipsis display-string="[[Execute shell|Execute shell in the container]]">
+        </kd-middle-ellipsis>
+      </a>
     </kd-info-card-entry>
   </kd-info-card-section>
 </kd-info-card>

--- a/src/app/frontend/pod/detail/containerinfo_component.js
+++ b/src/app/frontend/pod/detail/containerinfo_component.js
@@ -15,6 +15,7 @@
 import {StateParams} from 'common/resource/resourcedetail';
 import {stateName as configMapState} from 'configmap/detail/state';
 import {stateName as logsStateName, StateParams as LogsStateParams} from 'logs/state';
+import {stateName as shellStateName, StateParams as ShellStateParams} from 'shell/state';
 
 /**
  * @final
@@ -60,6 +61,16 @@ export default class ContainerInfoController {
   getLogsHref(container) {
     return this.state_.href(
         logsStateName, new LogsStateParams(this.namespace, this.podName, container.name));
+  }
+
+  /**
+   * @param {!backendApi.Container} container
+   * @return {string}
+   * @export
+   */
+  getShellHref(container) {
+    return this.state_.href(
+        shellStateName, new ShellStateParams(this.namespace, this.podName, container.name));
   }
 }
 

--- a/src/app/frontend/shell/controller.js
+++ b/src/app/frontend/shell/controller.js
@@ -1,0 +1,193 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as shell, StateParams} from './state';
+
+/**
+ * Controller for the shell view.
+ *
+ * @final
+ */
+export class ShellController {
+  /**
+   * @param {!backendApi.PodContainerList} podContainers
+   * @param {!angular.$sce} $sce
+   * @param {!angular.$document} $document
+   * @param {!./state.StateParams} $stateParams
+   * @param {!angular.$resource} $resource
+   * @param {!ui.router.$state} $state
+   * @ngInject
+   */
+  constructor(podContainers, $sce, $document, $resource, $stateParams, $state) {
+    /** @private {!angular.$sce} */
+    this.sce_ = $sce;
+
+    /** @private {!HTMLDocument} */
+    this.document_ = $document[0];
+
+    /** @private {!angular.$resource} */
+    this.resource_ = $resource;
+
+    /** @private {!./state.StateParams} $stateParams */
+    this.stateParams_ = $stateParams;
+
+    /** @export */
+    this.i18n = i18n;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+
+    /** @export {!Array<string>} */
+    this.containers = podContainers.containers ? podContainers.containers : [];
+
+    /** @export {string} */
+    this.container = this.stateParams_.container ? this.stateParams_.container : '';
+
+    /** @export {string} */
+    this.podName = this.stateParams_.objectName ? this.stateParams_.objectName : '';
+
+    /** private {hterm.Terminal} */
+    this.term = null;
+
+    /** private {hterm.Terminal.IO} */
+    this.io = null;
+
+    /** @private {SockJS} */
+    this.conn = null;
+
+    this.prepareTerminal();
+  }
+
+  prepareTerminal() {
+    // https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/doc/embed.md
+    hterm.defaultStorage = new lib.Storage.Memory();
+    this.term = new hterm.Terminal();
+    this.term.onTerminalReady = this.onTerminalReady.bind(this);
+  }
+
+  /**
+   * Attached to div.kd-shell-term term-open directive
+   * @export
+   */
+  openTerminal() {
+    let target = this.document_.getElementById('kd-shell-term');
+    this.term.decorate(target);
+    target.firstChild.style.position = null;
+    this.term.installKeyboard();
+  }
+
+  /**
+   * Attached to hterm.onTerminalReady
+   */
+  onTerminalReady() {
+    this.io = this.term.io.push();
+
+    let namespace = this.stateParams_.objectNamespace;
+    let podName = this.stateParams_.objectName;
+    let containerName = this.stateParams_.container || '';
+
+    this.resource_(`api/v1/pod/${namespace}/${podName}/shell/${containerName}`)
+        .get({}, this.onTerminalResponseReceived.bind(this));
+  }
+
+  /**
+   * Called when .../shell/... resource is fetched
+   */
+  onTerminalResponseReceived(terminalResponse) {
+    // https://github.com/sockjs/sockjs-client
+    this.conn = new SockJS(`api/sockjs?${terminalResponse.id}`);
+    this.conn.onopen = this.onConnectionOpen.bind(this, terminalResponse);
+    this.conn.onmessage = this.onConnectionMessage.bind(this);
+    this.conn.onclose = this.onConnectionClose.bind(this);
+  }
+
+  /**
+   * Attached to SockJS.onopen
+   */
+  onConnectionOpen(terminalResponse) {
+    this.conn.send(JSON.stringify({'Op': 'bind', 'SessionID': terminalResponse.id}));
+
+    // Send at at least one resize event after attach so pty has the initial size
+    this.onTerminalResize(this.term.screenSize.width, this.term.screenSize.height);
+
+    this.io.onVTKeystroke = this.onTerminalVTKeystroke.bind(this);
+    this.io.sendString = this.onTerminalSendString.bind(this);
+    this.io.onTerminalResize = this.onTerminalResize.bind(this);
+  }
+
+  /**
+   * Attached to SockJS.onmessage
+   */
+  onConnectionMessage(evt) {
+    let msg = JSON.parse(evt.data);
+    switch (msg['Op']) {
+      case 'stdout':
+        this.io.print(msg['Data']);
+        break;
+      case 'toast':
+        this.io.showOverlay(msg['Data']);
+        break;
+      default:
+        // console.error('Unexpected message type:', msg);
+    }
+  }
+
+  /**
+   * Attached to SockJS.onclose
+   */
+  onConnectionClose(evt) {
+    if (evt.reason !== '' && evt.code < 1000) {
+      this.io.showOverlay(evt.reason, null);
+    } else {
+      this.io.showOverlay('Connection closed', null);
+    }
+    this.conn.close();
+    this.term.uninstallKeyboard();
+  }
+
+  /**
+   * Attached to hterm.io.onVTKeystroke
+   */
+  onTerminalVTKeystroke(str) {
+    this.conn.send(JSON.stringify({'Op': 'stdin', 'Data': str}));
+  }
+
+  /**
+   * Attached to hterm.io.sendString
+   */
+  onTerminalSendString(str) {
+    this.conn.send(JSON.stringify({'Op': 'stdin', 'Data': str}));
+  }
+
+  /**
+   * Attached to hterm.io.onTerminalResize
+   */
+  onTerminalResize(columns, rows) {
+    this.conn.send(JSON.stringify({'Op': 'resize', 'Cols': columns, 'Rows': rows}));
+  }
+
+  /**
+   * Execute when a user changes the selected option of a container element.
+   * @param {string} container
+   * @export
+   */
+  onContainerChange(container) {
+    this.state_.go(
+        shell,
+        new StateParams(
+            this.stateParams_.objectNamespace, this.stateParams_.objectName, container));
+  }
+}
+
+const i18n = {};

--- a/src/app/frontend/shell/module.js
+++ b/src/app/frontend/shell/module.js
@@ -1,0 +1,30 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import stateConfig from './stateconfig';
+import termOpenDirective from './termopen_directive';
+
+/**
+ * Angular module for the shell view.
+ *
+ */
+export default angular
+    .module(
+        'kubernetesDashboard.shell',
+        [
+          'ngResource',
+          'ui.router',
+        ])
+    .config(stateConfig)
+    .directive('termOpen', ['$timeout', termOpenDirective]);

--- a/src/app/frontend/shell/shell.html
+++ b/src/app/frontend/shell/shell.html
@@ -1,0 +1,36 @@
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-content-card class="kd-shell-content-card">
+  <kd-title class="kd-shell-title">
+    [[Shell in|Title prefix for the shell card.]]
+    <md-select class="kd-shell-toolbar-select"
+               ng-model="ctrl.container"
+               md-on-close="ctrl.onContainerChange(ctrl.container)"
+               required>
+      <md-option ng-repeat="item in ctrl.containers"
+                 ng-value="item">
+        <span class="kd-shell-toolbar-text">{{::item}}</span>
+      </md-option>
+    </md-select>
+    [[in|Title part for the shell card.]] {{ctrl.podName}}
+  </kd-title>
+  <kd-content>
+    <div class="kd-shell-term"
+         id="kd-shell-term"
+         term-open="ctrl.openTerminal()"></div>
+  </kd-content>
+</kd-content-card>

--- a/src/app/frontend/shell/shell.scss
+++ b/src/app/frontend/shell/shell.scss
@@ -1,0 +1,67 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../variables';
+
+.kd-shell-term {
+  width: 100%;
+}
+
+// The style below is to make the shell view card full width & height.
+kd-content-card {
+  &.kd-shell-content-card {
+    box-sizing: border-box;
+    height: 100%;
+    margin: 0;
+    padding: 2.5 * $baseline-grid;
+
+    .kd-content-card {
+      height: 100%;
+
+      .kd-content-card-transclude-content {
+        display: flex;
+        flex: 1;
+
+        kd-content {
+          display: flex;
+          flex: 1;
+        }
+      }
+    }
+
+    .kd-content-card-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+  }
+}
+
+.kd-shell-toolbar-select {
+  display: inline-flex;
+  margin: 0;
+
+  .md-select-value {
+    font-size: $title-font-size-base;
+    min-width: 20 * $baseline-grid;
+  }
+
+  &:not([disabled]) {
+    &:focus {
+      .md-select-value {
+        color: $foreground-1;
+      }
+    }
+  }
+}

--- a/src/app/frontend/shell/state.js
+++ b/src/app/frontend/shell/state.js
@@ -1,0 +1,38 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {StateParams as ResourceStateParams} from 'common/resource/resourcedetail';
+
+/** Name of the state. Can be used in, e.g., $state.go method. */
+export const stateName = 'shell';
+
+/**
+ * Parameters for this state.
+ *
+ * All properties are @exported and in sync with URL param names.
+ * @final
+ */
+export class StateParams extends ResourceStateParams {
+  /**
+   * @param {string} objectNamespace
+   * @param {string} objectName
+   * @param {string=} opt_container
+   */
+  constructor(objectNamespace, objectName, opt_container) {
+    super(objectNamespace, objectName);
+
+    /** @export {string|undefined} Name of this pod container. */
+    this.container = opt_container;
+  }
+}

--- a/src/app/frontend/shell/stateconfig.js
+++ b/src/app/frontend/shell/stateconfig.js
@@ -1,0 +1,72 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as chromeStateName} from 'chrome/state';
+import {fillContentConfig} from 'chrome/state';
+import {breadcrumbsConfig} from 'common/components/breadcrumbs/service';
+import {appendDetailParamsToUrl} from 'common/resource/resourcedetail';
+
+import {ShellController} from './controller';
+import {stateName} from './state';
+
+/**
+ * Configures states for the shell view.
+ *
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  let views = {
+    '': {
+      templateUrl: 'shell/shell.html',
+      controller: ShellController,
+      controllerAs: 'ctrl',
+    },
+  };
+
+  $stateProvider.state(stateName, {
+    url: `${appendDetailParamsToUrl('/shell')}/:container`,
+    parent: chromeStateName,
+    resolve: {
+      'podContainers': resolvePodContainers,
+    },
+    data: {
+      [breadcrumbsConfig]: {
+        'label': i18n.MSG_BREADCRUMBS_SHELL_LABEL,
+      },
+      [fillContentConfig]: true,
+    },
+    views: views,
+  });
+}
+
+/**
+ * @param {!./state.StateParams} $stateParams
+ * @param {!angular.$resource} $resource
+ * @return {!angular.$q.Promise}
+ * @ngInject
+ */
+function resolvePodContainers($stateParams, $resource) {
+  let namespace = $stateParams.objectNamespace;
+  let podId = $stateParams.objectName;
+
+  /** @type {!angular.Resource<!backendApi.PodContainerList>} */
+  let resource = $resource(`api/v1/pod/${namespace}/${podId}/container`);
+  return resource.get().$promise;
+}
+
+const i18n = {
+  /** @type {string} @desc Breadcrum label for the shell view. */
+  MSG_BREADCRUMBS_SHELL_LABEL: goog.getMsg('Shell'),
+};

--- a/src/app/frontend/shell/termopen_directive.js
+++ b/src/app/frontend/shell/termopen_directive.js
@@ -1,0 +1,36 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Returns directive that runs code after a template render.
+ *
+ * @return {!angular.Directive}
+ * @ngInject
+ */
+export default function termOpenDirective($timeout) {
+  let def = {
+    restrict: 'A',
+    terminal: true,
+    transclude: false,
+    /** @param {!TermOpen.attrs} attrs */
+    link: function(scope, element, attrs) {
+      // We call $timeout with a zero timeout so that the function code
+      // is placed in the browser execution queue. Since the render is
+      // also already in the queue this ensures that the code is run after
+      // the template is rendered.
+      $timeout(scope.$eval(attrs.termOpen), 0);  // Calling a scoped method
+    },
+  };
+  return def;
+}

--- a/vendor/github.com/gorilla/websocket/AUTHORS
+++ b/vendor/github.com/gorilla/websocket/AUTHORS
@@ -1,0 +1,8 @@
+# This is the official list of Gorilla WebSocket authors for copyright
+# purposes.
+#
+# Please keep the list sorted.
+
+Gary Burd <gary@beagledreams.com>
+Joachim Bauch <mail@joachim-bauch.de>
+

--- a/vendor/github.com/gorilla/websocket/LICENSE
+++ b/vendor/github.com/gorilla/websocket/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gorilla/websocket/README.md
+++ b/vendor/github.com/gorilla/websocket/README.md
@@ -1,0 +1,64 @@
+# Gorilla WebSocket
+
+Gorilla WebSocket is a [Go](http://golang.org/) implementation of the
+[WebSocket](http://www.rfc-editor.org/rfc/rfc6455.txt) protocol.
+
+[![Build Status](https://travis-ci.org/gorilla/websocket.svg?branch=master)](https://travis-ci.org/gorilla/websocket)
+[![GoDoc](https://godoc.org/github.com/gorilla/websocket?status.svg)](https://godoc.org/github.com/gorilla/websocket)
+
+### Documentation
+
+* [API Reference](http://godoc.org/github.com/gorilla/websocket)
+* [Chat example](https://github.com/gorilla/websocket/tree/master/examples/chat)
+* [Command example](https://github.com/gorilla/websocket/tree/master/examples/command)
+* [Client and server example](https://github.com/gorilla/websocket/tree/master/examples/echo)
+* [File watch example](https://github.com/gorilla/websocket/tree/master/examples/filewatch)
+
+### Status
+
+The Gorilla WebSocket package provides a complete and tested implementation of
+the [WebSocket](http://www.rfc-editor.org/rfc/rfc6455.txt) protocol. The
+package API is stable.
+
+### Installation
+
+    go get github.com/gorilla/websocket
+
+### Protocol Compliance
+
+The Gorilla WebSocket package passes the server tests in the [Autobahn Test
+Suite](http://autobahn.ws/testsuite) using the application in the [examples/autobahn
+subdirectory](https://github.com/gorilla/websocket/tree/master/examples/autobahn).
+
+### Gorilla WebSocket compared with other packages
+
+<table>
+<tr>
+<th></th>
+<th><a href="http://godoc.org/github.com/gorilla/websocket">github.com/gorilla</a></th>
+<th><a href="http://godoc.org/golang.org/x/net/websocket">golang.org/x/net</a></th>
+</tr>
+<tr>
+<tr><td colspan="3"><a href="http://tools.ietf.org/html/rfc6455">RFC 6455</a> Features</td></tr>
+<tr><td>Passes <a href="http://autobahn.ws/testsuite/">Autobahn Test Suite</a></td><td><a href="https://github.com/gorilla/websocket/tree/master/examples/autobahn">Yes</a></td><td>No</td></tr>
+<tr><td>Receive <a href="https://tools.ietf.org/html/rfc6455#section-5.4">fragmented</a> message<td>Yes</td><td><a href="https://code.google.com/p/go/issues/detail?id=7632">No</a>, see note 1</td></tr>
+<tr><td>Send <a href="https://tools.ietf.org/html/rfc6455#section-5.5.1">close</a> message</td><td><a href="http://godoc.org/github.com/gorilla/websocket#hdr-Control_Messages">Yes</a></td><td><a href="https://code.google.com/p/go/issues/detail?id=4588">No</a></td></tr>
+<tr><td>Send <a href="https://tools.ietf.org/html/rfc6455#section-5.5.2">pings</a> and receive <a href="https://tools.ietf.org/html/rfc6455#section-5.5.3">pongs</a></td><td><a href="http://godoc.org/github.com/gorilla/websocket#hdr-Control_Messages">Yes</a></td><td>No</td></tr>
+<tr><td>Get the <a href="https://tools.ietf.org/html/rfc6455#section-5.6">type</a> of a received data message</td><td>Yes</td><td>Yes, see note 2</td></tr>
+<tr><td colspan="3">Other Features</tr></td>
+<tr><td><a href="https://tools.ietf.org/html/rfc7692">Compression Extensions</a></td><td>Experimental</td><td>No</td></tr>
+<tr><td>Read message using io.Reader</td><td><a href="http://godoc.org/github.com/gorilla/websocket#Conn.NextReader">Yes</a></td><td>No, see note 3</td></tr>
+<tr><td>Write message using io.WriteCloser</td><td><a href="http://godoc.org/github.com/gorilla/websocket#Conn.NextWriter">Yes</a></td><td>No, see note 3</td></tr>
+</table>
+
+Notes: 
+
+1. Large messages are fragmented in [Chrome's new WebSocket implementation](http://www.ietf.org/mail-archive/web/hybi/current/msg10503.html).
+2. The application can get the type of a received data message by implementing
+   a [Codec marshal](http://godoc.org/golang.org/x/net/websocket#Codec.Marshal)
+   function.
+3. The go.net io.Reader and io.Writer operate across WebSocket frame boundaries.
+  Read returns when the input buffer is full or a frame boundary is
+  encountered. Each call to Write sends a single frame message. The Gorilla
+  io.Reader and io.WriteCloser operate on a single WebSocket message.
+

--- a/vendor/github.com/gorilla/websocket/client.go
+++ b/vendor/github.com/gorilla/websocket/client.go
@@ -1,0 +1,392 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrBadHandshake is returned when the server response to opening handshake is
+// invalid.
+var ErrBadHandshake = errors.New("websocket: bad handshake")
+
+var errInvalidCompression = errors.New("websocket: invalid compression negotiation")
+
+// NewClient creates a new client connection using the given net connection.
+// The URL u specifies the host and request URI. Use requestHeader to specify
+// the origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies
+// (Cookie). Use the response.Header to get the selected subprotocol
+// (Sec-WebSocket-Protocol) and cookies (Set-Cookie).
+//
+// If the WebSocket handshake fails, ErrBadHandshake is returned along with a
+// non-nil *http.Response so that callers can handle redirects, authentication,
+// etc.
+//
+// Deprecated: Use Dialer instead.
+func NewClient(netConn net.Conn, u *url.URL, requestHeader http.Header, readBufSize, writeBufSize int) (c *Conn, response *http.Response, err error) {
+	d := Dialer{
+		ReadBufferSize:  readBufSize,
+		WriteBufferSize: writeBufSize,
+		NetDial: func(net, addr string) (net.Conn, error) {
+			return netConn, nil
+		},
+	}
+	return d.Dial(u.String(), requestHeader)
+}
+
+// A Dialer contains options for connecting to WebSocket server.
+type Dialer struct {
+	// NetDial specifies the dial function for creating TCP connections. If
+	// NetDial is nil, net.Dial is used.
+	NetDial func(network, addr string) (net.Conn, error)
+
+	// Proxy specifies a function to return a proxy for a given
+	// Request. If the function returns a non-nil error, the
+	// request is aborted with the provided error.
+	// If Proxy is nil or returns a nil *URL, no proxy is used.
+	Proxy func(*http.Request) (*url.URL, error)
+
+	// TLSClientConfig specifies the TLS configuration to use with tls.Client.
+	// If nil, the default configuration is used.
+	TLSClientConfig *tls.Config
+
+	// HandshakeTimeout specifies the duration for the handshake to complete.
+	HandshakeTimeout time.Duration
+
+	// ReadBufferSize and WriteBufferSize specify I/O buffer sizes. If a buffer
+	// size is zero, then a useful default size is used. The I/O buffer sizes
+	// do not limit the size of the messages that can be sent or received.
+	ReadBufferSize, WriteBufferSize int
+
+	// Subprotocols specifies the client's requested subprotocols.
+	Subprotocols []string
+
+	// EnableCompression specifies if the client should attempt to negotiate
+	// per message compression (RFC 7692). Setting this value to true does not
+	// guarantee that compression will be supported. Currently only "no context
+	// takeover" modes are supported.
+	EnableCompression bool
+
+	// Jar specifies the cookie jar.
+	// If Jar is nil, cookies are not sent in requests and ignored
+	// in responses.
+	Jar http.CookieJar
+}
+
+var errMalformedURL = errors.New("malformed ws or wss URL")
+
+// parseURL parses the URL.
+//
+// This function is a replacement for the standard library url.Parse function.
+// In Go 1.4 and earlier, url.Parse loses information from the path.
+func parseURL(s string) (*url.URL, error) {
+	// From the RFC:
+	//
+	// ws-URI = "ws:" "//" host [ ":" port ] path [ "?" query ]
+	// wss-URI = "wss:" "//" host [ ":" port ] path [ "?" query ]
+	var u url.URL
+	switch {
+	case strings.HasPrefix(s, "ws://"):
+		u.Scheme = "ws"
+		s = s[len("ws://"):]
+	case strings.HasPrefix(s, "wss://"):
+		u.Scheme = "wss"
+		s = s[len("wss://"):]
+	default:
+		return nil, errMalformedURL
+	}
+
+	if i := strings.Index(s, "?"); i >= 0 {
+		u.RawQuery = s[i+1:]
+		s = s[:i]
+	}
+
+	if i := strings.Index(s, "/"); i >= 0 {
+		u.Opaque = s[i:]
+		s = s[:i]
+	} else {
+		u.Opaque = "/"
+	}
+
+	u.Host = s
+
+	if strings.Contains(u.Host, "@") {
+		// Don't bother parsing user information because user information is
+		// not allowed in websocket URIs.
+		return nil, errMalformedURL
+	}
+
+	return &u, nil
+}
+
+func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
+	hostPort = u.Host
+	hostNoPort = u.Host
+	if i := strings.LastIndex(u.Host, ":"); i > strings.LastIndex(u.Host, "]") {
+		hostNoPort = hostNoPort[:i]
+	} else {
+		switch u.Scheme {
+		case "wss":
+			hostPort += ":443"
+		case "https":
+			hostPort += ":443"
+		default:
+			hostPort += ":80"
+		}
+	}
+	return hostPort, hostNoPort
+}
+
+// DefaultDialer is a dialer with all fields set to the default zero values.
+var DefaultDialer = &Dialer{
+	Proxy: http.ProxyFromEnvironment,
+}
+
+// Dial creates a new client connection. Use requestHeader to specify the
+// origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies (Cookie).
+// Use the response.Header to get the selected subprotocol
+// (Sec-WebSocket-Protocol) and cookies (Set-Cookie).
+//
+// If the WebSocket handshake fails, ErrBadHandshake is returned along with a
+// non-nil *http.Response so that callers can handle redirects, authentication,
+// etcetera. The response body may not contain the entire response and does not
+// need to be closed by the application.
+func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
+
+	if d == nil {
+		d = &Dialer{
+			Proxy: http.ProxyFromEnvironment,
+		}
+	}
+
+	challengeKey, err := generateChallengeKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u, err := parseURL(urlStr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch u.Scheme {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	default:
+		return nil, nil, errMalformedURL
+	}
+
+	if u.User != nil {
+		// User name and password are not allowed in websocket URIs.
+		return nil, nil, errMalformedURL
+	}
+
+	req := &http.Request{
+		Method:     "GET",
+		URL:        u,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Host:       u.Host,
+	}
+
+	// Set the cookies present in the cookie jar of the dialer
+	if d.Jar != nil {
+		for _, cookie := range d.Jar.Cookies(u) {
+			req.AddCookie(cookie)
+		}
+	}
+
+	// Set the request headers using the capitalization for names and values in
+	// RFC examples. Although the capitalization shouldn't matter, there are
+	// servers that depend on it. The Header.Set method is not used because the
+	// method canonicalizes the header names.
+	req.Header["Upgrade"] = []string{"websocket"}
+	req.Header["Connection"] = []string{"Upgrade"}
+	req.Header["Sec-WebSocket-Key"] = []string{challengeKey}
+	req.Header["Sec-WebSocket-Version"] = []string{"13"}
+	if len(d.Subprotocols) > 0 {
+		req.Header["Sec-WebSocket-Protocol"] = []string{strings.Join(d.Subprotocols, ", ")}
+	}
+	for k, vs := range requestHeader {
+		switch {
+		case k == "Host":
+			if len(vs) > 0 {
+				req.Host = vs[0]
+			}
+		case k == "Upgrade" ||
+			k == "Connection" ||
+			k == "Sec-Websocket-Key" ||
+			k == "Sec-Websocket-Version" ||
+			k == "Sec-Websocket-Extensions" ||
+			(k == "Sec-Websocket-Protocol" && len(d.Subprotocols) > 0):
+			return nil, nil, errors.New("websocket: duplicate header not allowed: " + k)
+		default:
+			req.Header[k] = vs
+		}
+	}
+
+	if d.EnableCompression {
+		req.Header.Set("Sec-Websocket-Extensions", "permessage-deflate; server_no_context_takeover; client_no_context_takeover")
+	}
+
+	hostPort, hostNoPort := hostPortNoPort(u)
+
+	var proxyURL *url.URL
+	// Check wether the proxy method has been configured
+	if d.Proxy != nil {
+		proxyURL, err = d.Proxy(req)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var targetHostPort string
+	if proxyURL != nil {
+		targetHostPort, _ = hostPortNoPort(proxyURL)
+	} else {
+		targetHostPort = hostPort
+	}
+
+	var deadline time.Time
+	if d.HandshakeTimeout != 0 {
+		deadline = time.Now().Add(d.HandshakeTimeout)
+	}
+
+	netDial := d.NetDial
+	if netDial == nil {
+		netDialer := &net.Dialer{Deadline: deadline}
+		netDial = netDialer.Dial
+	}
+
+	netConn, err := netDial("tcp", targetHostPort)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer func() {
+		if netConn != nil {
+			netConn.Close()
+		}
+	}()
+
+	if err := netConn.SetDeadline(deadline); err != nil {
+		return nil, nil, err
+	}
+
+	if proxyURL != nil {
+		connectHeader := make(http.Header)
+		if user := proxyURL.User; user != nil {
+			proxyUser := user.Username()
+			if proxyPassword, passwordSet := user.Password(); passwordSet {
+				credential := base64.StdEncoding.EncodeToString([]byte(proxyUser + ":" + proxyPassword))
+				connectHeader.Set("Proxy-Authorization", "Basic "+credential)
+			}
+		}
+		connectReq := &http.Request{
+			Method: "CONNECT",
+			URL:    &url.URL{Opaque: hostPort},
+			Host:   hostPort,
+			Header: connectHeader,
+		}
+
+		connectReq.Write(netConn)
+
+		// Read response.
+		// Okay to use and discard buffered reader here, because
+		// TLS server will not speak until spoken to.
+		br := bufio.NewReader(netConn)
+		resp, err := http.ReadResponse(br, connectReq)
+		if err != nil {
+			return nil, nil, err
+		}
+		if resp.StatusCode != 200 {
+			f := strings.SplitN(resp.Status, " ", 2)
+			return nil, nil, errors.New(f[1])
+		}
+	}
+
+	if u.Scheme == "https" {
+		cfg := cloneTLSConfig(d.TLSClientConfig)
+		if cfg.ServerName == "" {
+			cfg.ServerName = hostNoPort
+		}
+		tlsConn := tls.Client(netConn, cfg)
+		netConn = tlsConn
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, nil, err
+		}
+		if !cfg.InsecureSkipVerify {
+			if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	conn := newConn(netConn, false, d.ReadBufferSize, d.WriteBufferSize)
+
+	if err := req.Write(netConn); err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := http.ReadResponse(conn.br, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if d.Jar != nil {
+		if rc := resp.Cookies(); len(rc) > 0 {
+			d.Jar.SetCookies(u, rc)
+		}
+	}
+
+	if resp.StatusCode != 101 ||
+		!strings.EqualFold(resp.Header.Get("Upgrade"), "websocket") ||
+		!strings.EqualFold(resp.Header.Get("Connection"), "upgrade") ||
+		resp.Header.Get("Sec-Websocket-Accept") != computeAcceptKey(challengeKey) {
+		// Before closing the network connection on return from this
+		// function, slurp up some of the response to aid application
+		// debugging.
+		buf := make([]byte, 1024)
+		n, _ := io.ReadFull(resp.Body, buf)
+		resp.Body = ioutil.NopCloser(bytes.NewReader(buf[:n]))
+		return nil, resp, ErrBadHandshake
+	}
+
+	for _, ext := range parseExtensions(resp.Header) {
+		if ext[""] != "permessage-deflate" {
+			continue
+		}
+		_, snct := ext["server_no_context_takeover"]
+		_, cnct := ext["client_no_context_takeover"]
+		if !snct || !cnct {
+			return nil, resp, errInvalidCompression
+		}
+		conn.newCompressionWriter = compressNoContextTakeover
+		conn.newDecompressionReader = decompressNoContextTakeover
+		break
+	}
+
+	resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	conn.subprotocol = resp.Header.Get("Sec-Websocket-Protocol")
+
+	netConn.SetDeadline(time.Time{})
+	netConn = nil // to avoid close in defer.
+	return conn, resp, nil
+}

--- a/vendor/github.com/gorilla/websocket/client_clone.go
+++ b/vendor/github.com/gorilla/websocket/client_clone.go
@@ -1,0 +1,16 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.8
+
+package websocket
+
+import "crypto/tls"
+
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return cfg.Clone()
+}

--- a/vendor/github.com/gorilla/websocket/client_clone_legacy.go
+++ b/vendor/github.com/gorilla/websocket/client_clone_legacy.go
@@ -1,0 +1,38 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.8
+
+package websocket
+
+import "crypto/tls"
+
+// cloneTLSConfig clones all public fields except the fields
+// SessionTicketsDisabled and SessionTicketKey. This avoids copying the
+// sync.Mutex in the sync.Once and makes it safe to call cloneTLSConfig on a
+// config in active use.
+func cloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return &tls.Config{
+		Rand:                     cfg.Rand,
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
+}

--- a/vendor/github.com/gorilla/websocket/client_server_test.go
+++ b/vendor/github.com/gorilla/websocket/client_server_test.go
@@ -1,0 +1,512 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var cstUpgrader = Upgrader{
+	Subprotocols:      []string{"p0", "p1"},
+	ReadBufferSize:    1024,
+	WriteBufferSize:   1024,
+	EnableCompression: true,
+	Error: func(w http.ResponseWriter, r *http.Request, status int, reason error) {
+		http.Error(w, reason.Error(), status)
+	},
+}
+
+var cstDialer = Dialer{
+	Subprotocols:    []string{"p1", "p2"},
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+type cstHandler struct{ *testing.T }
+
+type cstServer struct {
+	*httptest.Server
+	URL string
+}
+
+const (
+	cstPath       = "/a/b"
+	cstRawQuery   = "x=y"
+	cstRequestURI = cstPath + "?" + cstRawQuery
+)
+
+func newServer(t *testing.T) *cstServer {
+	var s cstServer
+	s.Server = httptest.NewServer(cstHandler{t})
+	s.Server.URL += cstRequestURI
+	s.URL = makeWsProto(s.Server.URL)
+	return &s
+}
+
+func newTLSServer(t *testing.T) *cstServer {
+	var s cstServer
+	s.Server = httptest.NewTLSServer(cstHandler{t})
+	s.Server.URL += cstRequestURI
+	s.URL = makeWsProto(s.Server.URL)
+	return &s
+}
+
+func (t cstHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != cstPath {
+		t.Logf("path=%v, want %v", r.URL.Path, cstPath)
+		http.Error(w, "bad path", 400)
+		return
+	}
+	if r.URL.RawQuery != cstRawQuery {
+		t.Logf("query=%v, want %v", r.URL.RawQuery, cstRawQuery)
+		http.Error(w, "bad path", 400)
+		return
+	}
+	subprotos := Subprotocols(r)
+	if !reflect.DeepEqual(subprotos, cstDialer.Subprotocols) {
+		t.Logf("subprotols=%v, want %v", subprotos, cstDialer.Subprotocols)
+		http.Error(w, "bad protocol", 400)
+		return
+	}
+	ws, err := cstUpgrader.Upgrade(w, r, http.Header{"Set-Cookie": {"sessionID=1234"}})
+	if err != nil {
+		t.Logf("Upgrade: %v", err)
+		return
+	}
+	defer ws.Close()
+
+	if ws.Subprotocol() != "p1" {
+		t.Logf("Subprotocol() = %s, want p1", ws.Subprotocol())
+		ws.Close()
+		return
+	}
+	op, rd, err := ws.NextReader()
+	if err != nil {
+		t.Logf("NextReader: %v", err)
+		return
+	}
+	wr, err := ws.NextWriter(op)
+	if err != nil {
+		t.Logf("NextWriter: %v", err)
+		return
+	}
+	if _, err = io.Copy(wr, rd); err != nil {
+		t.Logf("NextWriter: %v", err)
+		return
+	}
+	if err := wr.Close(); err != nil {
+		t.Logf("Close: %v", err)
+		return
+	}
+}
+
+func makeWsProto(s string) string {
+	return "ws" + strings.TrimPrefix(s, "http")
+}
+
+func sendRecv(t *testing.T, ws *Conn) {
+	const message = "Hello World!"
+	if err := ws.SetWriteDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetWriteDeadline: %v", err)
+	}
+	if err := ws.WriteMessage(TextMessage, []byte(message)); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	if err := ws.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, p, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if string(p) != message {
+		t.Fatalf("message=%s, want %s", p, message)
+	}
+}
+
+func TestProxyDial(t *testing.T) {
+
+	s := newServer(t)
+	defer s.Close()
+
+	surl, _ := url.Parse(s.URL)
+
+	cstDialer.Proxy = http.ProxyURL(surl)
+
+	connect := false
+	origHandler := s.Server.Config.Handler
+
+	// Capture the request Host header.
+	s.Server.Config.Handler = http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "CONNECT" {
+				connect = true
+				w.WriteHeader(200)
+				return
+			}
+
+			if !connect {
+				t.Log("connect not recieved")
+				http.Error(w, "connect not recieved", 405)
+				return
+			}
+			origHandler.ServeHTTP(w, r)
+		})
+
+	ws, _, err := cstDialer.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+
+	cstDialer.Proxy = http.ProxyFromEnvironment
+}
+
+func TestProxyAuthorizationDial(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	surl, _ := url.Parse(s.URL)
+	surl.User = url.UserPassword("username", "password")
+	cstDialer.Proxy = http.ProxyURL(surl)
+
+	connect := false
+	origHandler := s.Server.Config.Handler
+
+	// Capture the request Host header.
+	s.Server.Config.Handler = http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			proxyAuth := r.Header.Get("Proxy-Authorization")
+			expectedProxyAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("username:password"))
+			if r.Method == "CONNECT" && proxyAuth == expectedProxyAuth {
+				connect = true
+				w.WriteHeader(200)
+				return
+			}
+
+			if !connect {
+				t.Log("connect with proxy authorization not recieved")
+				http.Error(w, "connect with proxy authorization not recieved", 405)
+				return
+			}
+			origHandler.ServeHTTP(w, r)
+		})
+
+	ws, _, err := cstDialer.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+
+	cstDialer.Proxy = http.ProxyFromEnvironment
+}
+
+func TestDial(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	ws, _, err := cstDialer.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+}
+
+func TestDialCookieJar(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	jar, _ := cookiejar.New(nil)
+	d := cstDialer
+	d.Jar = jar
+
+	u, _ := parseURL(s.URL)
+
+	switch u.Scheme {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	}
+
+	cookies := []*http.Cookie{&http.Cookie{Name: "gorilla", Value: "ws", Path: "/"}}
+	d.Jar.SetCookies(u, cookies)
+
+	ws, _, err := d.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+
+	var gorilla string
+	var sessionID string
+	for _, c := range d.Jar.Cookies(u) {
+		if c.Name == "gorilla" {
+			gorilla = c.Value
+		}
+
+		if c.Name == "sessionID" {
+			sessionID = c.Value
+		}
+	}
+	if gorilla != "ws" {
+		t.Error("Cookie not present in jar.")
+	}
+
+	if sessionID != "1234" {
+		t.Error("Set-Cookie not received from the server.")
+	}
+
+	sendRecv(t, ws)
+}
+
+func TestDialTLS(t *testing.T) {
+	s := newTLSServer(t)
+	defer s.Close()
+
+	certs := x509.NewCertPool()
+	for _, c := range s.TLS.Certificates {
+		roots, err := x509.ParseCertificates(c.Certificate[len(c.Certificate)-1])
+		if err != nil {
+			t.Fatalf("error parsing server's root cert: %v", err)
+		}
+		for _, root := range roots {
+			certs.AddCert(root)
+		}
+	}
+
+	d := cstDialer
+	d.TLSClientConfig = &tls.Config{RootCAs: certs}
+	ws, _, err := d.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+}
+
+func xTestDialTLSBadCert(t *testing.T) {
+	// This test is deactivated because of noisy logging from the net/http package.
+	s := newTLSServer(t)
+	defer s.Close()
+
+	ws, _, err := cstDialer.Dial(s.URL, nil)
+	if err == nil {
+		ws.Close()
+		t.Fatalf("Dial: nil")
+	}
+}
+
+func TestDialTLSNoVerify(t *testing.T) {
+	s := newTLSServer(t)
+	defer s.Close()
+
+	d := cstDialer
+	d.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	ws, _, err := d.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+}
+
+func TestDialTimeout(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	d := cstDialer
+	d.HandshakeTimeout = -1
+	ws, _, err := d.Dial(s.URL, nil)
+	if err == nil {
+		ws.Close()
+		t.Fatalf("Dial: nil")
+	}
+}
+
+func TestDialBadScheme(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	ws, _, err := cstDialer.Dial(s.Server.URL, nil)
+	if err == nil {
+		ws.Close()
+		t.Fatalf("Dial: nil")
+	}
+}
+
+func TestDialBadOrigin(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	ws, resp, err := cstDialer.Dial(s.URL, http.Header{"Origin": {"bad"}})
+	if err == nil {
+		ws.Close()
+		t.Fatalf("Dial: nil")
+	}
+	if resp == nil {
+		t.Fatalf("resp=nil, err=%v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestDialBadHeader(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	for _, k := range []string{"Upgrade",
+		"Connection",
+		"Sec-Websocket-Key",
+		"Sec-Websocket-Version",
+		"Sec-Websocket-Protocol"} {
+		h := http.Header{}
+		h.Set(k, "bad")
+		ws, _, err := cstDialer.Dial(s.URL, http.Header{"Origin": {"bad"}})
+		if err == nil {
+			ws.Close()
+			t.Errorf("Dial with header %s returned nil", k)
+		}
+	}
+}
+
+func TestBadMethod(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := cstUpgrader.Upgrade(w, r, nil)
+		if err == nil {
+			t.Errorf("handshake succeeded, expect fail")
+			ws.Close()
+		}
+	}))
+	defer s.Close()
+
+	resp, err := http.PostForm(s.URL, url.Values{})
+	if err != nil {
+		t.Fatalf("PostForm returned error %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("Status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandshake(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	ws, resp, err := cstDialer.Dial(s.URL, http.Header{"Origin": {s.URL}})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+
+	var sessionID string
+	for _, c := range resp.Cookies() {
+		if c.Name == "sessionID" {
+			sessionID = c.Value
+		}
+	}
+	if sessionID != "1234" {
+		t.Error("Set-Cookie not received from the server.")
+	}
+
+	if ws.Subprotocol() != "p1" {
+		t.Errorf("ws.Subprotocol() = %s, want p1", ws.Subprotocol())
+	}
+	sendRecv(t, ws)
+}
+
+func TestRespOnBadHandshake(t *testing.T) {
+	const expectedStatus = http.StatusGone
+	const expectedBody = "This is the response body."
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(expectedStatus)
+		io.WriteString(w, expectedBody)
+	}))
+	defer s.Close()
+
+	ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
+	if err == nil {
+		ws.Close()
+		t.Fatalf("Dial: nil")
+	}
+
+	if resp == nil {
+		t.Fatalf("resp=nil, err=%v", err)
+	}
+
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("resp.StatusCode=%d, want %d", resp.StatusCode, expectedStatus)
+	}
+
+	p, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadFull(resp.Body) returned error %v", err)
+	}
+
+	if string(p) != expectedBody {
+		t.Errorf("resp.Body=%s, want %s", p, expectedBody)
+	}
+}
+
+// TestHostHeader confirms that the host header provided in the call to Dial is
+// sent to the server.
+func TestHostHeader(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	specifiedHost := make(chan string, 1)
+	origHandler := s.Server.Config.Handler
+
+	// Capture the request Host header.
+	s.Server.Config.Handler = http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			specifiedHost <- r.Host
+			origHandler.ServeHTTP(w, r)
+		})
+
+	ws, _, err := cstDialer.Dial(s.URL, http.Header{"Host": {"testhost"}})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+
+	if gotHost := <-specifiedHost; gotHost != "testhost" {
+		t.Fatalf("gotHost = %q, want \"testhost\"", gotHost)
+	}
+
+	sendRecv(t, ws)
+}
+
+func TestDialCompression(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	dialer := cstDialer
+	dialer.EnableCompression = true
+	ws, _, err := dialer.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+}

--- a/vendor/github.com/gorilla/websocket/client_test.go
+++ b/vendor/github.com/gorilla/websocket/client_test.go
@@ -1,0 +1,72 @@
+// Copyright 2014 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+var parseURLTests = []struct {
+	s   string
+	u   *url.URL
+	rui string
+}{
+	{"ws://example.com/", &url.URL{Scheme: "ws", Host: "example.com", Opaque: "/"}, "/"},
+	{"ws://example.com", &url.URL{Scheme: "ws", Host: "example.com", Opaque: "/"}, "/"},
+	{"ws://example.com:7777/", &url.URL{Scheme: "ws", Host: "example.com:7777", Opaque: "/"}, "/"},
+	{"wss://example.com/", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/"}, "/"},
+	{"wss://example.com/a/b", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/a/b"}, "/a/b"},
+	{"ss://example.com/a/b", nil, ""},
+	{"ws://webmaster@example.com/", nil, ""},
+	{"wss://example.com/a/b?x=y", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/a/b", RawQuery: "x=y"}, "/a/b?x=y"},
+	{"wss://example.com?x=y", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/", RawQuery: "x=y"}, "/?x=y"},
+}
+
+func TestParseURL(t *testing.T) {
+	for _, tt := range parseURLTests {
+		u, err := parseURL(tt.s)
+		if tt.u != nil && err != nil {
+			t.Errorf("parseURL(%q) returned error %v", tt.s, err)
+			continue
+		}
+		if tt.u == nil {
+			if err == nil {
+				t.Errorf("parseURL(%q) did not return error", tt.s)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(u, tt.u) {
+			t.Errorf("parseURL(%q) = %v, want %v", tt.s, u, tt.u)
+			continue
+		}
+		if u.RequestURI() != tt.rui {
+			t.Errorf("parseURL(%q).RequestURI() = %v, want %v", tt.s, u.RequestURI(), tt.rui)
+		}
+	}
+}
+
+var hostPortNoPortTests = []struct {
+	u                    *url.URL
+	hostPort, hostNoPort string
+}{
+	{&url.URL{Scheme: "ws", Host: "example.com"}, "example.com:80", "example.com"},
+	{&url.URL{Scheme: "wss", Host: "example.com"}, "example.com:443", "example.com"},
+	{&url.URL{Scheme: "ws", Host: "example.com:7777"}, "example.com:7777", "example.com"},
+	{&url.URL{Scheme: "wss", Host: "example.com:7777"}, "example.com:7777", "example.com"},
+}
+
+func TestHostPortNoPort(t *testing.T) {
+	for _, tt := range hostPortNoPortTests {
+		hostPort, hostNoPort := hostPortNoPort(tt.u)
+		if hostPort != tt.hostPort {
+			t.Errorf("hostPortNoPort(%v) returned hostPort %q, want %q", tt.u, hostPort, tt.hostPort)
+		}
+		if hostNoPort != tt.hostNoPort {
+			t.Errorf("hostPortNoPort(%v) returned hostNoPort %q, want %q", tt.u, hostNoPort, tt.hostNoPort)
+		}
+	}
+}

--- a/vendor/github.com/gorilla/websocket/compression.go
+++ b/vendor/github.com/gorilla/websocket/compression.go
@@ -1,0 +1,148 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"compress/flate"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+)
+
+const (
+	minCompressionLevel     = -2 // flate.HuffmanOnly not defined in Go < 1.6
+	maxCompressionLevel     = flate.BestCompression
+	defaultCompressionLevel = 1
+)
+
+var (
+	flateWriterPools [maxCompressionLevel - minCompressionLevel + 1]sync.Pool
+	flateReaderPool  = sync.Pool{New: func() interface{} {
+		return flate.NewReader(nil)
+	}}
+)
+
+func decompressNoContextTakeover(r io.Reader) io.ReadCloser {
+	const tail =
+	// Add four bytes as specified in RFC
+	"\x00\x00\xff\xff" +
+		// Add final block to squelch unexpected EOF error from flate reader.
+		"\x01\x00\x00\xff\xff"
+
+	fr, _ := flateReaderPool.Get().(io.ReadCloser)
+	fr.(flate.Resetter).Reset(io.MultiReader(r, strings.NewReader(tail)), nil)
+	return &flateReadWrapper{fr}
+}
+
+func isValidCompressionLevel(level int) bool {
+	return minCompressionLevel <= level && level <= maxCompressionLevel
+}
+
+func compressNoContextTakeover(w io.WriteCloser, level int) io.WriteCloser {
+	p := &flateWriterPools[level-minCompressionLevel]
+	tw := &truncWriter{w: w}
+	fw, _ := p.Get().(*flate.Writer)
+	if fw == nil {
+		fw, _ = flate.NewWriter(tw, level)
+	} else {
+		fw.Reset(tw)
+	}
+	return &flateWriteWrapper{fw: fw, tw: tw, p: p}
+}
+
+// truncWriter is an io.Writer that writes all but the last four bytes of the
+// stream to another io.Writer.
+type truncWriter struct {
+	w io.WriteCloser
+	n int
+	p [4]byte
+}
+
+func (w *truncWriter) Write(p []byte) (int, error) {
+	n := 0
+
+	// fill buffer first for simplicity.
+	if w.n < len(w.p) {
+		n = copy(w.p[w.n:], p)
+		p = p[n:]
+		w.n += n
+		if len(p) == 0 {
+			return n, nil
+		}
+	}
+
+	m := len(p)
+	if m > len(w.p) {
+		m = len(w.p)
+	}
+
+	if nn, err := w.w.Write(w.p[:m]); err != nil {
+		return n + nn, err
+	}
+
+	copy(w.p[:], w.p[m:])
+	copy(w.p[len(w.p)-m:], p[len(p)-m:])
+	nn, err := w.w.Write(p[:len(p)-m])
+	return n + nn, err
+}
+
+type flateWriteWrapper struct {
+	fw *flate.Writer
+	tw *truncWriter
+	p  *sync.Pool
+}
+
+func (w *flateWriteWrapper) Write(p []byte) (int, error) {
+	if w.fw == nil {
+		return 0, errWriteClosed
+	}
+	return w.fw.Write(p)
+}
+
+func (w *flateWriteWrapper) Close() error {
+	if w.fw == nil {
+		return errWriteClosed
+	}
+	err1 := w.fw.Flush()
+	w.p.Put(w.fw)
+	w.fw = nil
+	if w.tw.p != [4]byte{0, 0, 0xff, 0xff} {
+		return errors.New("websocket: internal error, unexpected bytes at end of flate stream")
+	}
+	err2 := w.tw.w.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+type flateReadWrapper struct {
+	fr io.ReadCloser
+}
+
+func (r *flateReadWrapper) Read(p []byte) (int, error) {
+	if r.fr == nil {
+		return 0, io.ErrClosedPipe
+	}
+	n, err := r.fr.Read(p)
+	if err == io.EOF {
+		// Preemptively place the reader back in the pool. This helps with
+		// scenarios where the application does not call NextReader() soon after
+		// this final read.
+		r.Close()
+	}
+	return n, err
+}
+
+func (r *flateReadWrapper) Close() error {
+	if r.fr == nil {
+		return io.ErrClosedPipe
+	}
+	err := r.fr.Close()
+	flateReaderPool.Put(r.fr)
+	r.fr = nil
+	return err
+}

--- a/vendor/github.com/gorilla/websocket/compression_test.go
+++ b/vendor/github.com/gorilla/websocket/compression_test.go
@@ -1,0 +1,80 @@
+package websocket
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+type nopCloser struct{ io.Writer }
+
+func (nopCloser) Close() error { return nil }
+
+func TestTruncWriter(t *testing.T) {
+	const data = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz987654321"
+	for n := 1; n <= 10; n++ {
+		var b bytes.Buffer
+		w := &truncWriter{w: nopCloser{&b}}
+		p := []byte(data)
+		for len(p) > 0 {
+			m := len(p)
+			if m > n {
+				m = n
+			}
+			w.Write(p[:m])
+			p = p[m:]
+		}
+		if b.String() != data[:len(data)-len(w.p)] {
+			t.Errorf("%d: %q", n, b.String())
+		}
+	}
+}
+
+func textMessages(num int) [][]byte {
+	messages := make([][]byte, num)
+	for i := 0; i < num; i++ {
+		msg := fmt.Sprintf("planet: %d, country: %d, city: %d, street: %d", i, i, i, i)
+		messages[i] = []byte(msg)
+	}
+	return messages
+}
+
+func BenchmarkWriteNoCompression(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WriteMessage(TextMessage, messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkWriteWithCompression(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	c.enableWriteCompression = true
+	c.newCompressionWriter = compressNoContextTakeover
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WriteMessage(TextMessage, messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}
+
+func TestValidCompressionLevel(t *testing.T) {
+	c := newConn(fakeNetConn{}, false, 1024, 1024)
+	for _, level := range []int{minCompressionLevel - 1, maxCompressionLevel + 1} {
+		if err := c.SetCompressionLevel(level); err == nil {
+			t.Errorf("no error for level %d", level)
+		}
+	}
+	for _, level := range []int{minCompressionLevel, maxCompressionLevel} {
+		if err := c.SetCompressionLevel(level); err != nil {
+			t.Errorf("error for level %d", level)
+		}
+	}
+}

--- a/vendor/github.com/gorilla/websocket/conn.go
+++ b/vendor/github.com/gorilla/websocket/conn.go
@@ -1,0 +1,1149 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// Frame header byte 0 bits from Section 5.2 of RFC 6455
+	finalBit = 1 << 7
+	rsv1Bit  = 1 << 6
+	rsv2Bit  = 1 << 5
+	rsv3Bit  = 1 << 4
+
+	// Frame header byte 1 bits from Section 5.2 of RFC 6455
+	maskBit = 1 << 7
+
+	maxFrameHeaderSize         = 2 + 8 + 4 // Fixed header + length + mask
+	maxControlFramePayloadSize = 125
+
+	writeWait = time.Second
+
+	defaultReadBufferSize  = 4096
+	defaultWriteBufferSize = 4096
+
+	continuationFrame = 0
+	noFrame           = -1
+)
+
+// Close codes defined in RFC 6455, section 11.7.
+const (
+	CloseNormalClosure           = 1000
+	CloseGoingAway               = 1001
+	CloseProtocolError           = 1002
+	CloseUnsupportedData         = 1003
+	CloseNoStatusReceived        = 1005
+	CloseAbnormalClosure         = 1006
+	CloseInvalidFramePayloadData = 1007
+	ClosePolicyViolation         = 1008
+	CloseMessageTooBig           = 1009
+	CloseMandatoryExtension      = 1010
+	CloseInternalServerErr       = 1011
+	CloseServiceRestart          = 1012
+	CloseTryAgainLater           = 1013
+	CloseTLSHandshake            = 1015
+)
+
+// The message types are defined in RFC 6455, section 11.8.
+const (
+	// TextMessage denotes a text data message. The text message payload is
+	// interpreted as UTF-8 encoded text data.
+	TextMessage = 1
+
+	// BinaryMessage denotes a binary data message.
+	BinaryMessage = 2
+
+	// CloseMessage denotes a close control message. The optional message
+	// payload contains a numeric code and text. Use the FormatCloseMessage
+	// function to format a close message payload.
+	CloseMessage = 8
+
+	// PingMessage denotes a ping control message. The optional message payload
+	// is UTF-8 encoded text.
+	PingMessage = 9
+
+	// PongMessage denotes a ping control message. The optional message payload
+	// is UTF-8 encoded text.
+	PongMessage = 10
+)
+
+// ErrCloseSent is returned when the application writes a message to the
+// connection after sending a close message.
+var ErrCloseSent = errors.New("websocket: close sent")
+
+// ErrReadLimit is returned when reading a message that is larger than the
+// read limit set for the connection.
+var ErrReadLimit = errors.New("websocket: read limit exceeded")
+
+// netError satisfies the net Error interface.
+type netError struct {
+	msg       string
+	temporary bool
+	timeout   bool
+}
+
+func (e *netError) Error() string   { return e.msg }
+func (e *netError) Temporary() bool { return e.temporary }
+func (e *netError) Timeout() bool   { return e.timeout }
+
+// CloseError represents close frame.
+type CloseError struct {
+
+	// Code is defined in RFC 6455, section 11.7.
+	Code int
+
+	// Text is the optional text payload.
+	Text string
+}
+
+func (e *CloseError) Error() string {
+	s := []byte("websocket: close ")
+	s = strconv.AppendInt(s, int64(e.Code), 10)
+	switch e.Code {
+	case CloseNormalClosure:
+		s = append(s, " (normal)"...)
+	case CloseGoingAway:
+		s = append(s, " (going away)"...)
+	case CloseProtocolError:
+		s = append(s, " (protocol error)"...)
+	case CloseUnsupportedData:
+		s = append(s, " (unsupported data)"...)
+	case CloseNoStatusReceived:
+		s = append(s, " (no status)"...)
+	case CloseAbnormalClosure:
+		s = append(s, " (abnormal closure)"...)
+	case CloseInvalidFramePayloadData:
+		s = append(s, " (invalid payload data)"...)
+	case ClosePolicyViolation:
+		s = append(s, " (policy violation)"...)
+	case CloseMessageTooBig:
+		s = append(s, " (message too big)"...)
+	case CloseMandatoryExtension:
+		s = append(s, " (mandatory extension missing)"...)
+	case CloseInternalServerErr:
+		s = append(s, " (internal server error)"...)
+	case CloseTLSHandshake:
+		s = append(s, " (TLS handshake error)"...)
+	}
+	if e.Text != "" {
+		s = append(s, ": "...)
+		s = append(s, e.Text...)
+	}
+	return string(s)
+}
+
+// IsCloseError returns boolean indicating whether the error is a *CloseError
+// with one of the specified codes.
+func IsCloseError(err error, codes ...int) bool {
+	if e, ok := err.(*CloseError); ok {
+		for _, code := range codes {
+			if e.Code == code {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsUnexpectedCloseError returns boolean indicating whether the error is a
+// *CloseError with a code not in the list of expected codes.
+func IsUnexpectedCloseError(err error, expectedCodes ...int) bool {
+	if e, ok := err.(*CloseError); ok {
+		for _, code := range expectedCodes {
+			if e.Code == code {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+var (
+	errWriteTimeout        = &netError{msg: "websocket: write timeout", timeout: true, temporary: true}
+	errUnexpectedEOF       = &CloseError{Code: CloseAbnormalClosure, Text: io.ErrUnexpectedEOF.Error()}
+	errBadWriteOpCode      = errors.New("websocket: bad write message type")
+	errWriteClosed         = errors.New("websocket: write closed")
+	errInvalidControlFrame = errors.New("websocket: invalid control frame")
+)
+
+func newMaskKey() [4]byte {
+	n := rand.Uint32()
+	return [4]byte{byte(n), byte(n >> 8), byte(n >> 16), byte(n >> 24)}
+}
+
+func hideTempErr(err error) error {
+	if e, ok := err.(net.Error); ok && e.Temporary() {
+		err = &netError{msg: e.Error(), timeout: e.Timeout()}
+	}
+	return err
+}
+
+func isControl(frameType int) bool {
+	return frameType == CloseMessage || frameType == PingMessage || frameType == PongMessage
+}
+
+func isData(frameType int) bool {
+	return frameType == TextMessage || frameType == BinaryMessage
+}
+
+var validReceivedCloseCodes = map[int]bool{
+	// see http://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number
+
+	CloseNormalClosure:           true,
+	CloseGoingAway:               true,
+	CloseProtocolError:           true,
+	CloseUnsupportedData:         true,
+	CloseNoStatusReceived:        false,
+	CloseAbnormalClosure:         false,
+	CloseInvalidFramePayloadData: true,
+	ClosePolicyViolation:         true,
+	CloseMessageTooBig:           true,
+	CloseMandatoryExtension:      true,
+	CloseInternalServerErr:       true,
+	CloseServiceRestart:          true,
+	CloseTryAgainLater:           true,
+	CloseTLSHandshake:            false,
+}
+
+func isValidReceivedCloseCode(code int) bool {
+	return validReceivedCloseCodes[code] || (code >= 3000 && code <= 4999)
+}
+
+// The Conn type represents a WebSocket connection.
+type Conn struct {
+	conn        net.Conn
+	isServer    bool
+	subprotocol string
+
+	// Write fields
+	mu            chan bool // used as mutex to protect write to conn
+	writeBuf      []byte    // frame is constructed in this buffer.
+	writeDeadline time.Time
+	writer        io.WriteCloser // the current writer returned to the application
+	isWriting     bool           // for best-effort concurrent write detection
+
+	writeErrMu sync.Mutex
+	writeErr   error
+
+	enableWriteCompression bool
+	compressionLevel       int
+	newCompressionWriter   func(io.WriteCloser, int) io.WriteCloser
+
+	// Read fields
+	reader        io.ReadCloser // the current reader returned to the application
+	readErr       error
+	br            *bufio.Reader
+	readRemaining int64 // bytes remaining in current frame.
+	readFinal     bool  // true the current message has more frames.
+	readLength    int64 // Message size.
+	readLimit     int64 // Maximum message size.
+	readMaskPos   int
+	readMaskKey   [4]byte
+	handlePong    func(string) error
+	handlePing    func(string) error
+	handleClose   func(int, string) error
+	readErrCount  int
+	messageReader *messageReader // the current low-level reader
+
+	readDecompress         bool // whether last read frame had RSV1 set
+	newDecompressionReader func(io.Reader) io.ReadCloser
+}
+
+func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int) *Conn {
+	return newConnBRW(conn, isServer, readBufferSize, writeBufferSize, nil)
+}
+
+type writeHook struct {
+	p []byte
+}
+
+func (wh *writeHook) Write(p []byte) (int, error) {
+	wh.p = p
+	return len(p), nil
+}
+
+func newConnBRW(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int, brw *bufio.ReadWriter) *Conn {
+	mu := make(chan bool, 1)
+	mu <- true
+
+	var br *bufio.Reader
+	if readBufferSize == 0 && brw != nil && brw.Reader != nil {
+		// Reuse the supplied bufio.Reader if the buffer has a useful size.
+		// This code assumes that peek on a reader returns
+		// bufio.Reader.buf[:0].
+		brw.Reader.Reset(conn)
+		if p, err := brw.Reader.Peek(0); err == nil && cap(p) >= 256 {
+			br = brw.Reader
+		}
+	}
+	if br == nil {
+		if readBufferSize == 0 {
+			readBufferSize = defaultReadBufferSize
+		}
+		if readBufferSize < maxControlFramePayloadSize {
+			readBufferSize = maxControlFramePayloadSize
+		}
+		br = bufio.NewReaderSize(conn, readBufferSize)
+	}
+
+	var writeBuf []byte
+	if writeBufferSize == 0 && brw != nil && brw.Writer != nil {
+		// Use the bufio.Writer's buffer if the buffer has a useful size. This
+		// code assumes that bufio.Writer.buf[:1] is passed to the
+		// bufio.Writer's underlying writer.
+		var wh writeHook
+		brw.Writer.Reset(&wh)
+		brw.Writer.WriteByte(0)
+		brw.Flush()
+		if cap(wh.p) >= maxFrameHeaderSize+256 {
+			writeBuf = wh.p[:cap(wh.p)]
+		}
+	}
+
+	if writeBuf == nil {
+		if writeBufferSize == 0 {
+			writeBufferSize = defaultWriteBufferSize
+		}
+		writeBuf = make([]byte, writeBufferSize+maxFrameHeaderSize)
+	}
+
+	c := &Conn{
+		isServer:               isServer,
+		br:                     br,
+		conn:                   conn,
+		mu:                     mu,
+		readFinal:              true,
+		writeBuf:               writeBuf,
+		enableWriteCompression: true,
+		compressionLevel:       defaultCompressionLevel,
+	}
+	c.SetCloseHandler(nil)
+	c.SetPingHandler(nil)
+	c.SetPongHandler(nil)
+	return c
+}
+
+// Subprotocol returns the negotiated protocol for the connection.
+func (c *Conn) Subprotocol() string {
+	return c.subprotocol
+}
+
+// Close closes the underlying network connection without sending or waiting for a close frame.
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
+// LocalAddr returns the local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// Write methods
+
+func (c *Conn) writeFatal(err error) error {
+	err = hideTempErr(err)
+	c.writeErrMu.Lock()
+	if c.writeErr == nil {
+		c.writeErr = err
+	}
+	c.writeErrMu.Unlock()
+	return err
+}
+
+func (c *Conn) write(frameType int, deadline time.Time, bufs ...[]byte) error {
+	<-c.mu
+	defer func() { c.mu <- true }()
+
+	c.writeErrMu.Lock()
+	err := c.writeErr
+	c.writeErrMu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	c.conn.SetWriteDeadline(deadline)
+	for _, buf := range bufs {
+		if len(buf) > 0 {
+			_, err := c.conn.Write(buf)
+			if err != nil {
+				return c.writeFatal(err)
+			}
+		}
+	}
+
+	if frameType == CloseMessage {
+		c.writeFatal(ErrCloseSent)
+	}
+	return nil
+}
+
+// WriteControl writes a control message with the given deadline. The allowed
+// message types are CloseMessage, PingMessage and PongMessage.
+func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	if !isControl(messageType) {
+		return errBadWriteOpCode
+	}
+	if len(data) > maxControlFramePayloadSize {
+		return errInvalidControlFrame
+	}
+
+	b0 := byte(messageType) | finalBit
+	b1 := byte(len(data))
+	if !c.isServer {
+		b1 |= maskBit
+	}
+
+	buf := make([]byte, 0, maxFrameHeaderSize+maxControlFramePayloadSize)
+	buf = append(buf, b0, b1)
+
+	if c.isServer {
+		buf = append(buf, data...)
+	} else {
+		key := newMaskKey()
+		buf = append(buf, key[:]...)
+		buf = append(buf, data...)
+		maskBytes(key, 0, buf[6:])
+	}
+
+	d := time.Hour * 1000
+	if !deadline.IsZero() {
+		d = deadline.Sub(time.Now())
+		if d < 0 {
+			return errWriteTimeout
+		}
+	}
+
+	timer := time.NewTimer(d)
+	select {
+	case <-c.mu:
+		timer.Stop()
+	case <-timer.C:
+		return errWriteTimeout
+	}
+	defer func() { c.mu <- true }()
+
+	c.writeErrMu.Lock()
+	err := c.writeErr
+	c.writeErrMu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	c.conn.SetWriteDeadline(deadline)
+	_, err = c.conn.Write(buf)
+	if err != nil {
+		return c.writeFatal(err)
+	}
+	if messageType == CloseMessage {
+		c.writeFatal(ErrCloseSent)
+	}
+	return err
+}
+
+func (c *Conn) prepWrite(messageType int) error {
+	// Close previous writer if not already closed by the application. It's
+	// probably better to return an error in this situation, but we cannot
+	// change this without breaking existing applications.
+	if c.writer != nil {
+		c.writer.Close()
+		c.writer = nil
+	}
+
+	if !isControl(messageType) && !isData(messageType) {
+		return errBadWriteOpCode
+	}
+
+	c.writeErrMu.Lock()
+	err := c.writeErr
+	c.writeErrMu.Unlock()
+	return err
+}
+
+// NextWriter returns a writer for the next message to send. The writer's Close
+// method flushes the complete message to the network.
+//
+// There can be at most one open writer on a connection. NextWriter closes the
+// previous writer if the application has not already done so.
+func (c *Conn) NextWriter(messageType int) (io.WriteCloser, error) {
+	if err := c.prepWrite(messageType); err != nil {
+		return nil, err
+	}
+
+	mw := &messageWriter{
+		c:         c,
+		frameType: messageType,
+		pos:       maxFrameHeaderSize,
+	}
+	c.writer = mw
+	if c.newCompressionWriter != nil && c.enableWriteCompression && isData(messageType) {
+		w := c.newCompressionWriter(c.writer, c.compressionLevel)
+		mw.compress = true
+		c.writer = w
+	}
+	return c.writer, nil
+}
+
+type messageWriter struct {
+	c         *Conn
+	compress  bool // whether next call to flushFrame should set RSV1
+	pos       int  // end of data in writeBuf.
+	frameType int  // type of the current frame.
+	err       error
+}
+
+func (w *messageWriter) fatal(err error) error {
+	if w.err != nil {
+		w.err = err
+		w.c.writer = nil
+	}
+	return err
+}
+
+// flushFrame writes buffered data and extra as a frame to the network. The
+// final argument indicates that this is the last frame in the message.
+func (w *messageWriter) flushFrame(final bool, extra []byte) error {
+	c := w.c
+	length := w.pos - maxFrameHeaderSize + len(extra)
+
+	// Check for invalid control frames.
+	if isControl(w.frameType) &&
+		(!final || length > maxControlFramePayloadSize) {
+		return w.fatal(errInvalidControlFrame)
+	}
+
+	b0 := byte(w.frameType)
+	if final {
+		b0 |= finalBit
+	}
+	if w.compress {
+		b0 |= rsv1Bit
+	}
+	w.compress = false
+
+	b1 := byte(0)
+	if !c.isServer {
+		b1 |= maskBit
+	}
+
+	// Assume that the frame starts at beginning of c.writeBuf.
+	framePos := 0
+	if c.isServer {
+		// Adjust up if mask not included in the header.
+		framePos = 4
+	}
+
+	switch {
+	case length >= 65536:
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | 127
+		binary.BigEndian.PutUint64(c.writeBuf[framePos+2:], uint64(length))
+	case length > 125:
+		framePos += 6
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | 126
+		binary.BigEndian.PutUint16(c.writeBuf[framePos+2:], uint16(length))
+	default:
+		framePos += 8
+		c.writeBuf[framePos] = b0
+		c.writeBuf[framePos+1] = b1 | byte(length)
+	}
+
+	if !c.isServer {
+		key := newMaskKey()
+		copy(c.writeBuf[maxFrameHeaderSize-4:], key[:])
+		maskBytes(key, 0, c.writeBuf[maxFrameHeaderSize:w.pos])
+		if len(extra) > 0 {
+			return c.writeFatal(errors.New("websocket: internal error, extra used in client mode"))
+		}
+	}
+
+	// Write the buffers to the connection with best-effort detection of
+	// concurrent writes. See the concurrency section in the package
+	// documentation for more info.
+
+	if c.isWriting {
+		panic("concurrent write to websocket connection")
+	}
+	c.isWriting = true
+
+	err := c.write(w.frameType, c.writeDeadline, c.writeBuf[framePos:w.pos], extra)
+
+	if !c.isWriting {
+		panic("concurrent write to websocket connection")
+	}
+	c.isWriting = false
+
+	if err != nil {
+		return w.fatal(err)
+	}
+
+	if final {
+		c.writer = nil
+		return nil
+	}
+
+	// Setup for next frame.
+	w.pos = maxFrameHeaderSize
+	w.frameType = continuationFrame
+	return nil
+}
+
+func (w *messageWriter) ncopy(max int) (int, error) {
+	n := len(w.c.writeBuf) - w.pos
+	if n <= 0 {
+		if err := w.flushFrame(false, nil); err != nil {
+			return 0, err
+		}
+		n = len(w.c.writeBuf) - w.pos
+	}
+	if n > max {
+		n = max
+	}
+	return n, nil
+}
+
+func (w *messageWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	if len(p) > 2*len(w.c.writeBuf) && w.c.isServer {
+		// Don't buffer large messages.
+		err := w.flushFrame(false, p)
+		if err != nil {
+			return 0, err
+		}
+		return len(p), nil
+	}
+
+	nn := len(p)
+	for len(p) > 0 {
+		n, err := w.ncopy(len(p))
+		if err != nil {
+			return 0, err
+		}
+		copy(w.c.writeBuf[w.pos:], p[:n])
+		w.pos += n
+		p = p[n:]
+	}
+	return nn, nil
+}
+
+func (w *messageWriter) WriteString(p string) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	nn := len(p)
+	for len(p) > 0 {
+		n, err := w.ncopy(len(p))
+		if err != nil {
+			return 0, err
+		}
+		copy(w.c.writeBuf[w.pos:], p[:n])
+		w.pos += n
+		p = p[n:]
+	}
+	return nn, nil
+}
+
+func (w *messageWriter) ReadFrom(r io.Reader) (nn int64, err error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	for {
+		if w.pos == len(w.c.writeBuf) {
+			err = w.flushFrame(false, nil)
+			if err != nil {
+				break
+			}
+		}
+		var n int
+		n, err = r.Read(w.c.writeBuf[w.pos:])
+		w.pos += n
+		nn += int64(n)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			break
+		}
+	}
+	return nn, err
+}
+
+func (w *messageWriter) Close() error {
+	if w.err != nil {
+		return w.err
+	}
+	if err := w.flushFrame(true, nil); err != nil {
+		return err
+	}
+	w.err = errWriteClosed
+	return nil
+}
+
+// WritePreparedMessage writes prepared message into connection.
+func (c *Conn) WritePreparedMessage(pm *PreparedMessage) error {
+	frameType, frameData, err := pm.frame(prepareKey{
+		isServer:         c.isServer,
+		compress:         c.newCompressionWriter != nil && c.enableWriteCompression && isData(pm.messageType),
+		compressionLevel: c.compressionLevel,
+	})
+	if err != nil {
+		return err
+	}
+	if c.isWriting {
+		panic("concurrent write to websocket connection")
+	}
+	c.isWriting = true
+	err = c.write(frameType, c.writeDeadline, frameData, nil)
+	if !c.isWriting {
+		panic("concurrent write to websocket connection")
+	}
+	c.isWriting = false
+	return err
+}
+
+// WriteMessage is a helper method for getting a writer using NextWriter,
+// writing the message and closing the writer.
+func (c *Conn) WriteMessage(messageType int, data []byte) error {
+
+	if c.isServer && (c.newCompressionWriter == nil || !c.enableWriteCompression) {
+		// Fast path with no allocations and single frame.
+
+		if err := c.prepWrite(messageType); err != nil {
+			return err
+		}
+		mw := messageWriter{c: c, frameType: messageType, pos: maxFrameHeaderSize}
+		n := copy(c.writeBuf[mw.pos:], data)
+		mw.pos += n
+		data = data[n:]
+		return mw.flushFrame(true, data)
+	}
+
+	w, err := c.NextWriter(messageType)
+	if err != nil {
+		return err
+	}
+	if _, err = w.Write(data); err != nil {
+		return err
+	}
+	return w.Close()
+}
+
+// SetWriteDeadline sets the write deadline on the underlying network
+// connection. After a write has timed out, the websocket state is corrupt and
+// all future writes will return an error. A zero value for t means writes will
+// not time out.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline = t
+	return nil
+}
+
+// Read methods
+
+func (c *Conn) advanceFrame() (int, error) {
+
+	// 1. Skip remainder of previous frame.
+
+	if c.readRemaining > 0 {
+		if _, err := io.CopyN(ioutil.Discard, c.br, c.readRemaining); err != nil {
+			return noFrame, err
+		}
+	}
+
+	// 2. Read and parse first two bytes of frame header.
+
+	p, err := c.read(2)
+	if err != nil {
+		return noFrame, err
+	}
+
+	final := p[0]&finalBit != 0
+	frameType := int(p[0] & 0xf)
+	mask := p[1]&maskBit != 0
+	c.readRemaining = int64(p[1] & 0x7f)
+
+	c.readDecompress = false
+	if c.newDecompressionReader != nil && (p[0]&rsv1Bit) != 0 {
+		c.readDecompress = true
+		p[0] &^= rsv1Bit
+	}
+
+	if rsv := p[0] & (rsv1Bit | rsv2Bit | rsv3Bit); rsv != 0 {
+		return noFrame, c.handleProtocolError("unexpected reserved bits 0x" + strconv.FormatInt(int64(rsv), 16))
+	}
+
+	switch frameType {
+	case CloseMessage, PingMessage, PongMessage:
+		if c.readRemaining > maxControlFramePayloadSize {
+			return noFrame, c.handleProtocolError("control frame length > 125")
+		}
+		if !final {
+			return noFrame, c.handleProtocolError("control frame not final")
+		}
+	case TextMessage, BinaryMessage:
+		if !c.readFinal {
+			return noFrame, c.handleProtocolError("message start before final message frame")
+		}
+		c.readFinal = final
+	case continuationFrame:
+		if c.readFinal {
+			return noFrame, c.handleProtocolError("continuation after final message frame")
+		}
+		c.readFinal = final
+	default:
+		return noFrame, c.handleProtocolError("unknown opcode " + strconv.Itoa(frameType))
+	}
+
+	// 3. Read and parse frame length.
+
+	switch c.readRemaining {
+	case 126:
+		p, err := c.read(2)
+		if err != nil {
+			return noFrame, err
+		}
+		c.readRemaining = int64(binary.BigEndian.Uint16(p))
+	case 127:
+		p, err := c.read(8)
+		if err != nil {
+			return noFrame, err
+		}
+		c.readRemaining = int64(binary.BigEndian.Uint64(p))
+	}
+
+	// 4. Handle frame masking.
+
+	if mask != c.isServer {
+		return noFrame, c.handleProtocolError("incorrect mask flag")
+	}
+
+	if mask {
+		c.readMaskPos = 0
+		p, err := c.read(len(c.readMaskKey))
+		if err != nil {
+			return noFrame, err
+		}
+		copy(c.readMaskKey[:], p)
+	}
+
+	// 5. For text and binary messages, enforce read limit and return.
+
+	if frameType == continuationFrame || frameType == TextMessage || frameType == BinaryMessage {
+
+		c.readLength += c.readRemaining
+		if c.readLimit > 0 && c.readLength > c.readLimit {
+			c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(writeWait))
+			return noFrame, ErrReadLimit
+		}
+
+		return frameType, nil
+	}
+
+	// 6. Read control frame payload.
+
+	var payload []byte
+	if c.readRemaining > 0 {
+		payload, err = c.read(int(c.readRemaining))
+		c.readRemaining = 0
+		if err != nil {
+			return noFrame, err
+		}
+		if c.isServer {
+			maskBytes(c.readMaskKey, 0, payload)
+		}
+	}
+
+	// 7. Process control frame payload.
+
+	switch frameType {
+	case PongMessage:
+		if err := c.handlePong(string(payload)); err != nil {
+			return noFrame, err
+		}
+	case PingMessage:
+		if err := c.handlePing(string(payload)); err != nil {
+			return noFrame, err
+		}
+	case CloseMessage:
+		closeCode := CloseNoStatusReceived
+		closeText := ""
+		if len(payload) >= 2 {
+			closeCode = int(binary.BigEndian.Uint16(payload))
+			if !isValidReceivedCloseCode(closeCode) {
+				return noFrame, c.handleProtocolError("invalid close code")
+			}
+			closeText = string(payload[2:])
+			if !utf8.ValidString(closeText) {
+				return noFrame, c.handleProtocolError("invalid utf8 payload in close frame")
+			}
+		}
+		if err := c.handleClose(closeCode, closeText); err != nil {
+			return noFrame, err
+		}
+		return noFrame, &CloseError{Code: closeCode, Text: closeText}
+	}
+
+	return frameType, nil
+}
+
+func (c *Conn) handleProtocolError(message string) error {
+	c.WriteControl(CloseMessage, FormatCloseMessage(CloseProtocolError, message), time.Now().Add(writeWait))
+	return errors.New("websocket: " + message)
+}
+
+// NextReader returns the next data message received from the peer. The
+// returned messageType is either TextMessage or BinaryMessage.
+//
+// There can be at most one open reader on a connection. NextReader discards
+// the previous message if the application has not already consumed it.
+//
+// Applications must break out of the application's read loop when this method
+// returns a non-nil error value. Errors returned from this method are
+// permanent. Once this method returns a non-nil error, all subsequent calls to
+// this method return the same error.
+func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
+	// Close previous reader, only relevant for decompression.
+	if c.reader != nil {
+		c.reader.Close()
+		c.reader = nil
+	}
+
+	c.messageReader = nil
+	c.readLength = 0
+
+	for c.readErr == nil {
+		frameType, err := c.advanceFrame()
+		if err != nil {
+			c.readErr = hideTempErr(err)
+			break
+		}
+		if frameType == TextMessage || frameType == BinaryMessage {
+			c.messageReader = &messageReader{c}
+			c.reader = c.messageReader
+			if c.readDecompress {
+				c.reader = c.newDecompressionReader(c.reader)
+			}
+			return frameType, c.reader, nil
+		}
+	}
+
+	// Applications that do handle the error returned from this method spin in
+	// tight loop on connection failure. To help application developers detect
+	// this error, panic on repeated reads to the failed connection.
+	c.readErrCount++
+	if c.readErrCount >= 1000 {
+		panic("repeated read on failed websocket connection")
+	}
+
+	return noFrame, nil, c.readErr
+}
+
+type messageReader struct{ c *Conn }
+
+func (r *messageReader) Read(b []byte) (int, error) {
+	c := r.c
+	if c.messageReader != r {
+		return 0, io.EOF
+	}
+
+	for c.readErr == nil {
+
+		if c.readRemaining > 0 {
+			if int64(len(b)) > c.readRemaining {
+				b = b[:c.readRemaining]
+			}
+			n, err := c.br.Read(b)
+			c.readErr = hideTempErr(err)
+			if c.isServer {
+				c.readMaskPos = maskBytes(c.readMaskKey, c.readMaskPos, b[:n])
+			}
+			c.readRemaining -= int64(n)
+			if c.readRemaining > 0 && c.readErr == io.EOF {
+				c.readErr = errUnexpectedEOF
+			}
+			return n, c.readErr
+		}
+
+		if c.readFinal {
+			c.messageReader = nil
+			return 0, io.EOF
+		}
+
+		frameType, err := c.advanceFrame()
+		switch {
+		case err != nil:
+			c.readErr = hideTempErr(err)
+		case frameType == TextMessage || frameType == BinaryMessage:
+			c.readErr = errors.New("websocket: internal error, unexpected text or binary in Reader")
+		}
+	}
+
+	err := c.readErr
+	if err == io.EOF && c.messageReader == r {
+		err = errUnexpectedEOF
+	}
+	return 0, err
+}
+
+func (r *messageReader) Close() error {
+	return nil
+}
+
+// ReadMessage is a helper method for getting a reader using NextReader and
+// reading from that reader to a buffer.
+func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
+	var r io.Reader
+	messageType, r, err = c.NextReader()
+	if err != nil {
+		return messageType, nil, err
+	}
+	p, err = ioutil.ReadAll(r)
+	return messageType, p, err
+}
+
+// SetReadDeadline sets the read deadline on the underlying network connection.
+// After a read has timed out, the websocket connection state is corrupt and
+// all future reads will return an error. A zero value for t means reads will
+// not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetReadLimit sets the maximum size for a message read from the peer. If a
+// message exceeds the limit, the connection sends a close frame to the peer
+// and returns ErrReadLimit to the application.
+func (c *Conn) SetReadLimit(limit int64) {
+	c.readLimit = limit
+}
+
+// CloseHandler returns the current close handler
+func (c *Conn) CloseHandler() func(code int, text string) error {
+	return c.handleClose
+}
+
+// SetCloseHandler sets the handler for close messages received from the peer.
+// The code argument to h is the received close code or CloseNoStatusReceived
+// if the close message is empty. The default close handler sends a close frame
+// back to the peer.
+//
+// The application must read the connection to process close messages as
+// described in the section on Control Frames above.
+//
+// The connection read methods return a CloseError when a close frame is
+// received. Most applications should handle close messages as part of their
+// normal error handling. Applications should only set a close handler when the
+// application must perform some action before sending a close frame back to
+// the peer.
+func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
+	if h == nil {
+		h = func(code int, text string) error {
+			message := []byte{}
+			if code != CloseNoStatusReceived {
+				message = FormatCloseMessage(code, "")
+			}
+			c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			return nil
+		}
+	}
+	c.handleClose = h
+}
+
+// PingHandler returns the current ping handler
+func (c *Conn) PingHandler() func(appData string) error {
+	return c.handlePing
+}
+
+// SetPingHandler sets the handler for ping messages received from the peer.
+// The appData argument to h is the PING frame application data. The default
+// ping handler sends a pong to the peer.
+//
+// The application must read the connection to process ping messages as
+// described in the section on Control Frames above.
+func (c *Conn) SetPingHandler(h func(appData string) error) {
+	if h == nil {
+		h = func(message string) error {
+			err := c.WriteControl(PongMessage, []byte(message), time.Now().Add(writeWait))
+			if err == ErrCloseSent {
+				return nil
+			} else if e, ok := err.(net.Error); ok && e.Temporary() {
+				return nil
+			}
+			return err
+		}
+	}
+	c.handlePing = h
+}
+
+// PongHandler returns the current pong handler
+func (c *Conn) PongHandler() func(appData string) error {
+	return c.handlePong
+}
+
+// SetPongHandler sets the handler for pong messages received from the peer.
+// The appData argument to h is the PONG frame application data. The default
+// pong handler does nothing.
+//
+// The application must read the connection to process ping messages as
+// described in the section on Control Frames above.
+func (c *Conn) SetPongHandler(h func(appData string) error) {
+	if h == nil {
+		h = func(string) error { return nil }
+	}
+	c.handlePong = h
+}
+
+// UnderlyingConn returns the internal net.Conn. This can be used to further
+// modifications to connection specific flags.
+func (c *Conn) UnderlyingConn() net.Conn {
+	return c.conn
+}
+
+// EnableWriteCompression enables and disables write compression of
+// subsequent text and binary messages. This function is a noop if
+// compression was not negotiated with the peer.
+func (c *Conn) EnableWriteCompression(enable bool) {
+	c.enableWriteCompression = enable
+}
+
+// SetCompressionLevel sets the flate compression level for subsequent text and
+// binary messages. This function is a noop if compression was not negotiated
+// with the peer. See the compress/flate package for a description of
+// compression levels.
+func (c *Conn) SetCompressionLevel(level int) error {
+	if !isValidCompressionLevel(level) {
+		return errors.New("websocket: invalid compression level")
+	}
+	c.compressionLevel = level
+	return nil
+}
+
+// FormatCloseMessage formats closeCode and text as a WebSocket close message.
+func FormatCloseMessage(closeCode int, text string) []byte {
+	buf := make([]byte, 2+len(text))
+	binary.BigEndian.PutUint16(buf, uint16(closeCode))
+	copy(buf[2:], text)
+	return buf
+}

--- a/vendor/github.com/gorilla/websocket/conn_broadcast_test.go
+++ b/vendor/github.com/gorilla/websocket/conn_broadcast_test.go
@@ -1,0 +1,134 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package websocket
+
+import (
+	"io"
+	"io/ioutil"
+	"sync/atomic"
+	"testing"
+)
+
+// broadcastBench allows to run broadcast benchmarks.
+// In every broadcast benchmark we create many connections, then send the same
+// message into every connection and wait for all writes complete. This emulates
+// an application where many connections listen to the same data - i.e. PUB/SUB
+// scenarios with many subscribers in one channel.
+type broadcastBench struct {
+	w           io.Writer
+	message     *broadcastMessage
+	closeCh     chan struct{}
+	doneCh      chan struct{}
+	count       int32
+	conns       []*broadcastConn
+	compression bool
+	usePrepared bool
+}
+
+type broadcastMessage struct {
+	payload  []byte
+	prepared *PreparedMessage
+}
+
+type broadcastConn struct {
+	conn  *Conn
+	msgCh chan *broadcastMessage
+}
+
+func newBroadcastConn(c *Conn) *broadcastConn {
+	return &broadcastConn{
+		conn:  c,
+		msgCh: make(chan *broadcastMessage, 1),
+	}
+}
+
+func newBroadcastBench(usePrepared, compression bool) *broadcastBench {
+	bench := &broadcastBench{
+		w:           ioutil.Discard,
+		doneCh:      make(chan struct{}),
+		closeCh:     make(chan struct{}),
+		usePrepared: usePrepared,
+		compression: compression,
+	}
+	msg := &broadcastMessage{
+		payload: textMessages(1)[0],
+	}
+	if usePrepared {
+		pm, _ := NewPreparedMessage(TextMessage, msg.payload)
+		msg.prepared = pm
+	}
+	bench.message = msg
+	bench.makeConns(10000)
+	return bench
+}
+
+func (b *broadcastBench) makeConns(numConns int) {
+	conns := make([]*broadcastConn, numConns)
+
+	for i := 0; i < numConns; i++ {
+		c := newConn(fakeNetConn{Reader: nil, Writer: b.w}, true, 1024, 1024)
+		if b.compression {
+			c.enableWriteCompression = true
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		conns[i] = newBroadcastConn(c)
+		go func(c *broadcastConn) {
+			for {
+				select {
+				case msg := <-c.msgCh:
+					if b.usePrepared {
+						c.conn.WritePreparedMessage(msg.prepared)
+					} else {
+						c.conn.WriteMessage(TextMessage, msg.payload)
+					}
+					val := atomic.AddInt32(&b.count, 1)
+					if val%int32(numConns) == 0 {
+						b.doneCh <- struct{}{}
+					}
+				case <-b.closeCh:
+					return
+				}
+			}
+		}(conns[i])
+	}
+	b.conns = conns
+}
+
+func (b *broadcastBench) close() {
+	close(b.closeCh)
+}
+
+func (b *broadcastBench) runOnce() {
+	for _, c := range b.conns {
+		c.msgCh <- b.message
+	}
+	<-b.doneCh
+}
+
+func BenchmarkBroadcast(b *testing.B) {
+	benchmarks := []struct {
+		name        string
+		usePrepared bool
+		compression bool
+	}{
+		{"NoCompression", false, false},
+		{"WithCompression", false, true},
+		{"NoCompressionPrepared", true, false},
+		{"WithCompressionPrepared", true, true},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			bench := newBroadcastBench(bm.usePrepared, bm.compression)
+			defer bench.close()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bench.runOnce()
+			}
+			b.ReportAllocs()
+		})
+	}
+}

--- a/vendor/github.com/gorilla/websocket/conn_read.go
+++ b/vendor/github.com/gorilla/websocket/conn_read.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.5
+
+package websocket
+
+import "io"
+
+func (c *Conn) read(n int) ([]byte, error) {
+	p, err := c.br.Peek(n)
+	if err == io.EOF {
+		err = errUnexpectedEOF
+	}
+	c.br.Discard(len(p))
+	return p, err
+}

--- a/vendor/github.com/gorilla/websocket/conn_read_legacy.go
+++ b/vendor/github.com/gorilla/websocket/conn_read_legacy.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.5
+
+package websocket
+
+import "io"
+
+func (c *Conn) read(n int) ([]byte, error) {
+	p, err := c.br.Peek(n)
+	if err == io.EOF {
+		err = errUnexpectedEOF
+	}
+	if len(p) > 0 {
+		// advance over the bytes just read
+		io.ReadFull(c.br, p)
+	}
+	return p, err
+}

--- a/vendor/github.com/gorilla/websocket/conn_test.go
+++ b/vendor/github.com/gorilla/websocket/conn_test.go
@@ -1,0 +1,497 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"reflect"
+	"testing"
+	"testing/iotest"
+	"time"
+)
+
+var _ net.Error = errWriteTimeout
+
+type fakeNetConn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c fakeNetConn) Close() error                       { return nil }
+func (c fakeNetConn) LocalAddr() net.Addr                { return localAddr }
+func (c fakeNetConn) RemoteAddr() net.Addr               { return remoteAddr }
+func (c fakeNetConn) SetDeadline(t time.Time) error      { return nil }
+func (c fakeNetConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c fakeNetConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type fakeAddr int
+
+var (
+	localAddr  = fakeAddr(1)
+	remoteAddr = fakeAddr(2)
+)
+
+func (a fakeAddr) Network() string {
+	return "net"
+}
+
+func (a fakeAddr) String() string {
+	return "str"
+}
+
+func TestFraming(t *testing.T) {
+	frameSizes := []int{0, 1, 2, 124, 125, 126, 127, 128, 129, 65534, 65535, 65536, 65537}
+	var readChunkers = []struct {
+		name string
+		f    func(io.Reader) io.Reader
+	}{
+		{"half", iotest.HalfReader},
+		{"one", iotest.OneByteReader},
+		{"asis", func(r io.Reader) io.Reader { return r }},
+	}
+	writeBuf := make([]byte, 65537)
+	for i := range writeBuf {
+		writeBuf[i] = byte(i)
+	}
+	var writers = []struct {
+		name string
+		f    func(w io.Writer, n int) (int, error)
+	}{
+		{"iocopy", func(w io.Writer, n int) (int, error) {
+			nn, err := io.Copy(w, bytes.NewReader(writeBuf[:n]))
+			return int(nn), err
+		}},
+		{"write", func(w io.Writer, n int) (int, error) {
+			return w.Write(writeBuf[:n])
+		}},
+		{"string", func(w io.Writer, n int) (int, error) {
+			return io.WriteString(w, string(writeBuf[:n]))
+		}},
+	}
+
+	for _, compress := range []bool{false, true} {
+		for _, isServer := range []bool{true, false} {
+			for _, chunker := range readChunkers {
+
+				var connBuf bytes.Buffer
+				wc := newConn(fakeNetConn{Reader: nil, Writer: &connBuf}, isServer, 1024, 1024)
+				rc := newConn(fakeNetConn{Reader: chunker.f(&connBuf), Writer: nil}, !isServer, 1024, 1024)
+				if compress {
+					wc.newCompressionWriter = compressNoContextTakeover
+					rc.newDecompressionReader = decompressNoContextTakeover
+				}
+				for _, n := range frameSizes {
+					for _, writer := range writers {
+						name := fmt.Sprintf("z:%v, s:%v, r:%s, n:%d w:%s", compress, isServer, chunker.name, n, writer.name)
+
+						w, err := wc.NextWriter(TextMessage)
+						if err != nil {
+							t.Errorf("%s: wc.NextWriter() returned %v", name, err)
+							continue
+						}
+						nn, err := writer.f(w, n)
+						if err != nil || nn != n {
+							t.Errorf("%s: w.Write(writeBuf[:n]) returned %d, %v", name, nn, err)
+							continue
+						}
+						err = w.Close()
+						if err != nil {
+							t.Errorf("%s: w.Close() returned %v", name, err)
+							continue
+						}
+
+						opCode, r, err := rc.NextReader()
+						if err != nil || opCode != TextMessage {
+							t.Errorf("%s: NextReader() returned %d, r, %v", name, opCode, err)
+							continue
+						}
+						rbuf, err := ioutil.ReadAll(r)
+						if err != nil {
+							t.Errorf("%s: ReadFull() returned rbuf, %v", name, err)
+							continue
+						}
+
+						if len(rbuf) != n {
+							t.Errorf("%s: len(rbuf) is %d, want %d", name, len(rbuf), n)
+							continue
+						}
+
+						for i, b := range rbuf {
+							if byte(i) != b {
+								t.Errorf("%s: bad byte at offset %d", name, i)
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestControl(t *testing.T) {
+	const message = "this is a ping/pong messsage"
+	for _, isServer := range []bool{true, false} {
+		for _, isWriteControl := range []bool{true, false} {
+			name := fmt.Sprintf("s:%v, wc:%v", isServer, isWriteControl)
+			var connBuf bytes.Buffer
+			wc := newConn(fakeNetConn{Reader: nil, Writer: &connBuf}, isServer, 1024, 1024)
+			rc := newConn(fakeNetConn{Reader: &connBuf, Writer: nil}, !isServer, 1024, 1024)
+			if isWriteControl {
+				wc.WriteControl(PongMessage, []byte(message), time.Now().Add(time.Second))
+			} else {
+				w, err := wc.NextWriter(PongMessage)
+				if err != nil {
+					t.Errorf("%s: wc.NextWriter() returned %v", name, err)
+					continue
+				}
+				if _, err := w.Write([]byte(message)); err != nil {
+					t.Errorf("%s: w.Write() returned %v", name, err)
+					continue
+				}
+				if err := w.Close(); err != nil {
+					t.Errorf("%s: w.Close() returned %v", name, err)
+					continue
+				}
+				var actualMessage string
+				rc.SetPongHandler(func(s string) error { actualMessage = s; return nil })
+				rc.NextReader()
+				if actualMessage != message {
+					t.Errorf("%s: pong=%q, want %q", name, actualMessage, message)
+					continue
+				}
+			}
+		}
+	}
+}
+
+func TestCloseFrameBeforeFinalMessageFrame(t *testing.T) {
+	const bufSize = 512
+
+	expectedErr := &CloseError{Code: CloseNormalClosure, Text: "hello"}
+
+	var b1, b2 bytes.Buffer
+	wc := newConn(fakeNetConn{Reader: nil, Writer: &b1}, false, 1024, bufSize)
+	rc := newConn(fakeNetConn{Reader: &b1, Writer: &b2}, true, 1024, 1024)
+
+	w, _ := wc.NextWriter(BinaryMessage)
+	w.Write(make([]byte, bufSize+bufSize/2))
+	wc.WriteControl(CloseMessage, FormatCloseMessage(expectedErr.Code, expectedErr.Text), time.Now().Add(10*time.Second))
+	w.Close()
+
+	op, r, err := rc.NextReader()
+	if op != BinaryMessage || err != nil {
+		t.Fatalf("NextReader() returned %d, %v", op, err)
+	}
+	_, err = io.Copy(ioutil.Discard, r)
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf("io.Copy() returned %v, want %v", err, expectedErr)
+	}
+	_, _, err = rc.NextReader()
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf("NextReader() returned %v, want %v", err, expectedErr)
+	}
+}
+
+func TestEOFWithinFrame(t *testing.T) {
+	const bufSize = 64
+
+	for n := 0; ; n++ {
+		var b bytes.Buffer
+		wc := newConn(fakeNetConn{Reader: nil, Writer: &b}, false, 1024, 1024)
+		rc := newConn(fakeNetConn{Reader: &b, Writer: nil}, true, 1024, 1024)
+
+		w, _ := wc.NextWriter(BinaryMessage)
+		w.Write(make([]byte, bufSize))
+		w.Close()
+
+		if n >= b.Len() {
+			break
+		}
+		b.Truncate(n)
+
+		op, r, err := rc.NextReader()
+		if err == errUnexpectedEOF {
+			continue
+		}
+		if op != BinaryMessage || err != nil {
+			t.Fatalf("%d: NextReader() returned %d, %v", n, op, err)
+		}
+		_, err = io.Copy(ioutil.Discard, r)
+		if err != errUnexpectedEOF {
+			t.Fatalf("%d: io.Copy() returned %v, want %v", n, err, errUnexpectedEOF)
+		}
+		_, _, err = rc.NextReader()
+		if err != errUnexpectedEOF {
+			t.Fatalf("%d: NextReader() returned %v, want %v", n, err, errUnexpectedEOF)
+		}
+	}
+}
+
+func TestEOFBeforeFinalFrame(t *testing.T) {
+	const bufSize = 512
+
+	var b1, b2 bytes.Buffer
+	wc := newConn(fakeNetConn{Reader: nil, Writer: &b1}, false, 1024, bufSize)
+	rc := newConn(fakeNetConn{Reader: &b1, Writer: &b2}, true, 1024, 1024)
+
+	w, _ := wc.NextWriter(BinaryMessage)
+	w.Write(make([]byte, bufSize+bufSize/2))
+
+	op, r, err := rc.NextReader()
+	if op != BinaryMessage || err != nil {
+		t.Fatalf("NextReader() returned %d, %v", op, err)
+	}
+	_, err = io.Copy(ioutil.Discard, r)
+	if err != errUnexpectedEOF {
+		t.Fatalf("io.Copy() returned %v, want %v", err, errUnexpectedEOF)
+	}
+	_, _, err = rc.NextReader()
+	if err != errUnexpectedEOF {
+		t.Fatalf("NextReader() returned %v, want %v", err, errUnexpectedEOF)
+	}
+}
+
+func TestWriteAfterMessageWriterClose(t *testing.T) {
+	wc := newConn(fakeNetConn{Reader: nil, Writer: &bytes.Buffer{}}, false, 1024, 1024)
+	w, _ := wc.NextWriter(BinaryMessage)
+	io.WriteString(w, "hello")
+	if err := w.Close(); err != nil {
+		t.Fatalf("unxpected error closing message writer, %v", err)
+	}
+
+	if _, err := io.WriteString(w, "world"); err == nil {
+		t.Fatalf("no error writing after close")
+	}
+
+	w, _ = wc.NextWriter(BinaryMessage)
+	io.WriteString(w, "hello")
+
+	// close w by getting next writer
+	_, err := wc.NextWriter(BinaryMessage)
+	if err != nil {
+		t.Fatalf("unexpected error getting next writer, %v", err)
+	}
+
+	if _, err := io.WriteString(w, "world"); err == nil {
+		t.Fatalf("no error writing after close")
+	}
+}
+
+func TestReadLimit(t *testing.T) {
+
+	const readLimit = 512
+	message := make([]byte, readLimit+1)
+
+	var b1, b2 bytes.Buffer
+	wc := newConn(fakeNetConn{Reader: nil, Writer: &b1}, false, 1024, readLimit-2)
+	rc := newConn(fakeNetConn{Reader: &b1, Writer: &b2}, true, 1024, 1024)
+	rc.SetReadLimit(readLimit)
+
+	// Send message at the limit with interleaved pong.
+	w, _ := wc.NextWriter(BinaryMessage)
+	w.Write(message[:readLimit-1])
+	wc.WriteControl(PongMessage, []byte("this is a pong"), time.Now().Add(10*time.Second))
+	w.Write(message[:1])
+	w.Close()
+
+	// Send message larger than the limit.
+	wc.WriteMessage(BinaryMessage, message[:readLimit+1])
+
+	op, _, err := rc.NextReader()
+	if op != BinaryMessage || err != nil {
+		t.Fatalf("1: NextReader() returned %d, %v", op, err)
+	}
+	op, r, err := rc.NextReader()
+	if op != BinaryMessage || err != nil {
+		t.Fatalf("2: NextReader() returned %d, %v", op, err)
+	}
+	_, err = io.Copy(ioutil.Discard, r)
+	if err != ErrReadLimit {
+		t.Fatalf("io.Copy() returned %v", err)
+	}
+}
+
+func TestAddrs(t *testing.T) {
+	c := newConn(&fakeNetConn{}, true, 1024, 1024)
+	if c.LocalAddr() != localAddr {
+		t.Errorf("LocalAddr = %v, want %v", c.LocalAddr(), localAddr)
+	}
+	if c.RemoteAddr() != remoteAddr {
+		t.Errorf("RemoteAddr = %v, want %v", c.RemoteAddr(), remoteAddr)
+	}
+}
+
+func TestUnderlyingConn(t *testing.T) {
+	var b1, b2 bytes.Buffer
+	fc := fakeNetConn{Reader: &b1, Writer: &b2}
+	c := newConn(fc, true, 1024, 1024)
+	ul := c.UnderlyingConn()
+	if ul != fc {
+		t.Fatalf("Underlying conn is not what it should be.")
+	}
+}
+
+func TestBufioReadBytes(t *testing.T) {
+
+	// Test calling bufio.ReadBytes for value longer than read buffer size.
+
+	m := make([]byte, 512)
+	m[len(m)-1] = '\n'
+
+	var b1, b2 bytes.Buffer
+	wc := newConn(fakeNetConn{Reader: nil, Writer: &b1}, false, len(m)+64, len(m)+64)
+	rc := newConn(fakeNetConn{Reader: &b1, Writer: &b2}, true, len(m)-64, len(m)-64)
+
+	w, _ := wc.NextWriter(BinaryMessage)
+	w.Write(m)
+	w.Close()
+
+	op, r, err := rc.NextReader()
+	if op != BinaryMessage || err != nil {
+		t.Fatalf("NextReader() returned %d, %v", op, err)
+	}
+
+	br := bufio.NewReader(r)
+	p, err := br.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("ReadBytes() returned %v", err)
+	}
+	if len(p) != len(m) {
+		t.Fatalf("read returnd %d bytes, want %d bytes", len(p), len(m))
+	}
+}
+
+var closeErrorTests = []struct {
+	err   error
+	codes []int
+	ok    bool
+}{
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNormalClosure}, true},
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNoStatusReceived}, false},
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNoStatusReceived, CloseNormalClosure}, true},
+	{errors.New("hello"), []int{CloseNormalClosure}, false},
+}
+
+func TestCloseError(t *testing.T) {
+	for _, tt := range closeErrorTests {
+		ok := IsCloseError(tt.err, tt.codes...)
+		if ok != tt.ok {
+			t.Errorf("IsCloseError(%#v, %#v) returned %v, want %v", tt.err, tt.codes, ok, tt.ok)
+		}
+	}
+}
+
+var unexpectedCloseErrorTests = []struct {
+	err   error
+	codes []int
+	ok    bool
+}{
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNormalClosure}, false},
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNoStatusReceived}, true},
+	{&CloseError{Code: CloseNormalClosure}, []int{CloseNoStatusReceived, CloseNormalClosure}, false},
+	{errors.New("hello"), []int{CloseNormalClosure}, false},
+}
+
+func TestUnexpectedCloseErrors(t *testing.T) {
+	for _, tt := range unexpectedCloseErrorTests {
+		ok := IsUnexpectedCloseError(tt.err, tt.codes...)
+		if ok != tt.ok {
+			t.Errorf("IsUnexpectedCloseError(%#v, %#v) returned %v, want %v", tt.err, tt.codes, ok, tt.ok)
+		}
+	}
+}
+
+type blockingWriter struct {
+	c1, c2 chan struct{}
+}
+
+func (w blockingWriter) Write(p []byte) (int, error) {
+	// Allow main to continue
+	close(w.c1)
+	// Wait for panic in main
+	<-w.c2
+	return len(p), nil
+}
+
+func TestConcurrentWritePanic(t *testing.T) {
+	w := blockingWriter{make(chan struct{}), make(chan struct{})}
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	go func() {
+		c.WriteMessage(TextMessage, []byte{})
+	}()
+
+	// wait for goroutine to block in write.
+	<-w.c1
+
+	defer func() {
+		close(w.c2)
+		if v := recover(); v != nil {
+			return
+		}
+	}()
+
+	c.WriteMessage(TextMessage, []byte{})
+	t.Fatal("should not get here")
+}
+
+type failingReader struct{}
+
+func (r failingReader) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func TestFailedConnectionReadPanic(t *testing.T) {
+	c := newConn(fakeNetConn{Reader: failingReader{}, Writer: nil}, false, 1024, 1024)
+
+	defer func() {
+		if v := recover(); v != nil {
+			return
+		}
+	}()
+
+	for i := 0; i < 20000; i++ {
+		c.ReadMessage()
+	}
+	t.Fatal("should not get here")
+}
+
+func TestBufioReuse(t *testing.T) {
+	brw := bufio.NewReadWriter(bufio.NewReader(nil), bufio.NewWriter(nil))
+	c := newConnBRW(nil, false, 0, 0, brw)
+
+	if c.br != brw.Reader {
+		t.Error("connection did not reuse bufio.Reader")
+	}
+
+	var wh writeHook
+	brw.Writer.Reset(&wh)
+	brw.WriteByte(0)
+	brw.Flush()
+	if &c.writeBuf[0] != &wh.p[0] {
+		t.Error("connection did not reuse bufio.Writer")
+	}
+
+	brw = bufio.NewReadWriter(bufio.NewReaderSize(nil, 0), bufio.NewWriterSize(nil, 0))
+	c = newConnBRW(nil, false, 0, 0, brw)
+
+	if c.br == brw.Reader {
+		t.Error("connection used bufio.Reader with small size")
+	}
+
+	brw.Writer.Reset(&wh)
+	brw.WriteByte(0)
+	brw.Flush()
+	if &c.writeBuf[0] != &wh.p[0] {
+		t.Error("connection used bufio.Writer with small size")
+	}
+
+}

--- a/vendor/github.com/gorilla/websocket/doc.go
+++ b/vendor/github.com/gorilla/websocket/doc.go
@@ -1,0 +1,180 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package websocket implements the WebSocket protocol defined in RFC 6455.
+//
+// Overview
+//
+// The Conn type represents a WebSocket connection. A server application uses
+// the Upgrade function from an Upgrader object with a HTTP request handler
+// to get a pointer to a Conn:
+//
+//  var upgrader = websocket.Upgrader{
+//      ReadBufferSize:  1024,
+//      WriteBufferSize: 1024,
+//  }
+//
+//  func handler(w http.ResponseWriter, r *http.Request) {
+//      conn, err := upgrader.Upgrade(w, r, nil)
+//      if err != nil {
+//          log.Println(err)
+//          return
+//      }
+//      ... Use conn to send and receive messages.
+//  }
+//
+// Call the connection's WriteMessage and ReadMessage methods to send and
+// receive messages as a slice of bytes. This snippet of code shows how to echo
+// messages using these methods:
+//
+//  for {
+//      messageType, p, err := conn.ReadMessage()
+//      if err != nil {
+//          return
+//      }
+//      if err = conn.WriteMessage(messageType, p); err != nil {
+//          return err
+//      }
+//  }
+//
+// In above snippet of code, p is a []byte and messageType is an int with value
+// websocket.BinaryMessage or websocket.TextMessage.
+//
+// An application can also send and receive messages using the io.WriteCloser
+// and io.Reader interfaces. To send a message, call the connection NextWriter
+// method to get an io.WriteCloser, write the message to the writer and close
+// the writer when done. To receive a message, call the connection NextReader
+// method to get an io.Reader and read until io.EOF is returned. This snippet
+// shows how to echo messages using the NextWriter and NextReader methods:
+//
+//  for {
+//      messageType, r, err := conn.NextReader()
+//      if err != nil {
+//          return
+//      }
+//      w, err := conn.NextWriter(messageType)
+//      if err != nil {
+//          return err
+//      }
+//      if _, err := io.Copy(w, r); err != nil {
+//          return err
+//      }
+//      if err := w.Close(); err != nil {
+//          return err
+//      }
+//  }
+//
+// Data Messages
+//
+// The WebSocket protocol distinguishes between text and binary data messages.
+// Text messages are interpreted as UTF-8 encoded text. The interpretation of
+// binary messages is left to the application.
+//
+// This package uses the TextMessage and BinaryMessage integer constants to
+// identify the two data message types. The ReadMessage and NextReader methods
+// return the type of the received message. The messageType argument to the
+// WriteMessage and NextWriter methods specifies the type of a sent message.
+//
+// It is the application's responsibility to ensure that text messages are
+// valid UTF-8 encoded text.
+//
+// Control Messages
+//
+// The WebSocket protocol defines three types of control messages: close, ping
+// and pong. Call the connection WriteControl, WriteMessage or NextWriter
+// methods to send a control message to the peer.
+//
+// Connections handle received close messages by sending a close message to the
+// peer and returning a *CloseError from the the NextReader, ReadMessage or the
+// message Read method.
+//
+// Connections handle received ping and pong messages by invoking callback
+// functions set with SetPingHandler and SetPongHandler methods. The callback
+// functions are called from the NextReader, ReadMessage and the message Read
+// methods.
+//
+// The default ping handler sends a pong to the peer. The application's reading
+// goroutine can block for a short time while the handler writes the pong data
+// to the connection.
+//
+// The application must read the connection to process ping, pong and close
+// messages sent from the peer. If the application is not otherwise interested
+// in messages from the peer, then the application should start a goroutine to
+// read and discard messages from the peer. A simple example is:
+//
+//  func readLoop(c *websocket.Conn) {
+//      for {
+//          if _, _, err := c.NextReader(); err != nil {
+//              c.Close()
+//              break
+//          }
+//      }
+//  }
+//
+// Concurrency
+//
+// Connections support one concurrent reader and one concurrent writer.
+//
+// Applications are responsible for ensuring that no more than one goroutine
+// calls the write methods (NextWriter, SetWriteDeadline, WriteMessage,
+// WriteJSON, EnableWriteCompression, SetCompressionLevel) concurrently and
+// that no more than one goroutine calls the read methods (NextReader,
+// SetReadDeadline, ReadMessage, ReadJSON, SetPongHandler, SetPingHandler)
+// concurrently.
+//
+// The Close and WriteControl methods can be called concurrently with all other
+// methods.
+//
+// Origin Considerations
+//
+// Web browsers allow Javascript applications to open a WebSocket connection to
+// any host. It's up to the server to enforce an origin policy using the Origin
+// request header sent by the browser.
+//
+// The Upgrader calls the function specified in the CheckOrigin field to check
+// the origin. If the CheckOrigin function returns false, then the Upgrade
+// method fails the WebSocket handshake with HTTP status 403.
+//
+// If the CheckOrigin field is nil, then the Upgrader uses a safe default: fail
+// the handshake if the Origin request header is present and not equal to the
+// Host request header.
+//
+// An application can allow connections from any origin by specifying a
+// function that always returns true:
+//
+//  var upgrader = websocket.Upgrader{
+//      CheckOrigin: func(r *http.Request) bool { return true },
+//  }
+//
+// The deprecated Upgrade function does not enforce an origin policy. It's the
+// application's responsibility to check the Origin header before calling
+// Upgrade.
+//
+// Compression EXPERIMENTAL
+//
+// Per message compression extensions (RFC 7692) are experimentally supported
+// by this package in a limited capacity. Setting the EnableCompression option
+// to true in Dialer or Upgrader will attempt to negotiate per message deflate
+// support.
+//
+//  var upgrader = websocket.Upgrader{
+//      EnableCompression: true,
+//  }
+//
+// If compression was successfully negotiated with the connection's peer, any
+// message received in compressed form will be automatically decompressed.
+// All Read methods will return uncompressed bytes.
+//
+// Per message compression of messages written to a connection can be enabled
+// or disabled by calling the corresponding Conn method:
+//
+//  conn.EnableWriteCompression(false)
+//
+// Currently this package does not support compression with "context takeover".
+// This means that messages must be compressed and decompressed in isolation,
+// without retaining sliding window or dictionary state across messages. For
+// more details refer to RFC 7692.
+//
+// Use of compression is experimental and may result in decreased performance.
+package websocket

--- a/vendor/github.com/gorilla/websocket/example_test.go
+++ b/vendor/github.com/gorilla/websocket/example_test.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket_test
+
+import (
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	c   *websocket.Conn
+	req *http.Request
+)
+
+// The websocket.IsUnexpectedCloseError function is useful for identifying
+// application and protocol errors.
+//
+// This server application works with a client application running in the
+// browser. The client application does not explicitly close the websocket. The
+// only expected close message from the client has the code
+// websocket.CloseGoingAway. All other other close messages are likely the
+// result of an application or protocol error and are logged to aid debugging.
+func ExampleIsUnexpectedCloseError() {
+
+	for {
+		messageType, p, err := c.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
+				log.Printf("error: %v, user-agent: %v", err, req.Header.Get("User-Agent"))
+			}
+			return
+		}
+		processMesage(messageType, p)
+	}
+}
+
+func processMesage(mt int, p []byte) {}
+
+// TestX prevents godoc from showing this entire file in the example. Remove
+// this function when a second example is added.
+func TestX(t *testing.T) {}

--- a/vendor/github.com/gorilla/websocket/json.go
+++ b/vendor/github.com/gorilla/websocket/json.go
@@ -1,0 +1,55 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// WriteJSON is deprecated, use c.WriteJSON instead.
+func WriteJSON(c *Conn, v interface{}) error {
+	return c.WriteJSON(v)
+}
+
+// WriteJSON writes the JSON encoding of v to the connection.
+//
+// See the documentation for encoding/json Marshal for details about the
+// conversion of Go values to JSON.
+func (c *Conn) WriteJSON(v interface{}) error {
+	w, err := c.NextWriter(TextMessage)
+	if err != nil {
+		return err
+	}
+	err1 := json.NewEncoder(w).Encode(v)
+	err2 := w.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// ReadJSON is deprecated, use c.ReadJSON instead.
+func ReadJSON(c *Conn, v interface{}) error {
+	return c.ReadJSON(v)
+}
+
+// ReadJSON reads the next JSON-encoded message from the connection and stores
+// it in the value pointed to by v.
+//
+// See the documentation for the encoding/json Unmarshal function for details
+// about the conversion of JSON to a Go value.
+func (c *Conn) ReadJSON(v interface{}) error {
+	_, r, err := c.NextReader()
+	if err != nil {
+		return err
+	}
+	err = json.NewDecoder(r).Decode(v)
+	if err == io.EOF {
+		// One value is expected in the message.
+		err = io.ErrUnexpectedEOF
+	}
+	return err
+}

--- a/vendor/github.com/gorilla/websocket/json_test.go
+++ b/vendor/github.com/gorilla/websocket/json_test.go
@@ -1,0 +1,119 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	var buf bytes.Buffer
+	c := fakeNetConn{&buf, &buf}
+	wc := newConn(c, true, 1024, 1024)
+	rc := newConn(c, false, 1024, 1024)
+
+	var actual, expect struct {
+		A int
+		B string
+	}
+	expect.A = 1
+	expect.B = "hello"
+
+	if err := wc.WriteJSON(&expect); err != nil {
+		t.Fatal("write", err)
+	}
+
+	if err := rc.ReadJSON(&actual); err != nil {
+		t.Fatal("read", err)
+	}
+
+	if !reflect.DeepEqual(&actual, &expect) {
+		t.Fatal("equal", actual, expect)
+	}
+}
+
+func TestPartialJSONRead(t *testing.T) {
+	var buf bytes.Buffer
+	c := fakeNetConn{&buf, &buf}
+	wc := newConn(c, true, 1024, 1024)
+	rc := newConn(c, false, 1024, 1024)
+
+	var v struct {
+		A int
+		B string
+	}
+	v.A = 1
+	v.B = "hello"
+
+	messageCount := 0
+
+	// Partial JSON values.
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := len(data) - 1; i >= 0; i-- {
+		if err := wc.WriteMessage(TextMessage, data[:i]); err != nil {
+			t.Fatal(err)
+		}
+		messageCount++
+	}
+
+	// Whitespace.
+
+	if err := wc.WriteMessage(TextMessage, []byte(" ")); err != nil {
+		t.Fatal(err)
+	}
+	messageCount++
+
+	// Close.
+
+	if err := wc.WriteMessage(CloseMessage, FormatCloseMessage(CloseNormalClosure, "")); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < messageCount; i++ {
+		err := rc.ReadJSON(&v)
+		if err != io.ErrUnexpectedEOF {
+			t.Error("read", i, err)
+		}
+	}
+
+	err = rc.ReadJSON(&v)
+	if _, ok := err.(*CloseError); !ok {
+		t.Error("final", err)
+	}
+}
+
+func TestDeprecatedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	c := fakeNetConn{&buf, &buf}
+	wc := newConn(c, true, 1024, 1024)
+	rc := newConn(c, false, 1024, 1024)
+
+	var actual, expect struct {
+		A int
+		B string
+	}
+	expect.A = 1
+	expect.B = "hello"
+
+	if err := WriteJSON(wc, &expect); err != nil {
+		t.Fatal("write", err)
+	}
+
+	if err := ReadJSON(rc, &actual); err != nil {
+		t.Fatal("read", err)
+	}
+
+	if !reflect.DeepEqual(&actual, &expect) {
+		t.Fatal("equal", actual, expect)
+	}
+}

--- a/vendor/github.com/gorilla/websocket/mask.go
+++ b/vendor/github.com/gorilla/websocket/mask.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.  Use of
+// this source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// +build !appengine
+
+package websocket
+
+import "unsafe"
+
+const wordSize = int(unsafe.Sizeof(uintptr(0)))
+
+func maskBytes(key [4]byte, pos int, b []byte) int {
+
+	// Mask one byte at a time for small buffers.
+	if len(b) < 2*wordSize {
+		for i := range b {
+			b[i] ^= key[pos&3]
+			pos++
+		}
+		return pos & 3
+	}
+
+	// Mask one byte at a time to word boundary.
+	if n := int(uintptr(unsafe.Pointer(&b[0]))) % wordSize; n != 0 {
+		n = wordSize - n
+		for i := range b[:n] {
+			b[i] ^= key[pos&3]
+			pos++
+		}
+		b = b[n:]
+	}
+
+	// Create aligned word size key.
+	var k [wordSize]byte
+	for i := range k {
+		k[i] = key[(pos+i)&3]
+	}
+	kw := *(*uintptr)(unsafe.Pointer(&k))
+
+	// Mask one word at a time.
+	n := (len(b) / wordSize) * wordSize
+	for i := 0; i < n; i += wordSize {
+		*(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&b[0])) + uintptr(i))) ^= kw
+	}
+
+	// Mask one byte at a time for remaining bytes.
+	b = b[n:]
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+
+	return pos & 3
+}

--- a/vendor/github.com/gorilla/websocket/mask_safe.go
+++ b/vendor/github.com/gorilla/websocket/mask_safe.go
@@ -1,0 +1,15 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.  Use of
+// this source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// +build appengine
+
+package websocket
+
+func maskBytes(key [4]byte, pos int, b []byte) int {
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+	return pos & 3
+}

--- a/vendor/github.com/gorilla/websocket/mask_test.go
+++ b/vendor/github.com/gorilla/websocket/mask_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 The Gorilla WebSocket Authors. All rights reserved.  Use of
+// this source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// Require 1.7 for sub-bencmarks
+// +build go1.7,!appengine
+
+package websocket
+
+import (
+	"fmt"
+	"testing"
+)
+
+func maskBytesByByte(key [4]byte, pos int, b []byte) int {
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+	return pos & 3
+}
+
+func notzero(b []byte) int {
+	for i := range b {
+		if b[i] != 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestMaskBytes(t *testing.T) {
+	key := [4]byte{1, 2, 3, 4}
+	for size := 1; size <= 1024; size++ {
+		for align := 0; align < wordSize; align++ {
+			for pos := 0; pos < 4; pos++ {
+				b := make([]byte, size+align)[align:]
+				maskBytes(key, pos, b)
+				maskBytesByByte(key, pos, b)
+				if i := notzero(b); i >= 0 {
+					t.Errorf("size:%d, align:%d, pos:%d, offset:%d", size, align, pos, i)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkMaskBytes(b *testing.B) {
+	for _, size := range []int{2, 4, 8, 16, 32, 512, 1024} {
+		b.Run(fmt.Sprintf("size-%d", size), func(b *testing.B) {
+			for _, align := range []int{wordSize / 2} {
+				b.Run(fmt.Sprintf("align-%d", align), func(b *testing.B) {
+					for _, fn := range []struct {
+						name string
+						fn   func(key [4]byte, pos int, b []byte) int
+					}{
+						{"byte", maskBytesByByte},
+						{"word", maskBytes},
+					} {
+						b.Run(fn.name, func(b *testing.B) {
+							key := newMaskKey()
+							data := make([]byte, size+align)[align:]
+							for i := 0; i < b.N; i++ {
+								fn.fn(key, 0, data)
+							}
+							b.SetBytes(int64(len(data)))
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/vendor/github.com/gorilla/websocket/prepared.go
+++ b/vendor/github.com/gorilla/websocket/prepared.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"time"
+)
+
+// PreparedMessage caches on the wire representations of a message payload.
+// Use PreparedMessage to efficiently send a message payload to multiple
+// connections. PreparedMessage is especially useful when compression is used
+// because the CPU and memory expensive compression operation can be executed
+// once for a given set of compression options.
+type PreparedMessage struct {
+	messageType int
+	data        []byte
+	err         error
+	mu          sync.Mutex
+	frames      map[prepareKey]*preparedFrame
+}
+
+// prepareKey defines a unique set of options to cache prepared frames in PreparedMessage.
+type prepareKey struct {
+	isServer         bool
+	compress         bool
+	compressionLevel int
+}
+
+// preparedFrame contains data in wire representation.
+type preparedFrame struct {
+	once sync.Once
+	data []byte
+}
+
+// NewPreparedMessage returns an initialized PreparedMessage. You can then send
+// it to connection using WritePreparedMessage method. Valid wire
+// representation will be calculated lazily only once for a set of current
+// connection options.
+func NewPreparedMessage(messageType int, data []byte) (*PreparedMessage, error) {
+	pm := &PreparedMessage{
+		messageType: messageType,
+		frames:      make(map[prepareKey]*preparedFrame),
+		data:        data,
+	}
+
+	// Prepare a plain server frame.
+	_, frameData, err := pm.frame(prepareKey{isServer: true, compress: false})
+	if err != nil {
+		return nil, err
+	}
+
+	// To protect against caller modifying the data argument, remember the data
+	// copied to the plain server frame.
+	pm.data = frameData[len(frameData)-len(data):]
+	return pm, nil
+}
+
+func (pm *PreparedMessage) frame(key prepareKey) (int, []byte, error) {
+	pm.mu.Lock()
+	frame, ok := pm.frames[key]
+	if !ok {
+		frame = &preparedFrame{}
+		pm.frames[key] = frame
+	}
+	pm.mu.Unlock()
+
+	var err error
+	frame.once.Do(func() {
+		// Prepare a frame using a 'fake' connection.
+		// TODO: Refactor code in conn.go to allow more direct construction of
+		// the frame.
+		mu := make(chan bool, 1)
+		mu <- true
+		var nc prepareConn
+		c := &Conn{
+			conn:                   &nc,
+			mu:                     mu,
+			isServer:               key.isServer,
+			compressionLevel:       key.compressionLevel,
+			enableWriteCompression: true,
+			writeBuf:               make([]byte, defaultWriteBufferSize+maxFrameHeaderSize),
+		}
+		if key.compress {
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		err = c.WriteMessage(pm.messageType, pm.data)
+		frame.data = nc.buf.Bytes()
+	})
+	return pm.messageType, frame.data, err
+}
+
+type prepareConn struct {
+	buf bytes.Buffer
+	net.Conn
+}
+
+func (pc *prepareConn) Write(p []byte) (int, error)        { return pc.buf.Write(p) }
+func (pc *prepareConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/vendor/github.com/gorilla/websocket/prepared_test.go
+++ b/vendor/github.com/gorilla/websocket/prepared_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bytes"
+	"compress/flate"
+	"math/rand"
+	"testing"
+)
+
+var preparedMessageTests = []struct {
+	messageType            int
+	isServer               bool
+	enableWriteCompression bool
+	compressionLevel       int
+}{
+	// Server
+	{TextMessage, true, false, flate.BestSpeed},
+	{TextMessage, true, true, flate.BestSpeed},
+	{TextMessage, true, true, flate.BestCompression},
+	{PingMessage, true, false, flate.BestSpeed},
+	{PingMessage, true, true, flate.BestSpeed},
+
+	// Client
+	{TextMessage, false, false, flate.BestSpeed},
+	{TextMessage, false, true, flate.BestSpeed},
+	{TextMessage, false, true, flate.BestCompression},
+	{PingMessage, false, false, flate.BestSpeed},
+	{PingMessage, false, true, flate.BestSpeed},
+}
+
+func TestPreparedMessage(t *testing.T) {
+	for _, tt := range preparedMessageTests {
+		var data = []byte("this is a test")
+		var buf bytes.Buffer
+		c := newConn(fakeNetConn{Reader: nil, Writer: &buf}, tt.isServer, 1024, 1024)
+		if tt.enableWriteCompression {
+			c.newCompressionWriter = compressNoContextTakeover
+		}
+		c.SetCompressionLevel(tt.compressionLevel)
+
+		// Seed random number generator for consistent frame mask.
+		rand.Seed(1234)
+
+		if err := c.WriteMessage(tt.messageType, data); err != nil {
+			t.Fatal(err)
+		}
+		want := buf.String()
+
+		pm, err := NewPreparedMessage(tt.messageType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Scribble on data to ensure that NewPreparedMessage takes a snapshot.
+		copy(data, "hello world")
+
+		// Seed random number generator for consistent frame mask.
+		rand.Seed(1234)
+
+		buf.Reset()
+		if err := c.WritePreparedMessage(pm); err != nil {
+			t.Fatal(err)
+		}
+		got := buf.String()
+
+		if got != want {
+			t.Errorf("write message != prepared message for %+v", tt)
+		}
+	}
+}

--- a/vendor/github.com/gorilla/websocket/server.go
+++ b/vendor/github.com/gorilla/websocket/server.go
@@ -1,0 +1,291 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// HandshakeError describes an error with the handshake from the peer.
+type HandshakeError struct {
+	message string
+}
+
+func (e HandshakeError) Error() string { return e.message }
+
+// Upgrader specifies parameters for upgrading an HTTP connection to a
+// WebSocket connection.
+type Upgrader struct {
+	// HandshakeTimeout specifies the duration for the handshake to complete.
+	HandshakeTimeout time.Duration
+
+	// ReadBufferSize and WriteBufferSize specify I/O buffer sizes. If a buffer
+	// size is zero, then buffers allocated by the HTTP server are used. The
+	// I/O buffer sizes do not limit the size of the messages that can be sent
+	// or received.
+	ReadBufferSize, WriteBufferSize int
+
+	// Subprotocols specifies the server's supported protocols in order of
+	// preference. If this field is set, then the Upgrade method negotiates a
+	// subprotocol by selecting the first match in this list with a protocol
+	// requested by the client.
+	Subprotocols []string
+
+	// Error specifies the function for generating HTTP error responses. If Error
+	// is nil, then http.Error is used to generate the HTTP response.
+	Error func(w http.ResponseWriter, r *http.Request, status int, reason error)
+
+	// CheckOrigin returns true if the request Origin header is acceptable. If
+	// CheckOrigin is nil, the host in the Origin header must not be set or
+	// must match the host of the request.
+	CheckOrigin func(r *http.Request) bool
+
+	// EnableCompression specify if the server should attempt to negotiate per
+	// message compression (RFC 7692). Setting this value to true does not
+	// guarantee that compression will be supported. Currently only "no context
+	// takeover" modes are supported.
+	EnableCompression bool
+}
+
+func (u *Upgrader) returnError(w http.ResponseWriter, r *http.Request, status int, reason string) (*Conn, error) {
+	err := HandshakeError{reason}
+	if u.Error != nil {
+		u.Error(w, r, status, err)
+	} else {
+		w.Header().Set("Sec-Websocket-Version", "13")
+		http.Error(w, http.StatusText(status), status)
+	}
+	return nil, err
+}
+
+// checkSameOrigin returns true if the origin is not set or is equal to the request host.
+func checkSameOrigin(r *http.Request) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	u, err := url.Parse(origin[0])
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host
+}
+
+func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {
+	if u.Subprotocols != nil {
+		clientProtocols := Subprotocols(r)
+		for _, serverProtocol := range u.Subprotocols {
+			for _, clientProtocol := range clientProtocols {
+				if clientProtocol == serverProtocol {
+					return clientProtocol
+				}
+			}
+		}
+	} else if responseHeader != nil {
+		return responseHeader.Get("Sec-Websocket-Protocol")
+	}
+	return ""
+}
+
+// Upgrade upgrades the HTTP server connection to the WebSocket protocol.
+//
+// The responseHeader is included in the response to the client's upgrade
+// request. Use the responseHeader to specify cookies (Set-Cookie) and the
+// application negotiated subprotocol (Sec-Websocket-Protocol).
+//
+// If the upgrade fails, then Upgrade replies to the client with an HTTP error
+// response.
+func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*Conn, error) {
+	if r.Method != "GET" {
+		return u.returnError(w, r, http.StatusMethodNotAllowed, "websocket: not a websocket handshake: request method is not GET")
+	}
+
+	if _, ok := responseHeader["Sec-Websocket-Extensions"]; ok {
+		return u.returnError(w, r, http.StatusInternalServerError, "websocket: application specific 'Sec-Websocket-Extensions' headers are unsupported")
+	}
+
+	if !tokenListContainsValue(r.Header, "Connection", "upgrade") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: 'upgrade' token not found in 'Connection' header")
+	}
+
+	if !tokenListContainsValue(r.Header, "Upgrade", "websocket") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: 'websocket' token not found in 'Upgrade' header")
+	}
+
+	if !tokenListContainsValue(r.Header, "Sec-Websocket-Version", "13") {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: unsupported version: 13 not found in 'Sec-Websocket-Version' header")
+	}
+
+	checkOrigin := u.CheckOrigin
+	if checkOrigin == nil {
+		checkOrigin = checkSameOrigin
+	}
+	if !checkOrigin(r) {
+		return u.returnError(w, r, http.StatusForbidden, "websocket: 'Origin' header value not allowed")
+	}
+
+	challengeKey := r.Header.Get("Sec-Websocket-Key")
+	if challengeKey == "" {
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: `Sec-Websocket-Key' header is missing or blank")
+	}
+
+	subprotocol := u.selectSubprotocol(r, responseHeader)
+
+	// Negotiate PMCE
+	var compress bool
+	if u.EnableCompression {
+		for _, ext := range parseExtensions(r.Header) {
+			if ext[""] != "permessage-deflate" {
+				continue
+			}
+			compress = true
+			break
+		}
+	}
+
+	var (
+		netConn net.Conn
+		err     error
+	)
+
+	h, ok := w.(http.Hijacker)
+	if !ok {
+		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
+	}
+	var brw *bufio.ReadWriter
+	netConn, brw, err = h.Hijack()
+	if err != nil {
+		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
+	}
+
+	if brw.Reader.Buffered() > 0 {
+		netConn.Close()
+		return nil, errors.New("websocket: client sent data before handshake is complete")
+	}
+
+	c := newConnBRW(netConn, true, u.ReadBufferSize, u.WriteBufferSize, brw)
+	c.subprotocol = subprotocol
+
+	if compress {
+		c.newCompressionWriter = compressNoContextTakeover
+		c.newDecompressionReader = decompressNoContextTakeover
+	}
+
+	p := c.writeBuf[:0]
+	p = append(p, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: "...)
+	p = append(p, computeAcceptKey(challengeKey)...)
+	p = append(p, "\r\n"...)
+	if c.subprotocol != "" {
+		p = append(p, "Sec-Websocket-Protocol: "...)
+		p = append(p, c.subprotocol...)
+		p = append(p, "\r\n"...)
+	}
+	if compress {
+		p = append(p, "Sec-Websocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n"...)
+	}
+	for k, vs := range responseHeader {
+		if k == "Sec-Websocket-Protocol" {
+			continue
+		}
+		for _, v := range vs {
+			p = append(p, k...)
+			p = append(p, ": "...)
+			for i := 0; i < len(v); i++ {
+				b := v[i]
+				if b <= 31 {
+					// prevent response splitting.
+					b = ' '
+				}
+				p = append(p, b)
+			}
+			p = append(p, "\r\n"...)
+		}
+	}
+	p = append(p, "\r\n"...)
+
+	// Clear deadlines set by HTTP server.
+	netConn.SetDeadline(time.Time{})
+
+	if u.HandshakeTimeout > 0 {
+		netConn.SetWriteDeadline(time.Now().Add(u.HandshakeTimeout))
+	}
+	if _, err = netConn.Write(p); err != nil {
+		netConn.Close()
+		return nil, err
+	}
+	if u.HandshakeTimeout > 0 {
+		netConn.SetWriteDeadline(time.Time{})
+	}
+
+	return c, nil
+}
+
+// Upgrade upgrades the HTTP server connection to the WebSocket protocol.
+//
+// This function is deprecated, use websocket.Upgrader instead.
+//
+// The application is responsible for checking the request origin before
+// calling Upgrade. An example implementation of the same origin policy is:
+//
+//	if req.Header.Get("Origin") != "http://"+req.Host {
+//		http.Error(w, "Origin not allowed", 403)
+//		return
+//	}
+//
+// If the endpoint supports subprotocols, then the application is responsible
+// for negotiating the protocol used on the connection. Use the Subprotocols()
+// function to get the subprotocols requested by the client. Use the
+// Sec-Websocket-Protocol response header to specify the subprotocol selected
+// by the application.
+//
+// The responseHeader is included in the response to the client's upgrade
+// request. Use the responseHeader to specify cookies (Set-Cookie) and the
+// negotiated subprotocol (Sec-Websocket-Protocol).
+//
+// The connection buffers IO to the underlying network connection. The
+// readBufSize and writeBufSize parameters specify the size of the buffers to
+// use. Messages can be larger than the buffers.
+//
+// If the request is not a valid WebSocket handshake, then Upgrade returns an
+// error of type HandshakeError. Applications should handle this error by
+// replying to the client with an HTTP error response.
+func Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header, readBufSize, writeBufSize int) (*Conn, error) {
+	u := Upgrader{ReadBufferSize: readBufSize, WriteBufferSize: writeBufSize}
+	u.Error = func(w http.ResponseWriter, r *http.Request, status int, reason error) {
+		// don't return errors to maintain backwards compatibility
+	}
+	u.CheckOrigin = func(r *http.Request) bool {
+		// allow all connections by default
+		return true
+	}
+	return u.Upgrade(w, r, responseHeader)
+}
+
+// Subprotocols returns the subprotocols requested by the client in the
+// Sec-Websocket-Protocol header.
+func Subprotocols(r *http.Request) []string {
+	h := strings.TrimSpace(r.Header.Get("Sec-Websocket-Protocol"))
+	if h == "" {
+		return nil
+	}
+	protocols := strings.Split(h, ",")
+	for i := range protocols {
+		protocols[i] = strings.TrimSpace(protocols[i])
+	}
+	return protocols
+}
+
+// IsWebSocketUpgrade returns true if the client requested upgrade to the
+// WebSocket protocol.
+func IsWebSocketUpgrade(r *http.Request) bool {
+	return tokenListContainsValue(r.Header, "Connection", "upgrade") &&
+		tokenListContainsValue(r.Header, "Upgrade", "websocket")
+}

--- a/vendor/github.com/gorilla/websocket/server_test.go
+++ b/vendor/github.com/gorilla/websocket/server_test.go
@@ -1,0 +1,51 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var subprotocolTests = []struct {
+	h         string
+	protocols []string
+}{
+	{"", nil},
+	{"foo", []string{"foo"}},
+	{"foo,bar", []string{"foo", "bar"}},
+	{"foo, bar", []string{"foo", "bar"}},
+	{" foo, bar", []string{"foo", "bar"}},
+	{" foo, bar ", []string{"foo", "bar"}},
+}
+
+func TestSubprotocols(t *testing.T) {
+	for _, st := range subprotocolTests {
+		r := http.Request{Header: http.Header{"Sec-Websocket-Protocol": {st.h}}}
+		protocols := Subprotocols(&r)
+		if !reflect.DeepEqual(st.protocols, protocols) {
+			t.Errorf("SubProtocols(%q) returned %#v, want %#v", st.h, protocols, st.protocols)
+		}
+	}
+}
+
+var isWebSocketUpgradeTests = []struct {
+	ok bool
+	h  http.Header
+}{
+	{false, http.Header{"Upgrade": {"websocket"}}},
+	{false, http.Header{"Connection": {"upgrade"}}},
+	{true, http.Header{"Connection": {"upgRade"}, "Upgrade": {"WebSocket"}}},
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	for _, tt := range isWebSocketUpgradeTests {
+		ok := IsWebSocketUpgrade(&http.Request{Header: tt.h})
+		if tt.ok != ok {
+			t.Errorf("IsWebSocketUpgrade(%v) returned %v, want %v", tt.h, ok, tt.ok)
+		}
+	}
+}

--- a/vendor/github.com/gorilla/websocket/util.go
+++ b/vendor/github.com/gorilla/websocket/util.go
@@ -1,0 +1,214 @@
+// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var keyGUID = []byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+
+func computeAcceptKey(challengeKey string) string {
+	h := sha1.New()
+	h.Write([]byte(challengeKey))
+	h.Write(keyGUID)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func generateChallengeKey() (string, error) {
+	p := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, p); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(p), nil
+}
+
+// Octet types from RFC 2616.
+var octetTypes [256]byte
+
+const (
+	isTokenOctet = 1 << iota
+	isSpaceOctet
+)
+
+func init() {
+	// From RFC 2616
+	//
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t byte
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpaceOctet
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isTokenOctet
+		}
+		octetTypes[c] = t
+	}
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpaceOctet == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func nextToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isTokenOctet == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func nextTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return nextToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j += 1
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j += 1
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+// tokenListContainsValue returns true if the 1#token header with the given
+// name contains token.
+func tokenListContainsValue(header http.Header, name string, value string) bool {
+headers:
+	for _, s := range header[name] {
+		for {
+			var t string
+			t, s = nextToken(skipSpace(s))
+			if t == "" {
+				continue headers
+			}
+			s = skipSpace(s)
+			if s != "" && s[0] != ',' {
+				continue headers
+			}
+			if strings.EqualFold(t, value) {
+				return true
+			}
+			if s == "" {
+				continue headers
+			}
+			s = s[1:]
+		}
+	}
+	return false
+}
+
+// parseExtensiosn parses WebSocket extensions from a header.
+func parseExtensions(header http.Header) []map[string]string {
+
+	// From RFC 6455:
+	//
+	//  Sec-WebSocket-Extensions = extension-list
+	//  extension-list = 1#extension
+	//  extension = extension-token *( ";" extension-param )
+	//  extension-token = registered-token
+	//  registered-token = token
+	//  extension-param = token [ "=" (token | quoted-string) ]
+	//     ;When using the quoted-string syntax variant, the value
+	//     ;after quoted-string unescaping MUST conform to the
+	//     ;'token' ABNF.
+
+	var result []map[string]string
+headers:
+	for _, s := range header["Sec-Websocket-Extensions"] {
+		for {
+			var t string
+			t, s = nextToken(skipSpace(s))
+			if t == "" {
+				continue headers
+			}
+			ext := map[string]string{"": t}
+			for {
+				s = skipSpace(s)
+				if !strings.HasPrefix(s, ";") {
+					break
+				}
+				var k string
+				k, s = nextToken(skipSpace(s[1:]))
+				if k == "" {
+					continue headers
+				}
+				s = skipSpace(s)
+				var v string
+				if strings.HasPrefix(s, "=") {
+					v, s = nextTokenOrQuoted(skipSpace(s[1:]))
+					s = skipSpace(s)
+				}
+				if s != "" && s[0] != ',' && s[0] != ';' {
+					continue headers
+				}
+				ext[k] = v
+			}
+			if s != "" && s[0] != ',' {
+				continue headers
+			}
+			result = append(result, ext)
+			if s == "" {
+				continue headers
+			}
+			s = s[1:]
+		}
+	}
+	return result
+}

--- a/vendor/github.com/gorilla/websocket/util_test.go
+++ b/vendor/github.com/gorilla/websocket/util_test.go
@@ -1,0 +1,74 @@
+// Copyright 2014 The Gorilla WebSocket Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package websocket
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var tokenListContainsValueTests = []struct {
+	value string
+	ok    bool
+}{
+	{"WebSocket", true},
+	{"WEBSOCKET", true},
+	{"websocket", true},
+	{"websockets", false},
+	{"x websocket", false},
+	{"websocket x", false},
+	{"other,websocket,more", true},
+	{"other, websocket, more", true},
+}
+
+func TestTokenListContainsValue(t *testing.T) {
+	for _, tt := range tokenListContainsValueTests {
+		h := http.Header{"Upgrade": {tt.value}}
+		ok := tokenListContainsValue(h, "Upgrade", "websocket")
+		if ok != tt.ok {
+			t.Errorf("tokenListContainsValue(h, n, %q) = %v, want %v", tt.value, ok, tt.ok)
+		}
+	}
+}
+
+var parseExtensionTests = []struct {
+	value      string
+	extensions []map[string]string
+}{
+	{`foo`, []map[string]string{map[string]string{"": "foo"}}},
+	{`foo, bar; baz=2`, []map[string]string{
+		map[string]string{"": "foo"},
+		map[string]string{"": "bar", "baz": "2"}}},
+	{`foo; bar="b,a;z"`, []map[string]string{
+		map[string]string{"": "foo", "bar": "b,a;z"}}},
+	{`foo , bar; baz = 2`, []map[string]string{
+		map[string]string{"": "foo"},
+		map[string]string{"": "bar", "baz": "2"}}},
+	{`foo, bar; baz=2 junk`, []map[string]string{
+		map[string]string{"": "foo"}}},
+	{`foo junk, bar; baz=2 junk`, nil},
+	{`mux; max-channels=4; flow-control, deflate-stream`, []map[string]string{
+		map[string]string{"": "mux", "max-channels": "4", "flow-control": ""},
+		map[string]string{"": "deflate-stream"}}},
+	{`permessage-foo; x="10"`, []map[string]string{
+		map[string]string{"": "permessage-foo", "x": "10"}}},
+	{`permessage-foo; use_y, permessage-foo`, []map[string]string{
+		map[string]string{"": "permessage-foo", "use_y": ""},
+		map[string]string{"": "permessage-foo"}}},
+	{`permessage-deflate; client_max_window_bits; server_max_window_bits=10 , permessage-deflate; client_max_window_bits`, []map[string]string{
+		map[string]string{"": "permessage-deflate", "client_max_window_bits": "", "server_max_window_bits": "10"},
+		map[string]string{"": "permessage-deflate", "client_max_window_bits": ""}}},
+}
+
+func TestParseExtensions(t *testing.T) {
+	for _, tt := range parseExtensionTests {
+		h := http.Header{http.CanonicalHeaderKey("Sec-WebSocket-Extensions"): {tt.value}}
+		extensions := parseExtensions(h)
+		if !reflect.DeepEqual(extensions, tt.extensions) {
+			t.Errorf("parseExtensions(%q)\n    = %v,\nwant %v", tt.value, extensions, tt.extensions)
+		}
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/LICENSE
+++ b/vendor/github.com/igm/sockjs-go/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2012-2014, sockjs-go authors
+All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met: 
+
+ * Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+ * Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the distribution. 
+ * Neither the name of  nor the names of its contributors may be used to 
+   endorse or promote products derived from this software without specific 
+   prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE. 

--- a/vendor/github.com/igm/sockjs-go/sockjs/benchmarks_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/benchmarks_test.go
@@ -1,0 +1,94 @@
+package sockjs
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func BenchmarkSimple(b *testing.B) {
+	var messages = make(chan string, 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for m := range messages {
+			session.Send(m)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", 1000), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		messages <- "some message"
+	}
+	fmt.Println(b.N)
+	close(messages)
+	resp.Body.Close()
+}
+
+func BenchmarkMessages(b *testing.B) {
+	msg := strings.Repeat("m", 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for n := 0; n < b.N; n++ {
+			session.Send(msg)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(session int) {
+			reqc := 0
+			// req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", session), nil)
+			req, _ := http.NewRequest("GET", server.URL+fmt.Sprintf("/echo/server/%d/eventsource", session), nil)
+			for {
+				reqc++
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					log.Fatal(err)
+				}
+				reader := bufio.NewReader(resp.Body)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						goto AGAIN
+					}
+					if strings.HasPrefix(line, "data: c[1024") {
+						resp.Body.Close()
+						goto DONE
+					}
+				}
+			AGAIN:
+				resp.Body.Close()
+			}
+		DONE:
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	server.Close()
+}
+
+func BenchmarkHandler_ParseSessionID(b *testing.B) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.parseSessionID(url)
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/doc.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/doc.go
@@ -1,0 +1,5 @@
+/*
+Package sockjs is a server side implementation of sockjs protocol.
+*/
+
+package sockjs

--- a/vendor/github.com/igm/sockjs-go/sockjs/eventsource.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/eventsource.go
@@ -1,0 +1,32 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (h *handler) eventSource(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/event-stream; charset=UTF-8")
+	fmt.Fprintf(rw, "\r\n")
+	rw.(http.Flusher).Flush()
+
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(eventSourceFrameWriter))
+	sess, _ := h.sessionByRequest(req)
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type eventSourceFrameWriter struct{}
+
+func (*eventSourceFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "data: %s\r\n\r\n", frame)
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/eventsource_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/eventsource_test.go
@@ -1,0 +1,73 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandler_EventSource(t *testing.T) {
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		h.sessionsMux.Lock()
+		defer h.sessionsMux.Unlock()
+		sess := h.sessions["session"]
+		sess.Lock()
+		defer sess.Unlock()
+		recv := sess.recv
+		recv.close()
+	}()
+	h.eventSource(rw, req)
+	contentType := rw.Header().Get("content-type")
+	expected := "text/event-stream; charset=UTF-8"
+	if contentType != expected {
+		t.Errorf("Unexpected content type, got '%s', extected '%s'", contentType, expected)
+	}
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+
+	if rw.Body.String() != "\r\ndata: o\r\n\r\n" {
+		t.Errorf("Event stream prelude, got '%s'", rw.Body)
+	}
+}
+
+func TestHandler_EventSourceMultipleConnections(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/sess/eventsource", nil)
+	go func() {
+		rw := &ClosableRecorder{httptest.NewRecorder(), nil}
+		h.eventSource(rw, req)
+		if rw.Body.String() != "\r\ndata: c[2010,\"Another connection still open\"]\r\n\r\n" {
+			t.Errorf("wrong, got '%v'", rw.Body)
+		}
+		h.sessionsMux.Lock()
+		sess := h.sessions["sess"]
+		sess.close()
+		h.sessionsMux.Unlock()
+	}()
+	h.eventSource(rw, req)
+}
+
+func TestHandler_EventSourceConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = SessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.eventSource(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != SessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/example_handler_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/example_handler_test.go
@@ -1,0 +1,39 @@
+package sockjs_test
+
+import (
+	"net/http"
+
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+func ExampleNewHandler_simple() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	http.ListenAndServe(":8080", handler)
+}
+
+func ExampleNewHandler_defaultMux() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	// need to provide path prefix for http.Mux
+	http.Handle("/echo/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/frame.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/frame.go
@@ -1,0 +1,11 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func closeFrame(status uint32, reason string) string {
+	bytes, _ := json.Marshal([]interface{}{status, reason})
+	return fmt.Sprintf("c%s", string(bytes))
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/frame_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/frame_test.go
@@ -1,0 +1,10 @@
+package sockjs
+
+import "testing"
+
+func TestCloseFrame(t *testing.T) {
+	cf := closeFrame(1024, "some close text")
+	if cf != "c[1024,\"some close text\"]" {
+		t.Errorf("Wrong close frame generated '%s'", cf)
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/handler.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/handler.go
@@ -1,0 +1,133 @@
+package sockjs
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	prefixRegexp   = make(map[string]*regexp.Regexp)
+	prefixRegexpMu sync.Mutex // protects prefixRegexp
+)
+
+type handler struct {
+	prefix      string
+	options     Options
+	handlerFunc func(Session)
+	mappings    []*mapping
+
+	sessionsMux sync.Mutex
+	sessions    map[string]*session
+}
+
+// NewHandler creates new HTTP handler that conforms to the basic net/http.Handler interface.
+// It takes path prefix, options and sockjs handler function as parameters
+func NewHandler(prefix string, opts Options, handleFunc func(Session)) http.Handler {
+	return newHandler(prefix, opts, handleFunc)
+}
+
+func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler {
+	h := &handler{
+		prefix:      prefix,
+		options:     opts,
+		handlerFunc: handlerFunc,
+		sessions:    make(map[string]*session),
+	}
+
+	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
+	h.mappings = []*mapping{
+		newMapping("GET", prefix+"[/]?$", welcomeHandler),
+		newMapping("OPTIONS", prefix+"/info$", opts.cookie, xhrCors, cacheFor, opts.info),
+		newMapping("GET", prefix+"/info$", xhrCors, noCache, opts.info),
+		// XHR
+		newMapping("POST", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, noCache, h.xhrSend),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr$", opts.cookie, xhrCors, noCache, h.xhrPoll),
+		newMapping("OPTIONS", sessionPrefix+"/xhr$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, noCache, h.xhrStreaming),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		// EventStream
+		newMapping("GET", sessionPrefix+"/eventsource$", opts.cookie, xhrCors, noCache, h.eventSource),
+		// Htmlfile
+		newMapping("GET", sessionPrefix+"/htmlfile$", opts.cookie, xhrCors, noCache, h.htmlFile),
+		// JsonP
+		newMapping("GET", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, noCache, h.jsonp),
+		newMapping("OPTIONS", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/jsonp_send$", opts.cookie, xhrCors, noCache, h.jsonpSend),
+		// IFrame
+		newMapping("GET", prefix+"/iframe[0-9-.a-z_]*.html$", cacheFor, h.iframe),
+	}
+	if opts.Websocket {
+		h.mappings = append(h.mappings, newMapping("GET", sessionPrefix+"/websocket$", h.sockjsWebsocket))
+	}
+	return h
+}
+
+func (h *handler) Prefix() string { return h.prefix }
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// iterate over mappings
+	allowedMethods := []string{}
+	for _, mapping := range h.mappings {
+		if match, method := mapping.matches(req); match == fullMatch {
+			for _, hf := range mapping.chain {
+				hf(rw, req)
+			}
+			return
+		} else if match == pathMatch {
+			allowedMethods = append(allowedMethods, method)
+		}
+	}
+	if len(allowedMethods) > 0 {
+		rw.Header().Set("allow", strings.Join(allowedMethods, ", "))
+		rw.Header().Set("Content-Type", "")
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	http.NotFound(rw, req)
+}
+
+func (h *handler) parseSessionID(url *url.URL) (string, error) {
+	// cache compiled regexp objects for most used prefixes
+	prefixRegexpMu.Lock()
+	session, ok := prefixRegexp[h.prefix]
+	if !ok {
+		session = regexp.MustCompile(h.prefix + "/(?P<server>[^/.]+)/(?P<session>[^/.]+)/.*")
+		prefixRegexp[h.prefix] = session
+	}
+	prefixRegexpMu.Unlock()
+
+	matches := session.FindStringSubmatch(url.Path)
+	if len(matches) == 3 {
+		return matches[2], nil
+	}
+	return "", errors.New("unable to parse URL for session")
+}
+
+func (h *handler) sessionByRequest(req *http.Request) (*session, error) {
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		return nil, err
+	}
+	sess, exists := h.sessions[sessionID]
+	if !exists {
+		sess = newSession(req, sessionID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+		h.sessions[sessionID] = sess
+		if h.handlerFunc != nil {
+			go h.handlerFunc(sess)
+		}
+		go func() {
+			<-sess.closedNotify()
+			h.sessionsMux.Lock()
+			delete(h.sessions, sessionID)
+			h.sessionsMux.Unlock()
+		}()
+	}
+	return sess, nil
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/handler_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/handler_test.go
@@ -1,0 +1,79 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestHandler_Create(t *testing.T) {
+	handler := newHandler("/echo", DefaultOptions, nil)
+	if handler.Prefix() != "/echo" {
+		t.Errorf("Prefix not properly set, got '%s' expected '%s'", handler.Prefix(), "/echo")
+	}
+	if handler.sessions == nil {
+		t.Errorf("Handler session map not made")
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/echo")
+	if err != nil {
+		t.Errorf("There should not be any error, got '%s'", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestHandler_ParseSessionId(t *testing.T) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+	if session, err := h.parseSessionID(url); session != "session" || err != nil {
+		t.Errorf("Wrong session parsed, got '%s' expected '%s' with error = '%v'", session, "session", err)
+	}
+	url, _ = url.Parse("http://server:80/asdasd/server/session/whatever")
+	if _, err := h.parseSessionID(url); err == nil {
+		t.Errorf("Should return error")
+	}
+}
+
+func TestHandler_SessionByRequest(t *testing.T) {
+	h := newHandler("", DefaultOptions, nil)
+	h.options.DisconnectDelay = 10 * time.Millisecond
+	var handlerFuncCalled = make(chan Session)
+	h.handlerFunc = func(conn Session) { handlerFuncCalled <- conn }
+	req, _ := http.NewRequest("POST", "/server/sessionid/whatever/follows", nil)
+	sess, err := h.sessionByRequest(req)
+	if sess == nil || err != nil {
+		t.Errorf("Session should be returned")
+		// test handlerFunc was called
+		select {
+		case conn := <-handlerFuncCalled: // ok
+			if conn != sess {
+				t.Errorf("Handler was not passed correct session")
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("HandlerFunc was not called")
+		}
+	}
+	// test session is reused for multiple requests with same sessionID
+	req2, _ := http.NewRequest("POST", "/server/sessionid/whatever", nil)
+	if sess2, err := h.sessionByRequest(req2); sess2 != sess || err != nil {
+		t.Errorf("Expected error, got session: '%v'", sess)
+	}
+	// test session expires after timeout
+	time.Sleep(15 * time.Millisecond)
+	h.sessionsMux.Lock()
+	if _, exists := h.sessions["sessionid"]; exists {
+		t.Errorf("Session should not exist in handler after timeout")
+	}
+	h.sessionsMux.Unlock()
+	// test proper behaviour in case URL is not correct
+	req, _ = http.NewRequest("POST", "", nil)
+	if _, err := h.sessionByRequest(req); err == nil {
+		t.Errorf("Expected parser sessionID from URL error, got 'nil'")
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/htmlfile.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/htmlfile.go
@@ -1,0 +1,58 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var iframeTemplate = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.%s;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`
+
+func init() {
+	iframeTemplate += strings.Repeat(" ", 1024-len(iframeTemplate)+14)
+	iframeTemplate += "\r\n\r\n"
+}
+
+func (h *handler) htmlFile(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/html; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprintf(rw, iframeTemplate, callback)
+	rw.(http.Flusher).Flush()
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(htmlfileFrameWriter))
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type htmlfileFrameWriter struct{}
+
+func (*htmlfileFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "<script>\np(%s);\n</script>\r\n", quote(frame))
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/htmlfile_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/htmlfile_test.go
@@ -1,0 +1,60 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler_htmlFileNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_htmlFile(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile?c=testCallback", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+	expectedContentType := "text/html; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content-type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	if rw.Body.String() != expectedIFrame {
+		t.Errorf("Unexpected response body, got '%s', expected '%s'", rw.Body, expectedIFrame)
+	}
+
+}
+
+func init() {
+	expectedIFrame += strings.Repeat(" ", 1024-len(expectedIFrame)+len("testCallack")+13)
+	expectedIFrame += "\r\n\r\n"
+	expectedIFrame += "<script>\np(\"o\");\n</script>\r\n"
+}
+
+var expectedIFrame = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.testCallback;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`

--- a/vendor/github.com/igm/sockjs-go/sockjs/httpreceiver.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/httpreceiver.go
@@ -1,0 +1,105 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type frameWriter interface {
+	write(writer io.Writer, frame string) (int, error)
+}
+
+type httpReceiverState int
+
+const (
+	stateHTTPReceiverActive httpReceiverState = iota
+	stateHTTPReceiverClosed
+)
+
+type httpReceiver struct {
+	sync.Mutex
+	state httpReceiverState
+
+	frameWriter         frameWriter
+	rw                  http.ResponseWriter
+	maxResponseSize     uint32
+	currentResponseSize uint32
+	doneCh              chan struct{}
+	interruptCh         chan struct{}
+}
+
+func newHTTPReceiver(rw http.ResponseWriter, maxResponse uint32, frameWriter frameWriter) *httpReceiver {
+	recv := &httpReceiver{
+		rw:              rw,
+		frameWriter:     frameWriter,
+		maxResponseSize: maxResponse,
+		doneCh:          make(chan struct{}),
+		interruptCh:     make(chan struct{}),
+	}
+	if closeNotifier, ok := rw.(http.CloseNotifier); ok {
+		// if supported check for close notifications from http.RW
+		closeNotifyCh := closeNotifier.CloseNotify()
+		go func() {
+			select {
+			case <-closeNotifyCh:
+				recv.Lock()
+				defer recv.Unlock()
+				if recv.state < stateHTTPReceiverClosed {
+					recv.state = stateHTTPReceiverClosed
+					close(recv.interruptCh)
+				}
+			case <-recv.doneCh:
+				// ok, no action needed here, receiver closed in correct way
+				// just finish the routine
+			}
+		}()
+	}
+	return recv
+}
+
+func (recv *httpReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		recv.sendFrame(fmt.Sprintf("a[%s]",
+			strings.Join(
+				transform(messages, quote),
+				",",
+			),
+		))
+	}
+}
+
+func (recv *httpReceiver) sendFrame(value string) {
+	recv.Lock()
+	defer recv.Unlock()
+
+	if recv.state == stateHTTPReceiverActive {
+		// TODO(igm) check err, possibly act as if interrupted
+		n, _ := recv.frameWriter.write(recv.rw, value)
+		recv.currentResponseSize += uint32(n)
+		if recv.currentResponseSize >= recv.maxResponseSize {
+			recv.state = stateHTTPReceiverClosed
+			close(recv.doneCh)
+		} else {
+			recv.rw.(http.Flusher).Flush()
+		}
+	}
+}
+
+func (recv *httpReceiver) doneNotify() <-chan struct{}        { return recv.doneCh }
+func (recv *httpReceiver) interruptedNotify() <-chan struct{} { return recv.interruptCh }
+func (recv *httpReceiver) close() {
+	recv.Lock()
+	defer recv.Unlock()
+	if recv.state < stateHTTPReceiverClosed {
+		recv.state = stateHTTPReceiverClosed
+		close(recv.doneCh)
+	}
+}
+func (recv *httpReceiver) canSend() bool {
+	recv.Lock()
+	defer recv.Unlock()
+	return recv.state != stateHTTPReceiverClosed
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/httpreceiver_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/httpreceiver_test.go
@@ -1,0 +1,101 @@
+package sockjs
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+)
+
+type testFrameWriter struct {
+	frames []string
+}
+
+func (t *testFrameWriter) write(w io.Writer, frame string) (int, error) {
+	t.frames = append(t.frames, frame)
+	return len(frame), nil
+}
+
+func TestHttpReceiver_Create(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	if recv.doneCh != recv.doneNotify() {
+		t.Errorf("Calling done() must return close channel, but it does not")
+	}
+	if recv.rw != rec {
+		t.Errorf("Http.ResponseWriter not properly initialized")
+	}
+	if recv.maxResponseSize != 1024 {
+		t.Errorf("MaxResponseSize not properly initialized")
+	}
+}
+
+func TestHttpReceiver_SendEmptyFrames(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	recv.sendBulk()
+	if rec.Body.String() != "" {
+		t.Errorf("Incorrect body content received from receiver '%s'", rec.Body.String())
+	}
+}
+
+func TestHttpReceiver_SendFrame(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	var frame = "some frame content"
+	recv.sendFrame(frame)
+	if len(fw.frames) != 1 || fw.frames[0] != frame {
+		t.Errorf("Incorrect body content received, got '%s', expected '%s'", fw.frames, frame)
+	}
+
+}
+
+func TestHttpReceiver_SendBulk(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	recv.sendBulk("message 1", "message 2", "message 3")
+	expected := "a[\"message 1\",\"message 2\",\"message 3\"]"
+	if len(fw.frames) != 1 || fw.frames[0] != expected {
+		t.Errorf("Incorrect body content received from receiver, got '%s' expected '%s'", fw.frames, expected)
+	}
+}
+
+func TestHttpReceiver_MaximumResponseSize(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 52, new(testFrameWriter))
+	recv.sendBulk("message 1", "message 2") // produces 26 bytes of response in 1 frame
+	if recv.currentResponseSize != 26 {
+		t.Errorf("Incorrect response size calcualated, got '%d' expected '%d'", recv.currentResponseSize, 26)
+	}
+	select {
+	case <-recv.doneNotify():
+		t.Errorf("Receiver should not be done yet")
+	default: // ok
+	}
+	recv.sendBulk("message 1", "message 2") // produces another 26 bytes of response in 1 frame to go over max resposne size
+	select {
+	case <-recv.doneNotify(): // ok
+	default:
+		t.Errorf("Receiver closed channel did not close")
+	}
+}
+
+func TestHttpReceiver_Close(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, nil)
+	recv.close()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}
+
+func TestHttpReceiver_ConnectionInterrupt(t *testing.T) {
+	rw := newClosableRecorder()
+	recv := newHTTPReceiver(rw, 1024, nil)
+	rw.closeNotifCh <- true
+	recv.Lock()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/iframe.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/iframe.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+var tmpl = template.Must(template.New("iframe").Parse(iframeBody))
+
+func (h *handler) iframe(rw http.ResponseWriter, req *http.Request) {
+	etagReq := req.Header.Get("If-None-Match")
+	hash := md5.New()
+	hash.Write([]byte(iframeBody))
+	etag := fmt.Sprintf("%x", hash.Sum(nil))
+	if etag == etagReq {
+		rw.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	rw.Header().Add("ETag", etag)
+	tmpl.Execute(rw, h.options.SockJSURL)
+}
+
+var iframeBody = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="{{.}}"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/vendor/github.com/igm/sockjs-go/sockjs/iframe_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/iframe_test.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_iframe(t *testing.T) {
+	h := newTestHandler()
+	h.options.SockJSURL = "http://sockjs.com/sockjs.js"
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/sess/iframe", nil)
+	h.iframe(rw, req)
+	if rw.Body.String() != expected {
+		t.Errorf("Unexpected html content,\ngot:\n'%s'\n\nexpected\n'%s'", rw.Body, expected)
+	}
+	eTag := rw.Header().Get("etag")
+	req.Header.Set("if-none-match", eTag)
+	rw = httptest.NewRecorder()
+	h.iframe(rw, req)
+	if rw.Code != http.StatusNotModified {
+		t.Errorf("Unexpected response, got '%d', expected '%d'", rw.Code, http.StatusNotModified)
+	}
+}
+
+var expected = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="http://sockjs.com/sockjs.js"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/vendor/github.com/igm/sockjs-go/sockjs/jsonp.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/jsonp.go
@@ -1,0 +1,77 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (h *handler) jsonp(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, 1, &jsonpFrameWriter{callback})
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+func (h *handler) jsonpSend(rw http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
+	var data io.Reader
+	data = req.Body
+
+	formReader := strings.NewReader(req.PostFormValue("d"))
+	if formReader.Len() != 0 {
+		data = formReader
+	}
+	if data == nil {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(data).Decode(&messages)
+	if err == io.EOF {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if err != nil {
+		http.Error(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, _ := h.parseSessionID(req.URL)
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...) // TODO(igm) reponse with http.StatusInternalServerError in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8")
+		rw.Write([]byte("ok"))
+	}
+}
+
+type jsonpFrameWriter struct {
+	callback string
+}
+
+func (j *jsonpFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s(%s);\r\n", j.callback, quote(frame))
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/jsonp_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/jsonp_test.go
@@ -1,0 +1,98 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_jsonpNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp", nil)
+	h.jsonp(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_jsonp(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp?c=testCallback", nil)
+	h.jsonp(rw, req)
+	expectedContentType := "application/javascript; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	expectedBody := "testCallback(\"o\");\r\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s', expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_jsonpSendNoPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", nil)
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendWrongPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("wrong payload"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendNoSession(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_jsonpSend(t *testing.T) {
+	h := newTestHandler()
+
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+
+	sess := newSession(req, "session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	var done = make(chan struct{})
+	go func() {
+		h.jsonpSend(rw, req)
+		close(done)
+	}()
+	msg, _ := sess.Recv()
+	if msg != "message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rw.Code != http.StatusOK {
+		t.Errorf("Wrong response status received %d, should be %d", rw.Code, http.StatusOK)
+	}
+	if rw.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rw.Header().Get("content-type"))
+	}
+	if rw.Body.String() != "ok" {
+		t.Errorf("Unexpected body, got '%s', expected 'ok'", rw.Body)
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/mapping.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/mapping.go
@@ -1,0 +1,36 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+)
+
+type mapping struct {
+	method string
+	path   *regexp.Regexp
+	chain  []http.HandlerFunc
+}
+
+func newMapping(method string, re string, handlers ...http.HandlerFunc) *mapping {
+	return &mapping{method, regexp.MustCompile(re), handlers}
+}
+
+type matchType uint32
+
+const (
+	fullMatch matchType = iota
+	pathMatch
+	noMatch
+)
+
+// matches checks if given req.URL is a match with a mapping. Match can be either full, partial (http method mismatch) or no match.
+func (m *mapping) matches(req *http.Request) (match matchType, method string) {
+	if !m.path.MatchString(req.URL.Path) {
+		match, method = noMatch, ""
+	} else if m.method != req.Method {
+		match, method = pathMatch, m.method
+	} else {
+		match, method = fullMatch, m.method
+	}
+	return
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/mapping_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/mapping_test.go
@@ -1,0 +1,38 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+func TestMappingMatcher(t *testing.T) {
+	mappingPrefix := mapping{"GET", regexp.MustCompile("prefix/$"), nil}
+	mappingPrefixRegExp := mapping{"GET", regexp.MustCompile(".*x/$"), nil}
+
+	var testRequests = []struct {
+		mapping       mapping
+		method        string
+		url           string
+		expectedMatch matchType
+	}{
+		{mappingPrefix, "GET", "http://foo/prefix/", fullMatch},
+		{mappingPrefix, "POST", "http://foo/prefix/", pathMatch},
+		{mappingPrefix, "GET", "http://foo/prefix_not_mapped", noMatch},
+		{mappingPrefixRegExp, "GET", "http://foo/prefix/", fullMatch},
+	}
+
+	for _, request := range testRequests {
+		req, _ := http.NewRequest(request.method, request.url, nil)
+		m := request.mapping
+		match, method := m.matches(req)
+		if match != request.expectedMatch {
+			t.Errorf("mapping %s should match url=%s", m.path, request.url)
+		}
+		if request.expectedMatch == pathMatch {
+			if method != m.method {
+				t.Errorf("Matcher method should be %s, but got %s", m.method, method)
+			}
+		}
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/options.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/options.go
@@ -1,0 +1,114 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	entropy      *rand.Rand
+	entropyMutex sync.Mutex
+)
+
+func init() {
+	entropy = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// Options type is used for defining various sockjs options
+type Options struct {
+	// Transports which don't support cross-domain communication natively ('eventsource' to name one) use an iframe trick.
+	// A simple page is served from the SockJS server (using its foreign domain) and is placed in an invisible iframe.
+	// Code run from this iframe doesn't need to worry about cross-domain issues, as it's being run from domain local to the SockJS server.
+	// This iframe also does need to load SockJS javascript client library, and this option lets you specify its url (if you're unsure,
+	// point it to the latest minified SockJS client release, this is the default). You must explicitly specify this url on the server
+	// side for security reasons - we don't want the possibility of running any foreign javascript within the SockJS domain (aka cross site scripting attack).
+	// Also, sockjs javascript library is probably already cached by the browser - it makes sense to reuse the sockjs url you're using in normally.
+	SockJSURL string
+	// Most streaming transports save responses on the client side and don't free memory used by delivered messages.
+	// Such transports need to be garbage-collected once in a while. `response_limit` sets a minimum number of bytes that can be send
+	// over a single http streaming request before it will be closed. After that client needs to open new request.
+	// Setting this value to one effectively disables streaming and will make streaming transports to behave like polling transports.
+	// The default value is 128K.
+	ResponseLimit uint32
+	// Some load balancers don't support websockets. This option can be used to disable websockets support by the server. By default websockets are enabled.
+	Websocket bool
+	// In order to keep proxies and load balancers from closing long running http requests we need to pretend that the connection is active
+	// and send a heartbeat packet once in a while. This setting controls how often this is done.
+	// By default a heartbeat packet is sent every 25 seconds.
+	HeartbeatDelay time.Duration
+	// The server closes a session when a client receiving connection have not been seen for a while.
+	// This delay is configured by this setting.
+	// By default the session is closed when a receiving connection wasn't seen for 5 seconds.
+	DisconnectDelay time.Duration
+	// Some hosting providers enable sticky sessions only to requests that have JSessionID cookie set.
+	// This setting controls if the server should set this cookie to a dummy value.
+	// By default setting JSessionID cookie is disabled. More sophisticated behaviour can be achieved by supplying a function.
+	JSessionID func(http.ResponseWriter, *http.Request)
+}
+
+// DefaultOptions is a convenient set of options to be used for sockjs
+var DefaultOptions = Options{
+	Websocket:       true,
+	JSessionID:      nil,
+	SockJSURL:       "//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.4/sockjs.min.js",
+	HeartbeatDelay:  25 * time.Second,
+	DisconnectDelay: 5 * time.Second,
+	ResponseLimit:   128 * 1024,
+}
+
+type info struct {
+	Websocket    bool     `json:"websocket"`
+	CookieNeeded bool     `json:"cookie_needed"`
+	Origins      []string `json:"origins"`
+	Entropy      int32    `json:"entropy"`
+}
+
+func (options *Options) info(rw http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		json.NewEncoder(rw).Encode(info{
+			Websocket:    options.Websocket,
+			CookieNeeded: options.JSessionID != nil,
+			Origins:      []string{"*:*"},
+			Entropy:      generateEntropy(),
+		})
+	case "OPTIONS":
+		rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET")
+		rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+		rw.WriteHeader(http.StatusNoContent) // 204
+	default:
+		http.NotFound(rw, req)
+	}
+}
+
+// DefaultJSessionID is a default behaviour function to be used in options for JSessionID if JSESSIONID is needed
+func DefaultJSessionID(rw http.ResponseWriter, req *http.Request) {
+	cookie, err := req.Cookie("JSESSIONID")
+	if err == http.ErrNoCookie {
+		cookie = &http.Cookie{
+			Name:  "JSESSIONID",
+			Value: "dummy",
+		}
+	}
+	cookie.Path = "/"
+	header := rw.Header()
+	header.Add("Set-Cookie", cookie.String())
+}
+
+func (options *Options) cookie(rw http.ResponseWriter, req *http.Request) {
+	if options.JSessionID != nil { // cookie is needed
+		options.JSessionID(rw, req)
+	}
+}
+
+func generateEntropy() int32 {
+	entropyMutex.Lock()
+	entropy := entropy.Int31()
+	entropyMutex.Unlock()
+	return entropy
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/options_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/options_test.go
@@ -1,0 +1,64 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+)
+import "testing"
+
+func TestInfoGet(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "", nil)
+	DefaultOptions.info(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Wrong status code, got '%d' expected '%d'", recorder.Code, http.StatusOK)
+	}
+
+	decoder := json.NewDecoder(recorder.Body)
+	var a info
+	decoder.Decode(&a)
+	if !a.Websocket {
+		t.Errorf("Websocket field should be set true")
+	}
+	if a.CookieNeeded {
+		t.Errorf("CookieNeeded should be set to false")
+	}
+}
+
+func TestInfoOptions(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("OPTIONS", "", nil)
+	DefaultOptions.info(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("Incorrect status code received, got '%d' expected '%d'", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestInfoUnknown(t *testing.T) {
+	req, _ := http.NewRequest("PUT", "", nil)
+	rec := httptest.NewRecorder()
+	DefaultOptions.info(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Incorrec response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "", nil)
+	optionsWithCookies := DefaultOptions
+	optionsWithCookies.JSessionID = DefaultJSessionID
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=dummy; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+	// cookie value set in request
+	req.AddCookie(&http.Cookie{Name: "JSESSIONID", Value: "some_jsession_id", Path: "/"})
+	rec = httptest.NewRecorder()
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=some_jsession_id; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/session.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/session.go
@@ -1,0 +1,233 @@
+package sockjs
+
+import (
+	"encoding/gob"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// SessionState defines the current state of the session
+type SessionState uint32
+
+const (
+	// brand new session, need to send "h" to receiver
+	SessionOpening SessionState = iota
+	// active session
+	SessionActive
+	// session being closed, sending "closeFrame" to receivers
+	SessionClosing
+	// closed session, no activity at all, should be removed from handler completely and not reused
+	SessionClosed
+)
+
+var (
+	// ErrSessionNotOpen error is used to denote session not in open state.
+	// Recv() and Send() operations are not suppored if session is closed.
+	ErrSessionNotOpen          = errors.New("sockjs: session not in open state")
+	errSessionReceiverAttached = errors.New("sockjs: another receiver already attached")
+)
+
+type session struct {
+	sync.RWMutex
+	id    string
+	req   *http.Request
+	state SessionState
+	// protocol dependent receiver (xhr, eventsource, ...)
+	recv receiver
+	// messages to be sent to client
+	sendBuffer []string
+	// messages received from client to be consumed by application
+	// receivedBuffer chan string
+	msgReader  *io.PipeReader
+	msgWriter  *io.PipeWriter
+	msgEncoder *gob.Encoder
+	msgDecoder *gob.Decoder
+
+	// closeFrame to send after session is closed
+	closeFrame string
+
+	// internal timer used to handle session expiration if no receiver is attached, or heartbeats if recevier is attached
+	sessionTimeoutInterval time.Duration
+	heartbeatInterval      time.Duration
+	timer                  *time.Timer
+	// once the session timeouts this channel also closes
+	closeCh chan struct{}
+}
+
+type receiver interface {
+	// sendBulk send multiple data messages in frame frame in format: a["msg 1", "msg 2", ....]
+	sendBulk(...string)
+	// sendFrame sends given frame over the wire (with possible chunking depending on receiver)
+	sendFrame(string)
+	// close closes the receiver in a "done" way (idempotent)
+	close()
+	canSend() bool
+	// done notification channel gets closed whenever receiver ends
+	doneNotify() <-chan struct{}
+	// interrupted channel gets closed whenever receiver is interrupted (i.e. http connection drops,...)
+	interruptedNotify() <-chan struct{}
+}
+
+// Session is a central component that handles receiving and sending frames. It maintains internal state
+func newSession(req *http.Request, sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration) *session {
+	r, w := io.Pipe()
+	s := &session{
+		id:                     sessionID,
+		req:                    req,
+		msgReader:              r,
+		msgWriter:              w,
+		msgEncoder:             gob.NewEncoder(w),
+		msgDecoder:             gob.NewDecoder(r),
+		sessionTimeoutInterval: sessionTimeoutInterval,
+		heartbeatInterval:      heartbeatInterval,
+		closeCh:                make(chan struct{})}
+	s.Lock() // "go test -race" complains if ommited, not sure why as no race can happen here
+	s.timer = time.AfterFunc(sessionTimeoutInterval, s.close)
+	s.Unlock()
+	return s
+}
+
+func (s *session) sendMessage(msg string) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.state > SessionActive {
+		return ErrSessionNotOpen
+	}
+	s.sendBuffer = append(s.sendBuffer, msg)
+	if s.recv != nil && s.recv.canSend() {
+		s.recv.sendBulk(s.sendBuffer...)
+		s.sendBuffer = nil
+	}
+	return nil
+}
+
+func (s *session) attachReceiver(recv receiver) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil {
+		return errSessionReceiverAttached
+	}
+	s.recv = recv
+	go func(r receiver) {
+		select {
+		case <-r.doneNotify():
+			s.detachReceiver()
+		case <-r.interruptedNotify():
+			s.detachReceiver()
+			s.close()
+		}
+	}(recv)
+
+	if s.state == SessionClosing {
+		s.recv.sendFrame(s.closeFrame)
+		s.recv.close()
+		return nil
+	}
+	if s.state == SessionOpening {
+		s.recv.sendFrame("o")
+		s.state = SessionActive
+	}
+	s.recv.sendBulk(s.sendBuffer...)
+	s.sendBuffer = nil
+	s.timer.Stop()
+	if s.heartbeatInterval > 0 {
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+	return nil
+}
+
+func (s *session) detachReceiver() {
+	s.Lock()
+	defer s.Unlock()
+	s.timer.Stop()
+	s.timer = time.AfterFunc(s.sessionTimeoutInterval, s.close)
+	s.recv = nil
+}
+
+func (s *session) heartbeat() {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil { // timer could have fired between Lock and timer.Stop in detachReceiver
+		s.recv.sendFrame("h")
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+}
+
+func (s *session) accept(messages ...string) error {
+	for _, msg := range messages {
+		if err := s.msgEncoder.Encode(msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// idempotent operation
+func (s *session) closing() {
+	s.Lock()
+	defer s.Unlock()
+	if s.state < SessionClosing {
+		s.msgReader.Close()
+		s.msgWriter.Close()
+		s.state = SessionClosing
+		if s.recv != nil {
+			s.recv.sendFrame(s.closeFrame)
+			s.recv.close()
+		}
+	}
+}
+
+// idempotent operation
+func (s *session) close() {
+	s.closing()
+	s.Lock()
+	defer s.Unlock()
+	if s.state < SessionClosed {
+		s.state = SessionClosed
+		s.timer.Stop()
+		close(s.closeCh)
+	}
+}
+
+func (s *session) closedNotify() <-chan struct{} { return s.closeCh }
+
+// Conn interface implementation
+func (s *session) Close(status uint32, reason string) error {
+	s.Lock()
+	if s.state < SessionClosing {
+		s.closeFrame = closeFrame(status, reason)
+		s.Unlock()
+		s.closing()
+		return nil
+	}
+	s.Unlock()
+	return ErrSessionNotOpen
+}
+
+func (s *session) Recv() (string, error) {
+	var msg string
+	err := s.msgDecoder.Decode(&msg)
+	if err == io.ErrClosedPipe {
+		err = ErrSessionNotOpen
+	}
+	return msg, err
+}
+
+func (s *session) Send(msg string) error {
+	return s.sendMessage(msg)
+}
+
+func (s *session) ID() string { return s.id }
+
+func (s *session) GetSessionState() SessionState {
+	s.RLock()
+	defer s.RUnlock()
+	return s.state
+}
+
+func (s *session) Request() *http.Request {
+	return s.req
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/session_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/session_test.go
@@ -1,0 +1,339 @@
+package sockjs
+
+import (
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestSession() *session {
+	// session with long expiration and heartbeats with ID
+	return newSession(nil, "sessionId", 1000*time.Second, 1000*time.Second)
+}
+
+func TestSession_Create(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("this is a message")
+	if len(session.sendBuffer) != 1 {
+		t.Errorf("Session send buffer should contain 1 message")
+	}
+	session.sendMessage("another message")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("Session send buffer should contain 2 messages")
+	}
+	if session.GetSessionState() != SessionOpening {
+		t.Errorf("Session in wrong state %v, should be %v", session.GetSessionState(), SessionOpening)
+	}
+}
+
+func TestSession_Request(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	sess := newSession(req, "session", time.Second, time.Second)
+
+	if sess.Request() == nil {
+		t.Error("Session initial request should have been saved.")
+	}
+	if sess.Request().URL.String() != req.URL.String() {
+		t.Errorf("Expected stored session request URL to equal %s, got %s", req.URL.String(), sess.Request().URL.String())
+	}
+}
+
+func TestSession_ConcurrentSend(t *testing.T) {
+	session := newTestSession()
+	done := make(chan bool)
+	for i := 0; i < 100; i++ {
+		go func() {
+			session.sendMessage("message D")
+			done <- true
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	if len(session.sendBuffer) != 100 {
+		t.Errorf("Session send buffer should contain 100 messages")
+	}
+}
+
+func TestSession_AttachReceiver(t *testing.T) {
+	session := newTestSession()
+	recv := &testReceiver{}
+	// recv := &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		if frame != "o" {
+	// 			t.Errorf("Incorrect open header received")
+	// 		}
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+	if session.GetSessionState() != SessionActive {
+		t.Errorf("Session in wrong state after receiver attached %d, should be %d", session.GetSessionState(), SessionActive)
+	}
+	session.detachReceiver()
+	// recv = &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		t.Errorf("No frame shold be send, got '%s'", frame)
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+}
+
+func TestSession_Timeout(t *testing.T) {
+	sess := newSession(nil, "id", 10*time.Millisecond, 10*time.Second)
+	select {
+	case <-sess.closeCh:
+	case <-time.After(20 * time.Millisecond):
+		t.Errorf("sess close notification channel should close")
+	}
+	if sess.GetSessionState() != SessionClosed {
+		t.Errorf("Session did not timeout")
+	}
+}
+
+func TestSession_TimeoutOfClosedSession(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	sess := newSession(nil, "id", 1*time.Millisecond, time.Second)
+	sess.closing()
+	time.Sleep(1 * time.Millisecond)
+	sess.closing()
+}
+
+func TestSession_AttachReceiverAndCheckHeartbeats(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	session := newSession(nil, "id", time.Second, 10*time.Millisecond) // 10ms heartbeats
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+	session.attachReceiver(recv)
+	time.Sleep(120 * time.Millisecond)
+	recv.Lock()
+	if len(recv.frames) < 10 || len(recv.frames) > 13 { // should get around 10 heartbeats (120ms/10ms)
+		t.Fatalf("Wrong number of frames received, got '%d'", len(recv.frames))
+	}
+	for i := 1; i < len(recv.frames); i++ {
+		if recv.frames[i] != "h" {
+			t.Errorf("Heartbeat no received")
+		}
+	}
+}
+
+func TestSession_AttachReceiverAndRefuse(t *testing.T) {
+	session := newTestSession()
+	if err := session.attachReceiver(newTestReceiver()); err != nil {
+		t.Errorf("Should not return error")
+	}
+	var a sync.WaitGroup
+	a.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer a.Done()
+			if err := session.attachReceiver(newTestReceiver()); err != errSessionReceiverAttached {
+				t.Errorf("Should return error as another receiver is already attached")
+			}
+		}()
+	}
+	a.Wait()
+}
+
+func TestSession_DetachRecevier(t *testing.T) {
+	session := newTestSession()
+	session.detachReceiver()
+	session.detachReceiver() // idempotent operation
+	session.attachReceiver(newTestReceiver())
+	session.detachReceiver()
+
+}
+
+func TestSession_SendWithRecv(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("message A")
+	session.sendMessage("message B")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("There should be 2 messages in buffer, but there are %d", len(session.sendBuffer))
+	}
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+
+	session.attachReceiver(recv)
+	if len(recv.frames[1:]) != 2 {
+		t.Errorf("Reciver should get 2 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message C")
+	if len(recv.frames[1:]) != 3 {
+		t.Errorf("Reciver should get 3 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message D")
+	if len(recv.frames[1:]) != 4 {
+		t.Errorf("Reciver should get 4 frames from session, got %d", len(recv.frames))
+	}
+	if len(session.sendBuffer) != 0 {
+		t.Errorf("Send buffer should be empty now, but there are %d messaged", len(session.sendBuffer))
+	}
+}
+
+func TestSession_Recv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic should not happen")
+		}
+	}()
+	session := newTestSession()
+	go func() {
+		session.accept("message A")
+		session.accept("message B")
+		if err := session.accept("message C"); err != io.ErrClosedPipe {
+			t.Errorf("Session should not accept new messages if closed, got '%v' expected '%v'", err, io.ErrClosedPipe)
+		}
+	}()
+	if msg, _ := session.Recv(); msg != "message A" {
+		t.Errorf("Got %s, should be %s", msg, "message A")
+	}
+	if msg, _ := session.Recv(); msg != "message B" {
+		t.Errorf("Got %s, should be %s", msg, "message B")
+	}
+	session.close()
+}
+
+func TestSession_Closing(t *testing.T) {
+	session := newTestSession()
+	session.closing()
+	if _, err := session.Recv(); err == nil {
+		t.Errorf("Session's receive buffer channel should close")
+	}
+	if err := session.sendMessage("some message"); err != ErrSessionNotOpen {
+		t.Errorf("Session should not accept new message after close")
+	}
+}
+
+// Session as Session Tests
+func TestSession_AsSession(t *testing.T) { var _ Session = newSession(nil, "id", 0, 0) }
+
+func TestSession_SessionRecv(t *testing.T) {
+	s := newTestSession()
+	go func() {
+		s.accept("message 1")
+	}()
+	msg, err := s.Recv()
+	if msg != "message 1" || err != nil {
+		t.Errorf("Should receive a message without error, got '%s' err '%v'", msg, err)
+	}
+	go func() {
+		s.closing()
+		_, err := s.Recv()
+		if err != ErrSessionNotOpen {
+			t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+		}
+	}()
+	_, err = s.Recv()
+	if err != ErrSessionNotOpen {
+		t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+	}
+}
+
+func TestSession_SessionSend(t *testing.T) {
+	s := newTestSession()
+	err := s.Send("message A")
+	if err != nil {
+		t.Errorf("Session should take messages by default")
+	}
+	if len(s.sendBuffer) != 1 || s.sendBuffer[0] != "message A" {
+		t.Errorf("Message not properly queued in session, got '%v'", s.sendBuffer)
+	}
+}
+
+func TestSession_SessionClose(t *testing.T) {
+	s := newTestSession()
+	s.state = SessionActive
+	recv := newTestReceiver()
+	s.attachReceiver(recv)
+	err := s.Close(1, "some reason")
+	if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+		t.Errorf("Expected close frame, got '%v'", recv.frames)
+	}
+	if err != nil {
+		t.Errorf("Should not get any error, got '%s'", err)
+	}
+	if s.closeFrame != "c[1,\"some reason\"]" {
+		t.Errorf("Incorrect closeFrame, got '%s'", s.closeFrame)
+	}
+	if s.GetSessionState() != SessionClosing {
+		t.Errorf("Incorrect session state, expected 'sessionClosing', got '%v'", s.GetSessionState())
+	}
+	// all the consequent receivers trying to attach shoult get the same close frame
+	var i = 100
+	for i > 0 {
+		recv := newTestReceiver()
+		err := s.attachReceiver(recv)
+		if err != nil {
+			// give a chance to a receiver to detach
+			runtime.Gosched()
+			continue
+		}
+		i--
+		if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+			t.Errorf("Close frame not received by recv, frames '%v'", recv.frames)
+		}
+	}
+	if err := s.Close(1, "some other reson"); err != ErrSessionNotOpen {
+		t.Errorf("Expected error, got '%v'", err)
+	}
+}
+
+func TestSession_SessionSessionId(t *testing.T) {
+	s := newTestSession()
+	if s.ID() != "sessionId" {
+		t.Errorf("Unexpected session ID, got '%s', expected '%s'", s.ID(), "sessionId")
+	}
+}
+
+func newTestReceiver() *testReceiver {
+	return &testReceiver{
+		doneCh:      make(chan struct{}),
+		interruptCh: make(chan struct{}),
+	}
+}
+
+type testReceiver struct {
+	sync.Mutex
+	doneCh, interruptCh chan struct{}
+	frames              []string
+}
+
+func (t *testReceiver) doneNotify() <-chan struct{}        { return t.doneCh }
+func (t *testReceiver) interruptedNotify() <-chan struct{} { return t.interruptCh }
+func (t *testReceiver) close()                             { close(t.doneCh) }
+func (t *testReceiver) canSend() bool {
+	select {
+	case <-t.doneCh:
+		return false // already closed
+	default:
+		return true
+	}
+}
+func (t *testReceiver) sendBulk(messages ...string) {
+	for _, m := range messages {
+		t.sendFrame(m)
+	}
+}
+func (t *testReceiver) sendFrame(frame string) {
+	t.Lock()
+	defer t.Unlock()
+	t.frames = append(t.frames, frame)
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/sockjs.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/sockjs.go
@@ -1,0 +1,19 @@
+package sockjs
+
+import "net/http"
+
+// Session represents a connection between server and client.
+type Session interface {
+	// Id returns a session id
+	ID() string
+	// Request returns the first http request
+	Request() *http.Request
+	// Recv reads one text frame from session
+	Recv() (string, error)
+	// Send sends one text frame to session
+	Send(string) error
+	// Close closes the session with provided code and reason.
+	Close(status uint32, reason string) error
+	//Gets the state of the session. SessionOpening/SessionActive/SessionClosing/SessionClosed;
+	GetSessionState() SessionState
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/sockjs_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/sockjs_test.go
@@ -1,0 +1,27 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func TestSockJS_ServeHTTP(t *testing.T) {
+	m := handler{mappings: make([]*mapping, 0)}
+	m.mappings = []*mapping{
+		&mapping{"POST", regexp.MustCompile("/foo/.*"), []http.HandlerFunc{func(http.ResponseWriter, *http.Request) {}}},
+	}
+	req, _ := http.NewRequest("GET", "/foo/bar", nil)
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusMethodNotAllowed)
+	}
+	req, _ = http.NewRequest("GET", "/bar", nil)
+	rec = httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/utils.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/utils.go
@@ -1,0 +1,16 @@
+package sockjs
+
+import "encoding/json"
+
+func quote(in string) string {
+	quoted, _ := json.Marshal(in)
+	return string(quoted)
+}
+
+func transform(values []string, transformFn func(string) string) []string {
+	ret := make([]string, len(values))
+	for i, msg := range values {
+		ret[i] = transformFn(msg)
+	}
+	return ret
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/utils_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/utils_test.go
@@ -1,0 +1,19 @@
+package sockjs
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	var quotationTests = []struct {
+		input  string
+		output string
+	}{
+		{"simple", "\"simple\""},
+		{"more complex \"", "\"more complex \\\"\""},
+	}
+
+	for _, testCase := range quotationTests {
+		if quote(testCase.input) != testCase.output {
+			t.Errorf("Expected '%s', got '%s'", testCase.output, quote(testCase.input))
+		}
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/web.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/web.go
@@ -1,0 +1,47 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func xhrCors(rw http.ResponseWriter, req *http.Request) {
+	header := rw.Header()
+	origin := req.Header.Get("origin")
+	if origin == "" {
+		origin = "*"
+	}
+	header.Set("Access-Control-Allow-Origin", origin)
+
+	if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
+		header.Add("Access-Control-Allow-Headers", allowHeaders)
+	}
+	header.Set("Access-Control-Allow-Credentials", "true")
+}
+
+func xhrOptions(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+	rw.WriteHeader(http.StatusNoContent) // 204
+}
+
+func cacheFor(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", 365*24*60*60))
+	rw.Header().Set("Expires", time.Now().AddDate(1, 0, 0).Format(time.RFC1123))
+	rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+}
+
+func noCache(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+}
+
+func welcomeHandler(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/plain;charset=UTF-8")
+	fmt.Fprintf(rw, "Welcome to SockJS!\n")
+}
+
+func httpError(w http.ResponseWriter, error string, code int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(code)
+	fmt.Fprintf(w, error)
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/web_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/web_test.go
@@ -1,0 +1,85 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestXhrCors(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "*" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "*")
+	}
+	req.Header.Set("origin", "localhost")
+	xhrCors(recorder, req)
+	acao = recorder.Header().Get("access-control-allow-origin")
+	if acao != "localhost" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "localhost")
+	}
+
+	req.Header.Set("access-control-request-headers", "some value")
+	rec := httptest.NewRecorder()
+	xhrCors(rec, req)
+	if rec.Header().Get("access-control-allow-headers") != "some value" {
+		t.Errorf("Incorent value for ACAH, got %s", rec.Header().Get("access-control-allow-headers"))
+	}
+
+	rec = httptest.NewRecorder()
+	xhrCors(rec, req)
+	if rec.Header().Get("access-control-allow-credentials") != "true" {
+		t.Errorf("Incorent value for ACAC, got %s", rec.Header().Get("access-control-allow-credentials"))
+	}
+
+	// verify that if Access-Control-Allow-Credentials was previously set that xhrCors() does not duplicate the value
+	rec = httptest.NewRecorder()
+	rec.Header().Set("Access-Control-Allow-Credentials", "true")
+	xhrCors(rec, req)
+	acac := rec.Header()["Access-Control-Allow-Credentials"]
+	if len(acac) != 1 || acac[0] != "true" {
+		t.Errorf("Incorent value for ACAC, got %s", strings.Join(acac, ","))
+	}
+}
+
+func TestXhrOptions(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrOptions(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status code, expected %d, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestCacheFor(t *testing.T) {
+	rec := httptest.NewRecorder()
+	cacheFor(rec, nil)
+	cacheControl := rec.Header().Get("cache-control")
+	if cacheControl != "public, max-age=31536000" {
+		t.Errorf("Incorrect cache-control header value, got '%s'", cacheControl)
+	}
+	expires := rec.Header().Get("expires")
+	if expires == "" {
+		t.Errorf("Expires header should not be empty") // TODO(igm) check proper formating of string
+	}
+	maxAge := rec.Header().Get("access-control-max-age")
+	if maxAge != "31536000" {
+		t.Errorf("Incorrect value for access-control-max-age, got '%s'", maxAge)
+	}
+}
+
+func TestNoCache(t *testing.T) {
+	rec := httptest.NewRecorder()
+	noCache(rec, nil)
+}
+
+func TestWelcomeHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	welcomeHandler(rec, nil)
+	if rec.Body.String() != "Welcome to SockJS!\n" {
+		t.Errorf("Incorrect welcome message received, got '%s'", rec.Body.String())
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/websocket.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/websocket.go
@@ -1,0 +1,97 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// WebSocketReadBufSize is a parameter that is used for WebSocket Upgrader.
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketReadBufSize = 4096
+
+// WebSocketWriteBufSize is a parameter that is used for WebSocket Upgrader
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketWriteBufSize = 4096
+
+func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
+	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	if _, ok := err.(websocket.HandshakeError); ok {
+		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
+		return
+	} else if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	sessID, _ := h.parseSessionID(req.URL)
+	sess := newSession(req, sessID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+	if h.handlerFunc != nil {
+		go h.handlerFunc(sess)
+	}
+
+	receiver := newWsReceiver(conn)
+	sess.attachReceiver(receiver)
+	readCloseCh := make(chan struct{})
+	go func() {
+		var d []string
+		for {
+			err := conn.ReadJSON(&d)
+			if err != nil {
+				close(readCloseCh)
+				return
+			}
+			sess.accept(d...)
+		}
+	}()
+
+	select {
+	case <-readCloseCh:
+	case <-receiver.doneNotify():
+	}
+	sess.close()
+	conn.Close()
+}
+
+type wsReceiver struct {
+	conn    *websocket.Conn
+	closeCh chan struct{}
+}
+
+func newWsReceiver(conn *websocket.Conn) *wsReceiver {
+	return &wsReceiver{
+		conn:    conn,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (w *wsReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		w.sendFrame(fmt.Sprintf("a[%s]", strings.Join(transform(messages, quote), ",")))
+	}
+}
+
+func (w *wsReceiver) sendFrame(frame string) {
+	if err := w.conn.WriteMessage(websocket.TextMessage, []byte(frame)); err != nil {
+		w.close()
+	}
+}
+
+func (w *wsReceiver) close() {
+	select {
+	case <-w.closeCh: // already closed
+	default:
+		close(w.closeCh)
+	}
+}
+func (w *wsReceiver) canSend() bool {
+	select {
+	case <-w.closeCh: // already closed
+		return false
+	default:
+		return true
+	}
+}
+func (w *wsReceiver) doneNotify() <-chan struct{}        { return w.closeCh }
+func (w *wsReceiver) interruptedNotify() <-chan struct{} { return nil }

--- a/vendor/github.com/igm/sockjs-go/sockjs/websocket_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/websocket_test.go
@@ -1,0 +1,119 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestHandler_WebSocketHandshakeError(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("origin", "https"+server.URL[4:])
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestHandler_WebSocket(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var connCh = make(chan Session)
+	h.handlerFunc = func(conn Session) { connCh <- conn }
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if conn == nil {
+		t.Errorf("Connection should not be nil")
+	}
+	if err != nil {
+		t.Errorf("Unexpected error '%v'", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("Wrong response code returned, got '%d', expected '%d'", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-connCh: //ok
+	case <-time.After(10 * time.Millisecond):
+		t.Errorf("Sockjs Handler not invoked")
+	}
+}
+
+func TestHandler_WebSocketTerminationByServer(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	h.handlerFunc = func(conn Session) {
+		conn.Close(1024, "some close message")
+		conn.Close(0, "this should be ignored")
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	_, msg, err := conn.ReadMessage()
+	if string(msg) != "o" || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, "o")
+	}
+	_, msg, err = conn.ReadMessage()
+	if string(msg) != `c[1024,"some close message"]` || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, `c[1024,"some close message"]`)
+	}
+	_, msg, err = conn.ReadMessage()
+	// gorilla websocket keeps `errUnexpectedEOF` private so we need to introspect the error message
+	if err != nil {
+		if !strings.Contains(err.Error(), "unexpected EOF") {
+			t.Errorf("Expected 'unexpected EOF' error or similar, got '%v'", err)
+		}
+	}
+}
+
+func TestHandler_WebSocketTerminationByClient(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		if _, err := conn.Recv(); err != ErrSessionNotOpen {
+			t.Errorf("Recv should fail")
+		}
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.Close()
+	<-done
+}
+
+func TestHandler_WebSocketCommunication(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	// defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		conn.Send("message 1")
+		conn.Send("message 2")
+		msg, err := conn.Recv()
+		if msg != "message 3" || err != nil {
+			t.Errorf("Got '%s', expecte '%s'", msg, "message 3")
+		}
+		conn.Close(123, "close")
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.WriteJSON([]string{"message 3"})
+	var expected = []string{"o", `a["message 1"]`, `a["message 2"]`, `c[123,"close"]`}
+	for _, exp := range expected {
+		_, msg, err := conn.ReadMessage()
+		if string(msg) != exp || err != nil {
+			t.Errorf("Wrong frame, got '%s' and error '%v', expected '%s' without error", msg, err, exp)
+		}
+	}
+	<-done
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/xhr.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/xhr.go
@@ -1,0 +1,88 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var (
+	cFrame              = closeFrame(2010, "Another connection still open")
+	xhrStreamingPrelude = strings.Repeat("h", 2048)
+)
+
+func (h *handler) xhrSend(rw http.ResponseWriter, req *http.Request) {
+	if req.Body == nil {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(req.Body).Decode(&messages)
+	if err == io.EOF {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if _, ok := err.(*json.SyntaxError); ok || err == io.ErrUnexpectedEOF {
+		httpError(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...)                                 // TODO(igm) reponse with SISE in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8") // Ignored by net/http (but protocol test complains), see https://code.google.com/p/go/source/detail?r=902dc062bff8
+		rw.WriteHeader(http.StatusNoContent)
+	}
+}
+
+type xhrFrameWriter struct{}
+
+func (*xhrFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s\n", frame)
+}
+
+func (h *handler) xhrPoll(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	sess, _ := h.sessionByRequest(req) // TODO(igm) add err handling, although err should not happen as handler should not pass req in that case
+	receiver := newHTTPReceiver(rw, 1, new(xhrFrameWriter))
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}
+
+func (h *handler) xhrStreaming(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	fmt.Fprintf(rw, "%s\n", xhrStreamingPrelude)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	receiver := newHTTPReceiver(rw, h.options.ResponseLimit, new(xhrFrameWriter))
+
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}

--- a/vendor/github.com/igm/sockjs-go/sockjs/xhr_test.go
+++ b/vendor/github.com/igm/sockjs-go/sockjs/xhr_test.go
@@ -1,0 +1,187 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_XhrSendNilBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", nil)
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendEmptyBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", strings.NewReader(""))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendWrongUrlPath(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "incorrect", strings.NewReader("[\"a\"]"))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexcpected response status, got '%d', expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendToExistingSession(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	sess := newSession(req, "session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	req, _ = http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	var done = make(chan bool)
+	go func() {
+		h.xhrSend(rec, req)
+		done <- true
+	}()
+	msg, _ := sess.Recv()
+	if msg != "some message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status received %d, should be %d", rec.Code, http.StatusNoContent)
+	}
+	if rec.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rec.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrSendInvalidInput(t *testing.T) {
+	h := newTestHandler()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("some invalid message frame"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+
+	// unexpected EOF
+	req, _ = http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"x"))
+	rec = httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendSessionNotFound(t *testing.T) {
+	h := handler{}
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_XhrPoll(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	h.xhrPoll(rw, req)
+	if rw.Header().Get("content-type") != "application/javascript; charset=UTF-8" {
+		t.Errorf("Wrong content type received, got '%s'", rw.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrPollConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = SessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.xhrPoll(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != SessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}
+
+func TestHandler_XhrPollAnotherConnectionExists(t *testing.T) {
+	h := newTestHandler()
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	// turn of timeoutes and heartbeats
+	sess := newSession(req, "session", time.Hour, time.Hour)
+	h.sessions["session"] = sess
+	sess.attachReceiver(newTestReceiver())
+	req, _ = http.NewRequest("POST", "/server/session/xhr", nil)
+	rw2 := httptest.NewRecorder()
+	h.xhrPoll(rw2, req)
+	if rw2.Body.String() != "c[2010,\"Another connection still open\"]\n" {
+		t.Errorf("Unexpected body, got '%s'", rw2.Body)
+	}
+}
+
+func TestHandler_XhrStreaming(t *testing.T) {
+	h := newTestHandler()
+	rw := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	h.xhrStreaming(rw, req)
+	expectedBody := strings.Repeat("h", 2048) + "\no\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s' expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_XhrStreamingAnotherReceiver(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 4096
+	rw1 := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	go func() {
+		rec := httptest.NewRecorder()
+		h.xhrStreaming(rec, req)
+		expectedBody := strings.Repeat("h", 2048) + "\n" + "c[2010,\"Another connection still open\"]\n"
+		if rec.Body.String() != expectedBody {
+			t.Errorf("Unexpected body got '%s', expected '%s', ", rec.Body, expectedBody)
+		}
+		close(rw1.closeNotifCh)
+	}()
+	h.xhrStreaming(rw1, req)
+}
+
+// various test only structs
+func newTestHandler() *handler {
+	h := &handler{sessions: make(map[string]*session)}
+	h.options.HeartbeatDelay = time.Hour
+	h.options.DisconnectDelay = time.Hour
+	return h
+}
+
+type ClosableRecorder struct {
+	*httptest.ResponseRecorder
+	closeNotifCh chan bool
+}
+
+func newClosableRecorder() *ClosableRecorder {
+	return &ClosableRecorder{httptest.NewRecorder(), make(chan bool)}
+}
+
+func (cr *ClosableRecorder) CloseNotify() <-chan bool { return cr.closeNotifCh }

--- a/vendor/gopkg.in/igm/sockjs-go.v2/LICENSE
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2012-2014, sockjs-go authors
+All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met: 
+
+ * Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+ * Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the distribution. 
+ * Neither the name of  nor the names of its contributors may be used to 
+   endorse or promote products derived from this software without specific 
+   prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE. 

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/benchmarks_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/benchmarks_test.go
@@ -1,0 +1,94 @@
+package sockjs
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func BenchmarkSimple(b *testing.B) {
+	var messages = make(chan string, 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for m := range messages {
+			session.Send(m)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", 1000), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		messages <- "some message"
+	}
+	fmt.Println(b.N)
+	close(messages)
+	resp.Body.Close()
+}
+
+func BenchmarkMessages(b *testing.B) {
+	msg := strings.Repeat("m", 10)
+	h := NewHandler("/echo", DefaultOptions, func(session Session) {
+		for n := 0; n < b.N; n++ {
+			session.Send(msg)
+		}
+		session.Close(1024, "Close")
+	})
+	server := httptest.NewServer(h)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(session int) {
+			reqc := 0
+			// req, _ := http.NewRequest("POST", server.URL+fmt.Sprintf("/echo/server/%d/xhr_streaming", session), nil)
+			req, _ := http.NewRequest("GET", server.URL+fmt.Sprintf("/echo/server/%d/eventsource", session), nil)
+			for {
+				reqc++
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					log.Fatal(err)
+				}
+				reader := bufio.NewReader(resp.Body)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						goto AGAIN
+					}
+					if strings.HasPrefix(line, "data: c[1024") {
+						resp.Body.Close()
+						goto DONE
+					}
+				}
+			AGAIN:
+				resp.Body.Close()
+			}
+		DONE:
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	server.Close()
+}
+
+func BenchmarkHandler_ParseSessionID(b *testing.B) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.parseSessionID(url)
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/doc.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/doc.go
@@ -1,0 +1,5 @@
+/*
+Package sockjs is a server side implementation of sockjs protocol.
+*/
+
+package sockjs

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/eventsource.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/eventsource.go
@@ -1,0 +1,32 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (h *handler) eventSource(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/event-stream; charset=UTF-8")
+	fmt.Fprintf(rw, "\r\n")
+	rw.(http.Flusher).Flush()
+
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(eventSourceFrameWriter))
+	sess, _ := h.sessionByRequest(req)
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type eventSourceFrameWriter struct{}
+
+func (*eventSourceFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "data: %s\r\n\r\n", frame)
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/eventsource_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/eventsource_test.go
@@ -1,0 +1,73 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandler_EventSource(t *testing.T) {
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		h.sessionsMux.Lock()
+		defer h.sessionsMux.Unlock()
+		sess := h.sessions["session"]
+		sess.Lock()
+		defer sess.Unlock()
+		recv := sess.recv
+		recv.close()
+	}()
+	h.eventSource(rw, req)
+	contentType := rw.Header().Get("content-type")
+	expected := "text/event-stream; charset=UTF-8"
+	if contentType != expected {
+		t.Errorf("Unexpected content type, got '%s', extected '%s'", contentType, expected)
+	}
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+
+	if rw.Body.String() != "\r\ndata: o\r\n\r\n" {
+		t.Errorf("Event stream prelude, got '%s'", rw.Body)
+	}
+}
+
+func TestHandler_EventSourceMultipleConnections(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 1024
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/sess/eventsource", nil)
+	go func() {
+		rw := &ClosableRecorder{httptest.NewRecorder(), nil}
+		h.eventSource(rw, req)
+		if rw.Body.String() != "\r\ndata: c[2010,\"Another connection still open\"]\r\n\r\n" {
+			t.Errorf("wrong, got '%v'", rw.Body)
+		}
+		h.sessionsMux.Lock()
+		sess := h.sessions["sess"]
+		sess.close()
+		h.sessionsMux.Unlock()
+	}()
+	h.eventSource(rw, req)
+}
+
+func TestHandler_EventSourceConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = sessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/eventsource", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.eventSource(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/example_handler_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/example_handler_test.go
@@ -1,0 +1,39 @@
+package sockjs_test
+
+import (
+	"net/http"
+
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+func ExampleNewHandler_simple() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	http.ListenAndServe(":8080", handler)
+}
+
+func ExampleNewHandler_defaultMux() {
+	handler := sockjs.NewHandler("/echo", sockjs.DefaultOptions, func(session sockjs.Session) {
+		for {
+			if msg, err := session.Recv(); err == nil {
+				if session.Send(msg) != nil {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	})
+	// need to provide path prefix for http.Mux
+	http.Handle("/echo/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/frame.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/frame.go
@@ -1,0 +1,11 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func closeFrame(status uint32, reason string) string {
+	bytes, _ := json.Marshal([]interface{}{status, reason})
+	return fmt.Sprintf("c%s", string(bytes))
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/frame_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/frame_test.go
@@ -1,0 +1,10 @@
+package sockjs
+
+import "testing"
+
+func TestCloseFrame(t *testing.T) {
+	cf := closeFrame(1024, "some close text")
+	if cf != "c[1024,\"some close text\"]" {
+		t.Errorf("Wrong close frame generated '%s'", cf)
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler.go
@@ -1,0 +1,133 @@
+package sockjs
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	prefixRegexp   = make(map[string]*regexp.Regexp)
+	prefixRegexpMu sync.Mutex // protects prefixRegexp
+)
+
+type handler struct {
+	prefix      string
+	options     Options
+	handlerFunc func(Session)
+	mappings    []*mapping
+
+	sessionsMux sync.Mutex
+	sessions    map[string]*session
+}
+
+// NewHandler creates new HTTP handler that conforms to the basic net/http.Handler interface.
+// It takes path prefix, options and sockjs handler function as parameters
+func NewHandler(prefix string, opts Options, handleFunc func(Session)) http.Handler {
+	return newHandler(prefix, opts, handleFunc)
+}
+
+func newHandler(prefix string, opts Options, handlerFunc func(Session)) *handler {
+	h := &handler{
+		prefix:      prefix,
+		options:     opts,
+		handlerFunc: handlerFunc,
+		sessions:    make(map[string]*session),
+	}
+
+	sessionPrefix := prefix + "/[^/.]+/[^/.]+"
+	h.mappings = []*mapping{
+		newMapping("GET", prefix+"[/]?$", welcomeHandler),
+		newMapping("OPTIONS", prefix+"/info$", opts.cookie, xhrCors, cacheFor, opts.info),
+		newMapping("GET", prefix+"/info$", xhrCors, noCache, opts.info),
+		// XHR
+		newMapping("POST", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, noCache, h.xhrSend),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_send$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr$", opts.cookie, xhrCors, noCache, h.xhrPoll),
+		newMapping("OPTIONS", sessionPrefix+"/xhr$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, noCache, h.xhrStreaming),
+		newMapping("OPTIONS", sessionPrefix+"/xhr_streaming$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		// EventStream
+		newMapping("GET", sessionPrefix+"/eventsource$", opts.cookie, xhrCors, noCache, h.eventSource),
+		// Htmlfile
+		newMapping("GET", sessionPrefix+"/htmlfile$", opts.cookie, xhrCors, noCache, h.htmlFile),
+		// JsonP
+		newMapping("GET", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, noCache, h.jsonp),
+		newMapping("OPTIONS", sessionPrefix+"/jsonp$", opts.cookie, xhrCors, cacheFor, xhrOptions),
+		newMapping("POST", sessionPrefix+"/jsonp_send$", opts.cookie, xhrCors, noCache, h.jsonpSend),
+		// IFrame
+		newMapping("GET", prefix+"/iframe[0-9-.a-z_]*.html$", cacheFor, h.iframe),
+	}
+	if opts.Websocket {
+		h.mappings = append(h.mappings, newMapping("GET", sessionPrefix+"/websocket$", h.sockjsWebsocket))
+	}
+	return h
+}
+
+func (h *handler) Prefix() string { return h.prefix }
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// iterate over mappings
+	allowedMethods := []string{}
+	for _, mapping := range h.mappings {
+		if match, method := mapping.matches(req); match == fullMatch {
+			for _, hf := range mapping.chain {
+				hf(rw, req)
+			}
+			return
+		} else if match == pathMatch {
+			allowedMethods = append(allowedMethods, method)
+		}
+	}
+	if len(allowedMethods) > 0 {
+		rw.Header().Set("allow", strings.Join(allowedMethods, ", "))
+		rw.Header().Set("Content-Type", "")
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	http.NotFound(rw, req)
+}
+
+func (h *handler) parseSessionID(url *url.URL) (string, error) {
+	// cache compiled regexp objects for most used prefixes
+	prefixRegexpMu.Lock()
+	session, ok := prefixRegexp[h.prefix]
+	if !ok {
+		session = regexp.MustCompile(h.prefix + "/(?P<server>[^/.]+)/(?P<session>[^/.]+)/.*")
+		prefixRegexp[h.prefix] = session
+	}
+	prefixRegexpMu.Unlock()
+
+	matches := session.FindStringSubmatch(url.Path)
+	if len(matches) == 3 {
+		return matches[2], nil
+	}
+	return "", errors.New("unable to parse URL for session")
+}
+
+func (h *handler) sessionByRequest(req *http.Request) (*session, error) {
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		return nil, err
+	}
+	sess, exists := h.sessions[sessionID]
+	if !exists {
+		sess = newSession(sessionID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+		h.sessions[sessionID] = sess
+		if h.handlerFunc != nil {
+			go h.handlerFunc(sess)
+		}
+		go func() {
+			<-sess.closedNotify()
+			h.sessionsMux.Lock()
+			delete(h.sessions, sessionID)
+			h.sessionsMux.Unlock()
+		}()
+	}
+	return sess, nil
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/handler_test.go
@@ -1,0 +1,79 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestHandler_Create(t *testing.T) {
+	handler := newHandler("/echo", DefaultOptions, nil)
+	if handler.Prefix() != "/echo" {
+		t.Errorf("Prefix not properly set, got '%s' expected '%s'", handler.Prefix(), "/echo")
+	}
+	if handler.sessions == nil {
+		t.Errorf("Handler session map not made")
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/echo")
+	if err != nil {
+		t.Errorf("There should not be any error, got '%s'", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected status code receiver, got '%d' expected '%d'", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestHandler_ParseSessionId(t *testing.T) {
+	h := handler{prefix: "/prefix"}
+	url, _ := url.Parse("http://server:80/prefix/server/session/whatever")
+	if session, err := h.parseSessionID(url); session != "session" || err != nil {
+		t.Errorf("Wrong session parsed, got '%s' expected '%s' with error = '%v'", session, "session", err)
+	}
+	url, _ = url.Parse("http://server:80/asdasd/server/session/whatever")
+	if _, err := h.parseSessionID(url); err == nil {
+		t.Errorf("Should return error")
+	}
+}
+
+func TestHandler_SessionByRequest(t *testing.T) {
+	h := newHandler("", DefaultOptions, nil)
+	h.options.DisconnectDelay = 10 * time.Millisecond
+	var handlerFuncCalled = make(chan Session)
+	h.handlerFunc = func(conn Session) { handlerFuncCalled <- conn }
+	req, _ := http.NewRequest("POST", "/server/sessionid/whatever/follows", nil)
+	sess, err := h.sessionByRequest(req)
+	if sess == nil || err != nil {
+		t.Errorf("Session should be returned")
+		// test handlerFunc was called
+		select {
+		case conn := <-handlerFuncCalled: // ok
+			if conn != sess {
+				t.Errorf("Handler was not passed correct session")
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("HandlerFunc was not called")
+		}
+	}
+	// test session is reused for multiple requests with same sessionID
+	req2, _ := http.NewRequest("POST", "/server/sessionid/whatever", nil)
+	if sess2, err := h.sessionByRequest(req2); sess2 != sess || err != nil {
+		t.Errorf("Expected error, got session: '%v'", sess)
+	}
+	// test session expires after timeout
+	time.Sleep(15 * time.Millisecond)
+	h.sessionsMux.Lock()
+	if _, exists := h.sessions["sessionid"]; exists {
+		t.Errorf("Session should not exist in handler after timeout")
+	}
+	h.sessionsMux.Unlock()
+	// test proper behaviour in case URL is not correct
+	req, _ = http.NewRequest("POST", "", nil)
+	if _, err := h.sessionByRequest(req); err == nil {
+		t.Errorf("Expected parser sessionID from URL error, got 'nil'")
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/htmlfile.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/htmlfile.go
@@ -1,0 +1,58 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var iframeTemplate = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.%s;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`
+
+func init() {
+	iframeTemplate += strings.Repeat(" ", 1024-len(iframeTemplate)+14)
+	iframeTemplate += "\r\n\r\n"
+}
+
+func (h *handler) htmlFile(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/html; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprintf(rw, iframeTemplate, callback)
+	rw.(http.Flusher).Flush()
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, h.options.ResponseLimit, new(htmlfileFrameWriter))
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+type htmlfileFrameWriter struct{}
+
+func (*htmlfileFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "<script>\np(%s);\n</script>\r\n", quote(frame))
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/htmlfile_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/htmlfile_test.go
@@ -1,0 +1,60 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler_htmlFileNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_htmlFile(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/htmlfile?c=testCallback", nil)
+	h.htmlFile(rw, req)
+	if rw.Code != http.StatusOK {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusOK)
+	}
+	expectedContentType := "text/html; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content-type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	if rw.Body.String() != expectedIFrame {
+		t.Errorf("Unexpected response body, got '%s', expected '%s'", rw.Body, expectedIFrame)
+	}
+
+}
+
+func init() {
+	expectedIFrame += strings.Repeat(" ", 1024-len(expectedIFrame)+len("testCallack")+13)
+	expectedIFrame += "\r\n\r\n"
+	expectedIFrame += "<script>\np(\"o\");\n</script>\r\n"
+}
+
+var expectedIFrame = `<!doctype html>
+<html><head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head><body><h2>Don't panic!</h2>
+  <script>
+    document.domain = document.domain;
+    var c = parent.testCallback;
+    c.start();
+    function p(d) {c.message(d);};
+    window.onload = function() {c.stop();};
+  </script>
+`

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/httpreceiver.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/httpreceiver.go
@@ -1,0 +1,105 @@
+package sockjs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type frameWriter interface {
+	write(writer io.Writer, frame string) (int, error)
+}
+
+type httpReceiverState int
+
+const (
+	stateHTTPReceiverActive httpReceiverState = iota
+	stateHTTPReceiverClosed
+)
+
+type httpReceiver struct {
+	sync.Mutex
+	state httpReceiverState
+
+	frameWriter         frameWriter
+	rw                  http.ResponseWriter
+	maxResponseSize     uint32
+	currentResponseSize uint32
+	doneCh              chan struct{}
+	interruptCh         chan struct{}
+}
+
+func newHTTPReceiver(rw http.ResponseWriter, maxResponse uint32, frameWriter frameWriter) *httpReceiver {
+	recv := &httpReceiver{
+		rw:              rw,
+		frameWriter:     frameWriter,
+		maxResponseSize: maxResponse,
+		doneCh:          make(chan struct{}),
+		interruptCh:     make(chan struct{}),
+	}
+	if closeNotifier, ok := rw.(http.CloseNotifier); ok {
+		// if supported check for close notifications from http.RW
+		closeNotifyCh := closeNotifier.CloseNotify()
+		go func() {
+			select {
+			case <-closeNotifyCh:
+				recv.Lock()
+				defer recv.Unlock()
+				if recv.state < stateHTTPReceiverClosed {
+					recv.state = stateHTTPReceiverClosed
+					close(recv.interruptCh)
+				}
+			case <-recv.doneCh:
+				// ok, no action needed here, receiver closed in correct way
+				// just finish the routine
+			}
+		}()
+	}
+	return recv
+}
+
+func (recv *httpReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		recv.sendFrame(fmt.Sprintf("a[%s]",
+			strings.Join(
+				transform(messages, quote),
+				",",
+			),
+		))
+	}
+}
+
+func (recv *httpReceiver) sendFrame(value string) {
+	recv.Lock()
+	defer recv.Unlock()
+
+	if recv.state == stateHTTPReceiverActive {
+		// TODO(igm) check err, possibly act as if interrupted
+		n, _ := recv.frameWriter.write(recv.rw, value)
+		recv.currentResponseSize += uint32(n)
+		if recv.currentResponseSize >= recv.maxResponseSize {
+			recv.state = stateHTTPReceiverClosed
+			close(recv.doneCh)
+		} else {
+			recv.rw.(http.Flusher).Flush()
+		}
+	}
+}
+
+func (recv *httpReceiver) doneNotify() <-chan struct{}        { return recv.doneCh }
+func (recv *httpReceiver) interruptedNotify() <-chan struct{} { return recv.interruptCh }
+func (recv *httpReceiver) close() {
+	recv.Lock()
+	defer recv.Unlock()
+	if recv.state < stateHTTPReceiverClosed {
+		recv.state = stateHTTPReceiverClosed
+		close(recv.doneCh)
+	}
+}
+func (recv *httpReceiver) canSend() bool {
+	recv.Lock()
+	defer recv.Unlock()
+	return recv.state != stateHTTPReceiverClosed
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/httpreceiver_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/httpreceiver_test.go
@@ -1,0 +1,101 @@
+package sockjs
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+)
+
+type testFrameWriter struct {
+	frames []string
+}
+
+func (t *testFrameWriter) write(w io.Writer, frame string) (int, error) {
+	t.frames = append(t.frames, frame)
+	return len(frame), nil
+}
+
+func TestHttpReceiver_Create(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	if recv.doneCh != recv.doneNotify() {
+		t.Errorf("Calling done() must return close channel, but it does not")
+	}
+	if recv.rw != rec {
+		t.Errorf("Http.ResponseWriter not properly initialized")
+	}
+	if recv.maxResponseSize != 1024 {
+		t.Errorf("MaxResponseSize not properly initialized")
+	}
+}
+
+func TestHttpReceiver_SendEmptyFrames(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, new(testFrameWriter))
+	recv.sendBulk()
+	if rec.Body.String() != "" {
+		t.Errorf("Incorrect body content received from receiver '%s'", rec.Body.String())
+	}
+}
+
+func TestHttpReceiver_SendFrame(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	var frame = "some frame content"
+	recv.sendFrame(frame)
+	if len(fw.frames) != 1 || fw.frames[0] != frame {
+		t.Errorf("Incorrect body content received, got '%s', expected '%s'", fw.frames, frame)
+	}
+
+}
+
+func TestHttpReceiver_SendBulk(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fw := new(testFrameWriter)
+	recv := newHTTPReceiver(rec, 1024, fw)
+	recv.sendBulk("message 1", "message 2", "message 3")
+	expected := "a[\"message 1\",\"message 2\",\"message 3\"]"
+	if len(fw.frames) != 1 || fw.frames[0] != expected {
+		t.Errorf("Incorrect body content received from receiver, got '%s' expected '%s'", fw.frames, expected)
+	}
+}
+
+func TestHttpReceiver_MaximumResponseSize(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 52, new(testFrameWriter))
+	recv.sendBulk("message 1", "message 2") // produces 26 bytes of response in 1 frame
+	if recv.currentResponseSize != 26 {
+		t.Errorf("Incorrect response size calcualated, got '%d' expected '%d'", recv.currentResponseSize, 26)
+	}
+	select {
+	case <-recv.doneNotify():
+		t.Errorf("Receiver should not be done yet")
+	default: // ok
+	}
+	recv.sendBulk("message 1", "message 2") // produces another 26 bytes of response in 1 frame to go over max resposne size
+	select {
+	case <-recv.doneNotify(): // ok
+	default:
+		t.Errorf("Receiver closed channel did not close")
+	}
+}
+
+func TestHttpReceiver_Close(t *testing.T) {
+	rec := httptest.NewRecorder()
+	recv := newHTTPReceiver(rec, 1024, nil)
+	recv.close()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}
+
+func TestHttpReceiver_ConnectionInterrupt(t *testing.T) {
+	rw := newClosableRecorder()
+	recv := newHTTPReceiver(rw, 1024, nil)
+	rw.closeNotifCh <- true
+	recv.Lock()
+	if recv.state != stateHTTPReceiverClosed {
+		t.Errorf("Unexpected state, got '%d', expected '%d'", recv.state, stateHTTPReceiverClosed)
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/iframe.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/iframe.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+var tmpl = template.Must(template.New("iframe").Parse(iframeBody))
+
+func (h *handler) iframe(rw http.ResponseWriter, req *http.Request) {
+	etagReq := req.Header.Get("If-None-Match")
+	hash := md5.New()
+	hash.Write([]byte(iframeBody))
+	etag := fmt.Sprintf("%x", hash.Sum(nil))
+	if etag == etagReq {
+		rw.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	rw.Header().Add("ETag", etag)
+	tmpl.Execute(rw, h.options.SockJSURL)
+}
+
+var iframeBody = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="{{.}}"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/iframe_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/iframe_test.go
@@ -1,0 +1,42 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_iframe(t *testing.T) {
+	h := newTestHandler()
+	h.options.SockJSURL = "http://sockjs.com/sockjs.js"
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/sess/iframe", nil)
+	h.iframe(rw, req)
+	if rw.Body.String() != expected {
+		t.Errorf("Unexpected html content,\ngot:\n'%s'\n\nexpected\n'%s'", rw.Body, expected)
+	}
+	eTag := rw.Header().Get("etag")
+	req.Header.Set("if-none-match", eTag)
+	rw = httptest.NewRecorder()
+	h.iframe(rw, req)
+	if rw.Code != http.StatusNotModified {
+		t.Errorf("Unexpected response, got '%d', expected '%d'", rw.Code, http.StatusNotModified)
+	}
+}
+
+var expected = `<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+  </script>
+  <script src="http://sockjs.com/sockjs.js"></script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+</body>
+</html>`

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/jsonp.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/jsonp.go
@@ -1,0 +1,77 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (h *handler) jsonp(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+
+	req.ParseForm()
+	callback := req.Form.Get("c")
+	if callback == "" {
+		http.Error(rw, `"callback" parameter required`, http.StatusInternalServerError)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	recv := newHTTPReceiver(rw, 1, &jsonpFrameWriter{callback})
+	if err := sess.attachReceiver(recv); err != nil {
+		recv.sendFrame(cFrame)
+		recv.close()
+		return
+	}
+	select {
+	case <-recv.doneNotify():
+	case <-recv.interruptedNotify():
+	}
+}
+
+func (h *handler) jsonpSend(rw http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
+	var data io.Reader
+	data = req.Body
+
+	formReader := strings.NewReader(req.PostFormValue("d"))
+	if formReader.Len() != 0 {
+		data = formReader
+	}
+	if data == nil {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(data).Decode(&messages)
+	if err == io.EOF {
+		http.Error(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if err != nil {
+		http.Error(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, _ := h.parseSessionID(req.URL)
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...) // TODO(igm) reponse with http.StatusInternalServerError in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8")
+		rw.Write([]byte("ok"))
+	}
+}
+
+type jsonpFrameWriter struct {
+	callback string
+}
+
+func (j *jsonpFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s(%s);\r\n", j.callback, quote(frame))
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/jsonp_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/jsonp_test.go
@@ -1,0 +1,96 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_jsonpNoCallback(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp", nil)
+	h.jsonp(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+	expectedContentType := "text/plain; charset=utf-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+}
+
+func TestHandler_jsonp(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/server/session/jsonp?c=testCallback", nil)
+	h.jsonp(rw, req)
+	expectedContentType := "application/javascript; charset=UTF-8"
+	if rw.Header().Get("content-type") != expectedContentType {
+		t.Errorf("Unexpected content type, got '%s', expected '%s'", rw.Header().Get("content-type"), expectedContentType)
+	}
+	expectedBody := "testCallback(\"o\");\r\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s', expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_jsonpSendNoPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", nil)
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendWrongPayload(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("wrong payload"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_jsonpSendNoSession(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	h.jsonpSend(rw, req)
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", rw.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_jsonpSend(t *testing.T) {
+	h := newTestHandler()
+	sess := newSession("session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/jsonp_send", strings.NewReader("[\"message\"]"))
+	var done = make(chan struct{})
+	go func() {
+		h.jsonpSend(rw, req)
+		close(done)
+	}()
+	msg, _ := sess.Recv()
+	if msg != "message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rw.Code != http.StatusOK {
+		t.Errorf("Wrong response status received %d, should be %d", rw.Code, http.StatusOK)
+	}
+	if rw.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rw.Header().Get("content-type"))
+	}
+	if rw.Body.String() != "ok" {
+		t.Errorf("Unexpected body, got '%s', expected 'ok'", rw.Body)
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/mapping.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/mapping.go
@@ -1,0 +1,36 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+)
+
+type mapping struct {
+	method string
+	path   *regexp.Regexp
+	chain  []http.HandlerFunc
+}
+
+func newMapping(method string, re string, handlers ...http.HandlerFunc) *mapping {
+	return &mapping{method, regexp.MustCompile(re), handlers}
+}
+
+type matchType uint32
+
+const (
+	fullMatch matchType = iota
+	pathMatch
+	noMatch
+)
+
+// matches checks if given req.URL is a match with a mapping. Match can be either full, partial (http method mismatch) or no match.
+func (m *mapping) matches(req *http.Request) (match matchType, method string) {
+	if !m.path.MatchString(req.URL.Path) {
+		match, method = noMatch, ""
+	} else if m.method != req.Method {
+		match, method = pathMatch, m.method
+	} else {
+		match, method = fullMatch, m.method
+	}
+	return
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/mapping_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/mapping_test.go
@@ -1,0 +1,38 @@
+package sockjs
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+func TestMappingMatcher(t *testing.T) {
+	mappingPrefix := mapping{"GET", regexp.MustCompile("prefix/$"), nil}
+	mappingPrefixRegExp := mapping{"GET", regexp.MustCompile(".*x/$"), nil}
+
+	var testRequests = []struct {
+		mapping       mapping
+		method        string
+		url           string
+		expectedMatch matchType
+	}{
+		{mappingPrefix, "GET", "http://foo/prefix/", fullMatch},
+		{mappingPrefix, "POST", "http://foo/prefix/", pathMatch},
+		{mappingPrefix, "GET", "http://foo/prefix_not_mapped", noMatch},
+		{mappingPrefixRegExp, "GET", "http://foo/prefix/", fullMatch},
+	}
+
+	for _, request := range testRequests {
+		req, _ := http.NewRequest(request.method, request.url, nil)
+		m := request.mapping
+		match, method := m.matches(req)
+		if match != request.expectedMatch {
+			t.Errorf("mapping %s should match url=%s", m.path, request.url)
+		}
+		if request.expectedMatch == pathMatch {
+			if method != m.method {
+				t.Errorf("Matcher method should be %s, but got %s", m.method, method)
+			}
+		}
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/options.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/options.go
@@ -1,0 +1,114 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	entropy      *rand.Rand
+	entropyMutex sync.Mutex
+)
+
+func init() {
+	entropy = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// Options type is used for defining various sockjs options
+type Options struct {
+	// Transports which don't support cross-domain communication natively ('eventsource' to name one) use an iframe trick.
+	// A simple page is served from the SockJS server (using its foreign domain) and is placed in an invisible iframe.
+	// Code run from this iframe doesn't need to worry about cross-domain issues, as it's being run from domain local to the SockJS server.
+	// This iframe also does need to load SockJS javascript client library, and this option lets you specify its url (if you're unsure,
+	// point it to the latest minified SockJS client release, this is the default). You must explicitly specify this url on the server
+	// side for security reasons - we don't want the possibility of running any foreign javascript within the SockJS domain (aka cross site scripting attack).
+	// Also, sockjs javascript library is probably already cached by the browser - it makes sense to reuse the sockjs url you're using in normally.
+	SockJSURL string
+	// Most streaming transports save responses on the client side and don't free memory used by delivered messages.
+	// Such transports need to be garbage-collected once in a while. `response_limit` sets a minimum number of bytes that can be send
+	// over a single http streaming request before it will be closed. After that client needs to open new request.
+	// Setting this value to one effectively disables streaming and will make streaming transports to behave like polling transports.
+	// The default value is 128K.
+	ResponseLimit uint32
+	// Some load balancers don't support websockets. This option can be used to disable websockets support by the server. By default websockets are enabled.
+	Websocket bool
+	// In order to keep proxies and load balancers from closing long running http requests we need to pretend that the connection is active
+	// and send a heartbeat packet once in a while. This setting controls how often this is done.
+	// By default a heartbeat packet is sent every 25 seconds.
+	HeartbeatDelay time.Duration
+	// The server closes a session when a client receiving connection have not been seen for a while.
+	// This delay is configured by this setting.
+	// By default the session is closed when a receiving connection wasn't seen for 5 seconds.
+	DisconnectDelay time.Duration
+	// Some hosting providers enable sticky sessions only to requests that have JSessionID cookie set.
+	// This setting controls if the server should set this cookie to a dummy value.
+	// By default setting JSessionID cookie is disabled. More sophisticated behaviour can be achieved by supplying a function.
+	JSessionID func(http.ResponseWriter, *http.Request)
+}
+
+// DefaultOptions is a convenient set of options to be used for sockjs
+var DefaultOptions = Options{
+	Websocket:       true,
+	JSessionID:      nil,
+	SockJSURL:       "http://cdn.sockjs.org/sockjs-0.3.min.js",
+	HeartbeatDelay:  25 * time.Second,
+	DisconnectDelay: 5 * time.Second,
+	ResponseLimit:   128 * 1024,
+}
+
+type info struct {
+	Websocket    bool     `json:"websocket"`
+	CookieNeeded bool     `json:"cookie_needed"`
+	Origins      []string `json:"origins"`
+	Entropy      int32    `json:"entropy"`
+}
+
+func (options *Options) info(rw http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		json.NewEncoder(rw).Encode(info{
+			Websocket:    options.Websocket,
+			CookieNeeded: options.JSessionID != nil,
+			Origins:      []string{"*:*"},
+			Entropy:      generateEntropy(),
+		})
+	case "OPTIONS":
+		rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET")
+		rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+		rw.WriteHeader(http.StatusNoContent) // 204
+	default:
+		http.NotFound(rw, req)
+	}
+}
+
+// DefaultJSessionID is a default behaviour function to be used in options for JSessionID if JSESSIONID is needed
+func DefaultJSessionID(rw http.ResponseWriter, req *http.Request) {
+	cookie, err := req.Cookie("JSESSIONID")
+	if err == http.ErrNoCookie {
+		cookie = &http.Cookie{
+			Name:  "JSESSIONID",
+			Value: "dummy",
+		}
+	}
+	cookie.Path = "/"
+	header := rw.Header()
+	header.Add("Set-Cookie", cookie.String())
+}
+
+func (options *Options) cookie(rw http.ResponseWriter, req *http.Request) {
+	if options.JSessionID != nil { // cookie is needed
+		options.JSessionID(rw, req)
+	}
+}
+
+func generateEntropy() int32 {
+	entropyMutex.Lock()
+	entropy := entropy.Int31()
+	entropyMutex.Unlock()
+	return entropy
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/options_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/options_test.go
@@ -1,0 +1,64 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+)
+import "testing"
+
+func TestInfoGet(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "", nil)
+	DefaultOptions.info(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Wrong status code, got '%d' expected '%d'", recorder.Code, http.StatusOK)
+	}
+
+	decoder := json.NewDecoder(recorder.Body)
+	var a info
+	decoder.Decode(&a)
+	if !a.Websocket {
+		t.Errorf("Websocket field should be set true")
+	}
+	if a.CookieNeeded {
+		t.Errorf("CookieNeede should be set to false")
+	}
+}
+
+func TestInfoOptions(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest("OPTIONS", "", nil)
+	DefaultOptions.info(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("Incorrect status code received, got '%d' expected '%d'", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestInfoUnknown(t *testing.T) {
+	req, _ := http.NewRequest("PUT", "", nil)
+	rec := httptest.NewRecorder()
+	DefaultOptions.info(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Incorrec response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "", nil)
+	optionsWithCookies := DefaultOptions
+	optionsWithCookies.JSessionID = DefaultJSessionID
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=dummy; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+	// cookie value set in request
+	req.AddCookie(&http.Cookie{Name: "JSESSIONID", Value: "some_jsession_id", Path: "/"})
+	rec = httptest.NewRecorder()
+	optionsWithCookies.cookie(rec, req)
+	if rec.Header().Get("set-cookie") != "JSESSIONID=some_jsession_id; Path=/" {
+		t.Errorf("Cookie not properly set in response")
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/session.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/session.go
@@ -1,0 +1,219 @@
+package sockjs
+
+import (
+	"encoding/gob"
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+type sessionState uint32
+
+const (
+	// brand new session, need to send "h" to receiver
+	sessionOpening sessionState = iota
+	// active session
+	sessionActive
+	// session being closed, sending "closeFrame" to receivers
+	sessionClosing
+	// closed session, no activity at all, should be removed from handler completely and not reused
+	sessionClosed
+)
+
+var (
+	// ErrSessionNotOpen error is used to denote session not in open state.
+	// Recv() and Send() operations are not suppored if session is closed.
+	ErrSessionNotOpen          = errors.New("sockjs: session not in open state")
+	errSessionReceiverAttached = errors.New("sockjs: another receiver already attached")
+)
+
+type session struct {
+	sync.Mutex
+	id    string
+	state sessionState
+	// protocol dependent receiver (xhr, eventsource, ...)
+	recv receiver
+	// messages to be sent to client
+	sendBuffer []string
+	// messages received from client to be consumed by application
+	// receivedBuffer chan string
+	msgReader  *io.PipeReader
+	msgWriter  *io.PipeWriter
+	msgEncoder *gob.Encoder
+	msgDecoder *gob.Decoder
+
+	// closeFrame to send after session is closed
+	closeFrame string
+
+	// internal timer used to handle session expiration if no receiver is attached, or heartbeats if recevier is attached
+	sessionTimeoutInterval time.Duration
+	heartbeatInterval      time.Duration
+	timer                  *time.Timer
+	// once the session timeouts this channel also closes
+	closeCh chan struct{}
+}
+
+type receiver interface {
+	// sendBulk send multiple data messages in frame frame in format: a["msg 1", "msg 2", ....]
+	sendBulk(...string)
+	// sendFrame sends given frame over the wire (with possible chunking depending on receiver)
+	sendFrame(string)
+	// close closes the receiver in a "done" way (idempotent)
+	close()
+	canSend() bool
+	// done notification channel gets closed whenever receiver ends
+	doneNotify() <-chan struct{}
+	// interrupted channel gets closed whenever receiver is interrupted (i.e. http connection drops,...)
+	interruptedNotify() <-chan struct{}
+}
+
+// Session is a central component that handles receiving and sending frames. It maintains internal state
+func newSession(sessionID string, sessionTimeoutInterval, heartbeatInterval time.Duration) *session {
+	r, w := io.Pipe()
+	s := &session{
+		id:                     sessionID,
+		msgReader:              r,
+		msgWriter:              w,
+		msgEncoder:             gob.NewEncoder(w),
+		msgDecoder:             gob.NewDecoder(r),
+		sessionTimeoutInterval: sessionTimeoutInterval,
+		heartbeatInterval:      heartbeatInterval,
+		closeCh:                make(chan struct{})}
+	s.Lock() // "go test -race" complains if ommited, not sure why as no race can happen here
+	s.timer = time.AfterFunc(sessionTimeoutInterval, s.close)
+	s.Unlock()
+	return s
+}
+
+func (s *session) sendMessage(msg string) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.state > sessionActive {
+		return ErrSessionNotOpen
+	}
+	s.sendBuffer = append(s.sendBuffer, msg)
+	if s.recv != nil && s.recv.canSend() {
+		s.recv.sendBulk(s.sendBuffer...)
+		s.sendBuffer = nil
+	}
+	return nil
+}
+
+func (s *session) attachReceiver(recv receiver) error {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil {
+		return errSessionReceiverAttached
+	}
+	s.recv = recv
+	go func(r receiver) {
+		select {
+		case <-r.doneNotify():
+			s.detachReceiver()
+		case <-r.interruptedNotify():
+			s.detachReceiver()
+			s.close()
+		}
+	}(recv)
+
+	if s.state == sessionClosing {
+		s.recv.sendFrame(s.closeFrame)
+		s.recv.close()
+		return nil
+	}
+	if s.state == sessionOpening {
+		s.recv.sendFrame("o")
+		s.state = sessionActive
+	}
+	s.recv.sendBulk(s.sendBuffer...)
+	s.sendBuffer = nil
+	s.timer.Stop()
+	if s.heartbeatInterval > 0 {
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+	return nil
+}
+
+func (s *session) detachReceiver() {
+	s.Lock()
+	defer s.Unlock()
+	s.timer.Stop()
+	s.timer = time.AfterFunc(s.sessionTimeoutInterval, s.close)
+	s.recv = nil
+}
+
+func (s *session) heartbeat() {
+	s.Lock()
+	defer s.Unlock()
+	if s.recv != nil { // timer could have fired between Lock and timer.Stop in detachReceiver
+		s.recv.sendFrame("h")
+		s.timer = time.AfterFunc(s.heartbeatInterval, s.heartbeat)
+	}
+}
+
+func (s *session) accept(messages ...string) error {
+	for _, msg := range messages {
+		if err := s.msgEncoder.Encode(msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// idempotent operation
+func (s *session) closing() {
+	s.Lock()
+	defer s.Unlock()
+	if s.state < sessionClosing {
+		s.msgReader.Close()
+		s.msgWriter.Close()
+		s.state = sessionClosing
+		if s.recv != nil {
+			s.recv.sendFrame(s.closeFrame)
+			s.recv.close()
+		}
+	}
+}
+
+// idempotent operation
+func (s *session) close() {
+	s.closing()
+	s.Lock()
+	defer s.Unlock()
+	if s.state < sessionClosed {
+		s.state = sessionClosed
+		s.timer.Stop()
+		close(s.closeCh)
+	}
+}
+
+func (s *session) closedNotify() <-chan struct{} { return s.closeCh }
+
+// Conn interface implementation
+func (s *session) Close(status uint32, reason string) error {
+	s.Lock()
+	if s.state < sessionClosing {
+		s.closeFrame = closeFrame(status, reason)
+		s.Unlock()
+		s.closing()
+		return nil
+	}
+	s.Unlock()
+	return ErrSessionNotOpen
+}
+
+func (s *session) Recv() (string, error) {
+	var msg string
+	err := s.msgDecoder.Decode(&msg)
+	if err == io.ErrClosedPipe {
+		err = ErrSessionNotOpen
+	}
+	return msg, err
+}
+
+func (s *session) Send(msg string) error {
+	return s.sendMessage(msg)
+}
+
+func (s *session) ID() string { return s.id }

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/session_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/session_test.go
@@ -1,0 +1,327 @@
+package sockjs
+
+import (
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestSession() *session {
+	// session with long expiration and heartbeats with ID
+	return newSession("sessionId", 1000*time.Second, 1000*time.Second)
+}
+
+func TestSession_Create(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("this is a message")
+	if len(session.sendBuffer) != 1 {
+		t.Errorf("Session send buffer should contain 1 message")
+	}
+	session.sendMessage("another message")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("Session send buffer should contain 2 messages")
+	}
+	if session.state != sessionOpening {
+		t.Errorf("Session in wrong state %v, should be %v", session.state, sessionOpening)
+	}
+}
+
+func TestSession_ConcurrentSend(t *testing.T) {
+	session := newTestSession()
+	done := make(chan bool)
+	for i := 0; i < 100; i++ {
+		go func() {
+			session.sendMessage("message D")
+			done <- true
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	if len(session.sendBuffer) != 100 {
+		t.Errorf("Session send buffer should contain 102 messages")
+	}
+}
+
+func TestSession_AttachReceiver(t *testing.T) {
+	session := newTestSession()
+	recv := &testReceiver{}
+	// recv := &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		if frame != "o" {
+	// 			t.Errorf("Incorrect open header received")
+	// 		}
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+	if session.state != sessionActive {
+		t.Errorf("Session in wrong state after receiver attached %d, should be %d", session.state, sessionActive)
+	}
+	session.detachReceiver()
+	// recv = &mockRecv{
+	// 	_sendFrame: func(frame string) {
+	// 		t.Errorf("No frame shold be send, got '%s'", frame)
+	// 	},
+	// 	_sendBulk: func(...string) {},
+	// }
+	if err := session.attachReceiver(recv); err != nil {
+		t.Errorf("Should not return error")
+	}
+}
+
+func TestSession_Timeout(t *testing.T) {
+	sess := newSession("id", 10*time.Millisecond, 10*time.Second)
+	select {
+	case <-sess.closeCh:
+	case <-time.After(20 * time.Millisecond):
+		t.Errorf("sess close notification channel should close")
+	}
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session did not timeout")
+	}
+	sess.Unlock()
+}
+
+func TestSession_TimeoutOfClosedSession(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	sess := newSession("id", 1*time.Millisecond, time.Second)
+	sess.closing()
+	time.Sleep(1 * time.Millisecond)
+	sess.closing()
+}
+
+func TestSession_AttachReceiverAndCheckHeartbeats(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Unexcpected error '%v'", r)
+		}
+	}()
+	session := newSession("id", time.Second, 10*time.Millisecond) // 10ms heartbeats
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+	session.attachReceiver(recv)
+	time.Sleep(120 * time.Millisecond)
+	recv.Lock()
+	if len(recv.frames) < 10 || len(recv.frames) > 13 { // should get around 10 heartbeats (120ms/10ms)
+		t.Fatalf("Wrong number of frames received, got '%d'", len(recv.frames))
+	}
+	for i := 1; i < len(recv.frames); i++ {
+		if recv.frames[i] != "h" {
+			t.Errorf("Heartbeat no received")
+		}
+	}
+}
+
+func TestSession_AttachReceiverAndRefuse(t *testing.T) {
+	session := newTestSession()
+	if err := session.attachReceiver(newTestReceiver()); err != nil {
+		t.Errorf("Should not return error")
+	}
+	var a sync.WaitGroup
+	a.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer a.Done()
+			if err := session.attachReceiver(newTestReceiver()); err != errSessionReceiverAttached {
+				t.Errorf("Should return error as another receiver is already attached")
+			}
+		}()
+	}
+	a.Wait()
+}
+
+func TestSession_DetachRecevier(t *testing.T) {
+	session := newTestSession()
+	session.detachReceiver()
+	session.detachReceiver() // idempotent operation
+	session.attachReceiver(newTestReceiver())
+	session.detachReceiver()
+
+}
+
+func TestSession_SendWithRecv(t *testing.T) {
+	session := newTestSession()
+	session.sendMessage("message A")
+	session.sendMessage("message B")
+	if len(session.sendBuffer) != 2 {
+		t.Errorf("There should be 2 messages in buffer, but there are %d", len(session.sendBuffer))
+	}
+	recv := newTestReceiver()
+	defer close(recv.doneCh)
+
+	session.attachReceiver(recv)
+	if len(recv.frames[1:]) != 2 {
+		t.Errorf("Reciver should get 2 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message C")
+	if len(recv.frames[1:]) != 3 {
+		t.Errorf("Reciver should get 3 message frames from session, got %d", len(recv.frames))
+	}
+	session.sendMessage("message D")
+	if len(recv.frames[1:]) != 4 {
+		t.Errorf("Reciver should get 4 frames from session, got %d", len(recv.frames))
+	}
+	if len(session.sendBuffer) != 0 {
+		t.Errorf("Send buffer should be empty now, but there are %d messaged", len(session.sendBuffer))
+	}
+}
+
+func TestSession_Recv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic should not happen")
+		}
+	}()
+	session := newTestSession()
+	go func() {
+		session.accept("message A")
+		session.accept("message B")
+		if err := session.accept("message C"); err != io.ErrClosedPipe {
+			t.Errorf("Session should not accept new messages if closed, got '%v' expected '%v'", err, io.ErrClosedPipe)
+		}
+	}()
+	if msg, _ := session.Recv(); msg != "message A" {
+		t.Errorf("Got %s, should be %s", msg, "message A")
+	}
+	if msg, _ := session.Recv(); msg != "message B" {
+		t.Errorf("Got %s, should be %s", msg, "message B")
+	}
+	session.close()
+}
+
+func TestSession_Closing(t *testing.T) {
+	session := newTestSession()
+	session.closing()
+	if _, err := session.Recv(); err == nil {
+		t.Errorf("Session's receive buffer channel should close")
+	}
+	if err := session.sendMessage("some message"); err != ErrSessionNotOpen {
+		t.Errorf("Session should not accept new message after close")
+	}
+}
+
+// Session as Session Tests
+func TestSession_AsSession(t *testing.T) { var _ Session = newSession("id", 0, 0) }
+
+func TestSession_SessionRecv(t *testing.T) {
+	s := newTestSession()
+	go func() {
+		s.accept("message 1")
+	}()
+	msg, err := s.Recv()
+	if msg != "message 1" || err != nil {
+		t.Errorf("Should receive a message without error, got '%s' err '%v'", msg, err)
+	}
+	go func() {
+		s.closing()
+		_, err := s.Recv()
+		if err != ErrSessionNotOpen {
+			t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+		}
+	}()
+	_, err = s.Recv()
+	if err != ErrSessionNotOpen {
+		t.Errorf("Session not in correct state, got '%v', expected '%v'", err, ErrSessionNotOpen)
+	}
+}
+
+func TestSession_SessionSend(t *testing.T) {
+	s := newTestSession()
+	err := s.Send("message A")
+	if err != nil {
+		t.Errorf("Session should take messages by default")
+	}
+	if len(s.sendBuffer) != 1 || s.sendBuffer[0] != "message A" {
+		t.Errorf("Message not properly queued in session, got '%v'", s.sendBuffer)
+	}
+}
+
+func TestSession_SessionClose(t *testing.T) {
+	s := newTestSession()
+	s.state = sessionActive
+	recv := newTestReceiver()
+	s.attachReceiver(recv)
+	err := s.Close(1, "some reason")
+	if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+		t.Errorf("Expected close frame, got '%v'", recv.frames)
+	}
+	if err != nil {
+		t.Errorf("Should not get any error, got '%s'", err)
+	}
+	if s.closeFrame != "c[1,\"some reason\"]" {
+		t.Errorf("Incorrect closeFrame, got '%s'", s.closeFrame)
+	}
+	if s.state != sessionClosing {
+		t.Errorf("Incorrect session state, expected 'sessionClosing', got '%v'", s.state)
+	}
+	// all the consequent receivers trying to attach shoult get the same close frame
+	var i = 100
+	for i > 0 {
+		recv := newTestReceiver()
+		err := s.attachReceiver(recv)
+		if err != nil {
+			// give a chance to a receiver to detach
+			runtime.Gosched()
+			continue
+		}
+		i--
+		if len(recv.frames) != 1 || recv.frames[0] != "c[1,\"some reason\"]" {
+			t.Errorf("Close frame not received by recv, frames '%v'", recv.frames)
+		}
+	}
+	if err := s.Close(1, "some other reson"); err != ErrSessionNotOpen {
+		t.Errorf("Expected error, got '%v'", err)
+	}
+}
+
+func TestSession_SessionSessionId(t *testing.T) {
+	s := newTestSession()
+	if s.ID() != "sessionId" {
+		t.Errorf("Unexpected session ID, got '%s', expected '%s'", s.ID(), "sessionId")
+	}
+}
+
+func newTestReceiver() *testReceiver {
+	return &testReceiver{
+		doneCh:      make(chan struct{}),
+		interruptCh: make(chan struct{}),
+	}
+}
+
+type testReceiver struct {
+	sync.Mutex
+	doneCh, interruptCh chan struct{}
+	frames              []string
+}
+
+func (t *testReceiver) doneNotify() <-chan struct{}        { return t.doneCh }
+func (t *testReceiver) interruptedNotify() <-chan struct{} { return t.interruptCh }
+func (t *testReceiver) close()                             { close(t.doneCh) }
+func (t *testReceiver) canSend() bool {
+	select {
+	case <-t.doneCh:
+		return false // already closed
+	default:
+		return true
+	}
+}
+func (t *testReceiver) sendBulk(messages ...string) {
+	for _, m := range messages {
+		t.sendFrame(m)
+	}
+}
+func (t *testReceiver) sendFrame(frame string) {
+	t.Lock()
+	defer t.Unlock()
+	t.frames = append(t.frames, frame)
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/sockjs.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/sockjs.go
@@ -1,0 +1,13 @@
+package sockjs
+
+// Session represents a connection between server and client.
+type Session interface {
+	// Id returns a session id
+	ID() string
+	// Recv reads one text frame from session
+	Recv() (string, error)
+	// Send sends one text frame to session
+	Send(string) error
+	// Close closes the session with provided code and reason.
+	Close(status uint32, reason string) error
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/sockjs_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/sockjs_test.go
@@ -1,0 +1,27 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+func TestSockJS_ServeHTTP(t *testing.T) {
+	m := handler{mappings: make([]*mapping, 0)}
+	m.mappings = []*mapping{
+		&mapping{"POST", regexp.MustCompile("/foo/.*"), []http.HandlerFunc{func(http.ResponseWriter, *http.Request) {}}},
+	}
+	req, _ := http.NewRequest("GET", "/foo/bar", nil)
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusMethodNotAllowed)
+	}
+	req, _ = http.NewRequest("GET", "/bar", nil)
+	rec = httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/utils.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/utils.go
@@ -1,0 +1,16 @@
+package sockjs
+
+import "encoding/json"
+
+func quote(in string) string {
+	quoted, _ := json.Marshal(in)
+	return string(quoted)
+}
+
+func transform(values []string, transformFn func(string) string) []string {
+	ret := make([]string, len(values))
+	for i, msg := range values {
+		ret[i] = transformFn(msg)
+	}
+	return ret
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/utils_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/utils_test.go
@@ -1,0 +1,19 @@
+package sockjs
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	var quotationTests = []struct {
+		input  string
+		output string
+	}{
+		{"simple", "\"simple\""},
+		{"more complex \"", "\"more complex \\\"\""},
+	}
+
+	for _, testCase := range quotationTests {
+		if quote(testCase.input) != testCase.output {
+			t.Errorf("Expected '%s', got '%s'", testCase.output, quote(testCase.input))
+		}
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/web.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/web.go
@@ -1,0 +1,47 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func xhrCors(rw http.ResponseWriter, req *http.Request) {
+	header := rw.Header()
+	origin := req.Header.Get("origin")
+	if origin == "" || origin == "null" {
+		origin = "*"
+	}
+	header.Set("Access-Control-Allow-Origin", origin)
+
+	if allowHeaders := req.Header.Get("Access-Control-Request-Headers"); allowHeaders != "" && allowHeaders != "null" {
+		header.Add("Access-Control-Allow-Headers", allowHeaders)
+	}
+	header.Add("Access-Control-Allow-Credentials", "true")
+}
+
+func xhrOptions(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+	rw.WriteHeader(http.StatusNoContent) // 204
+}
+
+func cacheFor(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", 365*24*60*60))
+	rw.Header().Set("Expires", time.Now().AddDate(1, 0, 0).Format(time.RFC1123))
+	rw.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", 365*24*60*60))
+}
+
+func noCache(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+}
+
+func welcomeHandler(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "text/plain;charset=UTF-8")
+	fmt.Fprintf(rw, "Welcome to SockJS!\n")
+}
+
+func httpError(w http.ResponseWriter, error string, code int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(code)
+	fmt.Fprintf(w, error)
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/web_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/web_test.go
@@ -1,0 +1,69 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestXhrCors(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrCors(recorder, req)
+	acao := recorder.Header().Get("access-control-allow-origin")
+	if acao != "*" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "*")
+	}
+	req.Header.Set("origin", "localhost")
+	xhrCors(recorder, req)
+	acao = recorder.Header().Get("access-control-allow-origin")
+	if acao != "localhost" {
+		t.Errorf("Incorrect value for access-control-allow-origin header, got %s, expected %s", acao, "localhost")
+	}
+
+	req.Header.Set("access-control-request-headers", "some value")
+	rec := httptest.NewRecorder()
+	xhrCors(rec, req)
+	if rec.Header().Get("access-control-allow-headers") != "some value" {
+		t.Errorf("Incorent value for ACAH, got %s", rec.Header().Get("access-control-allow-headers"))
+	}
+}
+
+func TestXhrOptions(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	xhrOptions(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status code, expected %d, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestCacheFor(t *testing.T) {
+	rec := httptest.NewRecorder()
+	cacheFor(rec, nil)
+	cacheControl := rec.Header().Get("cache-control")
+	if cacheControl != "public, max-age=31536000" {
+		t.Errorf("Incorrect cache-control header value, got '%s'", cacheControl)
+	}
+	expires := rec.Header().Get("expires")
+	if expires == "" {
+		t.Errorf("Expires header should not be empty") // TODO(igm) check proper formating of string
+	}
+	maxAge := rec.Header().Get("access-control-max-age")
+	if maxAge != "31536000" {
+		t.Errorf("Incorrect value for access-control-max-age, got '%s'", maxAge)
+	}
+}
+
+func TestNoCache(t *testing.T) {
+	rec := httptest.NewRecorder()
+	noCache(rec, nil)
+}
+
+func TestWelcomeHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	welcomeHandler(rec, nil)
+	if rec.Body.String() != "Welcome to SockJS!\n" {
+		t.Errorf("Incorrect welcome message received, got '%s'", rec.Body.String())
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/websocket.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/websocket.go
@@ -1,0 +1,97 @@
+package sockjs
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// WebSocketReadBufSize is a parameter that is used for WebSocket Upgrader.
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketReadBufSize = 4096
+
+// WebSocketWriteBufSize is a parameter that is used for WebSocket Upgrader
+// https://github.com/gorilla/websocket/blob/master/server.go#L230
+var WebSocketWriteBufSize = 4096
+
+func (h *handler) sockjsWebsocket(rw http.ResponseWriter, req *http.Request) {
+	conn, err := websocket.Upgrade(rw, req, nil, WebSocketReadBufSize, WebSocketWriteBufSize)
+	if _, ok := err.(websocket.HandshakeError); ok {
+		http.Error(rw, `Can "Upgrade" only to "WebSocket".`, http.StatusBadRequest)
+		return
+	} else if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	sessID, _ := h.parseSessionID(req.URL)
+	sess := newSession(sessID, h.options.DisconnectDelay, h.options.HeartbeatDelay)
+	if h.handlerFunc != nil {
+		go h.handlerFunc(sess)
+	}
+
+	receiver := newWsReceiver(conn)
+	sess.attachReceiver(receiver)
+	readCloseCh := make(chan struct{})
+	go func() {
+		var d []string
+		for {
+			err := conn.ReadJSON(&d)
+			if err != nil {
+				close(readCloseCh)
+				return
+			}
+			sess.accept(d...)
+		}
+	}()
+
+	select {
+	case <-readCloseCh:
+	case <-receiver.doneNotify():
+	}
+	sess.close()
+	conn.Close()
+}
+
+type wsReceiver struct {
+	conn    *websocket.Conn
+	closeCh chan struct{}
+}
+
+func newWsReceiver(conn *websocket.Conn) *wsReceiver {
+	return &wsReceiver{
+		conn:    conn,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (w *wsReceiver) sendBulk(messages ...string) {
+	if len(messages) > 0 {
+		w.sendFrame(fmt.Sprintf("a[%s]", strings.Join(transform(messages, quote), ",")))
+	}
+}
+
+func (w *wsReceiver) sendFrame(frame string) {
+	if err := w.conn.WriteMessage(websocket.TextMessage, []byte(frame)); err != nil {
+		w.close()
+	}
+}
+
+func (w *wsReceiver) close() {
+	select {
+	case <-w.closeCh: // already closed
+	default:
+		close(w.closeCh)
+	}
+}
+func (w *wsReceiver) canSend() bool {
+	select {
+	case <-w.closeCh: // already closed
+		return false
+	default:
+		return true
+	}
+}
+func (w *wsReceiver) doneNotify() <-chan struct{}        { return w.closeCh }
+func (w *wsReceiver) interruptedNotify() <-chan struct{} { return nil }

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/websocket_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/websocket_test.go
@@ -1,0 +1,119 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestHandler_WebSocketHandshakeError(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("origin", "https"+server.URL[4:])
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Unexpected response code, got '%d', expected '%d'", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestHandler_WebSocket(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var connCh = make(chan Session)
+	h.handlerFunc = func(conn Session) { connCh <- conn }
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if conn == nil {
+		t.Errorf("Connection should not be nil")
+	}
+	if err != nil {
+		t.Errorf("Unexpected error '%v'", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("Wrong response code returned, got '%d', expected '%d'", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+	select {
+	case <-connCh: //ok
+	case <-time.After(10 * time.Millisecond):
+		t.Errorf("Sockjs Handler not invoked")
+	}
+}
+
+func TestHandler_WebSocketTerminationByServer(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	h.handlerFunc = func(conn Session) {
+		conn.Close(1024, "some close message")
+		conn.Close(0, "this should be ignored")
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	_, msg, err := conn.ReadMessage()
+	if string(msg) != "o" || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, "o")
+	}
+	_, msg, err = conn.ReadMessage()
+	if string(msg) != `c[1024,"some close message"]` || err != nil {
+		t.Errorf("Open frame expected, got '%s' and error '%v', expected '%s' without error", msg, err, `c[1024,"some close message"]`)
+	}
+	_, msg, err = conn.ReadMessage()
+	// gorilla websocket keeps `errUnexpectedEOF` private so we need to introspect the error message
+	if err != nil {
+		if !strings.Contains(err.Error(), "unexpected EOF") {
+			t.Errorf("Expected 'unexpected EOF' error or similar, got '%v'", err)
+		}
+	}
+}
+
+func TestHandler_WebSocketTerminationByClient(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		if _, err := conn.Recv(); err != ErrSessionNotOpen {
+			t.Errorf("Recv should fail")
+		}
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.Close()
+	<-done
+}
+
+func TestHandler_WebSocketCommunication(t *testing.T) {
+	h := newTestHandler()
+	server := httptest.NewServer(http.HandlerFunc(h.sockjsWebsocket))
+	// defer server.CloseClientConnections()
+	url := "ws" + server.URL[4:]
+	var done = make(chan struct{})
+	h.handlerFunc = func(conn Session) {
+		conn.Send("message 1")
+		conn.Send("message 2")
+		msg, err := conn.Recv()
+		if msg != "message 3" || err != nil {
+			t.Errorf("Got '%s', expecte '%s'", msg, "message 3")
+		}
+		conn.Close(123, "close")
+		close(done)
+	}
+	conn, _, _ := websocket.DefaultDialer.Dial(url, map[string][]string{"Origin": []string{server.URL}})
+	conn.WriteJSON([]string{"message 3"})
+	var expected = []string{"o", `a["message 1"]`, `a["message 2"]`, `c[123,"close"]`}
+	for _, exp := range expected {
+		_, msg, err := conn.ReadMessage()
+		if string(msg) != exp || err != nil {
+			t.Errorf("Wrong frame, got '%s' and error '%v', expected '%s' without error", msg, err, exp)
+		}
+	}
+	<-done
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/xhr.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/xhr.go
@@ -1,0 +1,88 @@
+package sockjs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var (
+	cFrame              = closeFrame(2010, "Another connection still open")
+	xhrStreamingPrelude = strings.Repeat("h", 2048)
+)
+
+func (h *handler) xhrSend(rw http.ResponseWriter, req *http.Request) {
+	if req.Body == nil {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	var messages []string
+	err := json.NewDecoder(req.Body).Decode(&messages)
+	if err == io.EOF {
+		httpError(rw, "Payload expected.", http.StatusInternalServerError)
+		return
+	}
+	if _, ok := err.(*json.SyntaxError); ok || err == io.ErrUnexpectedEOF {
+		httpError(rw, "Broken JSON encoding.", http.StatusInternalServerError)
+		return
+	}
+	sessionID, err := h.parseSessionID(req.URL)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	h.sessionsMux.Lock()
+	defer h.sessionsMux.Unlock()
+	if sess, ok := h.sessions[sessionID]; !ok {
+		http.NotFound(rw, req)
+	} else {
+		_ = sess.accept(messages...)                                 // TODO(igm) reponse with SISE in case of err?
+		rw.Header().Set("content-type", "text/plain; charset=UTF-8") // Ignored by net/http (but protocol test complains), see https://code.google.com/p/go/source/detail?r=902dc062bff8
+		rw.WriteHeader(http.StatusNoContent)
+	}
+}
+
+type xhrFrameWriter struct{}
+
+func (*xhrFrameWriter) write(w io.Writer, frame string) (int, error) {
+	return fmt.Fprintf(w, "%s\n", frame)
+}
+
+func (h *handler) xhrPoll(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	sess, _ := h.sessionByRequest(req) // TODO(igm) add err handling, although err should not happen as handler should not pass req in that case
+	receiver := newHTTPReceiver(rw, 1, new(xhrFrameWriter))
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}
+
+func (h *handler) xhrStreaming(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("content-type", "application/javascript; charset=UTF-8")
+	fmt.Fprintf(rw, "%s\n", xhrStreamingPrelude)
+	rw.(http.Flusher).Flush()
+
+	sess, _ := h.sessionByRequest(req)
+	receiver := newHTTPReceiver(rw, h.options.ResponseLimit, new(xhrFrameWriter))
+
+	if err := sess.attachReceiver(receiver); err != nil {
+		receiver.sendFrame(cFrame)
+		receiver.close()
+		return
+	}
+
+	select {
+	case <-receiver.doneNotify():
+	case <-receiver.interruptedNotify():
+	}
+}

--- a/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/xhr_test.go
+++ b/vendor/gopkg.in/igm/sockjs-go.v2/sockjs/xhr_test.go
@@ -1,0 +1,185 @@
+package sockjs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandler_XhrSendNilBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", nil)
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendEmptyBody(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/non_existing_session/xhr_send", strings.NewReader(""))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != "Payload expected." {
+		t.Errorf("Unexcpected body received: '%s'", rec.Body.String())
+	}
+}
+
+func TestHandler_XhrSendWrongUrlPath(t *testing.T) {
+	h := newTestHandler()
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "incorrect", strings.NewReader("[\"a\"]"))
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("Unexcpected response status, got '%d', expected '%d'", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendToExistingSession(t *testing.T) {
+	h := newTestHandler()
+	sess := newSession("session", time.Second, time.Second)
+	h.sessions["session"] = sess
+
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	var done = make(chan bool)
+	go func() {
+		h.xhrSend(rec, req)
+		done <- true
+	}()
+	msg, _ := sess.Recv()
+	if msg != "some message" {
+		t.Errorf("Incorrect message in the channel, should be '%s', was '%s'", "some message", msg)
+	}
+	<-done
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Wrong response status received %d, should be %d", rec.Code, http.StatusNoContent)
+	}
+	if rec.Header().Get("content-type") != "text/plain; charset=UTF-8" {
+		t.Errorf("Wrong content type received '%s'", rec.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrSendInvalidInput(t *testing.T) {
+	h := newTestHandler()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("some invalid message frame"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+
+	// unexpected EOF
+	req, _ = http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"x"))
+	rec = httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusInternalServerError || rec.Body.String() != "Broken JSON encoding." {
+		t.Errorf("Unexpected response, got '%d,%s' expected '%d,Broken JSON encoding.'", rec.Code, rec.Body.String(), http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_XhrSendSessionNotFound(t *testing.T) {
+	h := handler{}
+	req, _ := http.NewRequest("POST", "/server/session/xhr_send", strings.NewReader("[\"some message\"]"))
+	rec := httptest.NewRecorder()
+	h.xhrSend(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("Unexpected response status, got '%d' expected '%d'", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_XhrPoll(t *testing.T) {
+	h := newTestHandler()
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	h.xhrPoll(rw, req)
+	if rw.Header().Get("content-type") != "application/javascript; charset=UTF-8" {
+		t.Errorf("Wrong content type received, got '%s'", rw.Header().Get("content-type"))
+	}
+}
+
+func TestHandler_XhrPollConnectionInterrupted(t *testing.T) {
+	h := newTestHandler()
+	sess := newTestSession()
+	sess.state = sessionActive
+	h.sessions["session"] = sess
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	rw := newClosableRecorder()
+	close(rw.closeNotifCh)
+	h.xhrPoll(rw, req)
+	time.Sleep(1 * time.Millisecond)
+	sess.Lock()
+	if sess.state != sessionClosed {
+		t.Errorf("Session should be closed")
+	}
+}
+
+func TestHandler_XhrPollAnotherConnectionExists(t *testing.T) {
+	h := newTestHandler()
+	// turn of timeoutes and heartbeats
+	sess := newSession("session", time.Hour, time.Hour)
+	h.sessions["session"] = sess
+	sess.attachReceiver(newTestReceiver())
+	req, _ := http.NewRequest("POST", "/server/session/xhr", nil)
+	rw2 := httptest.NewRecorder()
+	h.xhrPoll(rw2, req)
+	if rw2.Body.String() != "c[2010,\"Another connection still open\"]\n" {
+		t.Errorf("Unexpected body, got '%s'", rw2.Body)
+	}
+}
+
+func TestHandler_XhrStreaming(t *testing.T) {
+	h := newTestHandler()
+	rw := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	h.xhrStreaming(rw, req)
+	expectedBody := strings.Repeat("h", 2048) + "\no\n"
+	if rw.Body.String() != expectedBody {
+		t.Errorf("Unexpected body, got '%s' expected '%s'", rw.Body, expectedBody)
+	}
+}
+
+func TestHandler_XhrStreamingAnotherReceiver(t *testing.T) {
+	h := newTestHandler()
+	h.options.ResponseLimit = 4096
+	rw1 := newClosableRecorder()
+	req, _ := http.NewRequest("POST", "/server/session/xhr_streaming", nil)
+	go func() {
+		rec := httptest.NewRecorder()
+		h.xhrStreaming(rec, req)
+		expectedBody := strings.Repeat("h", 2048) + "\n" + "c[2010,\"Another connection still open\"]\n"
+		if rec.Body.String() != expectedBody {
+			t.Errorf("Unexpected body got '%s', expected '%s', ", rec.Body, expectedBody)
+		}
+		close(rw1.closeNotifCh)
+	}()
+	h.xhrStreaming(rw1, req)
+}
+
+// various test only structs
+func newTestHandler() *handler {
+	h := &handler{sessions: make(map[string]*session)}
+	h.options.HeartbeatDelay = time.Hour
+	h.options.DisconnectDelay = time.Hour
+	return h
+}
+
+type ClosableRecorder struct {
+	*httptest.ResponseRecorder
+	closeNotifCh chan bool
+}
+
+func newClosableRecorder() *ClosableRecorder {
+	return &ClosableRecorder{httptest.NewRecorder(), make(chan bool)}
+}
+
+func (cr *ClosableRecorder) CloseNotify() <-chan bool { return cr.closeNotifCh }

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/BUILD
@@ -1,0 +1,64 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "errorstream.go",
+        "remotecommand.go",
+        "resize.go",
+        "v1.go",
+        "v2.go",
+        "v3.go",
+        "v4.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/util/exec:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/httpstream/spdy:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/remotecommand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/transport:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "v2_test.go",
+        "v4_test.go",
+    ],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/doc.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package remotecommand adds support for executing commands in containers,
+// with support for separate stdin, stdout, and stderr streams, as well as
+// TTY.
+package remotecommand // import "k8s.io/kubernetes/pkg/client/unversioned/remotecommand"

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/errorstream.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/errorstream.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// errorStreamDecoder interprets the data on the error channel and creates a go error object from it.
+type errorStreamDecoder interface {
+	decode(message []byte) error
+}
+
+// watchErrorStream watches the errorStream for remote command error data,
+// decodes it with the given errorStreamDecoder, sends the decoded error (or nil if the remote
+// command exited successfully) to the returned error channel, and closes it.
+// This function returns immediately.
+func watchErrorStream(errorStream io.Reader, d errorStreamDecoder) chan error {
+	errorChan := make(chan error)
+
+	go func() {
+		defer runtime.HandleCrash()
+
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil && err != io.EOF:
+			errorChan <- fmt.Errorf("error reading from error stream: %s", err)
+		case len(message) > 0:
+			errorChan <- d.decode(message)
+		default:
+			errorChan <- nil
+		}
+		close(errorChan)
+	}()
+
+	return errorChan
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// StreamOptions holds information pertaining to the current streaming session: supported stream
+// protocols, input/output streams, if the client is requesting a TTY, and a terminal size queue to
+// support terminal resizing.
+type StreamOptions struct {
+	SupportedProtocols []string
+	Stdin              io.Reader
+	Stdout             io.Writer
+	Stderr             io.Writer
+	Tty                bool
+	TerminalSizeQueue  TerminalSizeQueue
+}
+
+// Executor is an interface for transporting shell-style streams.
+type Executor interface {
+	// Stream initiates the transport of the standard shell streams. It will transport any
+	// non-nil stream to a remote system, and return an error if a problem occurs. If tty
+	// is set, the stderr stream is not used (raw TTY manages stdout and stderr over the
+	// stdout stream).
+	Stream(options StreamOptions) error
+}
+
+// StreamExecutor supports the ability to dial an httpstream connection and the ability to
+// run a command line stream protocol over that dialer.
+type StreamExecutor interface {
+	Executor
+	httpstream.Dialer
+}
+
+// streamExecutor handles transporting standard shell streams over an httpstream connection.
+type streamExecutor struct {
+	upgrader  httpstream.UpgradeRoundTripper
+	transport http.RoundTripper
+
+	method string
+	url    *url.URL
+}
+
+// NewExecutor connects to the provided server and upgrades the connection to
+// multiplexed bidirectional streams. The current implementation uses SPDY,
+// but this could be replaced with HTTP/2 once it's available, or something else.
+// TODO: the common code between this and portforward could be abstracted.
+func NewExecutor(config *restclient.Config, method string, url *url.URL) (StreamExecutor, error) {
+	tlsConfig, err := restclient.TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, true)
+	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
+	if err != nil {
+		return nil, err
+	}
+
+	return &streamExecutor{
+		upgrader:  upgradeRoundTripper,
+		transport: wrapper,
+		method:    method,
+		url:       url,
+	}, nil
+}
+
+// NewStreamExecutor upgrades the request so that it supports multiplexed bidirectional
+// streams. This method takes a stream upgrader and an optional function that is invoked
+// to wrap the round tripper. This method may be used by clients that are lower level than
+// Kubernetes clients or need to provide their own upgrade round tripper.
+func NewStreamExecutor(upgrader httpstream.UpgradeRoundTripper, fn func(http.RoundTripper) http.RoundTripper, method string, url *url.URL) (StreamExecutor, error) {
+	rt := http.RoundTripper(upgrader)
+	if fn != nil {
+		rt = fn(rt)
+	}
+	return &streamExecutor{
+		upgrader:  upgrader,
+		transport: rt,
+		method:    method,
+		url:       url,
+	}, nil
+}
+
+// Dial opens a connection to a remote server and attempts to negotiate a SPDY
+// connection. Upon success, it returns the connection and the protocol
+// selected by the server.
+func (e *streamExecutor) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	rt := transport.DebugWrappers(e.transport)
+
+	// TODO the client probably shouldn't be created here, as it doesn't allow
+	// flexibility to allow callers to configure it.
+	client := &http.Client{Transport: rt}
+
+	req, err := http.NewRequest(e.method, e.url.String(), nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating request: %v", err)
+	}
+	for i := range protocols {
+		req.Header.Add(httpstream.HeaderProtocolVersion, protocols[i])
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	conn, err := e.upgrader.NewConnection(resp)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return conn, resp.Header.Get(httpstream.HeaderProtocolVersion), nil
+}
+
+type streamCreator interface {
+	CreateStream(headers http.Header) (httpstream.Stream, error)
+}
+
+type streamProtocolHandler interface {
+	stream(conn streamCreator) error
+}
+
+// Stream opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects.
+func (e *streamExecutor) Stream(options StreamOptions) error {
+	conn, protocol, err := e.Dial(options.SupportedProtocols...)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	var streamer streamProtocolHandler
+
+	switch protocol {
+	case remotecommand.StreamProtocolV4Name:
+		streamer = newStreamProtocolV4(options)
+	case remotecommand.StreamProtocolV3Name:
+		streamer = newStreamProtocolV3(options)
+	case remotecommand.StreamProtocolV2Name:
+		streamer = newStreamProtocolV2(options)
+	case "":
+		glog.V(4).Infof("The server did not negotiate a streaming protocol version. Falling back to %s", remotecommand.StreamProtocolV1Name)
+		fallthrough
+	case remotecommand.StreamProtocolV1Name:
+		streamer = newStreamProtocolV1(options)
+	}
+
+	return streamer.stream(conn)
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/resize.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/resize.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+// TerminalSize and TerminalSizeQueue was a part of k8s.io/kubernetes/pkg/util/term
+// and were moved in order to decouple client from other term dependencies
+
+// TerminalSize represents the width and height of a terminal.
+type TerminalSize struct {
+	Width  uint16
+	Height uint16
+}
+
+// TerminalSizeQueue is capable of returning terminal resize events as they occur.
+type TerminalSizeQueue interface {
+	// Next returns the new terminal size after the terminal has been resized. It returns nil when
+	// monitoring has been stopped.
+	Next() *TerminalSize
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v1.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v1.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// streamProtocolV1 implements the first version of the streaming exec & attach
+// protocol. This version has some bugs, such as not being able to detect when
+// non-interactive stdin data has ended. See http://issues.k8s.io/13394 and
+// http://issues.k8s.io/13395 for more details.
+type streamProtocolV1 struct {
+	StreamOptions
+
+	errorStream  httpstream.Stream
+	remoteStdin  httpstream.Stream
+	remoteStdout httpstream.Stream
+	remoteStderr httpstream.Stream
+}
+
+var _ streamProtocolHandler = &streamProtocolV1{}
+
+func newStreamProtocolV1(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV1{
+		StreamOptions: options,
+	}
+}
+
+func (p *streamProtocolV1) stream(conn streamCreator) error {
+	doneChan := make(chan struct{}, 2)
+	errorChan := make(chan error)
+
+	cp := func(s string, dst io.Writer, src io.Reader) {
+		glog.V(6).Infof("Copying %s", s)
+		defer glog.V(6).Infof("Done copying %s", s)
+		if _, err := io.Copy(dst, src); err != nil && err != io.EOF {
+			glog.Errorf("Error copying %s: %v", s, err)
+		}
+		if s == api.StreamTypeStdout || s == api.StreamTypeStderr {
+			doneChan <- struct{}{}
+		}
+	}
+
+	// set up all the streams first
+	var err error
+	headers := http.Header{}
+	headers.Set(api.StreamType, api.StreamTypeError)
+	p.errorStream, err = conn.CreateStream(headers)
+	if err != nil {
+		return err
+	}
+	defer p.errorStream.Reset()
+
+	// Create all the streams first, then start the copy goroutines. The server doesn't start its copy
+	// goroutines until it's received all of the streams. If the client creates the stdin stream and
+	// immediately begins copying stdin data to the server, it's possible to overwhelm and wedge the
+	// spdy frame handler in the server so that it is full of unprocessed frames. The frames aren't
+	// getting processed because the server hasn't started its copying, and it won't do that until it
+	// gets all the streams. By creating all the streams first, we ensure that the server is ready to
+	// process data before the client starts sending any. See https://issues.k8s.io/16373 for more info.
+	if p.Stdin != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdin)
+		p.remoteStdin, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer p.remoteStdin.Reset()
+	}
+
+	if p.Stdout != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdout)
+		p.remoteStdout, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer p.remoteStdout.Reset()
+	}
+
+	if p.Stderr != nil && !p.Tty {
+		headers.Set(api.StreamType, api.StreamTypeStderr)
+		p.remoteStderr, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer p.remoteStderr.Reset()
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	// always read from errorStream
+	go func() {
+		message, err := ioutil.ReadAll(p.errorStream)
+		if err != nil && err != io.EOF {
+			errorChan <- fmt.Errorf("Error reading from error stream: %s", err)
+			return
+		}
+		if len(message) > 0 {
+			errorChan <- fmt.Errorf("Error executing remote command: %s", message)
+			return
+		}
+	}()
+
+	if p.Stdin != nil {
+		// TODO this goroutine will never exit cleanly (the io.Copy never unblocks)
+		// because stdin is not closed until the process exits. If we try to call
+		// stdin.Close(), it returns no error but doesn't unblock the copy. It will
+		// exit when the process exits, instead.
+		go cp(api.StreamTypeStdin, p.remoteStdin, p.Stdin)
+	}
+
+	waitCount := 0
+	completedStreams := 0
+
+	if p.Stdout != nil {
+		waitCount++
+		go cp(api.StreamTypeStdout, p.Stdout, p.remoteStdout)
+	}
+
+	if p.Stderr != nil && !p.Tty {
+		waitCount++
+		go cp(api.StreamTypeStderr, p.Stderr, p.remoteStderr)
+	}
+
+Loop:
+	for {
+		select {
+		case <-doneChan:
+			completedStreams++
+			if completedStreams == waitCount {
+				break Loop
+			}
+		case err := <-errorChan:
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// streamProtocolV2 implements version 2 of the streaming protocol for attach
+// and exec. The original streaming protocol was metav1. As a result, this
+// version is referred to as version 2, even though it is the first actual
+// numbered version.
+type streamProtocolV2 struct {
+	StreamOptions
+
+	errorStream  io.Reader
+	remoteStdin  io.ReadWriteCloser
+	remoteStdout io.Reader
+	remoteStderr io.Reader
+}
+
+var _ streamProtocolHandler = &streamProtocolV2{}
+
+func newStreamProtocolV2(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV2{
+		StreamOptions: options,
+	}
+}
+
+func (p *streamProtocolV2) createStreams(conn streamCreator) error {
+	var err error
+	headers := http.Header{}
+
+	// set up error stream
+	headers.Set(api.StreamType, api.StreamTypeError)
+	p.errorStream, err = conn.CreateStream(headers)
+	if err != nil {
+		return err
+	}
+
+	// set up stdin stream
+	if p.Stdin != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdin)
+		p.remoteStdin, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set up stdout stream
+	if p.Stdout != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdout)
+		p.remoteStdout, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set up stderr stream
+	if p.Stderr != nil && !p.Tty {
+		headers.Set(api.StreamType, api.StreamTypeStderr)
+		p.remoteStderr, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *streamProtocolV2) copyStdin() {
+	if p.Stdin != nil {
+		var once sync.Once
+
+		// copy from client's stdin to container's stdin
+		go func() {
+			defer runtime.HandleCrash()
+
+			// if p.stdin is noninteractive, p.g. `echo abc | kubectl exec -i <pod> -- cat`, make sure
+			// we close remoteStdin as soon as the copy from p.stdin to remoteStdin finishes. Otherwise
+			// the executed command will remain running.
+			defer once.Do(func() { p.remoteStdin.Close() })
+
+			if _, err := io.Copy(p.remoteStdin, p.Stdin); err != nil {
+				runtime.HandleError(err)
+			}
+		}()
+
+		// read from remoteStdin until the stream is closed. this is essential to
+		// be able to exit interactive sessions cleanly and not leak goroutines or
+		// hang the client's terminal.
+		//
+		// TODO we aren't using go-dockerclient any more; revisit this to determine if it's still
+		// required by engine-api.
+		//
+		// go-dockerclient's current hijack implementation
+		// (https://github.com/fsouza/go-dockerclient/blob/89f3d56d93788dfe85f864a44f85d9738fca0670/client.go#L564)
+		// waits for all three streams (stdin/stdout/stderr) to finish copying
+		// before returning. When hijack finishes copying stdout/stderr, it calls
+		// Close() on its side of remoteStdin, which allows this copy to complete.
+		// When that happens, we must Close() on our side of remoteStdin, to
+		// allow the copy in hijack to complete, and hijack to return.
+		go func() {
+			defer runtime.HandleCrash()
+			defer once.Do(func() { p.remoteStdin.Close() })
+
+			// this "copy" doesn't actually read anything - it's just here to wait for
+			// the server to close remoteStdin.
+			if _, err := io.Copy(ioutil.Discard, p.remoteStdin); err != nil {
+				runtime.HandleError(err)
+			}
+		}()
+	}
+}
+
+func (p *streamProtocolV2) copyStdout(wg *sync.WaitGroup) {
+	if p.Stdout == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+
+		if _, err := io.Copy(p.Stdout, p.remoteStdout); err != nil {
+			runtime.HandleError(err)
+		}
+	}()
+}
+
+func (p *streamProtocolV2) copyStderr(wg *sync.WaitGroup) {
+	if p.Stderr == nil || p.Tty {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+
+		if _, err := io.Copy(p.Stderr, p.remoteStderr); err != nil {
+			runtime.HandleError(err)
+		}
+	}()
+}
+
+func (p *streamProtocolV2) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV2{})
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+// errorDecoderV2 interprets the error channel data as plain text.
+type errorDecoderV2 struct{}
+
+func (d *errorDecoderV2) decode(message []byte) error {
+	return fmt.Errorf("error executing remote command: %s", message)
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+type fakeReader struct {
+	err error
+}
+
+func (r *fakeReader) Read([]byte) (int, error) { return 0, r.err }
+
+type fakeWriter struct{}
+
+func (*fakeWriter) Write([]byte) (int, error) { return 0, nil }
+
+type fakeStreamCreator struct {
+	created map[string]bool
+	errors  map[string]error
+}
+
+var _ streamCreator = &fakeStreamCreator{}
+
+func (f *fakeStreamCreator) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	streamType := headers.Get(api.StreamType)
+	f.created[streamType] = true
+	return nil, f.errors[streamType]
+}
+
+func TestV2CreateStreams(t *testing.T) {
+	tests := []struct {
+		name        string
+		stdin       bool
+		stdinError  error
+		stdout      bool
+		stdoutError error
+		stderr      bool
+		stderrError error
+		errorError  error
+		tty         bool
+		expectError bool
+	}{
+		{
+			name:        "stdin error",
+			stdin:       true,
+			stdinError:  errors.New("stdin error"),
+			expectError: true,
+		},
+		{
+			name:        "stdout error",
+			stdout:      true,
+			stdoutError: errors.New("stdout error"),
+			expectError: true,
+		},
+		{
+			name:        "stderr error",
+			stderr:      true,
+			stderrError: errors.New("stderr error"),
+			expectError: true,
+		},
+		{
+			name:        "error stream error",
+			stdin:       true,
+			stdout:      true,
+			stderr:      true,
+			errorError:  errors.New("error stream error"),
+			expectError: true,
+		},
+		{
+			name:        "no errors",
+			stdin:       true,
+			stdout:      true,
+			stderr:      true,
+			expectError: false,
+		},
+		{
+			name:        "no errors, stderr & tty set, don't expect stderr",
+			stdin:       true,
+			stdout:      true,
+			stderr:      true,
+			tty:         true,
+			expectError: false,
+		},
+	}
+	for _, test := range tests {
+		conn := &fakeStreamCreator{
+			created: make(map[string]bool),
+			errors: map[string]error{
+				api.StreamTypeStdin:  test.stdinError,
+				api.StreamTypeStdout: test.stdoutError,
+				api.StreamTypeStderr: test.stderrError,
+				api.StreamTypeError:  test.errorError,
+			},
+		}
+
+		opts := StreamOptions{Tty: test.tty}
+		if test.stdin {
+			opts.Stdin = &fakeReader{}
+		}
+		if test.stdout {
+			opts.Stdout = &fakeWriter{}
+		}
+		if test.stderr {
+			opts.Stderr = &fakeWriter{}
+		}
+
+		h := newStreamProtocolV2(opts).(*streamProtocolV2)
+		err := h.createStreams(conn)
+
+		if test.expectError {
+			if err == nil {
+				t.Errorf("%s: expected error", test.name)
+				continue
+			}
+			if e, a := test.stdinError, err; test.stdinError != nil && e != a {
+				t.Errorf("%s: expected %v, got %v", test.name, e, a)
+			}
+			if e, a := test.stdoutError, err; test.stdoutError != nil && e != a {
+				t.Errorf("%s: expected %v, got %v", test.name, e, a)
+			}
+			if e, a := test.stderrError, err; test.stderrError != nil && e != a {
+				t.Errorf("%s: expected %v, got %v", test.name, e, a)
+			}
+			if e, a := test.errorError, err; test.errorError != nil && e != a {
+				t.Errorf("%s: expected %v, got %v", test.name, e, a)
+			}
+			continue
+		}
+
+		if !test.expectError && err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+			continue
+		}
+
+		if test.stdin && !conn.created[api.StreamTypeStdin] {
+			t.Errorf("%s: expected stdin stream", test.name)
+		}
+		if test.stdout && !conn.created[api.StreamTypeStdout] {
+			t.Errorf("%s: expected stdout stream", test.name)
+		}
+		if test.stderr {
+			if test.tty && conn.created[api.StreamTypeStderr] {
+				t.Errorf("%s: unexpected stderr stream because tty is set", test.name)
+			} else if !test.tty && !conn.created[api.StreamTypeStderr] {
+				t.Errorf("%s: expected stderr stream", test.name)
+			}
+		}
+		if !conn.created[api.StreamTypeError] {
+			t.Errorf("%s: expected error stream", test.name)
+		}
+
+	}
+}
+
+func TestV2ErrorStreamReading(t *testing.T) {
+	tests := []struct {
+		name          string
+		stream        io.Reader
+		expectedError error
+	}{
+		{
+			name:          "error reading from stream",
+			stream:        &fakeReader{errors.New("foo")},
+			expectedError: errors.New("error reading from error stream: foo"),
+		},
+		{
+			name:          "stream returns an error",
+			stream:        strings.NewReader("some error"),
+			expectedError: errors.New("error executing remote command: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		h := newStreamProtocolV2(StreamOptions{}).(*streamProtocolV2)
+		h.errorStream = test.stream
+
+		ch := watchErrorStream(h.errorStream, &errorDecoderV2{})
+		if ch == nil {
+			t.Fatalf("%s: unexpected nil channel", test.name)
+		}
+
+		var err error
+		select {
+		case err = <-ch:
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("%s: timed out", test.name)
+		}
+
+		if test.expectedError != nil {
+			if err == nil {
+				t.Errorf("%s: expected an error", test.name)
+			} else if e, a := test.expectedError, err; e.Error() != a.Error() {
+				t.Errorf("%s: expected %q, got %q", test.name, e, a)
+			}
+			continue
+		}
+
+		if test.expectedError == nil && err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+			continue
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v3.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v3.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// streamProtocolV3 implements version 3 of the streaming protocol for attach
+// and exec. This version adds support for resizing the container's terminal.
+type streamProtocolV3 struct {
+	*streamProtocolV2
+
+	resizeStream io.Writer
+}
+
+var _ streamProtocolHandler = &streamProtocolV3{}
+
+func newStreamProtocolV3(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV3{
+		streamProtocolV2: newStreamProtocolV2(options).(*streamProtocolV2),
+	}
+}
+
+func (p *streamProtocolV3) createStreams(conn streamCreator) error {
+	// set up the streams from v2
+	if err := p.streamProtocolV2.createStreams(conn); err != nil {
+		return err
+	}
+
+	// set up resize stream
+	if p.Tty {
+		headers := http.Header{}
+		headers.Set(api.StreamType, api.StreamTypeResize)
+		var err error
+		p.resizeStream, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *streamProtocolV3) handleResizes() {
+	if p.resizeStream == nil || p.TerminalSizeQueue == nil {
+		return
+	}
+	go func() {
+		defer runtime.HandleCrash()
+
+		encoder := json.NewEncoder(p.resizeStream)
+		for {
+			size := p.TerminalSizeQueue.Next()
+			if size == nil {
+				return
+			}
+			if err := encoder.Encode(&size); err != nil {
+				runtime.HandleError(err)
+			}
+		}
+	}()
+}
+
+func (p *streamProtocolV3) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV3{})
+
+	p.handleResizes()
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+type errorDecoderV3 struct {
+	errorDecoderV2
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v4.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v4.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/kubernetes/pkg/util/exec"
+)
+
+// streamProtocolV4 implements version 4 of the streaming protocol for attach
+// and exec. This version adds support for exit codes on the error stream through
+// the use of metav1.Status instead of plain text messages.
+type streamProtocolV4 struct {
+	*streamProtocolV3
+}
+
+var _ streamProtocolHandler = &streamProtocolV4{}
+
+func newStreamProtocolV4(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV4{
+		streamProtocolV3: newStreamProtocolV3(options).(*streamProtocolV3),
+	}
+}
+
+func (p *streamProtocolV4) createStreams(conn streamCreator) error {
+	return p.streamProtocolV3.createStreams(conn)
+}
+
+func (p *streamProtocolV4) handleResizes() {
+	p.streamProtocolV3.handleResizes()
+}
+
+func (p *streamProtocolV4) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV4{})
+
+	p.handleResizes()
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+// errorDecoderV4 interprets the json-marshaled metav1.Status on the error channel
+// and creates an exec.ExitError from it.
+type errorDecoderV4 struct{}
+
+func (d *errorDecoderV4) decode(message []byte) error {
+	status := metav1.Status{}
+	err := json.Unmarshal(message, &status)
+	if err != nil {
+		return fmt.Errorf("error stream protocol error: %v in %q", err, string(message))
+	}
+	switch status.Status {
+	case metav1.StatusSuccess:
+		return nil
+	case metav1.StatusFailure:
+		if status.Reason == remotecommand.NonZeroExitCodeReason {
+			if status.Details == nil {
+				return errors.New("error stream protocol error: details must be set")
+			}
+			for i := range status.Details.Causes {
+				c := &status.Details.Causes[i]
+				if c.Type != remotecommand.ExitCodeCauseType {
+					continue
+				}
+
+				rc, err := strconv.ParseUint(c.Message, 10, 8)
+				if err != nil {
+					return fmt.Errorf("error stream protocol error: invalid exit code value %q", c.Message)
+				}
+				return exec.CodeExitError{
+					Err:  fmt.Errorf("command terminated with exit code %d", rc),
+					Code: int(rc),
+				}
+			}
+
+			return fmt.Errorf("error stream protocol error: no %s cause given", remotecommand.ExitCodeCauseType)
+		}
+	default:
+		return errors.New("error stream protocol error: unknown error")
+	}
+
+	return fmt.Errorf(status.Message)
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v4_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v4_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestV4ErrorDecoder(t *testing.T) {
+	dec := errorDecoderV4{}
+
+	type Test struct {
+		message string
+		err     string
+	}
+
+	for _, test := range []Test{
+		{
+			message: "{}",
+			err:     "error stream protocol error: unknown error",
+		},
+		{
+			message: "{",
+			err:     "error stream protocol error: unexpected end of JSON input in \"{\"",
+		},
+		{
+			message: `{"status": "Success" }`,
+			err:     "",
+		},
+		{
+			message: `{"status": "Failure", "message": "foobar" }`,
+			err:     "foobar",
+		},
+		{
+			message: `{"status": "Failure", "message": "foobar", "reason": "NonZeroExitCode", "details": {"causes": [{"reason": "foo"}] } }`,
+			err:     "error stream protocol error: no ExitCode cause given",
+		},
+		{
+			message: `{"status": "Failure", "message": "foobar", "reason": "NonZeroExitCode", "details": {"causes": [{"reason": "ExitCode"}] } }`,
+			err:     "error stream protocol error: invalid exit code value \"\"",
+		},
+		{
+			message: `{"status": "Failure", "message": "foobar", "reason": "NonZeroExitCode", "details": {"causes": [{"reason": "ExitCode", "message": "42"}] } }`,
+			err:     "command terminated with exit code 42",
+		},
+	} {
+		err := dec.decode([]byte(test.message))
+		want := test.err
+		if want == "" {
+			want = "<nil>"
+		}
+		if got := fmt.Sprintf("%v", err); got != want {
+			t.Errorf("wrong error for message %q: want=%q, got=%q", test.message, want, got)
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -877,6 +877,12 @@
 			"revisionTime": "2016-02-01T17:48:07Z"
 		},
 		{
+			"checksumSHA1": "G9xlHV7kNV0SFK4mwyym9O5qWZ0=",
+			"path": "github.com/gorilla/websocket",
+			"revision": "a91eba7f97777409bc2c443f5534d41dd20c5720",
+			"revisionTime": "2017-03-19T17:27:27Z"
+		},
+		{
 			"checksumSHA1": "yst2ieNYOiHFoAcA2+jJFtfan+g=",
 			"path": "github.com/grpc-ecosystem/grpc-gateway/examples/examplepb",
 			"revision": "325488925d6af252d18cc5ade7032127bc898ac7",
@@ -923,6 +929,12 @@
 			"path": "github.com/howeyc/gopass",
 			"revision": "f5387c492211eb133053880d23dfae62aa14123d",
 			"revisionTime": "2016-10-03T13:09:00Z"
+		},
+		{
+			"checksumSHA1": "1quR5pQNYFEgMLp987my6ZXh3vU=",
+			"path": "github.com/igm/sockjs-go/sockjs",
+			"revision": "1f275fbd3bcc9a21ec90217b80f40db44404410b",
+			"revisionTime": "2016-11-15T19:28:38Z"
 		},
 		{
 			"checksumSHA1": "n/llKRPzxcWttjZtpAWA7VW9iJA=",
@@ -1717,6 +1729,12 @@
 			"path": "gopkg.in/check.v1",
 			"revision": "4f90aeace3a26ad7021961c297b22c42160c7b25",
 			"revisionTime": "2016-01-05T16:49:36Z"
+		},
+		{
+			"checksumSHA1": "ubw5EnGNT/r1hmOchk9YrwqHJvk=",
+			"path": "gopkg.in/igm/sockjs-go.v2/sockjs",
+			"revision": "d276e9ffe5cc5c271b81198cc77a2adf6c4482d2",
+			"revisionTime": "2016-11-15T19:38:03Z"
 		},
 		{
 			"checksumSHA1": "puukSI4sk1NrZynJws6JPuOUnj8=",
@@ -4165,6 +4183,12 @@
 			"path": "k8s.io/kubernetes/pkg/client/unversioned",
 			"revision": "21f30db4c68eae6cda0955ac3d7912326e65d135",
 			"revisionTime": "2017-04-26T00:56:44Z"
+		},
+		{
+			"checksumSHA1": "LZF+rOOAb+paoWURMdmYDNYF8Ww=",
+			"path": "k8s.io/kubernetes/pkg/client/unversioned/remotecommand",
+			"revision": "3dfffac7f918ef4c2409b898b3d40a89419dce24",
+			"revisionTime": "2017-05-11T19:20:17Z"
 		},
 		{
 			"checksumSHA1": "jFgbQj6gWZGErv0Q/4EIS4exwTw=",


### PR DESCRIPTION
**Prototype** -- please comment extensively. This is building on code/ideas/comments from #1455 and #1345, so some of the problems/suggestions mentioned there are addressed.

Task list:
- [x] Builds prod
- [x] You can actually execute a shell and get a terminal in the containers
- [x] Support trying different shells (tries `bash` than `sh` for now)
- [x] Using hterm. So copy-paste, colors, mouse, etc.
- [x] Resizing
- [x] Moon buggy!!
- [x] Message on disconnect
- [x] SockJS transport (kubectl proxy does not support websockets (kubernetes/kubernetes#32026) which is a major use case. So if websockets do not work it falls back on different kinds of http streaming. It is jerkier and much less efficient than websockets but at least it works.)
- [ ] Ability to attach as in kubectl attach
- [x] Come up with a better name than "Attach" for the shell exec link
- [x] Make code look not horrible. For example, find better names for all the `*attach*` functions and structures. Dependencies for gorilla/websocket should be removed.
- [ ] Implement locking for session map (while the current code is _bad_, actually triggering the problem is unlikely)
- [ ] Add links leading to exec view (something like logs button)
- [ ] Serve `SockJSURL` from dashboard
- [ ] utf-8 _input_ (needs hterm needs configuration)
- [ ] Add some tests
- [ ] Some solution to respawn if the user exits the shell (?)
- [ ] Some padding on the left (?)

I have been running it like this:
`DOCKER_RUN_OPTS="-v $HOME/.kube/config:/kubeconfig.yaml:ro -e KUBE_DASHBOARD_KUBECONFIG=/kubeconfig.yaml" build/run-gulp-in-docker.sh serve
`

![moon-buggy](https://cloud.githubusercontent.com/assets/1122543/25977317/afb82866-36b2-11e7-8a14-811543485067.png)
