### PR TITLE
Load logs with memory limits

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -439,6 +439,7 @@
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="1223986507449568472" key="MSG_LOGS_LOGS_3" desc="Footer part for logs card.">to</translation>
+  <translation id="3402202863027894322" key="MSG_LOGS_TRUNCATED_WARNING" desc="Error dialog indicating that parts of the log file is missing due to memory constraints.">The middle part of the log file cannot be loaded, because it is too big.</translation>
   <translation id="7594890250973129963" key="MSG_LOGS_ZEROSTATE_TEXT" desc="Text for logs card zerostate in logs page.">The selected container has not logged any messages yet.</translation>
   <translation id="8066049814492652432" key="MSG_NAMESPACE_DETAIL_INFO_0" desc="Header in a detail view">Details</translation>
   <translation id="6352041840775187168" key="MSG_NAMESPACE_DETAIL_INFO_1" desc="Label \'Status\' for the namespace namespace on the namespace details page.">Status</translation>

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -1723,6 +1723,7 @@ func (apiHandler *APIHandler) handleLogs(request *restful.Request, response *res
 
 	offsetFrom, err1 := strconv.Atoi(request.QueryParameter("offsetFrom"))
 	offsetTo, err2 := strconv.Atoi(request.QueryParameter("offsetTo"))
+	logFilePosition := request.QueryParameter("logFilePosition")
 
 	var logSelector *logs.Selection
 	if err1 != nil || err2 != nil {
@@ -1733,8 +1734,9 @@ func (apiHandler *APIHandler) handleLogs(request *restful.Request, response *res
 				LogTimestamp: logs.LogTimestamp(refTimestamp),
 				LineNum:      refLineNum,
 			},
-			OffsetFrom: offsetFrom,
-			OffsetTo:   offsetTo,
+			OffsetFrom:      offsetFrom,
+			OffsetTo:        offsetTo,
+			LogFilePosition: logFilePosition,
 		}
 	}
 

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -24,6 +24,12 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+// maximum number of lines loaded from the apiserver
+var lineReadLimit = int64(5000)
+
+// maximum number of bytes loaded from the apiserver
+var byteReadLimit = int64(500000)
+
 // PodContainerList is a list of containers of a pod.
 type PodContainerList struct {
 	Containers []string `json:"containers"`
@@ -58,19 +64,35 @@ func GetPodLogs(client *client.Clientset, namespace, podID string, container str
 		container = pod.Spec.Containers[0].Name
 	}
 
-	logOptions := &v1.PodLogOptions{
-		Container:  container,
-		Follow:     false,
-		Previous:   false,
-		Timestamps: true,
-	}
-
+	logOptions := mapToLogOptions(container, logSelector)
 	rawLogs, err := getRawPodLogs(client, namespace, podID, logOptions)
 	if err != nil {
 		return nil, err
 	}
+	details := ConstructLogs(podID, rawLogs, container, logSelector)
+	return details, nil
+}
 
-	return ConstructLogs(podID, rawLogs, container, logSelector), nil
+func mapToLogOptions(container string, logSelector *logs.Selection) *v1.PodLogOptions {
+	if logSelector.LogFilePosition == logs.Beginning {
+		logOptions := &v1.PodLogOptions{
+			Container:  container,
+			Follow:     false,
+			Previous:   false,
+			Timestamps: true,
+			LimitBytes: &byteReadLimit,
+		}
+		return logOptions
+	} else {
+		logOptions := &v1.PodLogOptions{
+			Container:  container,
+			Follow:     false,
+			Previous:   false,
+			Timestamps: true,
+			TailLines:  &lineReadLimit,
+		}
+		return logOptions
+	}
 }
 
 // Construct a request for getting the logs for a pod and retrieves the logs.
@@ -100,12 +122,18 @@ func getRawPodLogs(client *client.Clientset, namespace, podID string, logOptions
 
 // Build logs structure for given parameters.
 func ConstructLogs(podID string, rawLogs string, container string, logSelector *logs.Selection) *logs.LogDetails {
-	logLines, fromDate, toDate, logSelection := logs.ToLogLines(rawLogs).SelectLogs(logSelector)
+	parsedLines := logs.ToLogLines(rawLogs)
+	logLines, fromDate, toDate, logSelection, lastPage := parsedLines.SelectLogs(logSelector)
+
+	readLimitReached := (int64(len(rawLogs))) == byteReadLimit || (int64(len(parsedLines)) == lineReadLimit)
+	truncated := readLimitReached && lastPage
+
 	info := logs.LogInfo{
 		PodName:       podID,
 		ContainerName: container,
 		FromDate:      fromDate,
 		ToDate:        toDate,
+		Truncated:     truncated,
 	}
 	return &logs.LogDetails{
 		Info:      info,

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -143,5 +143,4 @@ func ConstructLogs(podID string, rawLogs string, container string, logSelector *
 func isReadLimitReached(bytesLoaded int64, linesLoaded int64, logFilePosition string) bool {
 	return (logFilePosition == logs.Beginning && bytesLoaded >= byteReadLimit) ||
 		(logFilePosition == logs.End && linesLoaded >= lineReadLimit)
-	return false
 }

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -141,11 +141,7 @@ func ConstructLogs(podID string, rawLogs string, container string, logSelector *
 
 // Checks if the amount of log file returned from the apiserver is equal to the read limits
 func isReadLimitReached(bytesLoaded int64, linesLoaded int64, logFilePosition string) bool {
-	if logFilePosition == logs.Beginning && bytesLoaded >= byteReadLimit {
-		return true
-	}
-	if logFilePosition == logs.End && linesLoaded >= lineReadLimit {
-		return true
-	}
+	return (logFilePosition == logs.Beginning && bytesLoaded >= byteReadLimit) ||
+		(logFilePosition == logs.End && linesLoaded >= lineReadLimit)
 	return false
 }

--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -325,25 +325,6 @@ func TestGetLogs(t *testing.T) {
 	}
 }
 
-func TestTruncateOfLogs(t *testing.T) {
-	cases := []struct {
-		info        string
-		podId       string
-		rawLogs     string
-		container   string
-		logSelector *logs.Selection
-		expected    *logs.LogDetails
-	}{}
-	lineReadLimit = int64(10)
-	for _, c := range cases {
-		actual := ConstructLogs(c.podId, c.rawLogs, c.container, c.logSelector)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("Test Case: %s.\nReceived: %#v \nExpected: %#v\n\n", c.info, actual, c.expected)
-		}
-
-	}
-}
-
 func TestMapToLogOptions(t *testing.T) {
 	cases := []struct {
 		info        string

--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/logs"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 var log1 = logs.LogLine{
@@ -47,7 +48,8 @@ var log5 = logs.LogLine{
 }
 
 func TestGetLogs(t *testing.T) {
-
+	// for the test cases, the line read limit is reduced to 10
+	lineReadLimit = int64(10)
 	cases := []struct {
 		info        string
 		podId       string
@@ -273,11 +275,110 @@ func TestGetLogs(t *testing.T) {
 					OffsetTo:   1},
 			},
 		},
+		{
+			"set truncated flag if read limit is reached",
+			"pod-1",
+			"1 log1\n2 log2\n3 log3\n4 log4\n5 log5\n6 log6\n7 log7\n8 log8\n9 log9\n10 log10",
+			"test",
+			&logs.Selection{
+				ReferencePoint: logs.LogLineId{
+					LogTimestamp: logs.LogTimestamp("5"),
+					LineNum:      1,
+				},
+				OffsetFrom:      -10,
+				OffsetTo:        -8, // request indices ouside (beginning) of available log lines
+				LogFilePosition: "end",
+			},
+			&logs.LogDetails{
+				Info: logs.LogInfo{
+					PodName:       "pod-1",
+					ContainerName: "test",
+					FromDate:      "1",
+					ToDate:        "2",
+					Truncated:     true, // Read limit is set to 10. Log lines could not be loaded
+				},
+				LogLines: logs.LogLines{logs.LogLine{ // Last available page of logs is returned
+					Timestamp: "1",
+					Content:   "log1",
+				}, logs.LogLine{
+					Timestamp: "2",
+					Content:   "log2",
+				}},
+				Selection: logs.Selection{
+					ReferencePoint: logs.LogLineId{
+						LogTimestamp: "6",
+						LineNum:      -1,
+					},
+					OffsetFrom:      -5,
+					OffsetTo:        -3,
+					LogFilePosition: "end",
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		actual := ConstructLogs(c.podId, c.rawLogs, c.container, c.logSelector)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("Test Case: %s.\nReceived: %#v \nExpected: %#v\n\n", c.info, actual, c.expected)
 		}
+
+	}
+}
+
+func TestTruncateOfLogs(t *testing.T) {
+	cases := []struct {
+		info        string
+		podId       string
+		rawLogs     string
+		container   string
+		logSelector *logs.Selection
+		expected    *logs.LogDetails
+	}{}
+	lineReadLimit = int64(10)
+	for _, c := range cases {
+		actual := ConstructLogs(c.podId, c.rawLogs, c.container, c.logSelector)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Test Case: %s.\nReceived: %#v \nExpected: %#v\n\n", c.info, actual, c.expected)
+		}
+
+	}
+}
+
+func TestMapToLogOptions(t *testing.T) {
+	cases := []struct {
+		info        string
+		container   string
+		logSelector *logs.Selection
+		expected    *v1.PodLogOptions
+	}{
+		{"Byte limit must be set, when reading the log file from the beginning",
+			"test",
+			&logs.Selection{
+				LogFilePosition: "beginning",
+			},
+			&v1.PodLogOptions{
+				Container:  "test",
+				Timestamps: true,
+				LimitBytes: &byteReadLimit,
+			},
+		},
+		{"Line limit must be set, when reading the log file from the end",
+			"test",
+			&logs.Selection{
+				LogFilePosition: "end",
+			},
+			&v1.PodLogOptions{
+				Container:  "test",
+				Timestamps: true,
+				TailLines:  &lineReadLimit,
+			},
+		},
+	}
+	for _, c := range cases {
+		actual := mapToLogOptions(c.container, c.logSelector)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Test Case: %s.\nReceived: %#v \nExpected: %#v\n\n", c.info, actual, c.expected)
+		}
+
 	}
 }

--- a/src/app/backend/resource/logs/logs.go
+++ b/src/app/backend/resource/logs/logs.go
@@ -33,6 +33,8 @@ const (
 	OldestTimestamp = "oldest"
 )
 
+// Load logs from the beginning or the end of the of the log file.
+// This matters only if the log file is too large to be loaded completely.
 const (
 	Beginning = "beginning"
 	End       = "end"
@@ -92,6 +94,7 @@ type LogInfo struct {
 	// Date of the last log line
 	ToDate LogTimestamp `json:"toDate"`
 
+	// Some log lines in the middle of the log file could not be loaded, because the log file is too large.
 	Truncated bool `json:"truncated"`
 }
 

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -936,6 +936,7 @@ backendApi.LogDetails;
  *   containerName: string,
  *   fromDate: string,
  *   toDate: string,
+ *   truncated: boolean
  * }}
  */
 backendApi.LogInfo;
@@ -950,6 +951,7 @@ backendApi.LogLine;
 
 /**
  * @typedef {{
+ *   logFilePosition: string,
  *   referencePoint: !backendApi.LogLineReference,
  *   offsetFrom: number,
  *   offsetTo: number

--- a/src/app/frontend/logs/controller.js
+++ b/src/app/frontend/logs/controller.js
@@ -16,7 +16,11 @@ import {stateName as logs, StateParams} from './state';
 
 const logsPerView = 100;
 const maxLogSize = 2e9;
+// Load logs from the beginning of the log file. This matters only if the log file is too large to
+// be loaded completely.
 const beginningOfLogFile = 'beginning';
+// Load logs from the end of the log file. This matters only if the log file is too large to be
+// loaded completely.
 const endOfLogFile = 'end';
 const oldestTimestamp = 'oldest';
 const newestTimestamp = 'newest';

--- a/src/test/frontend/logs/controller_test.js
+++ b/src/test/frontend/logs/controller_test.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import errorModule from 'common/errorhandling/module';
 import {LogsController} from 'logs/controller';
 import LogsModule from 'logs/module';
 import {StateParams} from 'logs/state';
@@ -53,6 +54,7 @@ describe('Logs controller', () => {
     ],
     info: {podName: 'test-pod', containerName: 'container-name', fromDate: '1', toDate: '3'},
     selection: {
+      logFilePosition: 'beginning',
       referencePoint: {'timestamp': 'X', 'lineNum': 11},
       'offsetFrom': 22,
       'offsetTo': 25,
@@ -71,12 +73,14 @@ describe('Logs controller', () => {
 
   beforeEach(() => {
     angular.mock.module(LogsModule.name);
+    angular.mock.module(errorModule.name);
 
-    angular.mock.inject(($controller, $httpBackend) => {
+    angular.mock.inject(($controller, $httpBackend, errorDialog) => {
       ctrl = $controller(LogsController, {
         podLogs: angular.copy(podLogs),
         podContainers: podContainers,
         $stateParams: stateParams,
+        errorDialog: errorDialog,
       });
       httpBackend = $httpBackend;
     });
@@ -122,7 +126,7 @@ describe('Logs controller', () => {
     expect(ctrl.logsSet.length).toEqual(3);
     httpBackend
         .expectGET(
-            'api/v1/pod/namespace11/pod2/log/con22?offsetFrom=25&offsetTo=125&referenceLineNum=11&referenceTimestamp=X')
+            'api/v1/pod/namespace11/pod2/log/con22?logFilePosition=beginning&offsetFrom=25&offsetTo=125&referenceLineNum=11&referenceTimestamp=X')
         .respond(200, otherLogs);
     httpBackend.flush();
     expect(ctrl.logsSet.length).toEqual(2);
@@ -135,7 +139,7 @@ describe('Logs controller', () => {
     expect(ctrl.logsSet.length).toEqual(3);
     httpBackend
         .expectGET(
-            'api/v1/pod/namespace11/pod2/log/con22?offsetFrom=-78&offsetTo=22&referenceLineNum=11&referenceTimestamp=X')
+            'api/v1/pod/namespace11/pod2/log/con22?logFilePosition=beginning&offsetFrom=-78&offsetTo=22&referenceLineNum=11&referenceTimestamp=X')
         .respond(200, otherLogs);
     httpBackend.flush();
     expect(ctrl.logsSet.length).toEqual(2);
@@ -148,7 +152,7 @@ describe('Logs controller', () => {
     expect(ctrl.logsSet.length).toEqual(3);
     httpBackend
         .expectGET(
-            'api/v1/pod/namespace11/pod2/log/con22?offsetFrom=2000000000&offsetTo=2000000100&referenceLineNum=11&referenceTimestamp=X')
+            'api/v1/pod/namespace11/pod2/log/con22?logFilePosition=end&offsetFrom=2000000000&offsetTo=2000000100&referenceLineNum=0&referenceTimestamp=newest')
         .respond(200, otherLogs);
     httpBackend.flush();
     expect(ctrl.logsSet.length).toEqual(2);
@@ -162,10 +166,12 @@ describe('Logs controller', () => {
     expect(ctrl.logsSet.length).toEqual(3);
     httpBackend
         .expectGET(
-            'api/v1/pod/namespace11/pod2/log/con22?offsetFrom=-2000000100&offsetTo=-2000000000&referenceLineNum=11&referenceTimestamp=X')
+            'api/v1/pod/namespace11/pod2/log/con22?logFilePosition=beginning&offsetFrom=-2000000100&offsetTo=-2000000000&referenceLineNum=0&referenceTimestamp=oldest')
         .respond(200, otherLogs);
     httpBackend.flush();
     expect(ctrl.logsSet.length).toEqual(2);
     expect(ctrl.currentSelection).toEqual(otherLogs.selection);
   });
+
+
 });


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dashboard/issues/1834

Kubernetes stores logs in files and rotates them once a day if they become too large. Up to now Dashboard loads the full log file from server and returns a small portion to the browser.

I changed the behavior to return only a number of pages in the beginning and end. In other words the first 50 pages and the last 50 pages are loaded.

