### PR TITLE
[WIP] Update documentation for single/multi tenant configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,48 +13,43 @@ itself.
 ![Dashboard UI workloads page](docs/dashboard-ui.png)
 
 ## Deployment
-Provided instructions are compliant with kubernetes 1.6+. If you plan to deploy dashboard on older kubernetes version please
-follow [these instructions](#older-kubernetes-versions).
+Provided instructions are compliant with Kubernetes 1.6+. If you plan to deploy Dashboard on older Kubernetes version please
+follow [these instructions](docs/user-guide/deployment-old.md) or if you want to check out latest
+features that the team works on try our HEAD releases [installation guide](docs/devel/head-releases.md).
+
+For security reasons installation has been split into two parts:
+[Deployment](#deployment) and [Configuration](#configuration). Deployment part will deploy Dashboard on your
+cluster without any privileges. It will only work if RBACs are disabled on your cluster.
 
 It is likely that the Dashboard is already installed on your cluster. Check it with the following command:
 ```shell
 $ kubectl get pods --all-namespaces | grep dashboard
 ```
 
-If it is missing please follow installation instructions provided below. For security reasons installation has been split into two parts.
-First part will deploy dashboard on your cluster without any privileges. It will only work if RBACs are disabled on your cluster. Second part
-will grant dashboard necessary privileges based on chosen cluster configuration.
-
-Deploy dashboard by running:
+If it is missing deploy Dashboard by running:
 ```shell
 $ kubectl create -f https://git.io/kube-dashboard
 ```
 
-### Multi-tenant configuration
+## Configuration
+Now that Dashboard is deployed in your cluster you need to  grant it necessary privileges. Please choose one of the following
+configurations that suits you best.
+#### Multi-tenant configuration
 This configuration should be used if cluster will be used by multiple users with different privileges. It grants
 dashboard minimal access to apiserver required to start it. Read more about this configuration in [multi tenant setup](docs/user-guide/multi-tenant.md).
 ```shell
 TODO multi-tenant SA, Role deployment
 ```
 
-### Single-tenant configuration
+#### Single-tenant configuration
 This configuration should be used only if cluster will be used by trusted users and all of them are allowed to access all of its' resources.
 ```shell
 TODO single-tenant SA, Role deployment
 ```
 
-### Older kubernetes versions
-If you are using Kubernetes 1.5 or earlier, you can install the latest stable release by running the following command:
-```shell
-$ kubectl create -f https://git.io/kube-dashboard-no-rbac
-```
-**IMPORATNT:** Please keep in mind that this will only work if RBACs are disabled in your cluster.
-
-### Head releases
-You can also install unstable HEAD builds with the newest features that the team works on by
-following the [development guide](docs/devel/head-releases.md).
-
-### Graphs
+## Addons
+Dashboard can use cluster addons to enhance user experience, i.e. show metrics and graphs.
+#### Graphs
 For the metrics and graphs to be available you need to
 have [Heapster](https://github.com/kubernetes/heapster/) running on your cluster. We require heapster to be deployed in `kube-system` namespace
 together with service named `heapster`. 

--- a/README.md
+++ b/README.md
@@ -13,26 +13,51 @@ itself.
 ![Dashboard UI workloads page](docs/dashboard-ui.png)
 
 ## Deployment
-It is likely that the Dashboard is already installed on your cluster. Check with the following command:
+Provided instructions are compliant with kubernetes 1.6+. If you plan to deploy dashboard on older kubernetes version please
+follow [these instructions](#older-kubernetes-versions).
+
+It is likely that the Dashboard is already installed on your cluster. Check it with the following command:
 ```shell
 $ kubectl get pods --all-namespaces | grep dashboard
 ```
 
-If it is missing, you can install the latest stable release by running the following command:
+If it is missing please follow installation instructions provided below. For security reasons installation has been split into two parts.
+First part will deploy dashboard on your cluster without any privileges. It will only work if RBACs are disabled on your cluster. Second part
+will grant dashboard necessary privileges based on chosen cluster configuration.
+
+Deploy dashboard by running:
 ```shell
 $ kubectl create -f https://git.io/kube-dashboard
 ```
 
+### Multi-tenant configuration
+This configuration should be used if cluster will be used by multiple users with different privileges. It grants
+dashboard minimal access to apiserver required to start it. Read more about this configuration in [multi tenant setup](docs/user-guide/multi-tenant.md).
+```shell
+TODO multi-tenant SA, Role deployment
+```
+
+### Single-tenant configuration
+This configuration should be used only if cluster will be used by trusted users and all of them are allowed to access all of its' resources.
+```shell
+TODO single-tenant SA, Role deployment
+```
+
+### Older kubernetes versions
 If you are using Kubernetes 1.5 or earlier, you can install the latest stable release by running the following command:
 ```shell
 $ kubectl create -f https://git.io/kube-dashboard-no-rbac
 ```
+**IMPORATNT:** Please keep in mind that this will only work if RBACs are disabled in your cluster.
 
+### Head releases
 You can also install unstable HEAD builds with the newest features that the team works on by
 following the [development guide](docs/devel/head-releases.md).
 
-Note that for the metrics and graphs to be available you need to
-have [Heapster](https://github.com/kubernetes/heapster/) running in your cluster.
+### Graphs
+For the metrics and graphs to be available you need to
+have [Heapster](https://github.com/kubernetes/heapster/) running on your cluster. We require heapster to be deployed in `kube-system` namespace
+together with service named `heapster`. 
 
 ## Usage
 The easiest way to access Dashboard is to use kubectl. Run the following command in your desktop environment:

--- a/docs/user-guide/deployment-old.md
+++ b/docs/user-guide/deployment-old.md
@@ -1,0 +1,6 @@
+### Older kubernetes versions
+If you are using Kubernetes 1.5 or earlier, you can install the latest stable release by running the following command:
+```shell
+$ kubectl create -f https://git.io/kube-dashboard-no-rbac
+```
+**IMPORATNT:** Please keep in mind that this will only work if RBACs are disabled in your cluster.

--- a/docs/user-guide/multi-tenant.md
+++ b/docs/user-guide/multi-tenant.md
@@ -1,0 +1,1 @@
+TODO: describe dashboard authorization mechanism and provide generic description on configuration


### PR DESCRIPTION
Closes #2045. Related to discussion started in #574.

First we have to state what we will support. What I think we should do is:

1. Provide good documentation for latest supported kubernetes release (currently 1.6).
1. Provide option to deploy on older clusters but leave advanced configuration up to the users. Only basic yaml without RBAC configuration.
1. Split deployment into 2 parts: dashboard, rbac configuration
1. Document details about single/multi tenant approach that our proposed configuration supports.
1. For multi-tenant setup describe how to authorize users using authorization header and tokens but without specific examples as we don't have enough people to maintain them well.
1. Simplify head releases and support only latest kubernetes versions with full access to the cluster (by providing yaml file). Of course we will add information about that to warn potential users.
1. Remove other arch yaml files and just document what architectures we support with example that in order to deploy for different arch user can use this command `curl -sSL <dashboard_url> | sed "s/amd64/arm64/g" | kubectl create -f -`
1. State that `kubectl proxy` is not the right way to authorize users for multi-tenant configurations.

I have updated documentation a bit and if we agree on required changes I will update yamls and remaining docs.

Calling everyone involved in discussion. 

@bryk @cheld @rf232 @liggitt @maciaszczykm 
