### PR TITLE
Fix dashboard not working with gulp serve

### DIFF
--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -115,9 +115,10 @@ func (self *clientManager) ClientCmdConfig(req *restful.Request) (clientcmd.Clie
 
 	cmdCfg := api.NewConfig()
 	cmdCfg.Clusters[DefaultCmdConfigName] = &api.Cluster{
-		Server:                cfg.Host,
-		CertificateAuthority:  cfg.TLSClientConfig.CAFile,
-		InsecureSkipTLSVerify: cfg.TLSClientConfig.Insecure,
+		Server:                   cfg.Host,
+		CertificateAuthority:     cfg.TLSClientConfig.CAFile,
+		CertificateAuthorityData: cfg.TLSClientConfig.CAData,
+		InsecureSkipTLSVerify:    cfg.TLSClientConfig.Insecure,
 	}
 	cmdCfg.AuthInfos[DefaultCmdConfigName] = &authInfo
 	cmdCfg.Contexts[DefaultCmdConfigName] = &api.Context{


### PR DESCRIPTION
There was a problem when kubeconfig is used to run dashboard with `gulp serve` and certificate authority data is used instead of certificate file.

Fixes #2056