### PR TITLE
Hide roles menu entry if RBACs api not enabled or supported

### DIFF
--- a/src/app/backend/client/manager_test.go
+++ b/src/app/backend/client/manager_test.go
@@ -15,9 +15,10 @@
 package client
 
 import (
-	"github.com/emicklei/go-restful"
 	"net/http"
 	"testing"
+
+	"github.com/emicklei/go-restful"
 )
 
 func TestNewClientManager(t *testing.T) {

--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package handler
 
 import (

--- a/src/app/backend/resource/cluster/cluster.go
+++ b/src/app/backend/resource/cluster/cluster.go
@@ -64,7 +64,7 @@ func GetClusterFromChannels(client *kubernetes.Clientset, channels *common.Resou
 	pvChan := make(chan *persistentvolume.PersistentVolumeList)
 	roleChan := make(chan *rbacroles.RbacRoleList)
 	storageChan := make(chan *storageclass.StorageClassList)
-	numErrs := 4
+	numErrs := 5
 	errChan := make(chan error, numErrs)
 
 	go func() {
@@ -102,7 +102,9 @@ func GetClusterFromChannels(client *kubernetes.Clientset, channels *common.Resou
 	for i := 0; i < numErrs; i++ {
 		err := <-errChan
 		if err != nil {
-			return nil, err
+			// Log errors instead of forwarding. This way even if 1 resource fails
+			// other will be displayed
+			log.Print(err)
 		}
 	}
 

--- a/src/app/backend/resource/common/resourcechannels.go
+++ b/src/app/backend/resource/common/resourcechannels.go
@@ -25,7 +25,7 @@ import (
 	autoscaling "k8s.io/client-go/pkg/apis/autoscaling/v1"
 	batch "k8s.io/client-go/pkg/apis/batch/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	rbac "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	storage "k8s.io/client-go/pkg/apis/storage/v1beta1"
 )
 
@@ -643,7 +643,7 @@ func GetRoleListChannel(client client.Interface, numReads int) RoleListChannel {
 	}
 
 	go func() {
-		list, err := client.RbacV1alpha1().Roles("").List(listEverything)
+		list, err := client.RbacV1beta1().Roles("").List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -668,7 +668,7 @@ func GetClusterRoleListChannel(client client.Interface, numReads int) ClusterRol
 	}
 
 	go func() {
-		list, err := client.RbacV1alpha1().ClusterRoles().List(listEverything)
+		list, err := client.RbacV1beta1().ClusterRoles().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -693,7 +693,7 @@ func GetRoleBindingListChannel(client client.Interface, numReads int) RoleBindin
 	}
 
 	go func() {
-		list, err := client.RbacV1alpha1().RoleBindings("").List(listEverything)
+		list, err := client.RbacV1beta1().RoleBindings("").List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err
@@ -719,7 +719,7 @@ func GetClusterRoleBindingListChannel(client client.Interface,
 	}
 
 	go func() {
-		list, err := client.RbacV1alpha1().ClusterRoleBindings().List(listEverything)
+		list, err := client.RbacV1beta1().ClusterRoleBindings().List(listEverything)
 		for i := 0; i < numReads; i++ {
 			channel.List <- list
 			channel.Error <- err

--- a/src/app/backend/resource/deployment/events.go
+++ b/src/app/backend/resource/deployment/events.go
@@ -18,18 +18,18 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/kubernetes/pkg/api"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/api"
 )
 
 // GetDeploymentEvents returns model events for a deployment with the given name in the given
 // namespace
 func GetDeploymentEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace string, deploymentName string) (
 	*common.EventList, error) {
-	
+
 	fieldSelector, err := fields.ParseSelector(api.EventInvolvedNameField + "=" + deploymentName)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func GetDeploymentEvents(client client.Interface, dsQuery *dataselect.DataSelect
 			},
 			1),
 	}
-	
+
 	eventRaw := <-channels.EventList.List
 	if err := <-channels.EventList.Error; err != nil {
 		return nil, err

--- a/src/app/backend/resource/namespace/list.go
+++ b/src/app/backend/resource/namespace/list.go
@@ -52,7 +52,7 @@ func GetNamespaceListFromChannels(channels *common.ResourceChannels, dsQuery *da
 
 	namespaces := <-channels.NamespaceList.List
 	if err := <-channels.NamespaceList.Error; err != nil {
-		return nil, err
+		return &NamespaceList{Namespaces: []Namespace{}}, err
 	}
 
 	return toNamespaceList(namespaces.Items, dsQuery), nil

--- a/src/app/backend/resource/node/list.go
+++ b/src/app/backend/resource/node/list.go
@@ -52,7 +52,7 @@ func GetNodeListFromChannels(client client.Interface, channels *common.ResourceC
 
 	nodes := <-channels.NodeList.List
 	if err := <-channels.NodeList.Error; err != nil {
-		return nil, err
+		return &NodeList{Nodes: []Node{}}, err
 	}
 
 	return toNodeList(client, nodes.Items, dsQuery, heapsterClient), nil

--- a/src/app/backend/resource/persistentvolume/list.go
+++ b/src/app/backend/resource/persistentvolume/list.go
@@ -62,7 +62,7 @@ func GetPersistentVolumeListFromChannels(channels *common.ResourceChannels, dsQu
 
 	persistentVolumes := <-channels.PersistentVolumeList.List
 	if err := <-channels.PersistentVolumeList.Error; err != nil {
-		return nil, err
+		return &PersistentVolumeList{Items: []PersistentVolume{}}, err
 	}
 
 	result := getPersistentVolumeList(persistentVolumes.Items, dsQuery)

--- a/src/app/backend/resource/rbacrolebindings/list.go
+++ b/src/app/backend/resource/rbacrolebindings/list.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	client "k8s.io/client-go/kubernetes"
-	rbac "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 )
 
 // RbacRoleBindingList contains a list of Roles and ClusterRoles in the cluster.

--- a/src/app/backend/resource/rbacrolebindings/list_test.go
+++ b/src/app/backend/resource/rbacrolebindings/list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	rbac "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 )
 
 func TestGetRbacRoleBindingList(t *testing.T) {

--- a/src/app/backend/resource/rbacroles/list.go
+++ b/src/app/backend/resource/rbacroles/list.go
@@ -21,7 +21,8 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	client "k8s.io/client-go/kubernetes"
-	rbac "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
+	"fmt"
 )
 
 // RbacRoleList contains a list of Roles and ClusterRoles in the cluster.
@@ -41,6 +42,7 @@ type RbacRole struct {
 
 // GetRbacRoleList returns a list of all RBAC Roles in the cluster.
 func GetRbacRoleList(client *client.Clientset, dsQuery *dataselect.DataSelectQuery) (*RbacRoleList, error) {
+	fmt.Println(client.RbacV1beta1().RESTClient().APIVersion())
 	log.Println("Getting list of RBAC roles")
 	channels := &common.ResourceChannels{
 		RoleList:        common.GetRoleListChannel(client, 1),
@@ -55,11 +57,11 @@ func GetRbacRoleList(client *client.Clientset, dsQuery *dataselect.DataSelectQue
 func GetRbacRoleListFromChannels(channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery) (*RbacRoleList, error) {
 	roles := <-channels.RoleList.List
 	if err := <-channels.RoleList.Error; err != nil {
-		return nil, err
+		return &RbacRoleList{Items: []RbacRole{}}, err
 	}
 	clusterRoles := <-channels.ClusterRoleList.List
 	if err := <-channels.ClusterRoleList.Error; err != nil {
-		return nil, err
+		return &RbacRoleList{Items: []RbacRole{}}, err
 	}
 
 	result := SimplifyRbacRoleLists(roles.Items, clusterRoles.Items, dsQuery)

--- a/src/app/backend/resource/rbacroles/list.go
+++ b/src/app/backend/resource/rbacroles/list.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	client "k8s.io/client-go/kubernetes"
 	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
-	"fmt"
 )
 
 // RbacRoleList contains a list of Roles and ClusterRoles in the cluster.
@@ -42,7 +41,6 @@ type RbacRole struct {
 
 // GetRbacRoleList returns a list of all RBAC Roles in the cluster.
 func GetRbacRoleList(client *client.Clientset, dsQuery *dataselect.DataSelectQuery) (*RbacRoleList, error) {
-	fmt.Println(client.RbacV1beta1().RESTClient().APIVersion())
 	log.Println("Getting list of RBAC roles")
 	channels := &common.ResourceChannels{
 		RoleList:        common.GetRoleListChannel(client, 1),

--- a/src/app/backend/resource/rbacroles/list_test.go
+++ b/src/app/backend/resource/rbacroles/list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	rbac "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 )
 
 func TestGetRbacRoleList(t *testing.T) {

--- a/src/app/backend/resource/storageclass/list.go
+++ b/src/app/backend/resource/storageclass/list.go
@@ -47,7 +47,7 @@ func GetStorageClassList(client kubernetes.Interface, dsQuery *dataselect.DataSe
 func GetStorageClassListFromChannels(channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery) (*StorageClassList, error) {
 	storageClasses := <-channels.StorageClassList.List
 	if err := <-channels.StorageClassList.Error; err != nil {
-		return nil, err
+		return &StorageClassList{StorageClasses: []StorageClass{}}, err
 	}
 
 	return CreateStorageClassList(storageClasses.Items, dsQuery), nil

--- a/src/app/backend/validation/validaterbacstatus.go
+++ b/src/app/backend/validation/validaterbacstatus.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	rbac "k8s.io/client-go/pkg/apis/rbac/v1beta1"
+)
+
+// RBACStatus describes status of RBAC in the cluster.
+type RbacStatus struct {
+	// True when RBACs are enabled in the cluster.
+	Enabled bool `json:"enabled"`
+}
+
+// ValidateRBACStatus validates if RBACs are enabled in the cluster.
+// Supported version of RBAC api is: 'rbac.authorization.k8s.io/v1beta1'
+func ValidateRbacStatus(client kubernetes.Interface) (*RbacStatus, error) {
+	groupList, err := client.Discovery().ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get available api versions from server: %v\n", err)
+	}
+
+	apiVersions := metav1.ExtractGroupVersions(groupList)
+	return &RbacStatus{
+		Enabled: found(apiVersions, rbac.SchemeGroupVersion.String()),
+	}, nil
+}
+
+// Returns true if element has been found in given array, false otherwise.
+func found(arr []string, str string) bool {
+	sort.Strings(arr)
+	idx := sort.SearchStrings(arr, str)
+	return idx < len(arr) && arr[idx] == str
+}

--- a/src/app/backend/validation/validaterbacstatus.go
+++ b/src/app/backend/validation/validaterbacstatus.go
@@ -34,7 +34,7 @@ type RbacStatus struct {
 func ValidateRbacStatus(client kubernetes.Interface) (*RbacStatus, error) {
 	groupList, err := client.Discovery().ServerGroups()
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't get available api versions from server: %v\n", err)
+		return nil, fmt.Errorf("Couldn't get available api versions from server: %v", err)
 	}
 
 	apiVersions := metav1.ExtractGroupVersions(groupList)
@@ -47,5 +47,5 @@ func ValidateRbacStatus(client kubernetes.Interface) (*RbacStatus, error) {
 func contains(arr []string, str string) bool {
 	sort.Strings(arr)
 	idx := sort.SearchStrings(arr, str)
-	return idx < len(arr) && arr[idx] == str
+	return len(arr) > 0 && idx < len(arr) && arr[idx] == str
 }

--- a/src/app/backend/validation/validaterbacstatus.go
+++ b/src/app/backend/validation/validaterbacstatus.go
@@ -39,12 +39,12 @@ func ValidateRbacStatus(client kubernetes.Interface) (*RbacStatus, error) {
 
 	apiVersions := metav1.ExtractGroupVersions(groupList)
 	return &RbacStatus{
-		Enabled: found(apiVersions, rbac.SchemeGroupVersion.String()),
+		Enabled: contains(apiVersions, rbac.SchemeGroupVersion.String()),
 	}, nil
 }
 
 // Returns true if element has been found in given array, false otherwise.
-func found(arr []string, str string) bool {
+func contains(arr []string, str string) bool {
 	sort.Strings(arr)
 	idx := sort.SearchStrings(arr, str)
 	return idx < len(arr) && arr[idx] == str

--- a/src/app/backend/validation/validaterbacstatus_test.go
+++ b/src/app/backend/validation/validaterbacstatus_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	test "k8s.io/client-go/testing"
+)
+
+func areErrorsEqual(err1, err2 error) bool {
+	return (err1 != nil && err2 != nil && err1.Error() == err2.Error()) ||
+		(err1 == nil && err2 == nil)
+}
+
+type fakeServerGroupsMethod func() (*metav1.APIGroupList, error)
+
+type FakeClient struct {
+	fake.Clientset
+	fakeServerGroupsMethod
+}
+
+func (self *FakeClient) Discovery() discovery.DiscoveryInterface {
+	return &FakeDiscovery{
+		FakeDiscovery:          fakediscovery.FakeDiscovery{Fake: &self.Fake},
+		fakeServerGroupsMethod: self.fakeServerGroupsMethod,
+	}
+}
+
+type FakeDiscovery struct {
+	fakediscovery.FakeDiscovery
+	fakeServerGroupsMethod
+}
+
+func (self *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return self.fakeServerGroupsMethod()
+}
+
+func TestValidateRbacStatus(t *testing.T) {
+	cases := []struct {
+		info        string
+		mockMethod  fakeServerGroupsMethod
+		expected    *RbacStatus
+		expectedErr error
+	}{
+		{
+			"should throw an error when can't get api versions from server",
+			func() (*metav1.APIGroupList, error) {
+				return nil, errors.New("test-error")
+			},
+			nil,
+			errors.New("Couldn't get available api versions from server: test-error"),
+		},
+		{
+			"should disable rbacs when supported api version not enabled on the server",
+			func() (*metav1.APIGroupList, error) {
+				return &metav1.APIGroupList{Groups: []metav1.APIGroup{
+					{Name: "rbac", Versions: []metav1.GroupVersionForDiscovery{
+						{
+							GroupVersion: "rbac.authorization.k8s.io/v1alpha1",
+							Version:      "v1alpha1",
+						},
+					}},
+				}}, nil
+			},
+			&RbacStatus{false},
+			nil,
+		},
+		{
+			"should enable rbacs when supported api version is enabled on the server",
+			func() (*metav1.APIGroupList, error) {
+				return &metav1.APIGroupList{Groups: []metav1.APIGroup{
+					{Name: "rbac", Versions: []metav1.GroupVersionForDiscovery{
+						{
+							GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+							Version:      "v1beta1",
+						},
+					}},
+				}}, nil
+			},
+			&RbacStatus{true},
+			nil,
+		},
+	}
+
+	for _, c := range cases {
+		fakePtr := &test.Fake{}
+		client := &FakeClient{
+			Clientset:              fake.Clientset{Fake: *fakePtr},
+			fakeServerGroupsMethod: c.mockMethod,
+		}
+
+		status, err := ValidateRbacStatus(client)
+		if !areErrorsEqual(err, c.expectedErr) {
+			t.Fatalf("Test case: %s. Expected error to be: %v, but got %v.", c.info,
+				c.expectedErr, err)
+		}
+
+		if !reflect.DeepEqual(status, c.expected) {
+			t.Fatalf("Test case: %s. Expected status to be: %v, but got %v.", c.info,
+				c.expected, status)
+		}
+	}
+
+}

--- a/src/app/externs/hterm.js
+++ b/src/app/externs/hterm.js
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * @fileoverview Externs for hterm
  *

--- a/src/app/externs/shell.js
+++ b/src/app/externs/shell.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/externs/sockjs.js
+++ b/src/app/externs/sockjs.js
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * @fileoverview Externs for sockjs
  *

--- a/src/app/frontend/chrome/nav/module.js
+++ b/src/app/frontend/chrome/nav/module.js
@@ -45,6 +45,7 @@ export default angular
         'kubernetesDashboard.chrome.nav',
         [
           'ngMaterial',
+          'ngResource',
           'ui.router',
           stateModule.name,
         ])

--- a/src/app/frontend/chrome/nav/module.js
+++ b/src/app/frontend/chrome/nav/module.js
@@ -33,6 +33,7 @@ import {hamburgerComponent} from './hamburger_component';
 import {navComponent} from './nav_component';
 import {NavService} from './nav_service';
 import {navItemComponent} from './navitem_component';
+import {roleNavComponent} from './rolenav_component';
 import {thirdPartyResourceNavComponent} from './thirdpartyresourcenav_component';
 
 
@@ -51,4 +52,5 @@ export default angular
     .component('kdNavHamburger', hamburgerComponent)
     .component('kdNavItem', navItemComponent)
     .component('kdNav', navComponent)
+    .component('kdRoleNav', roleNavComponent)
     .component('kdThirdPartyResourceNav', thirdPartyResourceNavComponent);

--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -27,8 +27,8 @@ limitations under the License.
                  state="{{::$ctrl.states.node}}">[[Nodes|Nodes menu entry.]]</kd-nav-item>
     <kd-nav-item class="kd-nav-item"
                  state="{{::$ctrl.states.persistentVolume}}">[[Persistent Volumes|Persistent Volumes menu entry.]]</kd-nav-item>
-    <kd-nav-item class="kd-nav-item"
-                 state="{{::$ctrl.states.role}}">[[Roles|Roles menu entry.]]</kd-nav-item>
+    <!-- Enabled dynamically if there rbacs are enabled in the cluster. -->
+    <kd-role-nav states="$ctrl.states"></kd-role-nav>
     <kd-nav-item class="kd-nav-item"
                  state="{{::$ctrl.states.storageClass}}">[[Storage Classes|Storage Classes menu entry.]]</kd-nav-item>
   </div>

--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -62,7 +62,7 @@ limitations under the License.
   </div>
   <div class="kd-nav-group">
     <kd-nav-item class="kd-nav-group-item"
-                 state="{{::$ctrl.states.config}}">[[Config and Storage|Config and Storage group menu entryv.]]</kd-nav-item>
+                 state="{{::$ctrl.states.config}}">[[Config and Storage|Config and Storage group menu entry.]]</kd-nav-item>
     <kd-nav-item class="kd-nav-item"
                  state="{{::$ctrl.states.configMap}}">[[Config Maps|Config Maps menu entry.]]</kd-nav-item>
     <kd-nav-item class="kd-nav-item"

--- a/src/app/frontend/chrome/nav/nav_component.js
+++ b/src/app/frontend/chrome/nav/nav_component.js
@@ -28,7 +28,6 @@ import {stateName as persistentVolumeClaimState} from 'persistentvolumeclaim/lis
 import {stateName as podState} from 'pod/list/state';
 import {stateName as replicaSetState} from 'replicaset/list/state';
 import {stateName as replicationControllerState} from 'replicationcontroller/list/state';
-import {stateName as roleState} from 'role/list/state';
 import {stateName as secretState} from 'secret/list/state';
 import {stateName as serviceState} from 'service/list/state';
 import {stateName as statefulSetState} from 'statefulset/list/state';
@@ -72,7 +71,6 @@ export class NavController {
       'discovery': discoveryState,
       'config': configState,
       'storageClass': storageClassState,
-      'role': roleState,
       'about': aboutState,
     };
   }

--- a/src/app/frontend/chrome/nav/rolenav.html
+++ b/src/app/frontend/chrome/nav/rolenav.html
@@ -1,0 +1,21 @@
+<!--
+Copyright 2017 The Kubernetes Dashboard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-nav-item class="kd-nav-item"
+             state="{{::$ctrl.states.role}}"
+             ng-if="$ctrl.isVisible">
+  [[Roles|Roles menu entry.]]
+</kd-nav-item>

--- a/src/app/frontend/chrome/nav/rolenav_component.js
+++ b/src/app/frontend/chrome/nav/rolenav_component.js
@@ -1,0 +1,64 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {stateName as roleState} from 'role/list/state';
+
+/**
+ * @final
+ */
+export class RoleNavController {
+  /**
+   * @param {!angular.$resource} $resource
+   * @ngInject
+   */
+  constructor($resource) {
+    /** @export */
+    this.isVisible = false;
+
+    /** @private {!angular.$resource} */
+    this.resource_ = $resource;
+
+    /**
+     * Initialized from binding.
+     *
+     * @export {!Object<string, string>}
+     */
+    this.states;
+  }
+
+  /**
+   * Check status of rbacs in the cluster to show/hide Role menu entry.
+   *
+   * @export
+   */
+  $onInit() {
+    this.resource_('api/v1/rbac/status').get().$promise.then((result) => {
+      if (result && result.enabled) {
+        Object.assign(this.states, {'role': roleState});
+        this.isVisible = true;
+      }
+    });
+  }
+}
+
+/**
+ * @type {!angular.Component}
+ */
+export const roleNavComponent = {
+  controller: RoleNavController,
+  templateUrl: 'chrome/nav/rolenav.html',
+  bindings: {
+    'states': '=',
+  },
+};

--- a/src/app/frontend/common/errorhandling/localizer_service.js
+++ b/src/app/frontend/common/errorhandling/localizer_service.js
@@ -23,10 +23,6 @@ export class LocalizerService {
    */
   localize(err) {
     let localizedErr = kdErrors[err.trim()];
-    if (localizedErr === undefined) {
-      return err;
-    }
-
-    return localizedErr;
+    return localizedErr === undefined ? err : localizedErr;
   }
 }

--- a/src/app/frontend/role/list/controller.js
+++ b/src/app/frontend/role/list/controller.js
@@ -18,7 +18,7 @@
 export class RoleListController {
   /**
    * @param {!backendApi.RoleList} roleList
-   * @param {!angular.Resource}kdRoleListResource
+   * @param {!angular.Resource} kdRoleListResource
    * @ngInject
    */
   constructor(roleList, kdRoleListResource) {

--- a/src/app/frontend/role/list/stateconfig.js
+++ b/src/app/frontend/role/list/stateconfig.js
@@ -55,7 +55,7 @@ export const config = {
  * @ngInject
  */
 export function roleListResource($resource) {
-  return $resource('api/v1/rbacrole');
+  return $resource('api/v1/rbac/role');
 }
 
 /**

--- a/src/app/frontend/shell/controller.js
+++ b/src/app/frontend/shell/controller.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/module.js
+++ b/src/app/frontend/shell/module.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/shell.html
+++ b/src/app/frontend/shell/shell.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2015 Google Inc. All Rights Reserved.
+Copyright 2017 The Kubernetes Dashboard Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/state.js
+++ b/src/app/frontend/shell/state.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/stateconfig.js
+++ b/src/app/frontend/shell/stateconfig.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/termopen_directive.js
+++ b/src/app/frontend/shell/termopen_directive.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/frontend/chrome/nav/rolenav_component_test.js
+++ b/src/test/frontend/chrome/nav/rolenav_component_test.js
@@ -1,0 +1,32 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import module from 'chrome/nav/module';
+
+describe('Role nav component', () => {
+  /** @type {!RoleNavController} */
+  let ctrl;
+
+  beforeEach(() => {
+    angular.mock.module(module.name);
+    angular.mock.inject(($componentController, $resource, $rootScope) => {
+      ctrl = $componentController('kdRoleNav', {$resource: $resource, $scope: $rootScope});
+      ctrl.$onInit();
+    });
+  });
+
+  it('should instantiate the controller properly', () => {
+    expect(ctrl).not.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #2010.

There is a check now if rbac api group is enabled and its' version is supported by dashboard.
As kubernetes 1.6 added `v1beta1` version then this is what we'll support. In case some older version is enabled or RBACs are disabled menu entry will be hidden.

Additionally I have fixed `Cluster` page to hide resources in case of error. Error log will be available in backend.

### TODO
- [x] Add tests