### PR TITLE
Use history service in deploy from file

### DIFF
--- a/src/app/frontend/deploy/deployfromsettings_controller.js
+++ b/src/app/frontend/deploy/deployfromsettings_controller.js
@@ -246,7 +246,7 @@ export default class DeployFromSettingsController {
                 (savedConfig) => {
                   defer.resolve(savedConfig);  // Progress ends
                   this.log_.info('Successfully deployed application: ', savedConfig);
-                  this.state_.go(workloads);
+                  this.kdHistoryService_.back(workloads);
                 },
                 (err) => {
                   defer.reject(err);  // Progress ends


### PR DESCRIPTION
Just to be consistent changed simple `state.go` to use history service instead. After thinking about that issue described in #1894 it is actually a correct behavior. 

We could improve that a bit by respecting namespace selector when last page was not a detail page but I'm not sure if this is needed. Any ideas?

Closes #1894