### PR TITLE
Increase items per page in list views to 15

### DIFF
--- a/src/app/frontend/common/dataselect/builder.js
+++ b/src/app/frontend/common/dataselect/builder.js
@@ -23,7 +23,7 @@ export const SortableProperties = {
 };
 
 /** @const {number} **/
-export const ItemsPerPage = 10;
+export const ItemsPerPage = 15;
 
 /**
  * @final


### PR DESCRIPTION
It is only temporary improvement. When we will implement storage, we will add setting page where users will be able to pick number of items per page themselves.

Closes #1892.