### PR TITLE
Improve security for secret synchronization

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -183,6 +183,7 @@ function compileES6(translation) {
     path.join(conf.paths.externs, 'hterm.js'),
     path.join(conf.paths.externs, 'sockjs.js'),
     path.join(conf.paths.externs, 'graph.js'),
+    path.join(conf.paths.externs, 'errors.js'),
   ];
 
   let closureCompilerConfig = {

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -364,7 +364,7 @@
   <translation id="7869641598803414323" key="MSG_DESIRED_PODS_MSG" desc="Satisfies a way to make normal binding in angularjs to pass in google closure compiler.">
     <ph name="DESIRED_PODS"> desired.</ph>
   </translation>
-  <translation id="5000821072914833048" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again</translation>
+  <translation id="4942061082776173364" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again.</translation>
   <translation id="778882191405410811" key="MSG_ENDPOINTS_WARNING_LABEL" desc="Label 'Warning' for the endpoint selection drop-down.">Warning</translation>
   <translation id="4983649641173165689" key="MSG_ENDPOINT_CARDLIST_0" desc="Label which appears above the list of such objects.">Endpoints</translation>
   <translation id="4158586803314397594" key="MSG_ENDPOINT_CARDLIST_1" desc="(no description provided)">There are currently no Endpoints selected by this Service.</translation>
@@ -374,6 +374,7 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">Close</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">Send feedback</translation>
+  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">Events</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">Message</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">Source</translation>

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -200,6 +200,7 @@
   <translation id="8788831308012182190" key="MSG_DAEMONSET_LIST_LIST_1" desc="Title for graph card displaying memory metric of daemon sets.">Memory usage</translation>
   <translation id="2452514894533620787" key="MSG_DAEMONSET_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">The memory usage includes the caches in the pods managed by these daemon sets.</translation>
   <translation id="1183334493862832095" key="MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the daemon set.">Created at <ph name="CREATION_DATE"/></translation>
+  <translation id="2800447277288989088" key="MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="8731452969115857295" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">Deployment</translation>
   <translation id="4537205375409268523" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_1" desc="Label \'Deployment\' which will appear in the deployment dialog opened from the deployment details page.">Deployment</translation>
   <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU usage</translation>
@@ -374,7 +375,6 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">Close</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">Send feedback</translation>
-  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">Events</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">Message</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">Source</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -208,6 +208,7 @@
   <translation id="1183334493862832095" key="MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the daemon set.">
     <ph name="CREATION_DATE"> に作成</ph>
   </translation>
+  <translation id="2800447277288989088" key="MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="8731452969115857295" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">デプロイメント</translation>
   <translation id="4537205375409268523" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_1" desc="Label \'Deployment\' which will appear in the deployment dialog opened from the deployment details page.">Deployment</translation>
   <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU使用量</translation>
@@ -384,7 +385,6 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">閉じる</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">フィードバックを送信</translation>
-  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">イベント</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">メッセージ</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">ソース</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -374,7 +374,7 @@
   <translation id="7869641598803414323" key="MSG_DESIRED_PODS_MSG" desc="Satisfies a way to make normal binding in angularjs to pass in google closure compiler.">
     <ph name="DESIRED_PODS"> の要求</ph>
   </translation>
-  <translation id="5000821072914833048" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again</translation>
+  <translation id="4942061082776173364" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again.</translation>
   <translation id="778882191405410811" key="MSG_ENDPOINTS_WARNING_LABEL" desc="Label 'Warning' for the endpoint selection drop-down.">Warning</translation>
   <translation id="4983649641173165689" key="MSG_ENDPOINT_CARDLIST_0" desc="Label which appears above the list of such objects.">Endpoints</translation>
   <translation id="4158586803314397594" key="MSG_ENDPOINT_CARDLIST_1" desc="(no description provided)">There are currently no Endpoints selected by this Service.</translation>
@@ -384,6 +384,7 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">閉じる</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">フィードバックを送信</translation>
+  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">イベント</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">メッセージ</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">ソース</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -364,7 +364,7 @@
   <translation id="7869641598803414323" key="MSG_DESIRED_PODS_MSG" desc="Satisfies a way to make normal binding in angularjs to pass in google closure compiler.">
     <ph name="DESIRED_PODS"> 需要</ph>
   </translation>
-  <translation id="5000821072914833048" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again</translation>
+  <translation id="4942061082776173364" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">Session expired. Please log in again.</translation>
   <translation id="778882191405410811" key="MSG_ENDPOINTS_WARNING_LABEL" desc="Label 'Warning' for the endpoint selection drop-down.">Warning</translation>
   <translation id="4983649641173165689" key="MSG_ENDPOINT_CARDLIST_0" desc="Label which appears above the list of such objects.">Endpoints</translation>
   <translation id="4158586803314397594" key="MSG_ENDPOINT_CARDLIST_1" desc="(no description provided)">There are currently no Endpoints selected by this Service.</translation>
@@ -374,6 +374,7 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">关闭</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">发送反馈</translation>
+  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">事件</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">消息</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">来源</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -200,6 +200,7 @@
   <translation id="8788831308012182190" key="MSG_DAEMONSET_LIST_LIST_1" desc="Title for graph card displaying memory metric of daemon sets.">内存使用率</translation>
   <translation id="2452514894533620787" key="MSG_DAEMONSET_LIST_LIST_2" desc="Help message detailing what is included in the memory usage">这些守护进程集所管理容器组的内存占用包括缓存</translation>
   <translation id="1183334493862832095" key="MSG_DAEMON_SET_LIST_CREATED_AT_TOOLTIP" desc="Tooltip 'Created at [some date]' showing the exact creation time of the daemon set.">创建于 <ph name="CREATION_DATE"/></translation>
+  <translation id="2800447277288989088" key="MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="8731452969115857295" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_0" desc="Label \'Deployment\' which will appear in the deployment delete dialog opened from the deployment details page.">部署</translation>
   <translation id="4537205375409268523" key="MSG_DEPLOYMENT_DETAIL_ACTIONBAR_1" desc="Label \'Deployment\' which will appear in the deployment dialog opened from the deployment details page.">部署</translation>
   <translation id="916794903553842041" key="MSG_DEPLOYMENT_DETAIL_DETAIL_0" desc="Title for graph card displaying CPU metric of one deployment.">CPU 使用率</translation>
@@ -374,7 +375,6 @@
   <translation id="1608216445138526830" key="MSG_ENDPOINT_CARDLIST_5" desc="Label \'Sub-object\' for the respective column of the endpoints table (endpoints list page).">Ready </translation>
   <translation id="4162582061346784285" key="MSG_ERROR_HANDLING_DIALOG_CLOSE_ACTION" desc="Action &quot;Close&quot; which appears at the bottom of any displayed error dialog.">关闭</translation>
   <translation id="6020266409089609793" key="MSG_ERROR_INTERNALERROR_0" desc="This is a label for button displayed on error page used to send feedback to GitHub new issue.">发送反馈</translation>
-  <translation id="6939891796958111117" key="MSG_ERROR_UNAUTHORIZED_ERROR" desc="Text shown on internal error page when user tries to access resource he does not have permissions to.">Trying to access/modify dashboard exclusive resource.</translation>
   <translation id="1499717850384845922" key="MSG_EVENTS_CARDLIST_0" desc="Label which appears above the list of such objects.">事件</translation>
   <translation id="394833373610211124" key="MSG_EVENTS_CARDLIST_1" desc="Label \'Message\' for the event message column of the events table (events list page).">消息</translation>
   <translation id="397148110173555485" key="MSG_EVENTS_CARDLIST_2" desc="Label \'Source\' for the event source column of the events table (events list page).">来源</translation>

--- a/src/app/backend/auth/api/types.go
+++ b/src/app/backend/auth/api/types.go
@@ -14,13 +14,24 @@
 
 package api
 
-import "k8s.io/client-go/tools/clientcmd/api"
+import (
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+)
 
 // Resource information that are used as encryption key storage. Can be accessible by multiple dashboard replicas.
 const (
 	EncryptionKeyHolderName      = "kubernetes-dashboard-key-holder"
 	EncryptionKeyHolderNamespace = "kube-system"
 )
+
+// ShouldRejectRequest returns true if url contains name and namespace of resource that should be filtered out from
+// dashboard.
+func ShouldRejectRequest(url string) bool {
+	// For now we have only one resource that should be checked
+	return strings.Contains(url, EncryptionKeyHolderName) && strings.Contains(url, EncryptionKeyHolderNamespace)
+}
 
 // AuthManager is used for user authentication management.
 type AuthManager interface {

--- a/src/app/backend/errors/localizer.go
+++ b/src/app/backend/errors/localizer.go
@@ -22,6 +22,15 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+// Errors that can be used directly without localizing
+const (
+	MSG_DEPLOY_NAMESPACE_MISMATCH_ERROR    = "MSG_DEPLOY_NAMESPACE_MISMATCH_ERROR"
+	MSG_DEPLOY_EMPTY_NAMESPACE_ERROR       = "MSG_DEPLOY_EMPTY_NAMESPACE_ERROR"
+	MSG_LOGIN_UNAUTHORIZED_ERROR           = "MSG_LOGIN_UNAUTHORIZED_ERROR"
+	MSG_ENCRYPTION_KEY_CHANGED             = "MSG_ENCRYPTION_KEY_CHANGED"
+	MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR = "MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR"
+)
+
 // This file contains all errors that should be kept in sync with:
 // 'src/app/frontend/common/errorhandling/errors.js' and localized on frontend side.
 
@@ -29,12 +38,12 @@ import (
 // Key - unique partial string that can be used to differentiate error messages
 // Value - unique error code string that frontend can use to localize error message created using
 // 		   pattern MSG_<VIEW>_<CAUSE_OF_ERROR>_ERROR
+//		   <VIEW> - optional
 var partialsToErrorsMap = map[string]string{
-	"does not match the namespace":                               "MSG_DEPLOY_NAMESPACE_MISMATCH_ERROR",
-	"empty namespace may not be set":                             "MSG_DEPLOY_EMPTY_NAMESPACE_ERROR",
-	"the server has asked for the client to provide credentials": "MSG_LOGIN_UNAUTHORIZED_ERROR",
-	jose.ErrCryptoFailure.Error():                                "MSG_ENCRYPTION_KEY_CHANGED",
-	"not authorized":                                             "MSG_ERROR_UNAUTHORIZED_ERROR",
+	"does not match the namespace":                               MSG_DEPLOY_NAMESPACE_MISMATCH_ERROR,
+	"empty namespace may not be set":                             MSG_DEPLOY_EMPTY_NAMESPACE_ERROR,
+	"the server has asked for the client to provide credentials": MSG_LOGIN_UNAUTHORIZED_ERROR,
+	jose.ErrCryptoFailure.Error():                                MSG_ENCRYPTION_KEY_CHANGED,
 }
 
 // LocalizeError returns error code (string) that can be used by frontend to localize error message.

--- a/src/app/backend/errors/localizer.go
+++ b/src/app/backend/errors/localizer.go
@@ -34,6 +34,7 @@ var partialsToErrorsMap = map[string]string{
 	"empty namespace may not be set":                             "MSG_DEPLOY_EMPTY_NAMESPACE_ERROR",
 	"the server has asked for the client to provide credentials": "MSG_LOGIN_UNAUTHORIZED_ERROR",
 	jose.ErrCryptoFailure.Error():                                "MSG_ENCRYPTION_KEY_CHANGED",
+	"not authorized":                                             "MSG_ERROR_UNAUTHORIZED_ERROR",
 }
 
 // LocalizeError returns error code (string) that can be used by frontend to localize error message.

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -24,8 +24,11 @@ import (
 	"time"
 
 	restful "github.com/emicklei/go-restful"
+	authApi "github.com/kubernetes/dashboard/src/app/backend/auth/api"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
+	kdErrors "github.com/kubernetes/dashboard/src/app/backend/errors"
 	"golang.org/x/net/xsrftoken"
+	errorsK8s "k8s.io/apimachinery/pkg/api/errors"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
@@ -34,9 +37,21 @@ func InstallFilters(ws *restful.WebService, manager client.ClientManager) {
 	ws.Filter(requestAndResponseLogger)
 	ws.Filter(metricsFilter)
 	ws.Filter(validateXSRFFilter(manager.CSRFKey()))
+	ws.Filter(restrictedResourcesFilter)
 }
 
-// logRequestAndReponse is a web-service filter function used for request and response logging.
+// Filter used to restrict access to dashboard exclusive resource, i.e. secret used to store dashboard encryption key.
+func restrictedResourcesFilter(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+	if !authApi.ShouldRejectRequest(request.Request.URL.String()) {
+		chain.ProcessFilter(request, response)
+		return
+	}
+
+	err := errorsK8s.NewUnauthorized("")
+	response.WriteHeaderAndEntity(int(err.ErrStatus.Code), kdErrors.LocalizeError(err).Error())
+}
+
+// web-service filter function used for request and response logging.
 func requestAndResponseLogger(request *restful.Request, response *restful.Response,
 	chain *restful.FilterChain) {
 	log.Printf(formatRequestLog(request))

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -47,8 +47,8 @@ func restrictedResourcesFilter(request *restful.Request, response *restful.Respo
 		return
 	}
 
-	err := errorsK8s.NewUnauthorized("")
-	response.WriteHeaderAndEntity(int(err.ErrStatus.Code), kdErrors.LocalizeError(err).Error())
+	err := errorsK8s.NewUnauthorized(kdErrors.MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR)
+	response.WriteHeaderAndEntity(int(err.ErrStatus.Code), err.Error())
 }
 
 // web-service filter function used for request and response logging.

--- a/src/app/backend/resource/secret/list.go
+++ b/src/app/backend/resource/secret/list.go
@@ -65,9 +65,9 @@ func (spec *ImagePullSecretSpec) GetData() map[string][]byte {
 
 // Secret is a single secret returned to the frontend.
 type Secret struct {
-	ObjectMeta    api.ObjectMeta  `json:"objectMeta"`
-	TypeMeta      api.TypeMeta    `json:"typeMeta"`
-	Type          v1.SecretType   `json:"type"`
+	ObjectMeta api.ObjectMeta `json:"objectMeta"`
+	TypeMeta   api.TypeMeta   `json:"typeMeta"`
+	Type       v1.SecretType  `json:"type"`
 }
 
 // SecretsList is a response structure for a queried secrets list.
@@ -126,9 +126,9 @@ func CreateSecret(client kubernetes.Interface, spec SecretSpec) (*Secret, error)
 
 func toSecret(secret *v1.Secret) *Secret {
 	return &Secret{
-		ObjectMeta:    api.NewObjectMeta(secret.ObjectMeta),
-		TypeMeta:      api.NewTypeMeta(api.ResourceKindSecret),
-		Type:          secret.Type,
+		ObjectMeta: api.NewObjectMeta(secret.ObjectMeta),
+		TypeMeta:   api.NewTypeMeta(api.ResourceKindSecret),
+		Type:       secret.Type,
 	}
 }
 

--- a/src/app/externs/errors.js
+++ b/src/app/externs/errors.js
@@ -1,0 +1,22 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Externs for custom errors types defined in dashboard.
+ *
+ * @externs
+ */
+
+/** @typedef {string} */
+const kdError = '';

--- a/src/app/frontend/chrome/component.js
+++ b/src/app/frontend/chrome/component.js
@@ -70,7 +70,7 @@ export class ChromeController {
    * @export
    */
   isFillContentView() {
-    return this.state_.current.data[fillContentConfig] === true;
+    return !!(this.state_.current.data && this.state_.current.data[fillContentConfig] === true);
   }
 
   registerStateChangeListeners() {

--- a/src/app/frontend/chrome/controlpanel/controlpanel.html
+++ b/src/app/frontend/chrome/controlpanel/controlpanel.html
@@ -35,7 +35,8 @@ limitations under the License.
     </md-button>
     <md-menu-content width="4">
       <md-menu-item>
-        <md-button disabled="disabled">
+        <md-button disabled="disabled"
+                   aria-label="Control panel">
           <div class="kd-auth-status"
                ng-if="$ctrl.isLoginStatusLoaded">
             {{$ctrl.getAuthStatus()}}

--- a/src/app/frontend/common/errorhandling/errors.js
+++ b/src/app/frontend/common/errorhandling/errors.js
@@ -17,21 +17,21 @@
  * backend file: 'src/app/backend/errors/localizer.go'.
  */
 export const kdErrors = {
-  /** @export {string} @desc Text shown on in error dialog when there is namespace mismatch between dashboard and yaml file. */
+  /** @export {kdError} @desc Text shown on in error dialog when there is namespace mismatch between dashboard and yaml file. */
   MSG_DEPLOY_NAMESPACE_MISMATCH_ERROR: goog.getMsg(
       'Your file specifies a namespace that is inconsistent with the namespace currently selected in Dashboard. Either edit the namespace entry in your file or select a different namespace in Dashboard to deploy to (eg. \'All namespaces\' or the correct namespace provided in the file).'),
 
-  /** @export {string} @desc Text shown on in error dialog when there is no namespace provided selected in both dashboard and yaml file. */
+  /** @export {kdError} @desc Text shown on in error dialog when there is no namespace provided selected in both dashboard and yaml file. */
   MSG_DEPLOY_EMPTY_NAMESPACE_ERROR: goog.getMsg(
       'Dashboard and your file do not specify any namespace to deploy a resource. Please select a specific namespace in dashboard or add one in yaml file.'),
 
-  /** @export {string} @desc Text shown when unauthorized user tries to log in. */
+  /** @export {kdError} @desc Text shown when unauthorized user tries to log in. */
   MSG_LOGIN_UNAUTHORIZED_ERROR: goog.getMsg('Authentication failed. Please try again.'),
 
-  /** @export {string} @desc Text shown when saved token could not be decrypted by backend. */
+  /** @export {kdError} @desc Text shown when saved token could not be decrypted by backend. */
   MSG_ENCRYPTION_KEY_CHANGED: goog.getMsg('Session expired. Please log in again.'),
 
-  /** @export {string} @desc Text shown on internal error page when user tries to access resource he does not have permissions to. */
-  MSG_ERROR_UNAUTHORIZED_ERROR:
+  /** @export {kdError} @desc Text shown on internal error page when user tries to access resource he does not have permissions to. */
+  MSG_DASHBOARD_EXCLUSIVE_RESOURCE_ERROR:
       goog.getMsg('Trying to access/modify dashboard exclusive resource.'),
 };

--- a/src/app/frontend/common/errorhandling/errors.js
+++ b/src/app/frontend/common/errorhandling/errors.js
@@ -29,5 +29,9 @@ export const kdErrors = {
   MSG_LOGIN_UNAUTHORIZED_ERROR: goog.getMsg('Authentication failed. Please try again.'),
 
   /** @export {string} @desc Text shown when saved token could not be decrypted by backend. */
-  MSG_ENCRYPTION_KEY_CHANGED: goog.getMsg('Session expired. Please log in again'),
+  MSG_ENCRYPTION_KEY_CHANGED: goog.getMsg('Session expired. Please log in again.'),
+
+  /** @export {string} @desc Text shown on internal error page when user tries to access resource he does not have permissions to. */
+  MSG_ERROR_UNAUTHORIZED_ERROR:
+      goog.getMsg('Trying to access/modify dashboard exclusive resource.'),
 };

--- a/src/app/frontend/error/controller.js
+++ b/src/app/frontend/error/controller.js
@@ -65,6 +65,30 @@ export class InternalErrorController {
 
   /**
    * @export
+   * @return {boolean}
+   */
+  isKnownError() {
+    return !(this.isInternalError_() || !this.hasErrorCode_());
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isInternalError_() {
+    return this.error && angular.isNumber(this.error.status) && this.error.status >= 500;
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  hasErrorCode_() {
+    return !!(this.error && this.error.status);
+  }
+
+  /**
+   * @export
    * @return {string}
    */
   getErrorData() {

--- a/src/app/frontend/error/error.scss
+++ b/src/app/frontend/error/error.scss
@@ -30,6 +30,10 @@
   margin: $baseline-grid 0;
 }
 
+.kd-error-spacer {
+  padding-bottom: $baseline-grid;
+}
+
 .kd-error-center-fixed {
   align-content: center;
   align-items: center;

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -23,8 +23,9 @@ limitations under the License.
         <i class="material-icons kd-error-view-icon">error_outline</i>
         <span>{{ctrl.getErrorStatus()}}</span>
       </h2>
-      <pre>{{ctrl.getErrorData()}}</pre>
-      <div layout="row"
+      <pre ng-class="{'kd-error-spacer': ctrl.isKnownError()}">{{ctrl.getErrorData()}}</pre>
+      <div ng-if="!ctrl.isKnownError()"
+           layout="row"
            layout-align="end center">
         <a ng-href="{{ctrl.getLinkToFeedbackPage()}}">
           <md-button class="kd-error-feedback-button">

--- a/src/app/frontend/error/module.js
+++ b/src/app/frontend/error/module.js
@@ -34,10 +34,15 @@ export default angular
  * Configures event catchers for the error views.
  *
  * @param {!kdUiRouter.$state} $state
+ * @param {!../common/errorhandling/localizer_service.LocalizerService} localizerService
  * @ngInject
  */
-function errorConfig($state) {
+function errorConfig($state, localizerService) {
   $state.defaultErrorHandler((err) => {
+    if (err.detail && err.detail.data) {
+      err.detail.data = localizerService.localize(err.detail.data);
+    }
+
     $state.go(stateName, new StateParams(err.detail, $state.params.namespace));
   });
 }

--- a/src/test/frontend/error/controller_test.js
+++ b/src/test/frontend/error/controller_test.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import commonErrorModule from 'common/errorhandling/module';
 import {InternalErrorController} from 'error/controller';
 import errorModule from 'error/module';
 import {StateParams} from 'error/state';
@@ -24,6 +25,7 @@ describe('Internal error controller', () => {
 
   beforeEach(() => {
     angular.mock.module(errorModule.name);
+    angular.mock.module(commonErrorModule.name);
 
     angular.mock.inject(($controller) => {
       stateParams = new StateParams({status: undefined});


### PR DESCRIPTION
Related to #2207.

Restricts user from getting/modyfing dashboard exclusive resources. User with proper access still will be able to modify them using kubectl but dashboard itself won't allow it.

Additionally I have removed `SEND FEEDBACK` button from known status codes and left it only for 500+ error codes and in case error code is not known.

![zrzut ekranu z 2017-08-29 12-20-42](https://user-images.githubusercontent.com/2285385/29816478-804e99fe-8cb4-11e7-9cb4-ad3b63e67420.png)