### PR TITLE
Fix labels form not show when create an app use advanced options.

### DIFF
--- a/src/app/frontend/deploy/deploylabel.html
+++ b/src/app/frontend/deploy/deploylabel.html
@@ -48,7 +48,7 @@ limitations under the License.
                       flex="40">
     <input name="value"
            ng-model="labelCtrl.label.value"
-           placeholder="{{labelCtrl.label.value}}"
+           placeholder="{{labelCtrl.label.value()}}"
            ng-disabled="!labelCtrl.label.editable"
            kd-validate="labelValuePattern"
            ng-change="labelCtrl.check()"

--- a/src/app/frontend/deploy/deploylabel_component.js
+++ b/src/app/frontend/deploy/deploylabel_component.js
@@ -153,7 +153,7 @@ export default class DeployLabelController {
  *
  * @return {!angular.Component}
  */
-export const labelComponent = {
+export const deployLabelComponent = {
   controller: DeployLabelController,
   controllerAs: 'labelCtrl',
   templateUrl: 'deploy/deploylabel.html',

--- a/src/app/frontend/deploy/module.js
+++ b/src/app/frontend/deploy/module.js
@@ -18,7 +18,7 @@ import historyModule from 'common/history/module';
 import validatorsModule from 'common/validators/module';
 import errorHandlingModule from '../common/errorhandling/module';
 
-import deployLabelComponent from './deploylabel_component';
+import {deployLabelComponent} from './deploylabel_component';
 import {environmentVariablesComponent} from './environmentvariables_component';
 import fileReaderDirective from './filereader_directive';
 import helpSectionModule from './helpsection/helpsection_module';


### PR DESCRIPTION
The specified labels form is missing when create app use advanced options.

![10601497966914_ pic_hd](https://user-images.githubusercontent.com/10767027/27338289-58d49b0a-5607-11e7-9ac8-b5656f949700.jpg)

And the placeholder content is wrong.


![10701497967223_](https://user-images.githubusercontent.com/10767027/27338463-d9751a28-5607-11e7-8120-f2576c2c9999.jpg)
