### PR TITLE
Hide double border when there is no footer

### DIFF
--- a/src/app/frontend/common/components/contentcard/contentcard.scss
+++ b/src/app/frontend/common/components/contentcard/contentcard.scss
@@ -16,8 +16,9 @@
 
 .kd-content-card-content {
   background-color: $content-background;
-  border: 1px solid $border;
+  border: solid $border;
   border-radius: 2px;
+  border-width: 1px 1px 0;
   box-shadow: $whiteframe-shadow-1dp;
 }
 

--- a/src/app/frontend/common/components/contentcard/contentcard.scss
+++ b/src/app/frontend/common/components/contentcard/contentcard.scss
@@ -16,9 +16,8 @@
 
 .kd-content-card-content {
   background-color: $content-background;
-  border: solid $border;
+  border: 1px solid $border;
   border-radius: 2px;
-  border-width: 1px 1px 0;
   box-shadow: $whiteframe-shadow-1dp;
 }
 

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <div class="kd-resource-card-list-footer"
-     ng-style="$ctrl.getBottomBorderStyle()">
+     ng-class="{'kd-resource-card-list-footer-border': $ctrl.isBottomBorderVisible()}">
   <div ng-transclude
        class="kd-resource-card-list-footer-content"></div>
   <div ng-transclude="pagination"

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-resource-card-list-footer">
+<div class="kd-resource-card-list-footer"
+     ng-style="$ctrl.getBottomBorderStyle()">
   <div ng-transclude
        class="kd-resource-card-list-footer-content"></div>
   <div ng-transclude="pagination"

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
@@ -16,7 +16,6 @@
 
 .kd-resource-card-list-footer {
   align-items: center;
-  border-top: 1px solid $border;
   display: flex;
 }
 

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.scss
@@ -19,6 +19,10 @@
   display: flex;
 }
 
+.kd-resource-card-list-footer-border {
+  border-top: 1px solid $border;
+}
+
 .kd-resource-card-list-footer-content {
   flex: 1;
   padding-left: 2 * $baseline-grid;

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
@@ -14,11 +14,38 @@
 
 const PAGINATION_SLOT = 'pagination';
 
+class ResourceCardListFooterController {
+  /**
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($element) {
+    /** @private {!angular.JQLite} */
+    this.element_ = $element;
+  }
+
+  /**
+   * To avoid issue with duplicated bottom border on resource cards described in #1893 following
+   * function was added. Thanks to it footer border will not be displayed until there are pagination
+   * controls (this means, that footer is actually displayed).
+   *
+   * @export
+   * @return {{border-top: string}|undefined}
+   */
+  getBottomBorderStyle() {
+    if (this.element_[0].innerHTML.indexOf('dir-pagination-controls') > 0) {
+      return {'border-top': '1px solid rgba(0, 0, 0, .12)'};
+    }
+    return undefined;
+  }
+}
+
 /**
  * Resource card list footer component. See resource card for documentation.
  * @type {!angular.Component}
  */
 export const resourceCardListFooterComponent = {
+  controller: ResourceCardListFooterController,
   templateUrl: 'common/components/resourcecard/resourcecardlistfooter.html',
   transclude: {
     [PAGINATION_SLOT]: '?kdResourceCardListPagination',

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter_component.js
@@ -30,13 +30,10 @@ class ResourceCardListFooterController {
    * controls (this means, that footer is actually displayed).
    *
    * @export
-   * @return {{border-top: string}|undefined}
+   * @return {boolean}
    */
-  getBottomBorderStyle() {
-    if (this.element_[0].innerHTML.indexOf('dir-pagination-controls') > 0) {
-      return {'border-top': '1px solid rgba(0, 0, 0, .12)'};
-    }
-    return undefined;
+  isBottomBorderVisible() {
+    return this.element_[0].innerHTML.indexOf('dir-pagination-controls') > 0;
   }
 }
 

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistheader.scss
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistheader.scss
@@ -14,12 +14,6 @@
 
 @import '../../../variables';
 
-.kd-resource-card-list-footer {
-  align-items: center;
-  border-top: 1px solid $border;
-  display: flex;
-}
-
 kd-resource-card-list-header {
   align-items: center;
   border-bottom: 1px solid $border;

--- a/src/app/frontend/common/components/warnings/warnings.html
+++ b/src/app/frontend/common/components/warnings/warnings.html
@@ -19,7 +19,10 @@ limitations under the License.
   <div class="kd-warning-message"
        ng-repeat="warning in $ctrl.warnings | limitTo: $ctrl.limit">
     <md-icon class="material-icons">warning</md-icon>
-    <span class="kd-raw-warning" flex>  {{warning.ErrStatus.message}}</span>
+    <span class="kd-raw-warning"
+          flex>
+      {{warning.ErrStatus.message}}
+    </span>
     <md-icon ng-click="$ctrl.dismissWarning($index)"
              class="material-icons kd-dismiss-icon">
       close


### PR DESCRIPTION
This is workaround for issue described in #1893. Until now when there was no footer bottom border was displayed two times (first list has footer, second does not):

![image](https://user-images.githubusercontent.com/2823399/28317018-7c642184-6bc5-11e7-8f81-7c4a74eca06f.png)

After this fix:

![image](https://user-images.githubusercontent.com/2823399/28317042-a238f7ae-6bc5-11e7-9318-180601869c3f.png)

As you probably noticed it removes bottom border from the card, but it is almost not visible since we are using box shadows for every card and when there are no footer we have one border anyways. To do it in a cleaner way I can add missing border in pagination CSS, but then I would have to turn off option to add custom content to footer (we do not use it anyways). 

Fixes #1893.