### PR TITLE
Fix resouce limit display on namespace detail page

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -721,14 +721,14 @@
   <translation id="6842269165977804217" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage</translation>
   <translation id="8345903533746337382" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replication controllers.</translation>
   <translation id="8299490700020675585" key="MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of replica set.">Created at <ph name="CREATION_DATE"/></translation>
-  <translation id="8622510329837879978" key="MSG_RESOURCELIMIT_RESOURCELIMITS_0" desc="Title of resource limits card in the namespace details page.">Resource limits</translation>
-  <translation id="6879936491586186000" key="MSG_RESOURCELIMIT_RESOURCELIMITS_1" desc="Resource Limits name entry.">Type</translation>
-  <translation id="5268567494631464933" key="MSG_RESOURCELIMIT_RESOURCELIMITS_2" desc="Resource Limits resource entry.">Resource</translation>
-  <translation id="3101823090504084917" key="MSG_RESOURCELIMIT_RESOURCELIMITS_3" desc="]Resource Limits min entry.">Min</translation>
-  <translation id="3535089658933789537" key="MSG_RESOURCELIMIT_RESOURCELIMITS_4" desc="Resource Limits max entry.">Max</translation>
-  <translation id="6947338869559428640" key="MSG_RESOURCELIMIT_RESOURCELIMITS_5" desc="Resource Limits default request entry.">Default Request</translation>
-  <translation id="836896690388641861" key="MSG_RESOURCELIMIT_RESOURCELIMITS_6" desc="Resource Limits default limit entry.">Default Limit</translation>
-  <translation id="323516129286855678" key="MSG_RESOURCELIMIT_RESOURCELIMITS_7" desc="Resource Limits max limit/request ratio entry.">Max Limit/Request Ratio</translation>
+  <translation id="5695785595036964519" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_0" desc="Resource limit info details section title.">Resource Limits</translation>
+  <translation id="7188407971555381193" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_1" desc="Resource Limits name entry.">Type</translation>
+  <translation id="6234304804960810693" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_2" desc="Resource Limits resource entry.">Resource</translation>
+  <translation id="1527364212430197150" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_3" desc="]Resource Limits min entry.">Min</translation>
+  <translation id="4920141650632135528" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_4" desc="Resource Limits max entry.">Max</translation>
+  <translation id="6034104350428688973" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_5" desc="Resource Limits default request entry.">Default Request</translation>
+  <translation id="419672273675060335" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_6" desc="Resource Limits default limit entry.">Default Limit</translation>
+  <translation id="7475726307928755725" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_7" desc="Resource Limits max limit/request ratio entry.">Max Limit/Request Ratio</translation>
   <translation id="7531862076213500526" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_0" desc="Resource quota info details section title.">Resource Quotas</translation>
   <translation id="2839859779657386369" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_1" desc="Resource quota info details section name">Name</translation>
   <translation id="4649467264578406553" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_2" desc="Resource quota info details section scopes">Scopes</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -751,14 +751,14 @@
   <translation id="8299490700020675585" key="MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of replica set.">
     <ph name="CREATION_DATE"> に作成</ph>
   </translation>
-  <translation id="6205650542608928284" key="MSG_RESOURCELIMIT_RESOURCELIMITS_0" desc="Resource Limits name entry.">種別</translation>
-  <translation id="2131550401081026485" key="MSG_RESOURCELIMIT_RESOURCELIMITS_1" desc="Resource Limits resource entry.">リソース</translation>
-  <translation id="2541562557443174752" key="MSG_RESOURCELIMIT_RESOURCELIMITS_2" desc="]Resource Limits min entry.">最小</translation>
-  <translation id="612114430188796188" key="MSG_RESOURCELIMIT_RESOURCELIMITS_3" desc="Resource Limits max entry.">最大</translation>
-  <translation id="3535089658933789537" key="MSG_RESOURCELIMIT_RESOURCELIMITS_4" desc="Resource Limits max entry.">最大</translation>
-  <translation id="6070144888655765726" key="MSG_RESOURCELIMIT_RESOURCELIMITS_5" desc="Resource Limits default limit entry.">デフォルト制限</translation>
-  <translation id="836896690388641861" key="MSG_RESOURCELIMIT_RESOURCELIMITS_6" desc="Resource Limits default limit entry.">デフォルト制限</translation>
-  <translation id="323516129286855678" key="MSG_RESOURCELIMIT_RESOURCELIMITS_7" desc="Resource Limits max limit/request ratio entry.">最大上限/リクエスト</translation>
+  <translation id="5695785595036964519" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_0" desc="Resource limit info details section title.">Resource Limits</translation>
+  <translation id="7188407971555381193" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_1" desc="Resource Limits name entry.">Type</translation>
+  <translation id="6234304804960810693" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_2" desc="Resource Limits resource entry.">Resource</translation>
+  <translation id="1527364212430197150" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_3" desc="]Resource Limits min entry.">Min</translation>
+  <translation id="4920141650632135528" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_4" desc="Resource Limits max entry.">Max</translation>
+  <translation id="6034104350428688973" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_5" desc="Resource Limits default request entry.">Default Request</translation>
+  <translation id="419672273675060335" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_6" desc="Resource Limits default limit entry.">Default Limit</translation>
+  <translation id="7475726307928755725" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_7" desc="Resource Limits max limit/request ratio entry.">Max Limit/Request Ratio</translation>
   <translation id="7531862076213500526" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_0" desc="Resource quota info details section title.">Resource Quotas</translation>
   <translation id="2839859779657386369" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_1" desc="Resource quota info details section name">Name</translation>
   <translation id="4649467264578406553" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_2" desc="Resource quota info details section scopes">Scopes</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -721,14 +721,14 @@
   <translation id="6842269165977804217" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_1" desc="Title for graph card displaying memory metric of replication controllers.">Memory usage</translation>
   <translation id="8345903533746337382" key="MSG_REPLICATIONCONTROLLER_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these replication controllers.</translation>
   <translation id="8299490700020675585" key="MSG_REPLICA_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of replica set.">创建于<ph name="CREATION_DATE"/></translation>
-  <translation id="8622510329837879978" key="MSG_RESOURCELIMIT_RESOURCELIMITS_0" desc="Title of resource limits card in the namespace details page.">Resource limits</translation>
-  <translation id="6879936491586186000" key="MSG_RESOURCELIMIT_RESOURCELIMITS_1" desc="Resource Limits name entry.">类型(Type)</translation>
-  <translation id="5268567494631464933" key="MSG_RESOURCELIMIT_RESOURCELIMITS_2" desc="Resource Limits resource entry.">Resource</translation>
-  <translation id="3101823090504084917" key="MSG_RESOURCELIMIT_RESOURCELIMITS_3" desc="]Resource Limits min entry.">Min</translation>
-  <translation id="3535089658933789537" key="MSG_RESOURCELIMIT_RESOURCELIMITS_4" desc="Resource Limits max entry.">Max</translation>
-  <translation id="6947338869559428640" key="MSG_RESOURCELIMIT_RESOURCELIMITS_5" desc="Resource Limits default request entry.">Default Request</translation>
-  <translation id="836896690388641861" key="MSG_RESOURCELIMIT_RESOURCELIMITS_6" desc="Resource Limits default limit entry.">Default Limit</translation>
-  <translation id="323516129286855678" key="MSG_RESOURCELIMIT_RESOURCELIMITS_7" desc="Resource Limits max limit/request ratio entry.">Max Limit/Request Ratio</translation>
+  <translation id="5695785595036964519" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_0" desc="Resource limit info details section title.">Resource Limits</translation>
+  <translation id="7188407971555381193" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_1" desc="Resource Limits name entry.">Type</translation>
+  <translation id="6234304804960810693" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_2" desc="Resource Limits resource entry.">Resource</translation>
+  <translation id="1527364212430197150" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_3" desc="]Resource Limits min entry.">Min</translation>
+  <translation id="4920141650632135528" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_4" desc="Resource Limits max entry.">Max</translation>
+  <translation id="6034104350428688973" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_5" desc="Resource Limits default request entry.">Default Request</translation>
+  <translation id="419672273675060335" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_6" desc="Resource Limits default limit entry.">Default Limit</translation>
+  <translation id="7475726307928755725" key="MSG_RESOURCELIMIT_DETAIL_DETAIL_7" desc="Resource Limits max limit/request ratio entry.">Max Limit/Request Ratio</translation>
   <translation id="7531862076213500526" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_0" desc="Resource quota info details section title.">Resource Quotas</translation>
   <translation id="2839859779657386369" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_1" desc="Resource quota info details section name">Name</translation>
   <translation id="4649467264578406553" key="MSG_RESOURCEQUOTA_DETAIL_DETAIL_2" desc="Resource quota info details section scopes">Scopes</translation>

--- a/src/app/frontend/index_module.js
+++ b/src/app/frontend/index_module.js
@@ -40,6 +40,7 @@ import persistentVolumeClaimModule from './persistentvolumeclaim/module';
 import podModule from './pod/module';
 import replicaSetModule from './replicaset/module';
 import replicationControllerModule from './replicationcontroller/module';
+import resourceLimitModule from './resourcelimit/module';
 import resourceQuotaModule from './resourcequota/module';
 import roleModule from './role/module';
 import searchModule from './search/module';
@@ -86,6 +87,7 @@ export default angular
           statefulSetModule.name,
           persistentVolumeClaimModule.name,
           resourceQuotaModule.name,
+          resourceLimitModule.name,
           configMapModule.name,
           secretModule.name,
           ingressModule.name,

--- a/src/app/frontend/namespace/detail/detail.html
+++ b/src/app/frontend/namespace/detail/detail.html
@@ -26,6 +26,7 @@ limitations under the License.
     <kd-resource-limits resource-limits="ctrl.namespaceDetail.resourceLimits"></kd-resource-limits>
   </kd-content>
 </kd-content-card>
+
 <kd-event-card-list event-list="::ctrl.namespaceDetail.eventList"
                     event-list-resource="::ctrl.eventListResource">
 </kd-event-card-list>

--- a/src/app/frontend/resourcelimit/detail/detail.html
+++ b/src/app/frontend/resourcelimit/detail/detail.html
@@ -16,9 +16,13 @@ limitations under the License.
 
 <kd-resource-card-list selectable="false"
                        with-statuses="false">
+
   <kd-resource-card-list-header>
-    [[Resource limits|Title of resource limits card in the namespace details page.]]
+    <kd-resource-card-list-title ng-transclude="header">
+      [[Resource Limits|Resource limit info details section title.]]
+    </kd-resource-card-list-title>
   </kd-resource-card-list-header>
+
   <kd-resource-card-header-columns>
     <kd-resource-card-header-column size="small"
                                     grow="2">

--- a/src/app/frontend/resourcelimit/detail/detail_component.js
+++ b/src/app/frontend/resourcelimit/detail/detail_component.js
@@ -17,7 +17,7 @@
  */
 export default class ResourceLimitsController {
   /**
-   * Constructs pettion controller info object.
+   * Constructs resource limits controller info object.
    */
   constructor() {
     /**
@@ -34,8 +34,12 @@ export default class ResourceLimitsController {
  * @return {!angular.Component}
  */
 export const resourceLimitsComponent = {
+  transclude: {
+    // Optional header that is transcluded instead of the default one.
+    'header': '?kdHeader',
+  },
   controller: ResourceLimitsController,
-  templateUrl: 'resourcelimit/resourcelimits.html',
+  templateUrl: 'resourcelimit/detail/detail.html',
   bindings: {
     /** {Array<!backendApi.LimitRange>} */
     'resourceLimits': '=',

--- a/src/app/frontend/resourcelimit/module.js
+++ b/src/app/frontend/resourcelimit/module.js
@@ -16,7 +16,7 @@ import chromeModule from 'chrome/module';
 import componentsModule from 'common/components/module';
 import filtersModule from 'common/filters/module';
 import eventsModule from 'events/module';
-import {resourceLimitsComponent} from './resourcelimits_component';
+import {resourceLimitsComponent} from './detail/detail_component';
 
 /**
  * Angular module for the Limit Range details view.
@@ -25,7 +25,7 @@ import {resourceLimitsComponent} from './resourcelimits_component';
  */
 export default angular
     .module(
-        'kubernetesDashboard.limitRangeDetail',
+        'kubernetesDashboard.resourceLimit',
         [
           'ngMaterial',
           'ngResource',


### PR DESCRIPTION
Before there was nothing displayed.

![zrzut ekranu z 2017-07-06 11-12-19](https://user-images.githubusercontent.com/2285385/27904156-ff10dcf0-623b-11e7-9b1b-0574fe113a7a.png)
