### PR TITLE
Fix cascading delete

### DIFF
--- a/src/app/backend/resource/common/verber.go
+++ b/src/app/backend/resource/common/verber.go
@@ -17,8 +17,8 @@ package common
 import (
 	"fmt"
 
+	api "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/client-go/pkg/api/v1"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -82,9 +82,9 @@ func (verber *ResourceVerber) Delete(kind string, namespaceSet bool, namespace s
 	client := verber.getRESTClientByType(resourceSpec.ClientType)
 
 	// Do cascade delete by default, as this is what users typically expect.
-	defaultOrphanDependents := false
+	defaultPropagationPolicy := api.DeletePropagationForeground
 	defaultDeleteOptions := &api.DeleteOptions{
-		OrphanDependents: &defaultOrphanDependents,
+		PropagationPolicy: &defaultPropagationPolicy,
 	}
 
 	req := client.Delete().

--- a/src/app/backend/resource/common/verber_test.go
+++ b/src/app/backend/resource/common/verber_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	api "k8s.io/client-go/pkg/api/v1"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -31,7 +30,7 @@ func (c *FakeRESTClient) Delete() *restclient.Request {
 
 	groupVersion := schema.GroupVersion{Group: "meta.k8s.io", Version: "v1"}
 
-	scheme.AddKnownTypes(groupVersion, &api.DeleteOptions{})
+	scheme.AddKnownTypes(groupVersion, &metaV1.DeleteOptions{})
 
 	factory := runtimeserializer.NewCodecFactory(scheme)
 	codec := testapi.TestCodec(factory, metaV1.SchemeGroupVersion)


### PR DESCRIPTION
Closes #1570 

As recommended by @caesarxuchao I have added propagation policy `foreground` to out delete options. Deployment deletion now deletes related RS and Pods.