### PR TITLE
Add service events

### DIFF
--- a/src/app/backend/resource/service/detail.go
+++ b/src/app/backend/resource/service/detail.go
@@ -53,6 +53,9 @@ type ServiceDetail struct {
 	// a valid IP address. None can be specified for headless services when proxying is not required
 	ClusterIP string `json:"clusterIP"`
 
+	// List of events related to this Service
+	EventList common.EventList `json:"eventList"`
+
 	// PodList represents list of pods targeted by same label selector as this service.
 	PodList pod.PodList `json:"podList"`
 }
@@ -74,8 +77,14 @@ func GetServiceDetail(client k8sClient.Interface, heapsterClient heapster.Heapst
 		return nil, err
 	}
 
+	eventList, err := GetServiceEvents(client, dataselect.DefaultDataSelect, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
 	service := ToServiceDetail(serviceData)
 	service.PodList = *podList
+	service.EventList = *eventList
 
 	return &service, nil
 }

--- a/src/app/backend/resource/service/detail_test.go
+++ b/src/app/backend/resource/service/detail_test.go
@@ -55,7 +55,7 @@ func TestGetServiceDetail(t *testing.T) {
 				Name: "svc-1", Namespace: "ns-1", Labels: map[string]string{},
 			}},
 			namespace: "ns-1", name: "svc-1",
-			expectedActions: []string{"get", "get"},
+			expectedActions: []string{"get", "get", "list"},
 			expected: &ServiceDetail{
 				ObjectMeta: api.ObjectMeta{
 					Name:      "svc-1",
@@ -67,6 +67,9 @@ func TestGetServiceDetail(t *testing.T) {
 				PodList: pod.PodList{
 					Pods:              []pod.Pod{},
 					CumulativeMetrics: make([]metric.Metric, 0),
+				},
+				EventList: common.EventList{
+					Events: []common.Event{},
 				},
 			},
 		},
@@ -81,7 +84,7 @@ func TestGetServiceDetail(t *testing.T) {
 				},
 			},
 			namespace: "ns-2", name: "svc-2",
-			expectedActions: []string{"get", "get", "list"},
+			expectedActions: []string{"get", "get", "list", "list"},
 			expected: &ServiceDetail{
 				ObjectMeta: api.ObjectMeta{
 					Name:      "svc-2",
@@ -93,6 +96,9 @@ func TestGetServiceDetail(t *testing.T) {
 				PodList: pod.PodList{
 					Pods:              []pod.Pod{},
 					CumulativeMetrics: make([]metric.Metric, 0),
+				},
+				EventList: common.EventList{
+					Events: []common.Event{},
 				},
 			},
 		},

--- a/src/app/backend/resource/service/event_test.go
+++ b/src/app/backend/resource/service/event_test.go
@@ -1,0 +1,71 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes/dashboard/src/app/backend/api"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func TestServiceEvents(t *testing.T) {
+	cases := []struct {
+		service         *v1.Service
+		namespace, name string
+		eventList       *v1.EventList
+		expectedActions []string
+		expected        *common.EventList
+	}{
+		{
+			service: &v1.Service{ObjectMeta: metaV1.ObjectMeta{
+				Name: "svc-1", Namespace: "ns-1", Labels: map[string]string{"app": "test"},
+			}},
+			namespace: "ns-1", name: "svc-1",
+			eventList: &v1.EventList{Items: []v1.Event{
+				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
+					Name: "ev-1", Namespace: "ns-1", Labels: map[string]string{"app": "test"},
+				}},
+			}},
+			expectedActions: []string{"list"},
+			expected: &common.EventList{
+				ListMeta: api.ListMeta{TotalItems: 1},
+				Events: []common.Event{{
+					TypeMeta: api.TypeMeta{Kind: api.ResourceKindEvent},
+					ObjectMeta: api.ObjectMeta{Name: "ev-1", Namespace: "ns-1",
+						Labels: map[string]string{"app": "test"}},
+					Message: "test-message",
+					Type:    v1.EventTypeNormal,
+				}}},
+		},
+	}
+
+	for _, c := range cases {
+
+		fakeClient := fake.NewSimpleClientset(c.eventList, c.service)
+
+		actual, _ := GetServiceEvents(fakeClient, dataselect.NoDataSelect, c.namespace, c.name)
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetServiceEvents(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
+				c.namespace, c.name, actual, c.expected)
+		}
+	}
+}

--- a/src/app/backend/resource/service/events.go
+++ b/src/app/backend/resource/service/events.go
@@ -1,0 +1,45 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"log"
+
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
+	client "k8s.io/client-go/kubernetes"
+)
+
+// GetServiceEvents returns model events for a service with the given name in the given
+// namespace
+func GetServiceEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace, serviceName string) (
+	*common.EventList, error) {
+
+	serviceEvents, err := event.GetEvents(client, namespace, serviceName)
+
+	if err != nil {
+		return nil, err
+	}
+	if !event.IsTypeFilled(serviceEvents) {
+		serviceEvents = event.FillEventsType(serviceEvents)
+	}
+
+	events := event.CreateEventList(serviceEvents, dsQuery)
+	log.Printf("Found %d events related to %s service in %s namespace",
+		len(events.Events), serviceName, namespace)
+
+	return &events, nil
+}

--- a/src/app/frontend/service/detail/controller.js
+++ b/src/app/frontend/service/detail/controller.js
@@ -19,13 +19,17 @@ export class ServiceDetailController {
   /**
    * @param {!backendApi.ServiceDetail} serviceDetail
    * @param {!angular.Resource} kdServicePodsResource
+   * @param {!angular.Resource} kdServiceEventsResource
    * @ngInject
    */
-  constructor(serviceDetail, kdServicePodsResource) {
+  constructor(serviceDetail, kdServicePodsResource, kdServiceEventsResource) {
     /** @export {!backendApi.ServiceDetail} */
     this.serviceDetail = serviceDetail;
 
     /** {!angular.Resource} */
     this.servicePodsResource = kdServicePodsResource;
+
+    /** @export {!angular.Resource} */
+    this.eventListResource = kdServiceEventsResource;
   }
 }

--- a/src/app/frontend/service/detail/detail.html
+++ b/src/app/frontend/service/detail/detail.html
@@ -27,3 +27,6 @@ limitations under the License.
     </kd-pod-card-list>
   </kd-content>
 </kd-content-card>
+
+<kd-event-card-list event-list="::ctrl.serviceDetail.eventList"
+                    event-list-resource="::ctrl.eventListResource"></kd-event-card-list>

--- a/src/app/frontend/service/detail/stateconfig.js
+++ b/src/app/frontend/service/detail/stateconfig.js
@@ -58,10 +58,18 @@ export const config = {
  * @return {!angular.Resource}
  * @ngInject
  */
+export function serviceEventsResource($resource) {
+  return $resource('api/v1/service/:namespace/:name/event');
+}
+
+/**
+ * @param {!angular.$resource} $resource
+ * @return {!angular.Resource}
+ * @ngInject
+ */
 export function servicePodsResource($resource) {
   return $resource('api/v1/service/:namespace/:name/pod');
 }
-
 
 /**
  * @param {!./../../common/resource/resourcedetail.StateParams} $stateParams

--- a/src/app/frontend/service/module.js
+++ b/src/app/frontend/service/module.js
@@ -19,7 +19,7 @@ import namespaceModule from 'common/namespace/module';
 import eventsModule from 'events/module';
 
 import {serviceInfoComponent} from './detail/info_component';
-import {servicePodsResource} from './detail/stateconfig';
+import {serviceEventsResource, servicePodsResource} from './detail/stateconfig';
 import {serviceCardComponent} from './list/card_component';
 import {serviceCardListComponent} from './list/cardlist_component';
 import {serviceListResource} from './list/stateconfig';
@@ -46,4 +46,5 @@ export default angular
     .component('kdServiceCardList', serviceCardListComponent)
     .component('kdServiceInfo', serviceInfoComponent)
     .factory('kdServiceListResource', serviceListResource)
-    .factory('kdServicePodsResource', servicePodsResource);
+    .factory('kdServicePodsResource', servicePodsResource)
+    .factory('kdServiceEventsResource', serviceEventsResource);


### PR DESCRIPTION
I think I should know what happened to the service resource.

setup 1 example  my-service.yaml 
kind: Service
apiVersion: v1
metadata:
  name: my-service
spec:
  selector:
    app: MyApp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
      nodePort: 30061
  clusterIP: 10.254.63.159
  loadBalancerIP: 10.254.63.158
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
      - ip: 10.254.63.190
setup 2   kubectl   create -f  my-service.yaml
setup 3   kubectl describe service my-service
Name: my-service
Namespace: default
Labels: <none>
Annotations: <none>
Selector: app=MyApp
Type: LoadBalancer
IP: 10.254.63.159
Port: <unset> 80/TCP
NodePort: <unset> 30061/TCP
Endpoints: <none>
Session Affinity: None
Events:
FirstSeen LastSeen Count From SubObjectPath Type Reason Message
--------- -------- ----- ---- ------------- -------- ------ -------
15s 9s 2 service-controller Normal CreatingLoadBalancer Creating load balancer
14s 7s 2 service-controller Warning CreatingLoadBalancerFailed Error creating load balancer (will retry): Failed to create load balancer for service default/my-service: Error creating loadbalancer a023c8df05c0111e7ae13fa163ecc72d: Error creating loadbalancer
{a023c8df05c0111e7ae13fa163ecc72d Kubernetes external service a023c8df05c0111e7ae13fa163ecc72d 11741c92-2a4a-42b4-8dd5-0b35566cf9b2 10.254.63.158 <nil> }

: Invalid request due to incorrect syntax or missing required parameters.
