### PR TITLE
Replace "gofmt" code formating tool with "goimports"

### DIFF
--- a/build/check.js
+++ b/build/check.js
@@ -28,7 +28,7 @@ import path from 'path';
 import through from 'through2';
 
 import conf from './conf';
-import {gofmtCommand} from './gocommand';
+import {goimportsCommand} from './gocommand';
 
 /** HTML beautifier from js-beautify package */
 const htmlBeautify = beautify.html;
@@ -126,10 +126,10 @@ gulp.task('format-html', function() {
 });
 
 /**
- * Formats all project's Go files using gofmt.
+ * Formats all project's Go files using goimports tool.
  */
 gulp.task('format-go', function(doneFn) {
-  gofmtCommand(
+  goimportsCommand(
       [
         '-w',
         path.relative(conf.paths.base, conf.paths.backendSrc),

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -55,15 +55,15 @@ export default function goCommand(args, doneFn, envOverride) {
 }
 
 /**
- * Spawns a Gofmt process after making sure all Go prerequisites are present.
+ * Spawns a goimports process after making sure all Go prerequisites are present.
  *
  * @param {!Array<string>} args - Arguments of the go command.
  * @param {function(?Error=)} doneFn - Callback.
  * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
  */
-export function gofmtCommand(args, doneFn, envOverride) {
+export function goimportsCommand(args, doneFn, envOverride) {
   checkPrerequisites()
-      .then(() => spawnGofmtProcess(args, envOverride))
+      .then(() => spawnGoimportsProcess(args, envOverride))
       .then(doneFn)
       .fail((error) => doneFn(error));
 }
@@ -205,13 +205,13 @@ function spawnGoProcess(args, envOverride) {
 }
 
 /**
- * Spawns gofmt process.
+ * Spawns goimports process.
  * Promises an error if the go command process fails.
  *
  * @param {!Array<string>} args - Arguments of the go command.
  * @param {!Object<string, string>=} [envOverride] optional environment variables overrides map.
  * @return {Q.Promise} A promise object.
  */
-function spawnGofmtProcess(args, envOverride) {
-  return spawnProcess('gofmt', args, envOverride);
+function spawnGoimportsProcess(args, envOverride) {
+  return spawnProcess('goimports', args, envOverride);
 }

--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -173,7 +173,7 @@ $ gulp check-javascript-format
 
 Before committing any changes, please link/copy the pre-commit hook into your .git directory. This will keep you from accidentally committing non formatted code.
 
-The hook requires gofmt to be in your PATH.
+The hook requires goimports to be in your PATH.
 
 ```shell
 cd <dashboard_home>/.git/hooks/

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,7 +5,7 @@ readonly red=$(tput bold; tput setaf 1)
 readonly green=$(tput bold; tput setaf 2)
 
 exit_code=0
-gofmt_available=false
+goimports_available=false
 gulp_available=false
 
 # Pre checks
@@ -20,13 +20,13 @@ else
 fi
 
 echo "${reset}"
-echo -ne "Checking if gofmt is available in your PATH... "
-if ! OUT=$(which gofmt 2>&1); then
+echo -ne "Checking if goimports is available in your PATH... "
+if ! OUT=$(which goimports 2>&1); then
   echo "${red}ERROR!"
-  echo "Please add gofmt to your PATH"
+  echo "Please add goimports to your PATH"
   exit_code=1
 else
-  gofmt_available=true
+  goimports_available=true
   echo "${green}OK"
 fi
 
@@ -44,15 +44,15 @@ if ${gulp_available}; then
   fi
 fi
 
-if ${gofmt_available}; then
+if ${goimports_available}; then
   echo "${reset}"
   echo -ne "Checking go files formatting... "
-  unformatted=$(gofmt -l src/app/backend)
+  unformatted=$(goimports -l src/app/backend)
   if [ ! -z "$unformatted" ]; then
     echo "${red}ERROR!"
     echo "There is an issue with file formatting."
     echo "To format go files run:"
-    echo "  gofmt -w src/app/backend"
+    echo "  goimports -w src/app/backend"
     exit_code=1
   else
     echo "${green}OK"

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/src/app/backend/client/manager_test.go
+++ b/src/app/backend/client/manager_test.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 )
 
 func TestNewClientManager(t *testing.T) {

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/kubernetes/dashboard/src/app/backend/api"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"github.com/kubernetes/dashboard/src/app/backend/integration"

--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 )
 

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 	"golang.org/x/net/xsrftoken"
 	utilnet "k8s.io/apimachinery/pkg/util/net"

--- a/src/app/backend/integration/handler.go
+++ b/src/app/backend/integration/handler.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/kubernetes/dashboard/src/app/backend/integration/api"
 )
 

--- a/src/app/backend/integration/handler_test.go
+++ b/src/app/backend/integration/handler_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"testing"
 
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {


### PR DESCRIPTION
Replaced "gofmt" with "goimports" as default Golang formating tool for dashboard code base. I have formated the dashboard proj. prior to making this PR. However, I noticed that imports containing "-" get removed. Naming these imports solves the problem. I submitted an issue at https://github.com/golang/go/issues/21143 to see if this is a bug. 