### PR TITLE
Fix dashboard not serving on HTTPS

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -56,7 +56,6 @@ func main() {
 	pflag.Parse()
 	flag.CommandLine.Parse(make([]string, 0)) // Init for glog calls in kubernetes packages
 
-	log.Printf("Using HTTP port: %d", *argPort)
 	if *argApiserverHost != "" {
 		log.Printf("Using apiserver-host location: %s", *argApiserverHost)
 	}
@@ -104,10 +103,12 @@ func main() {
 
 	// Listen for http and https
 	addr := fmt.Sprintf("%s:%d", *argInsecureBindAddress, *argInsecurePort)
-	go log.Fatal(http.ListenAndServe(addr, nil))
+	log.Printf("Serving insecurely on HTTP port: %d", *argInsecurePort)
+	go func() {log.Fatal(http.ListenAndServe(addr, nil))}()
 	secureAddr := fmt.Sprintf("%s:%d", *argBindAddress, *argPort)
-	if len(*argCertFile) != 0 && len(*argKeyFile) != 0 {
-		go log.Fatal(http.ListenAndServeTLS(secureAddr, *argCertFile, *argKeyFile, nil))
+	if *argCertFile != "" && *argKeyFile != "" {
+		log.Printf("Serving securely on HTTPS port: %d", *argPort)
+		go func() {log.Fatal(http.ListenAndServeTLS(secureAddr, *argCertFile, *argKeyFile, nil))}()
 	}
 	select {}
 }

--- a/src/deploy/Dockerfile
+++ b/src/deploy/Dockerfile
@@ -26,5 +26,5 @@ ADD . /
 
 # The port that the application listens on.
 # TODO(bryk): Parametrize this argument so that other build tools are aware of the exposed port.
-EXPOSE 9090
-ENTRYPOINT ["/dashboard", "--insecure-bind-address=0.0.0.0"]
+EXPOSE 9090 8443
+ENTRYPOINT ["/dashboard", "--insecure-bind-address=0.0.0.0", "--bind-address=0.0.0.0"]


### PR DESCRIPTION
I have investigated issue mentioned in #2221 and confirmed that dashboard was not served correctly on HTTPS. Code after insecure server was not executed.

Additionally I have exposed secure port in dockerfile.