### PR TITLE
Added download button for log file

### DIFF
--- a/docs/testing/logs/100mb.yaml
+++ b/docs/testing/logs/100mb.yaml
@@ -22,5 +22,5 @@ spec:
   containers:
     - name: succeeded
       image: alpine:3.4
-      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 10000000; echo ----end"]
+      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 100000000; echo ----end"]
   restartPolicy: Never

--- a/docs/testing/logs/10mb.yaml
+++ b/docs/testing/logs/10mb.yaml
@@ -22,5 +22,5 @@ spec:
   containers:
     - name: succeeded
       image: alpine:3.4
-      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 1000000; echo ----end"]
+      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 10000000; echo ----end"]
   restartPolicy: Never

--- a/docs/testing/logs/1GB.yaml
+++ b/docs/testing/logs/1GB.yaml
@@ -22,5 +22,5 @@ spec:
   containers:
     - name: succeeded
       image: alpine:3.4
-      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 100000000; echo ----end"]
+      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 1000000000; echo ----end"]
   restartPolicy: Never

--- a/docs/testing/logs/500mb.yaml
+++ b/docs/testing/logs/500mb.yaml
@@ -22,5 +22,5 @@ spec:
   containers:
     - name: succeeded
       image: alpine:3.4
-      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 50000000; echo ----end"]
+      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 500000000; echo ----end"]
   restartPolicy: Never

--- a/docs/testing/logs/50mb.yaml
+++ b/docs/testing/logs/50mb.yaml
@@ -22,5 +22,5 @@ spec:
   containers:
     - name: succeeded
       image: alpine:3.4
-      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 5000000; echo ----end"]
+      command: ["/bin/sh", "-c", "echo start----; base64 /dev/urandom | head -c 50000000; echo ----end"]
   restartPolicy: Never

--- a/src/app/backend/handler/download.go
+++ b/src/app/backend/handler/download.go
@@ -1,0 +1,34 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"fmt"
+	"io"
+
+	restful "github.com/emicklei/go-restful"
+)
+
+func handleDownload(response *restful.Response, result io.ReadCloser, filename string) {
+	header := fmt.Sprintf("attachment; filename='%v'", filename)
+	response.AddHeader("Content-Disposition", header)
+
+	defer result.Close()
+	_, err := io.Copy(response, result)
+	if err != nil {
+		handleInternalError(response, err)
+		return
+	}
+}

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -126,13 +126,12 @@ func GetLogFile(client kubernetes.Interface, namespace, podID string, container 
 }
 
 func openStream(client kubernetes.Interface, namespace, podID string, logOptions *v1.PodLogOptions) (io.ReadCloser, error) {
-	req := client.CoreV1().RESTClient().Get().
+	return client.CoreV1().RESTClient().Get().
 		Namespace(namespace).
 		Name(podID).
 		Resource("pods").
 		SubResource("log").
-		VersionedParams(logOptions, scheme.ParameterCodec)
-	return req.Stream()
+		VersionedParams(logOptions, scheme.ParameterCodec).Stream()
 }
 
 // ConstructLogDetails creates a new log details structure for given parameters.

--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -317,7 +317,7 @@ func TestGetLogs(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		actual := ConstructLogs(c.podId, c.rawLogs, c.container, c.logSelector)
+		actual := ConstructLogDetails(c.podId, c.rawLogs, c.container, c.logSelector)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("Test Case: %s.\nReceived: %#v \nExpected: %#v\n\n", c.info, actual, c.expected)
 		}

--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -257,7 +257,7 @@ export class LogsController {
   /**
    * Return proper style class for logs content.
    * @export
-   * @returns {string}
+   * @return {string}
    */
   getStyleClass() {
     const logsTextColor = 'kd-logs-text-color';
@@ -270,7 +270,7 @@ export class LogsController {
   /**
    * Return proper style class for text color icon.
    * @export
-   * @returns {string}
+   * @return {string}
    */
   getColorIconClass() {
     const logsTextColor = 'kd-logs-color-icon';
@@ -283,7 +283,7 @@ export class LogsController {
   /**
    * Return proper style class for font size icon.
    * @export
-   * @returns {string}
+   * @return {string}
    */
   getSizeIconClass() {
     const logsTextColor = 'kd-logs-size-icon';
@@ -296,7 +296,7 @@ export class LogsController {
   /**
    * Return the proper icon depending on the selection state
    * @export
-   * @returns {string}
+   * @return {string}
    */
   getTimestampIcon() {
     if (this.logsService.getShowTimestamp()) {
@@ -308,7 +308,7 @@ export class LogsController {
   /**
    * Return the link to download the log file
    * @export
-   * @returns {string}
+   * @return {string}
    */
   getDownloadLink() {
     let namespace = this.stateParams_.objectNamespace;

--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -305,6 +305,15 @@ export class LogsController {
     return 'timer_off';
   }
 
+  /**
+   * Return the link to download the log file
+   * @export
+   * @returns {string}
+   */
+  getDownloadLink() {
+    let namespace = this.stateParams_.objectNamespace;
+    return `/api/v1/log/file/${namespace}/${this.pod}/${this.container}`;
+  }
 
   /**
    * Execute when a user changes the container from which logs should be loaded.

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -56,8 +56,15 @@ limitations under the License.
       <md-button class="kd-logs-toolbar-button"
                  ng-click="ctrl.onShowTimestamp()">
         <md-icon md-font-library="material-icons"
-                 class="kd-logs-timer-icon">
+                 class="kd-logs-icon">
           {{ctrl.getTimestampIcon()}}
+        </md-icon>
+      </md-button>
+      <md-button class="kd-logs-toolbar-button"
+                 ng-href="{{ctrl.getDownloadLink()}}">
+        <md-icon md-font-library="material-icons"
+                 class="kd-logs-icon">
+          file_download
         </md-icon>
       </md-button>
     </div>

--- a/src/app/frontend/logs/logs.scss
+++ b/src/app/frontend/logs/logs.scss
@@ -130,7 +130,7 @@ kd-content-card {
   transform: scale(-1, 1);
 }
 
-.kd-logs-timer-icon {
+.kd-logs-icon {
   color: $logs-color-black;
 }
 


### PR DESCRIPTION
Added button to log view to download the log file.

Alternative would be to open a new tab. Currently, we open already a tab for the log view and I didn't want to open yet another tab. On the other hand, this PR will create lot of files in the download folder that have to be removed by the user. (All files start with the same prefix (log-*) so removing is easy.)