### PR TITLE
Show node allocated resources in list view

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -768,6 +768,10 @@
   <translation id="5568169056290988879" key="MSG_NODE_LIST_CARDLIST_3" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
   <translation id="7563356541739732697" key="MSG_NODE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
   <translation id="2936243005887118324" key="MSG_NODE_LIST_CARDLIST_5" desc="Text for node card list zerostate.">There are no Nodes to display.</translation>
+  <translation id="122468837221390322" key="MSG_NODE_LIST_CARDLIST_6" desc="Label \'CPU requests (cores)\' which appears as a column label in the table of nodes (node list view).">CPU requests (cores)</translation>
+  <translation id="3265578351261846339" key="MSG_NODE_LIST_CARDLIST_7" desc="Label \'CPU limits (cores)\' which appears as a column label in the table of nodes (node list view).">CPU limits (cores)</translation>
+  <translation id="6356771158000155450" key="MSG_NODE_LIST_CARDLIST_8" desc="Label \'Memory requests (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory requests (bytes)</translation>
+  <translation id="3809309296866504854" key="MSG_NODE_LIST_CARDLIST_9" desc="Label \'Memory limits (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory limits (bytes)</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node.">Created at <ph name="CREATION_DATE"/></translation>
   <translation id="7165645741606687474" key="MSG_NODE_LIST_LIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
   <translation id="7938673888851238901" key="MSG_NODE_LIST_LIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
@@ -1017,6 +1021,7 @@
   <translation id="7254693136643899288" key="MSG_POD_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
   <translation id="9048608003178144260" key="MSG_POD_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
   <translation id="5738415577560264420" key="MSG_POD_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in this pod.</translation>
+  <translation id="3180983899887518304" key="MSG_POD_DETAIL_DETAIL_3" desc="Subtitle at the top of the container details.">Init Containers</translation>
   <translation id="855512770998820017" key="MSG_POD_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="1457675883548195036" key="MSG_POD_DETAIL_INFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
   <translation id="8753288911649190943" key="MSG_POD_DETAIL_INFO_2" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -1131,6 +1131,10 @@
   <translation id="5568169056290988879" key="MSG_NODE_LIST_CARDLIST_3" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
   <translation id="7563356541739732697" key="MSG_NODE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
   <translation id="2936243005887118324" key="MSG_NODE_LIST_CARDLIST_5" desc="Text for node card list zerostate.">There are no Nodes to display.</translation>
+  <translation id="122468837221390322" key="MSG_NODE_LIST_CARDLIST_6" desc="Label \'CPU requests (cores)\' which appears as a column label in the table of nodes (node list view).">CPU requests (cores)</translation>
+  <translation id="3265578351261846339" key="MSG_NODE_LIST_CARDLIST_7" desc="Label \'CPU limits (cores)\' which appears as a column label in the table of nodes (node list view).">CPU limits (cores)</translation>
+  <translation id="6356771158000155450" key="MSG_NODE_LIST_CARDLIST_8" desc="Label \'Memory requests (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory requests (bytes)</translation>
+  <translation id="3809309296866504854" key="MSG_NODE_LIST_CARDLIST_9" desc="Label \'Memory limits (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory limits (bytes)</translation>
   <translation id="7524676519411642380" key="MSG_NODE_LIST_CPU_GRAPH_CARD_TITLE" desc="Title for graph card displaying CPU metric of nodes.">CPU使用量の履歴</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node."><ph name="CREATION_DATE"/> に作成</translation>
   <translation id="8624223044783361486" key="MSG_NODE_LIST_LABELS_LABEL" desc="Label 'Labels' which appears as a column label in the table of nodes (node list view).">ラベル</translation>
@@ -1530,6 +1534,7 @@
   <translation id="7254693136643899288" key="MSG_POD_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
   <translation id="9048608003178144260" key="MSG_POD_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
   <translation id="5738415577560264420" key="MSG_POD_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in this pod.</translation>
+  <translation id="3180983899887518304" key="MSG_POD_DETAIL_DETAIL_3" desc="Subtitle at the top of the container details.">Init Containers</translation>
   <translation id="855512770998820017" key="MSG_POD_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="1457675883548195036" key="MSG_POD_DETAIL_INFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
   <translation id="8753288911649190943" key="MSG_POD_DETAIL_INFO_2" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -746,6 +746,10 @@
   <translation id="5568169056290988879" key="MSG_NODE_LIST_CARDLIST_3" desc="Label \'Ready\' which appears as a column label in the table of nodes (node list view).">Ready</translation>
   <translation id="7563356541739732697" key="MSG_NODE_LIST_CARDLIST_4" desc="Label \'Age\' which appears as a column label in the table of nodes (node list view).">Age</translation>
   <translation id="2936243005887118324" key="MSG_NODE_LIST_CARDLIST_5" desc="Text for node card list zerostate.">There are no Nodes to display.</translation>
+  <translation id="122468837221390322" key="MSG_NODE_LIST_CARDLIST_6" desc="Label \'CPU requests (cores)\' which appears as a column label in the table of nodes (node list view).">CPU requests (cores)</translation>
+  <translation id="3265578351261846339" key="MSG_NODE_LIST_CARDLIST_7" desc="Label \'CPU limits (cores)\' which appears as a column label in the table of nodes (node list view).">CPU limits (cores)</translation>
+  <translation id="6356771158000155450" key="MSG_NODE_LIST_CARDLIST_8" desc="Label \'Memory requests (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory requests (bytes)</translation>
+  <translation id="3809309296866504854" key="MSG_NODE_LIST_CARDLIST_9" desc="Label \'Memory limits (bytes)\' which appears as a column label in the table of nodes (node list view).">Memory limits (bytes)</translation>
   <translation id="3161651495562825748" key="MSG_NODE_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of node.">创建于<ph name="CREATION_DATE"/></translation>
   <translation id="7165645741606687474" key="MSG_NODE_LIST_LIST_0" desc="Title for graph card displaying CPU metric of nodes.">CPU usage</translation>
   <translation id="7938673888851238901" key="MSG_NODE_LIST_LIST_1" desc="Title for graph card displaying memory metric of nodes.">Memory usage</translation>
@@ -982,6 +986,7 @@
   <translation id="7254693136643899288" key="MSG_POD_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one pod.">CPU usage</translation>
   <translation id="9048608003178144260" key="MSG_POD_DETAIL_DETAIL_1" desc="Title for graph card displaying memory metric of one pod.">Memory usage</translation>
   <translation id="5738415577560264420" key="MSG_POD_DETAIL_DETAIL_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in this pod.</translation>
+  <translation id="3180983899887518304" key="MSG_POD_DETAIL_DETAIL_3" desc="Subtitle at the top of the container details.">Init Containers</translation>
   <translation id="855512770998820017" key="MSG_POD_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="1457675883548195036" key="MSG_POD_DETAIL_INFO_1" desc="Label \'Status\' for the pod status in details part (left) of the pod details view.">Status</translation>
   <translation id="8753288911649190943" key="MSG_POD_DETAIL_INFO_2" desc="Label for the pod logs in details part (left) of the pod details view.">View logs</translation>

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -846,7 +846,7 @@ func (apiHandler *APIHandler) handleGetServicePods(request *restful.Request, res
 func (apiHandler *APIHandler) handleGetNodeList(request *restful.Request, response *restful.Response) {
 	dataSelect := parseDataSelectPathParameter(request)
 	dataSelect.MetricQuery = dataselect.StandardMetrics
-	result, err := node.GetNodeList(getApiClient(request), dataSelect, &apiHandler.heapsterClient)
+	result, err := node.GetNodeList(getApiClient(request), dataSelect, apiHandler.heapsterClient)
 	if err != nil {
 		handleInternalError(response, err)
 		return

--- a/src/app/backend/resource/cluster/cluster.go
+++ b/src/app/backend/resource/cluster/cluster.go
@@ -50,12 +50,12 @@ func GetCluster(client *kubernetes.Clientset, dsQuery *dataselect.DataSelectQuer
 		StorageClassList:     common.GetStorageClassListChannel(client, 1),
 	}
 
-	return GetClusterFromChannels(channels, dsQuery, heapsterClient)
+	return GetClusterFromChannels(client, channels, dsQuery, heapsterClient)
 }
 
 // GetClusterFromChannels returns a list of all cluster in the cluster, from the
 // channel sources.
-func GetClusterFromChannels(channels *common.ResourceChannels,
+func GetClusterFromChannels(client *kubernetes.Clientset, channels *common.ResourceChannels,
 	dsQuery *dataselect.DataSelectQuery, heapsterClient *client.HeapsterClient) (*Cluster, error) {
 
 	nsChan := make(chan *namespace.NamespaceList)
@@ -73,7 +73,7 @@ func GetClusterFromChannels(channels *common.ResourceChannels,
 	}()
 
 	go func() {
-		items, err := node.GetNodeListFromChannels(channels,
+		items, err := node.GetNodeListFromChannels(client, channels,
 			dataselect.NewDataSelectQuery(dsQuery.PaginationQuery, dsQuery.SortQuery,
 				dsQuery.FilterQuery, dataselect.StandardMetrics), heapsterClient)
 		errChan <- err

--- a/src/app/backend/resource/cluster/cluster.go
+++ b/src/app/backend/resource/cluster/cluster.go
@@ -75,7 +75,7 @@ func GetClusterFromChannels(client *kubernetes.Clientset, channels *common.Resou
 	go func() {
 		items, err := node.GetNodeListFromChannels(client, channels,
 			dataselect.NewDataSelectQuery(dsQuery.PaginationQuery, dsQuery.SortQuery,
-				dsQuery.FilterQuery, dataselect.StandardMetrics), heapsterClient)
+				dsQuery.FilterQuery, dataselect.StandardMetrics), *heapsterClient)
 		errChan <- err
 		nodeChan <- items
 	}()

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -20,8 +20,8 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/logs"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // PodContainerList is a list of containers of a pod.

--- a/src/app/backend/resource/node/list.go
+++ b/src/app/backend/resource/node/list.go
@@ -30,9 +30,7 @@ import (
 
 // NodeList contains a list of nodes in the cluster.
 type NodeList struct {
-	ListMeta common.ListMeta `json:"listMeta"`
-
-	// Unordered list of Nodes.
+	ListMeta          common.ListMeta `json:"listMeta"`
 	Nodes             []Node          `json:"nodes"`
 	CumulativeMetrics []metric.Metric `json:"cumulativeMetrics"`
 }
@@ -40,15 +38,14 @@ type NodeList struct {
 // Node is a presentation layer view of Kubernetes nodes. This means it is node plus additional
 // augmented data we can get from other sources.
 type Node struct {
-	ObjectMeta common.ObjectMeta `json:"objectMeta"`
-	TypeMeta   common.TypeMeta   `json:"typeMeta"`
-
-	// Ready Status of the node
-	Ready api.ConditionStatus `json:"ready"`
+	ObjectMeta         common.ObjectMeta      `json:"objectMeta"`
+	TypeMeta           common.TypeMeta        `json:"typeMeta"`
+	Ready              api.ConditionStatus    `json:"ready"`
+	AllocatedResources NodeAllocatedResources `json:"allocatedResources"`
 }
 
 // GetNodeListFromChannels returns a list of all Nodes in the cluster.
-func GetNodeListFromChannels(channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery,
+func GetNodeListFromChannels(client client.Interface, channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery,
 	heapsterClient *heapster.HeapsterClient) (*NodeList, error) {
 	log.Print("Getting node list")
 
@@ -57,7 +54,7 @@ func GetNodeListFromChannels(channels *common.ResourceChannels, dsQuery *datasel
 		return nil, err
 	}
 
-	return toNodeList(nodes.Items, dsQuery, heapsterClient), nil
+	return toNodeList(client, nodes.Items, dsQuery, heapsterClient), nil
 }
 
 // GetNodeList returns a list of all Nodes in the cluster.
@@ -73,21 +70,28 @@ func GetNodeList(client client.Interface, dsQuery *dataselect.DataSelectQuery, h
 		return nil, err
 	}
 
-	return toNodeList(nodes.Items, dsQuery, heapsterClient), nil
+	return toNodeList(client, nodes.Items, dsQuery, heapsterClient), nil
 }
 
-func toNodeList(nodes []api.Node, dsQuery *dataselect.DataSelectQuery, heapsterClient *heapster.HeapsterClient) *NodeList {
+func toNodeList(client client.Interface, nodes []api.Node, dsQuery *dataselect.DataSelectQuery,
+	heapsterClient *heapster.HeapsterClient) *NodeList {
 	nodeList := &NodeList{
 		Nodes:    make([]Node, 0),
 		ListMeta: common.ListMeta{TotalItems: len(nodes)},
 	}
 
-	nodeCells, metricPromises, filteredTotal := dataselect.GenericDataSelectWithFilterAndMetrics(toCells(nodes), dsQuery, dataselect.NoResourceCache, heapsterClient)
+	nodeCells, metricPromises, filteredTotal := dataselect.GenericDataSelectWithFilterAndMetrics(toCells(nodes),
+		dsQuery, dataselect.NoResourceCache, heapsterClient)
 	nodes = fromCells(nodeCells)
 	nodeList.ListMeta = common.ListMeta{TotalItems: filteredTotal}
 
 	for _, node := range nodes {
-		nodeList.Nodes = append(nodeList.Nodes, toNode(node))
+		pods, err := getNodePods(client, node)
+		if err != nil {
+			log.Printf("Couldn't get pods of %s node\n", node.Name)
+		}
+
+		nodeList.Nodes = append(nodeList.Nodes, toNode(node, pods))
 	}
 
 	// this may be slow because heapster does not support all in one download for nodes.
@@ -100,11 +104,17 @@ func toNodeList(nodes []api.Node, dsQuery *dataselect.DataSelectQuery, heapsterC
 	return nodeList
 }
 
-func toNode(node api.Node) Node {
+func toNode(node api.Node, pods *api.PodList) Node {
+	allocatedResources, err := getNodeAllocatedResources(node, pods)
+	if err != nil {
+		log.Printf("Couldn't get allocated resources of %s node\n", node.Name)
+	}
+
 	return Node{
-		ObjectMeta: common.NewObjectMeta(node.ObjectMeta),
-		TypeMeta:   common.NewTypeMeta(common.ResourceKindNode),
-		Ready:      getNodeConditionStatus(node, api.NodeReady),
+		ObjectMeta:         common.NewObjectMeta(node.ObjectMeta),
+		TypeMeta:           common.NewTypeMeta(common.ResourceKindNode),
+		Ready:              getNodeConditionStatus(node, api.NodeReady),
+		AllocatedResources: allocatedResources,
 	}
 }
 

--- a/src/app/backend/resource/node/list.go
+++ b/src/app/backend/resource/node/list.go
@@ -46,7 +46,7 @@ type Node struct {
 
 // GetNodeListFromChannels returns a list of all Nodes in the cluster.
 func GetNodeListFromChannels(client client.Interface, channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery,
-	heapsterClient *heapster.HeapsterClient) (*NodeList, error) {
+	heapsterClient heapster.HeapsterClient) (*NodeList, error) {
 	log.Print("Getting node list")
 
 	nodes := <-channels.NodeList.List
@@ -58,7 +58,7 @@ func GetNodeListFromChannels(client client.Interface, channels *common.ResourceC
 }
 
 // GetNodeList returns a list of all Nodes in the cluster.
-func GetNodeList(client client.Interface, dsQuery *dataselect.DataSelectQuery, heapsterClient *heapster.HeapsterClient) (*NodeList, error) {
+func GetNodeList(client client.Interface, dsQuery *dataselect.DataSelectQuery, heapsterClient heapster.HeapsterClient) (*NodeList, error) {
 	log.Print("Getting list of all nodes in the cluster")
 
 	nodes, err := client.CoreV1().Nodes().List(metaV1.ListOptions{
@@ -74,14 +74,14 @@ func GetNodeList(client client.Interface, dsQuery *dataselect.DataSelectQuery, h
 }
 
 func toNodeList(client client.Interface, nodes []api.Node, dsQuery *dataselect.DataSelectQuery,
-	heapsterClient *heapster.HeapsterClient) *NodeList {
+	heapsterClient heapster.HeapsterClient) *NodeList {
 	nodeList := &NodeList{
 		Nodes:    make([]Node, 0),
 		ListMeta: common.ListMeta{TotalItems: len(nodes)},
 	}
 
 	nodeCells, metricPromises, filteredTotal := dataselect.GenericDataSelectWithFilterAndMetrics(toCells(nodes),
-		dsQuery, dataselect.NoResourceCache, heapsterClient)
+		dsQuery, dataselect.NoResourceCache, &heapsterClient)
 	nodes = fromCells(nodeCells)
 	nodeList.ListMeta = common.ListMeta{TotalItems: filteredTotal}
 

--- a/src/app/backend/resource/node/list.go
+++ b/src/app/backend/resource/node/list.go
@@ -89,6 +89,7 @@ func toNodeList(client client.Interface, nodes []api.Node, dsQuery *dataselect.D
 		pods, err := getNodePods(client, node)
 		if err != nil {
 			log.Printf("Couldn't get pods of %s node\n", node.Name)
+			log.Println(err)
 		}
 
 		nodeList.Nodes = append(nodeList.Nodes, toNode(node, pods))
@@ -108,6 +109,7 @@ func toNode(node api.Node, pods *api.PodList) Node {
 	allocatedResources, err := getNodeAllocatedResources(node, pods)
 	if err != nil {
 		log.Printf("Couldn't get allocated resources of %s node\n", node.Name)
+		log.Println(err)
 	}
 
 	return Node{

--- a/src/app/backend/resource/node/list_test.go
+++ b/src/app/backend/resource/node/list_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/metric"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	api "k8s.io/client-go/pkg/api/v1"
+)
+
+func TestGetNodeList(t *testing.T) {
+	cases := []struct {
+		node     *api.Node
+		expected *NodeList
+	}{
+		{
+			&api.Node{
+				ObjectMeta: metaV1.ObjectMeta{Name: "test-node"},
+				Spec: api.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+			&NodeList{
+				ListMeta: common.ListMeta{
+					TotalItems: 1,
+				},
+				CumulativeMetrics: make([]metric.Metric, 0),
+				Nodes: []Node{{
+					ObjectMeta: common.ObjectMeta{Name: "test-node"},
+					TypeMeta:   common.TypeMeta{Kind: common.ResourceKindNode},
+					Ready:      "Unknown",
+					AllocatedResources: NodeAllocatedResources{
+						CPURequests:            0,
+						CPURequestsFraction:    0,
+						CPULimits:              0,
+						CPULimitsFraction:      0,
+						CPUCapacity:            0,
+						MemoryRequests:         0,
+						MemoryRequestsFraction: 0,
+						MemoryLimits:           0,
+						MemoryLimitsFraction:   0,
+						MemoryCapacity:         0,
+						AllocatedPods:          0,
+						PodCapacity:            0,
+					},
+				},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		fakeClient := fake.NewSimpleClientset(c.node)
+		fakeHeapsterClient := FakeHeapsterClient{client: *fake.NewSimpleClientset()}
+		actual, _ := GetNodeList(fakeClient, dataselect.NoDataSelect, fakeHeapsterClient)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetNodeList() == \ngot: %#v, \nexpected %#v", actual, c.expected)
+		}
+	}
+}

--- a/src/app/backend/resource/pod/events.go
+++ b/src/app/backend/resource/pod/events.go
@@ -12,7 +12,7 @@ import (
 // GetEventsForPod gets events that are associated with this pod.
 func GetEventsForPod(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace,
 	podName string) (*common.EventList, error) {
-	
+
 	podEvents, err := event.GetPodEvents(client, namespace, podName)
 	if err != nil {
 		return nil, err

--- a/src/app/backend/resource/pod/events_test.go
+++ b/src/app/backend/resource/pod/events_test.go
@@ -31,9 +31,9 @@ func TestGetPodEvents(t *testing.T) {
 			}},
 			&api.PodList{Items: []api.Pod{
 				{ObjectMeta: metaV1.ObjectMeta{
-					Name: "pod-1",
+					Name:      "pod-1",
 					Namespace: "ns-1",
-					UID: "test-uid",
+					UID:       "test-uid",
 				}},
 			}},
 			&common.EventList{

--- a/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.scss
@@ -17,7 +17,6 @@
 .kd-resource-card-header-columns,
 kd-resource-card-header-columns {
   display: flex;
-  height: $baseline-grid * 3.5;
   width: 100%;
 }
 

--- a/src/app/frontend/node/list/card.html
+++ b/src/app/frontend/node/list/card.html
@@ -47,6 +47,18 @@ limitations under the License.
       {{::$ctrl.node.ready}}
     </kd-resource-card-column>
     <kd-resource-card-column>
+      {{::$ctrl.node.allocatedResources.cpuRequests | kdCores}} ({{$ctrl.node.allocatedResources.cpuRequestsFraction | number: 2}}%)
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.node.allocatedResources.cpuLimits | kdCores}} ({{$ctrl.node.allocatedResources.cpuLimitsFraction | number: 2}}%)
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.node.allocatedResources.memoryRequests | kdMemory}} ({{$ctrl.node.allocatedResources.memoryRequestsFraction | number: 2}}%)
+    </kd-resource-card-column>
+    <kd-resource-card-column>
+      {{::$ctrl.node.allocatedResources.memoryLimits | kdMemory}} ({{$ctrl.node.allocatedResources.memoryLimitsFraction | number: 2}}%)
+    </kd-resource-card-column>
+    <kd-resource-card-column>
       {{::$ctrl.node.objectMeta.creationTimestamp | relativeTime}}
       <md-tooltip>
         {{::$ctrl.getCreatedAtTooltip($ctrl.node.objectMeta.creationTimestamp)}}

--- a/src/app/frontend/node/list/card.html
+++ b/src/app/frontend/node/list/card.html
@@ -47,16 +47,28 @@ limitations under the License.
       {{::$ctrl.node.ready}}
     </kd-resource-card-column>
     <kd-resource-card-column>
-      {{::$ctrl.node.allocatedResources.cpuRequests | kdCores}} ({{$ctrl.node.allocatedResources.cpuRequestsFraction | number: 2}}%)
+      <div ng-if="::$ctrl.node.allocatedResources">
+        {{::$ctrl.node.allocatedResources.cpuRequests | kdCores}} ({{$ctrl.node.allocatedResources.cpuRequestsFraction | number: 2}}%)
+      </div>
+      <div ng-if="!::$ctrl.node.allocatedResources">-</div>
     </kd-resource-card-column>
     <kd-resource-card-column>
-      {{::$ctrl.node.allocatedResources.cpuLimits | kdCores}} ({{$ctrl.node.allocatedResources.cpuLimitsFraction | number: 2}}%)
+      <div ng-if="::$ctrl.node.allocatedResources">
+        {{::$ctrl.node.allocatedResources.cpuLimits | kdCores}} ({{$ctrl.node.allocatedResources.cpuLimitsFraction | number: 2}}%)
+      </div>
+      <div ng-if="!::$ctrl.node.allocatedResources">-</div>
     </kd-resource-card-column>
     <kd-resource-card-column>
-      {{::$ctrl.node.allocatedResources.memoryRequests | kdMemory}} ({{$ctrl.node.allocatedResources.memoryRequestsFraction | number: 2}}%)
+      <div ng-if="::$ctrl.node.allocatedResources">
+        {{::$ctrl.node.allocatedResources.memoryRequests | kdMemory}} ({{$ctrl.node.allocatedResources.memoryRequestsFraction | number: 2}}%)
+      </div>
+      <div ng-if="!::$ctrl.node.allocatedResources">-</div>
     </kd-resource-card-column>
     <kd-resource-card-column>
-      {{::$ctrl.node.allocatedResources.memoryLimits | kdMemory}} ({{$ctrl.node.allocatedResources.memoryLimitsFraction | number: 2}}%)
+      <div ng-if="::$ctrl.node.allocatedResources">
+        {{::$ctrl.node.allocatedResources.memoryLimits | kdMemory}} ({{$ctrl.node.allocatedResources.memoryLimitsFraction | number: 2}}%)
+      </div>
+      <div ng-if="!::$ctrl.node.allocatedResources">-</div>
     </kd-resource-card-column>
     <kd-resource-card-column>
       {{::$ctrl.node.objectMeta.creationTimestamp | relativeTime}}

--- a/src/app/frontend/node/list/cardlist.html
+++ b/src/app/frontend/node/list/cardlist.html
@@ -47,6 +47,22 @@ limitations under the License.
       [[Ready|Label 'Ready' which appears as a column label in the table of nodes (node list view).]]
     </kd-resource-card-header-column>
     <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[CPU requests (cores)|Label 'CPU requests (cores)' which appears as a column label in the table of nodes (node list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[CPU limits (cores)|Label 'CPU limits (cores)' which appears as a column label in the table of nodes (node list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Memory requests (bytes)|Label 'Memory requests (bytes)' which appears as a column label in the table of nodes (node list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
+                                    grow="1">
+      [[Memory limits (bytes)|Label 'Memory limits (bytes)' which appears as a column label in the table of nodes (node list view).]]
+    </kd-resource-card-header-column>
+    <kd-resource-card-header-column size="small"
                                     grow="1"
                                     sortable="true"
                                     sort-id="$root.SortableProperties.AGE">


### PR DESCRIPTION
To spare space in table I will use format similar to `kubectl`:

![zrzut ekranu 2017-05-19 o 12 35 03](https://cloud.githubusercontent.com/assets/2823399/26244383/b36a1928-3c8f-11e7-8087-a1dd05cd3cd1.png)

On details page it will look like before:

![zrzut ekranu 2017-05-19 o 12 36 12](https://cloud.githubusercontent.com/assets/2823399/26244406/c44c57f6-3c8f-11e7-85c0-58fc52bacd4f.png)

Checklist:

- [x] backend refactoring
- [x] showing data in frontend
- [x] tests

Closes #1259.