### PR TITLE
Adapt events to kubectls' behavior and fix warning events

### DIFF
--- a/src/app/backend/resource/common/pod_test.go
+++ b/src/app/backend/resource/common/pod_test.go
@@ -23,64 +23,6 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 )
 
-func TestFilterPodsBySelector(t *testing.T) {
-	firstLabelSelectorMap := make(map[string]string)
-	firstLabelSelectorMap["name"] = "app-name-first"
-	secondLabelSelectorMap := make(map[string]string)
-	secondLabelSelectorMap["name"] = "app-name-second"
-
-	cases := []struct {
-		selector map[string]string
-		pods     []api.Pod
-		expected []api.Pod
-	}{
-		{
-			firstLabelSelectorMap,
-			[]api.Pod{
-				{
-					ObjectMeta: metaV1.ObjectMeta{
-						Name:   "first-pod-ok",
-						Labels: firstLabelSelectorMap,
-					},
-				},
-				{
-					ObjectMeta: metaV1.ObjectMeta{
-						Name:   "second-pod-ok",
-						Labels: firstLabelSelectorMap,
-					},
-				},
-				{
-					ObjectMeta: metaV1.ObjectMeta{
-						Name:   "third-pod-wrong",
-						Labels: secondLabelSelectorMap,
-					},
-				},
-			},
-			[]api.Pod{
-				{
-					ObjectMeta: metaV1.ObjectMeta{
-						Name:   "first-pod-ok",
-						Labels: firstLabelSelectorMap,
-					},
-				},
-				{
-					ObjectMeta: metaV1.ObjectMeta{
-						Name:   "second-pod-ok",
-						Labels: firstLabelSelectorMap,
-					},
-				},
-			},
-		},
-	}
-	for _, c := range cases {
-		actual := FilterPodsBySelector(c.pods, c.selector)
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("FilterPodsBySelector(%+v, %+v) == %+v, expected %+v",
-				c.pods, c.selector, actual, c.expected)
-		}
-	}
-}
-
 func TestGetContainerImages(t *testing.T) {
 	cases := []struct {
 		podTemplate *api.PodSpec

--- a/src/app/backend/resource/daemonset/events.go
+++ b/src/app/backend/resource/daemonset/events.go
@@ -15,66 +15,22 @@
 package daemonset
 
 import (
-	"log"
-
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	api "k8s.io/client-go/pkg/api/v1"
 )
 
 // GetDaemonSetEvents gets events associated to daemon set.
 func GetDaemonSetEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace,
 	daemonSetName string) (*common.EventList, error) {
 
-	log.Printf("Getting events related to %s daemon set in %s namespace", daemonSetName,
-		namespace)
-
 	// Get events for daemon set.
 	dsEvents, err := event.GetEvents(client, namespace, daemonSetName)
-
 	if err != nil {
 		return nil, err
 	}
 
-	// Get events for pods in daemon set.
-	podEvents, err := GetDaemonSetPodsEvents(client, namespace, daemonSetName)
-
-	if err != nil {
-		return nil, err
-	}
-
-	apiEvents := append(dsEvents, podEvents...)
-
-	if !event.IsTypeFilled(apiEvents) {
-		apiEvents = event.FillEventsType(apiEvents)
-	}
-
-	events := event.CreateEventList(apiEvents, dsQuery)
-
-	log.Printf("Found %d events related to %s daemon set in %s namespace",
-		len(events.Events), daemonSetName, namespace)
-
+	events := event.CreateEventList(dsEvents, dsQuery)
 	return &events, nil
-}
-
-// GetDaemonSetPodsEvents gets events associated to pods in daemon set.
-func GetDaemonSetPodsEvents(client client.Interface, namespace, daemonSetName string) (
-	[]api.Event, error) {
-
-	daemonSet, err := client.ExtensionsV1beta1().DaemonSets(namespace).Get(daemonSetName, metaV1.GetOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	podEvents, err := event.GetPodsEvents(client, namespace, daemonSet.Spec.Selector.MatchLabels)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return podEvents, nil
 }

--- a/src/app/backend/resource/daemonset/events_test.go
+++ b/src/app/backend/resource/daemonset/events_test.go
@@ -52,7 +52,7 @@ func TestGetDaemonSetEvents(t *testing.T) {
 				}},
 			}},
 			&ds,
-			[]string{"list", "get", "list", "list"},
+			[]string{"list"},
 			&common.EventList{
 				ListMeta: api.ListMeta{TotalItems: 1},
 				Events: []common.Event{{
@@ -84,66 +84,6 @@ func TestGetDaemonSetEvents(t *testing.T) {
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetDaemonSetEvents(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
-				c.namespace, c.name, actual, c.expected)
-		}
-	}
-}
-
-func TestGetDaemonSetPodsEvents(t *testing.T) {
-	ds := CreateDaemonSet("ds-1", "test-namespace", map[string]string{"app": "test"})
-	cases := []struct {
-		namespace, name string
-		eventList       *v1.EventList
-		podList         *v1.PodList
-		daemonSet       *extensions.DaemonSet
-		expectedActions []string
-		expected        []v1.Event
-	}{
-		{
-			"test-namespace", "ds-1",
-			&v1.EventList{Items: []v1.Event{
-				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
-					Name:      "ev-1",
-					Namespace: "test-namespace",
-				}},
-			}},
-			&v1.PodList{Items: []v1.Pod{
-				{ObjectMeta: metaV1.ObjectMeta{
-					Name: "pod-1", Namespace: "test-namespace",
-					Labels: map[string]string{"app": "test"},
-				}},
-			}},
-			&ds,
-			[]string{"get", "list", "list"},
-			[]v1.Event{
-				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
-					Name:      "ev-1",
-					Namespace: "test-namespace",
-				}},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		fakeClient := fake.NewSimpleClientset(c.daemonSet, c.podList, c.eventList)
-
-		actual, _ := GetDaemonSetPodsEvents(fakeClient, c.namespace, c.name)
-
-		actions := fakeClient.Actions()
-		if len(actions) != len(c.expectedActions) {
-			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
-				len(c.expectedActions), len(actions))
-			continue
-		}
-
-		for i, verb := range c.expectedActions {
-			if actions[i].GetVerb() != verb {
-				t.Errorf("Unexpected action: %+v, expected %s", actions[i], verb)
-			}
-		}
-
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("GetDaemonSetPodsEvents(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
 				c.namespace, c.name, actual, c.expected)
 		}
 	}

--- a/src/app/backend/resource/daemonset/pods.go
+++ b/src/app/backend/resource/daemonset/pods.go
@@ -20,6 +20,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sClient "k8s.io/client-go/kubernetes"
@@ -37,7 +38,12 @@ func GetDaemonSetPods(client k8sClient.Interface, metricClient metricapi.MetricC
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, metricClient)
+	events, err := event.GetPodsEvents(client, namespace, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/deployment/detail.go
+++ b/src/app/backend/resource/deployment/detail.go
@@ -21,6 +21,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/horizontalpodautoscaler"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/replicaset"
@@ -159,6 +160,12 @@ func GetDeploymentDetail(client client.Interface, metricClient metricapi.MetricC
 	var newReplicaSet replicaset.ReplicaSet
 	if newRs != nil {
 		newRsPodInfo := common.GetPodInfo(newRs.Status.Replicas, *newRs.Spec.Replicas, rawPods.Items)
+		events, err := event.GetPodsEvents(client, namespace, rawPods.Items)
+		if err != nil {
+			return nil, err
+		}
+
+		newRsPodInfo.Warnings = event.CreateEventList(events, dataselect.NoDataSelect).Events
 		newReplicaSet = replicaset.ToReplicaSet(newRs, &newRsPodInfo)
 	}
 

--- a/src/app/backend/resource/deployment/detail_test.go
+++ b/src/app/backend/resource/deployment/detail_test.go
@@ -106,7 +106,7 @@ func TestGetDeploymentDetail(t *testing.T) {
 	}{
 		{
 			"ns-1", "dp-1",
-			[]string{"get", "list", "list", "get", "list", "list", "list", "list", "get", "list", "list", "list"},
+			[]string{"get", "list", "list", "get", "list", "list", "list", "list", "list", "get", "list", "list", "list", "list"},
 			deployment,
 			&DeploymentDetail{
 				ObjectMeta: api.ObjectMeta{

--- a/src/app/backend/resource/deployment/events.go
+++ b/src/app/backend/resource/deployment/events.go
@@ -18,11 +18,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	client "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/api"
 )
 
 // GetDeploymentEvents returns model events for a deployment with the given name in the given
@@ -30,32 +26,11 @@ import (
 func GetDeploymentEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace string, deploymentName string) (
 	*common.EventList, error) {
 
-	fieldSelector, err := fields.ParseSelector(api.EventInvolvedNameField + "=" + deploymentName)
+	dpEvents, err := event.GetEvents(client, namespace, deploymentName)
 	if err != nil {
 		return nil, err
 	}
 
-	channels := &common.ResourceChannels{
-		EventList: common.GetEventListChannelWithOptions(
-			client,
-			common.NewSameNamespaceQuery(namespace),
-			metaV1.ListOptions{
-				LabelSelector: labels.Everything().String(),
-				FieldSelector: fieldSelector.String(),
-			},
-			1),
-	}
-
-	eventRaw := <-channels.EventList.List
-	if err := <-channels.EventList.Error; err != nil {
-		return nil, err
-	}
-	dpEvents := eventRaw.Items
-	if !event.IsTypeFilled(dpEvents) {
-		dpEvents = event.FillEventsType(dpEvents)
-	}
-
 	eventList := event.CreateEventList(dpEvents, dsQuery)
-
 	return &eventList, nil
 }

--- a/src/app/backend/resource/deployment/pods.go
+++ b/src/app/backend/resource/deployment/pods.go
@@ -18,10 +18,10 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	api "k8s.io/client-go/pkg/api/v1"
 )
 
 // GetDeploymentPods returns list of pods targeting deployment.
@@ -49,7 +49,11 @@ func GetDeploymentPods(client client.Interface, metricClient metricapi.MetricCli
 	}
 
 	pods := common.FilterDeploymentPodsByOwnerReference(*deployment, rawRs.Items, rawPods.Items)
+	events, err := event.GetPodsEvents(client, namespace, pods)
+	if err != nil {
+		return nil, err
+	}
 
-	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, metricClient)
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
 	return &podList, nil
 }

--- a/src/app/backend/resource/event/common_test.go
+++ b/src/app/backend/resource/event/common_test.go
@@ -45,7 +45,7 @@ func TestGetEvents(t *testing.T) {
 			[]v1.Event{
 				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
 					Name: "ev-1", Namespace: "ns-1", Labels: map[string]string{"app": "test"},
-				}},
+				}, Type: v1.EventTypeNormal},
 			},
 		},
 	}
@@ -71,71 +71,6 @@ func TestGetEvents(t *testing.T) {
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetEvents(client,%#v,%#v) == %#v, expected %#v", c.namespace, c.name,
-				actual, c.expected)
-		}
-	}
-}
-
-func TestGetPodsEvents(t *testing.T) {
-	cases := []struct {
-		namespace       string
-		selector        map[string]string
-		podList         *v1.PodList
-		eventList       *v1.EventList
-		expectedActions []string
-		expected        []v1.Event
-	}{
-		{
-			"test-namespace", map[string]string{"app": "test"},
-			&v1.PodList{Items: []v1.Pod{{
-				ObjectMeta: metaV1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test-namespace",
-					UID:       "test-uid",
-					Labels:    map[string]string{"app": "test"},
-				}}, {
-				ObjectMeta: metaV1.ObjectMeta{
-					Name:      "test-pod-2",
-					Namespace: "test-namespace",
-					UID:       "test-uid",
-					Labels:    map[string]string{"app": "test-app"},
-				}},
-			}},
-			&v1.EventList{Items: []v1.Event{{
-				Message:        "event-test-msg",
-				ObjectMeta:     metaV1.ObjectMeta{Name: "ev-1", Namespace: "test-namespace"},
-				InvolvedObject: v1.ObjectReference{UID: "test-uid"},
-			}}},
-			[]string{"list", "list"},
-			[]v1.Event{{
-				Message:        "event-test-msg",
-				ObjectMeta:     metaV1.ObjectMeta{Name: "ev-1", Namespace: "test-namespace"},
-				InvolvedObject: v1.ObjectReference{UID: "test-uid"},
-			}},
-		},
-	}
-
-	for _, c := range cases {
-		fakeClient := fake.NewSimpleClientset(c.podList, c.eventList)
-
-		actual, _ := GetPodsEvents(fakeClient, c.namespace, c.selector)
-
-		actions := fakeClient.Actions()
-		if len(actions) != len(c.expectedActions) {
-			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
-				len(c.expectedActions), len(actions))
-			continue
-		}
-
-		for i, verb := range c.expectedActions {
-			if actions[i].GetVerb() != verb {
-				t.Errorf("Unexpected action: %+v, expected %s",
-					actions[i], verb)
-			}
-		}
-
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("GetPodsEvents(client,%#v,%#v) == %#v, expected %#v", c.namespace, c.selector,
 				actual, c.expected)
 		}
 	}

--- a/src/app/backend/resource/event/event.go
+++ b/src/app/backend/resource/event/event.go
@@ -15,7 +15,6 @@
 package event
 
 import (
-	"log"
 	"strings"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
@@ -26,11 +25,11 @@ import (
 // FailedReasonPartials  is an array of partial strings to correctly filter warning events.
 // Have to be lower case for correct case insensitive comparison.
 // Based on k8s official events reason file:
-// https://github.com/kubernetes/kubernetes/blob/53f0f9d59860131c2be301a0054adfc86e43945d/pkg/kubelet/container/event.go
+// https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/kubelet/events/event.go
 // Partial strings that are not in event.go file are added in order to support
 // older versions of k8s which contained additional event reason messages.
 var FailedReasonPartials = []string{"failed", "err", "exceeded", "invalid", "unhealthy",
-	"mismatch", "insufficient", "conflict", "outof", "nil"}
+	"mismatch", "insufficient", "conflict", "outof", "nil", "backoff"}
 
 // GetPodsEventWarnings returns warning pod events by filtering out events targeting only given pods
 // TODO(floreks) : Import and use Set instead of custom function to get rid of duplicates
@@ -79,9 +78,6 @@ func filterEventsByPodsUID(events []api.Event, pods []api.Pod) []api.Event {
 
 	for _, event := range events {
 		if _, exists := podEventMap[event.InvolvedObject.UID]; exists {
-			if event.InvolvedObject.UID == "1651423a-b85d-11e6-b62d-42010af00082" {
-				log.Printf("crashloopbackoff: %v", event)
-			}
 			result = append(result, event)
 		}
 	}

--- a/src/app/backend/resource/job/detail_test.go
+++ b/src/app/backend/resource/job/detail_test.go
@@ -56,7 +56,7 @@ func TestGetJobDetail(t *testing.T) {
 	}{
 		{
 			"ns-1", "job-1",
-			[]string{"get", "get", "list", "list", "list"},
+			[]string{"get", "get", "list", "list", "list", "list"},
 			createJob("job-1", "ns-1", map[string]string{"app": "test"}),
 			&JobDetail{
 				ObjectMeta: api.ObjectMeta{Name: "job-1", Namespace: "ns-1",

--- a/src/app/backend/resource/job/detail_test.go
+++ b/src/app/backend/resource/job/detail_test.go
@@ -56,7 +56,7 @@ func TestGetJobDetail(t *testing.T) {
 	}{
 		{
 			"ns-1", "job-1",
-			[]string{"get", "get", "list", "list", "list", "get", "list", "list"},
+			[]string{"get", "get", "list", "list", "list"},
 			createJob("job-1", "ns-1", map[string]string{"app": "test"}),
 			&JobDetail{
 				ObjectMeta: api.ObjectMeta{Name: "job-1", Namespace: "ns-1",

--- a/src/app/backend/resource/job/events.go
+++ b/src/app/backend/resource/job/events.go
@@ -15,66 +15,22 @@
 package job
 
 import (
-	"log"
-
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	api "k8s.io/client-go/pkg/api/v1"
 )
 
 // GetJobEvents gets events associated to job.
 func GetJobEvents(client client.Interface, dsQuery *dataselect.DataSelectQuery, namespace, jobName string) (
 	*common.EventList, error) {
 
-	log.Printf("Getting events related to %s job in %s namespace", jobName,
-		namespace)
-
 	// Get events for job.
-	rsEvents, err := event.GetEvents(client, namespace, jobName)
-
+	jobEvents, err := event.GetEvents(client, namespace, jobName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get events for pods in job.
-	podEvents, err := GetJobPodsEvents(client, namespace, jobName)
-
-	if err != nil {
-		return nil, err
-	}
-
-	apiEvents := append(rsEvents, podEvents...)
-
-	if !event.IsTypeFilled(apiEvents) {
-		apiEvents = event.FillEventsType(apiEvents)
-	}
-
-	events := event.CreateEventList(apiEvents, dsQuery)
-
-	log.Printf("Found %d events related to %s job in %s namespace",
-		len(events.Events), jobName, namespace)
-
+	events := event.CreateEventList(jobEvents, dsQuery)
 	return &events, nil
-}
-
-// GetJobPodsEvents gets events associated to pods in job.
-func GetJobPodsEvents(client client.Interface, namespace, jobName string) (
-	[]api.Event, error) {
-
-	job, err := client.Batch().Jobs(namespace).Get(jobName, metaV1.GetOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	podEvents, err := event.GetPodsEvents(client, namespace, job.Spec.Selector.MatchLabels)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return podEvents, nil
 }

--- a/src/app/backend/resource/job/events_test.go
+++ b/src/app/backend/resource/job/events_test.go
@@ -47,7 +47,7 @@ func TestGetJobEvents(t *testing.T) {
 				Name: "pod-1", Namespace: "ns-1",
 			}}}},
 			createJob("job-1", "ns-1", map[string]string{"app": "test"}),
-			[]string{"list", "get", "list", "list"},
+			[]string{"list"},
 			&common.EventList{
 				ListMeta: api.ListMeta{TotalItems: 1},
 				Events: []common.Event{{
@@ -81,61 +81,6 @@ func TestGetJobEvents(t *testing.T) {
 
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("TestGetJobEvents(client,metricClient,%#v, %#v) == \ngot: %#v, \nexpected %#v",
-				c.namespace, c.name, actual, c.expected)
-		}
-	}
-}
-
-func TestGetJobPodsEvents(t *testing.T) {
-	cases := []struct {
-		namespace, name string
-		eventList       *v1.EventList
-		podList         *v1.PodList
-		job             *batch.Job
-		expectedActions []string
-		expected        []v1.Event
-	}{
-		{
-			"ns-1", "job-1",
-			&v1.EventList{Items: []v1.Event{
-				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
-					Name: "ev-1", Namespace: "ns-1", Labels: map[string]string{"app": "test"},
-				}},
-			}},
-			&v1.PodList{Items: []v1.Pod{{ObjectMeta: metaV1.ObjectMeta{
-				Name: "pod-1", Namespace: "ns-1", Labels: map[string]string{"app": "test"},
-			}}}},
-			createJob("job-1", "ns-1", map[string]string{"app": "test"}),
-			[]string{"get", "list", "list"},
-			[]v1.Event{{
-				Message: "test-message",
-				ObjectMeta: metaV1.ObjectMeta{Name: "ev-1", Namespace: "ns-1",
-					Labels: map[string]string{"app": "test"}},
-			}},
-		},
-	}
-
-	for _, c := range cases {
-		fakeClient := fake.NewSimpleClientset(c.job, c.podList, c.eventList)
-
-		actual, _ := GetJobPodsEvents(fakeClient, c.namespace, c.name)
-
-		actions := fakeClient.Actions()
-		if len(actions) != len(c.expectedActions) {
-			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
-				len(c.expectedActions), len(actions))
-			continue
-		}
-
-		for i, verb := range c.expectedActions {
-			if actions[i].GetVerb() != verb {
-				t.Errorf("Unexpected action: %+v, expected %s",
-					actions[i], verb)
-			}
-		}
-
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("TestGetJobPodsEvents(client,metricClient,%#v, %#v) == \ngot: %#v, \nexpected %#v",
 				c.namespace, c.name, actual, c.expected)
 		}
 	}

--- a/src/app/backend/resource/job/list.go
+++ b/src/app/backend/resource/job/list.go
@@ -119,7 +119,7 @@ func CreateJobList(jobs []batch.Job, pods []v1.Pod, events []v1.Event,
 
 	for _, job := range jobs {
 		var completions int32
-		matchingPods := common.FilterPodsByOwnerReference(job.Namespace, job.UID, pods)
+		matchingPods := common.FilterPodsForJob(job, pods)
 		if job.Spec.Completions != nil {
 			completions = *job.Spec.Completions
 		}

--- a/src/app/backend/resource/job/list_test.go
+++ b/src/app/backend/resource/job/list_test.go
@@ -166,7 +166,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  21,
-						Failed:   1,
+						Failed:   2,
 						Warnings: []common.Event{},
 					},
 				}, {
@@ -180,7 +180,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  0,
-						Failed:   1,
+						Failed:   2,
 						Warnings: []common.Event{},
 					},
 				}},

--- a/src/app/backend/resource/job/pods.go
+++ b/src/app/backend/resource/job/pods.go
@@ -20,12 +20,13 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sClient "k8s.io/client-go/kubernetes"
-	api "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 	batch "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
@@ -39,19 +40,23 @@ func GetJobPods(client k8sClient.Interface, metricClient metricapi.MetricClient,
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, []api.Event{}, dsQuery, metricClient)
-	return &podList, nil
-}
-
-// Returns array of api pods targeting job with given name.
-func getRawJobPods(client k8sClient.Interface, petSetName, namespace string) ([]api.Pod, error) {
-
-	replicaSet, err := client.Batch().Jobs(namespace).Get(petSetName, metaV1.GetOptions{})
+	events, err := event.GetPodsEvents(client, namespace, pods)
 	if err != nil {
 		return nil, err
 	}
 
-	labelSelector := labels.SelectorFromSet(replicaSet.Spec.Selector.MatchLabels)
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
+	return &podList, nil
+}
+
+// Returns array of api pods targeting job with given name.
+func getRawJobPods(client k8sClient.Interface, petSetName, namespace string) ([]v1.Pod, error) {
+	job, err := client.Batch().Jobs(namespace).Get(petSetName, metaV1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := labels.SelectorFromSet(job.Spec.Selector.MatchLabels)
 	channels := &common.ResourceChannels{
 		PodList: common.GetPodListChannelWithOptions(client, common.NewSameNamespaceQuery(namespace),
 			metaV1.ListOptions{

--- a/src/app/backend/resource/pod/events.go
+++ b/src/app/backend/resource/pod/events.go
@@ -32,10 +32,6 @@ func GetEventsForPod(client client.Interface, dsQuery *dataselect.DataSelectQuer
 		return nil, err
 	}
 
-	if !event.IsTypeFilled(podEvents) {
-		podEvents = event.FillEventsType(podEvents)
-	}
-
 	events := event.CreateEventList(podEvents, dsQuery)
 
 	log.Printf("Found %d events related to %s pod in %s namespace", len(events.Events), podName,

--- a/src/app/backend/resource/replicaset/detail_test.go
+++ b/src/app/backend/resource/replicaset/detail_test.go
@@ -40,7 +40,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 	}{
 		{
 			"ns-1", "rs-1",
-			[]string{"get", "list", "get", "list", "list", "get", "list", "list", "get", "list", "list"},
+			[]string{"get", "list", "get", "list", "list", "get", "list", "list"},
 			&extensions.ReplicaSet{
 				ObjectMeta: metaV1.ObjectMeta{Name: "rs-1", Namespace: "ns-1",
 					Labels: map[string]string{"app": "test"}},

--- a/src/app/backend/resource/replicaset/detail_test.go
+++ b/src/app/backend/resource/replicaset/detail_test.go
@@ -40,7 +40,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 	}{
 		{
 			"ns-1", "rs-1",
-			[]string{"get", "list", "get", "list", "list", "get", "list", "list"},
+			[]string{"get", "list", "get", "list", "list", "list", "get", "list", "list"},
 			&extensions.ReplicaSet{
 				ObjectMeta: metaV1.ObjectMeta{Name: "rs-1", Namespace: "ns-1",
 					Labels: map[string]string{"app": "test"}},

--- a/src/app/backend/resource/replicaset/events_test.go
+++ b/src/app/backend/resource/replicaset/events_test.go
@@ -53,7 +53,7 @@ func TestGetReplicaSetEvents(t *testing.T) {
 					Selector: &metaV1.LabelSelector{
 						MatchLabels: labelSelector,
 					}}},
-			[]string{"list", "get", "list", "list"},
+			[]string{"list"},
 			&common.EventList{
 				ListMeta: api.ListMeta{TotalItems: 1},
 				Events: []common.Event{{
@@ -70,63 +70,6 @@ func TestGetReplicaSetEvents(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset(c.eventList, c.replicaSet, c.podList)
 
 		actual, _ := GetReplicaSetEvents(fakeClient, dataselect.NoDataSelect, c.namespace, c.name)
-
-		actions := fakeClient.Actions()
-		if len(actions) != len(c.expectedActions) {
-			t.Errorf("Unexpected actions: %v, expected %d actions got %d", actions,
-				len(c.expectedActions), len(actions))
-			continue
-		}
-
-		for i, verb := range c.expectedActions {
-			if actions[i].GetVerb() != verb {
-				t.Errorf("Unexpected action: %+v, expected %s",
-					actions[i], verb)
-			}
-		}
-
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("GetEvents(client,metricClient,%#v, %#v) == \ngot: %#v, \nexpected %#v",
-				c.namespace, c.name, actual, c.expected)
-		}
-	}
-}
-
-func TestGetReplicaSetPodsEvents(t *testing.T) {
-	labelSelector := map[string]string{"app": "test"}
-
-	cases := []struct {
-		namespace, name string
-		eventList       *v1.EventList
-		podList         *v1.PodList
-		replicaSet      *extensions.ReplicaSet
-		expectedActions []string
-		expected        []v1.Event
-	}{
-		{
-			"ns-1", "rs-1",
-			&v1.EventList{Items: []v1.Event{
-				{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
-					Name: "ev-1", Namespace: "ns-1", Labels: labelSelector}},
-			}},
-			&v1.PodList{Items: []v1.Pod{{ObjectMeta: metaV1.ObjectMeta{
-				Name: "pod-1", Namespace: "ns-1", Labels: labelSelector}}}},
-			&extensions.ReplicaSet{
-				ObjectMeta: metaV1.ObjectMeta{Name: "rs-1", Namespace: "ns-1", Labels: labelSelector},
-				Spec: extensions.ReplicaSetSpec{
-					Selector: &metaV1.LabelSelector{
-						MatchLabels: labelSelector,
-					}}},
-			[]string{"get", "list", "list"},
-			[]v1.Event{{Message: "test-message", ObjectMeta: metaV1.ObjectMeta{
-				Name: "ev-1", Namespace: "ns-1", Labels: labelSelector}}},
-		},
-	}
-
-	for _, c := range cases {
-		fakeClient := fake.NewSimpleClientset(c.replicaSet, c.podList, c.eventList)
-
-		actual, _ := GetReplicaSetPodsEvents(fakeClient, c.namespace, c.name)
 
 		actions := fakeClient.Actions()
 		if len(actions) != len(c.expectedActions) {

--- a/src/app/backend/resource/replicaset/pods.go
+++ b/src/app/backend/resource/replicaset/pods.go
@@ -20,6 +20,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -39,7 +40,12 @@ func GetReplicaSetPods(client k8sClient.Interface, metricClient metricapi.Metric
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, []v1.Event{}, dsQuery, metricClient)
+	events, err := event.GetPodsEvents(client, namespace, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/replicationcontroller/pods.go
+++ b/src/app/backend/resource/replicationcontroller/pods.go
@@ -20,6 +20,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -40,7 +41,12 @@ func GetReplicationControllerPods(client k8sClient.Interface,
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, []v1.Event{}, dsQuery, metricClient)
+	events, err := event.GetPodsEvents(client, namespace, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
 	return &podList, nil
 }
 

--- a/src/app/backend/resource/service/detail.go
+++ b/src/app/backend/resource/service/detail.go
@@ -21,6 +21,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -121,6 +122,11 @@ func GetServicePods(client k8sClient.Interface, metricClient metricapi.MetricCli
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(apiPodList.Items, []v1.Event{}, dsQuery, metricClient)
+	events, err := event.GetPodsEvents(client, namespace, apiPodList.Items)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(apiPodList.Items, events, dsQuery, metricClient)
 	return &podList, nil
 }

--- a/src/app/backend/resource/service/detail_test.go
+++ b/src/app/backend/resource/service/detail_test.go
@@ -69,7 +69,7 @@ func TestGetServiceDetail(t *testing.T) {
 				},
 			},
 			namespace: "ns-2", name: "svc-2",
-			expectedActions: []string{"get", "get", "list", "list"},
+			expectedActions: []string{"get", "get", "list", "list", "list"},
 			expected: &ServiceDetail{
 				ObjectMeta: api.ObjectMeta{
 					Name:      "svc-2",

--- a/src/app/backend/resource/statefulset/events.go
+++ b/src/app/backend/resource/statefulset/events.go
@@ -15,66 +15,22 @@
 package statefulset
 
 import (
-	"log"
-
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
-// GetStatefulSetEvents gets events associated to pet set.
+// GetStatefulSetEvents gets events associated to stateful set.
 func GetStatefulSetEvents(client *client.Clientset, dsQuery *dataselect.DataSelectQuery, namespace, statefulSetName string) (
 	*common.EventList, error) {
 
-	log.Printf("Getting events related to %s pet set in %s namespace", statefulSetName,
-		namespace)
-
-	// Get events for pet set.
-	rsEvents, err := event.GetEvents(client, namespace, statefulSetName)
-
+	// Get events for stateful set.
+	statefulSetEvents, err := event.GetEvents(client, namespace, statefulSetName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get events for pods in pet set.
-	podEvents, err := GetStatefulSetPodsEvents(client, namespace, statefulSetName)
-
-	if err != nil {
-		return nil, err
-	}
-
-	apiEvents := append(rsEvents, podEvents...)
-
-	if !event.IsTypeFilled(apiEvents) {
-		apiEvents = event.FillEventsType(apiEvents)
-	}
-
-	events := event.CreateEventList(apiEvents, dsQuery)
-
-	log.Printf("Found %d events related to %s pet set in %s namespace",
-		len(events.Events), statefulSetName, namespace)
-
+	events := event.CreateEventList(statefulSetEvents, dsQuery)
 	return &events, nil
-}
-
-// GetStatefulSetPodsEvents gets events associated to pods in pet set.
-func GetStatefulSetPodsEvents(client *client.Clientset, namespace, statefulSetName string) (
-	[]v1.Event, error) {
-
-	statefulSet, err := client.AppsV1beta1().StatefulSets(namespace).Get(statefulSetName, metaV1.GetOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	podEvents, err := event.GetPodsEvents(client, namespace, statefulSet.Spec.Selector.MatchLabels)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return podEvents, nil
 }

--- a/src/app/backend/resource/statefulset/pods.go
+++ b/src/app/backend/resource/statefulset/pods.go
@@ -20,6 +20,7 @@ import (
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/event"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/pod"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sClient "k8s.io/client-go/kubernetes"
@@ -38,7 +39,12 @@ func GetStatefulSetPods(client *k8sClient.Clientset, metricClient metricapi.Metr
 		return nil, err
 	}
 
-	podList := pod.CreatePodList(pods, []v1.Event{}, dsQuery, metricClient)
+	events, err := event.GetPodsEvents(client, namespace, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	podList := pod.CreatePodList(pods, events, dsQuery, metricClient)
 	return &podList, nil
 }
 

--- a/src/app/frontend/daemonset/detail/controller.js
+++ b/src/app/frontend/daemonset/detail/controller.js
@@ -28,7 +28,6 @@ export class DaemonSetDetailController {
       kdDaemonSetEventsResource) {
     /** @export {!backendApi.DaemonSetDetail} */
     this.daemonSetDetail = daemonSetDetail;
-    console.log(daemonSetDetail);
 
     /** @export {!angular.Resource} */
     this.daemonSetPodsResource = kdDaemonSetPodsResource;

--- a/src/app/frontend/daemonset/detail/controller.js
+++ b/src/app/frontend/daemonset/detail/controller.js
@@ -28,6 +28,7 @@ export class DaemonSetDetailController {
       kdDaemonSetEventsResource) {
     /** @export {!backendApi.DaemonSetDetail} */
     this.daemonSetDetail = daemonSetDetail;
+    console.log(daemonSetDetail);
 
     /** @export {!angular.Resource} */
     this.daemonSetPodsResource = kdDaemonSetPodsResource;

--- a/src/app/frontend/daemonset/list/card.html
+++ b/src/app/frontend/daemonset/list/card.html
@@ -78,4 +78,9 @@ limitations under the License.
       </kd-resource-card-menu>
     </kd-resource-card-column>
   </kd-resource-card-columns>
+  <kd-resource-card-footer ng-if="::$ctrl.hasWarnings()">
+    <div ng-repeat="warning in ::$ctrl.daemonSet.pods.warnings">
+      <span class="kd-error">{{::warning.message}}</span>
+    </div>
+  </kd-resource-card-footer>
 </kd-resource-card>

--- a/src/app/frontend/daemonset/list/card_component.js
+++ b/src/app/frontend/daemonset/list/card_component.js
@@ -65,7 +65,7 @@ export class DaemonSetCardController {
    * @export
    */
   hasWarnings() {
-    return this.daemonSet.pods.failed > 0;
+    return this.daemonSet.pods.warnings.length > 0;
   }
 
   /**

--- a/src/app/frontend/job/list/card_component.js
+++ b/src/app/frontend/job/list/card_component.js
@@ -67,7 +67,6 @@ export default class JobCardController {
    * @export
    */
   hasWarnings() {
-    console.log(this.job);
     return this.job.pods.warnings.length > 0;
   }
 

--- a/src/app/frontend/job/list/card_component.js
+++ b/src/app/frontend/job/list/card_component.js
@@ -67,6 +67,7 @@ export default class JobCardController {
    * @export
    */
   hasWarnings() {
+    console.log(this.job);
     return this.job.pods.warnings.length > 0;
   }
 


### PR DESCRIPTION
Closes #2075

## Changes
 - Fix warning events display on list/detail pages (often there was just a pod with pending icon shown)
 - Adapt events behavior to kubectl. In short kubectl only displays events related to a resource and other events are shown for pods. 
 - Fix creator feature for Jobs. Currently we show `Created by` list and annotation with link on pod detail page even if pod is not targeting correct Job. They should be matched by label `uid-controller` set on both Pod and Job during creation.
 - Fix bug where pod info was not displayed correctly on Job list page due to wrong filtering of matching pods.
 - Refactor the way we get events and remove dead code.

### TODO
 - [x] Fix tests
 - [x] Add tests