### PR TITLE
Add workaround to make heapster work with latest release

### DIFF
--- a/src/deploy/kubernetes-dashboard.yaml
+++ b/src/deploy/kubernetes-dashboard.yaml
@@ -69,6 +69,7 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+          - --heapster-host=http://heapster.kube-system:80
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Related to #2180.

This is only a workaround for now. We have to investigate why in-cluster config does not work and heapster service can not be found. This will work the same as in-cluster config as we require `heapster` service to exist in `kube-system` namespace.

As most people is using command from our master readme to deploy dashboard it will work for now. We will do next release with fix ASAP.