### PR TITLE
Make roles zero state consistent with other cluster resources

### DIFF
--- a/src/app/frontend/role/list/controller.js
+++ b/src/app/frontend/role/list/controller.js
@@ -28,12 +28,4 @@ export class RoleListController {
     /** @export {!angular.Resource} */
     this.roleListResource = kdRoleListResource;
   }
-
-  /**
-   * @return {boolean}
-   * @export
-   */
-  shouldShowZeroState() {
-    return this.roleList.items === null || this.roleList.items.length === 0;
-  }
 }

--- a/src/app/frontend/role/list/list.html
+++ b/src/app/frontend/role/list/list.html
@@ -18,11 +18,9 @@ limitations under the License.
 
 <kd-content-card>
   <kd-content>
-    <kd-role-card-list ng-if="!$ctrl.shouldShowZeroState()"
-                       role-list="$ctrl.roleList"
+    <kd-role-card-list role-list="$ctrl.roleList"
                        role-list-resource="$ctrl.roleListResource"
                        with-statuses="false">
     </kd-role-card-list>
-    <kd-zero-state ng-if="$ctrl.shouldShowZeroState()"></kd-zero-state>
   </kd-content>
 </kd-content-card>

--- a/src/test/frontend/role/list/controller_test.js
+++ b/src/test/frontend/role/list/controller_test.js
@@ -36,24 +36,4 @@ describe('Role controller', () => {
 
     expect(ctrl.roleList.items).toBe(ctrls);
   }));
-
-  it('should show zero state', () => {
-    expect(ctrl.shouldShowZeroState()).toBe(true);
-  });
-
-  it('should hide zero state', () => {
-    // given
-    ctrl.roleList = {items: ['mock']};
-
-    // then
-    expect(ctrl.shouldShowZeroState()).toBe(false);
-  });
-
-  it('should show zero state if returned items is null', () => {
-    // given
-    ctrl.roleList = {items: null};
-
-    // then
-    expect(ctrl.shouldShowZeroState()).toBe(true);
-  });
 });

--- a/src/test/frontend/role/list/controller_test.js
+++ b/src/test/frontend/role/list/controller_test.js
@@ -16,17 +16,8 @@ import {RoleListController} from 'role/list/controller';
 import roleModule from 'role/module';
 
 describe('Role controller', () => {
-  /**
-   * @type {!RoleListController}
-   */
-  let ctrl;
-
   beforeEach(() => {
     angular.mock.module(roleModule.name);
-
-    angular.mock.inject(($controller) => {
-      ctrl = $controller(RoleListController, {roleList: {items: []}});
-    });
   });
 
   it('should initialize role controller', angular.mock.inject(($controller) => {


### PR DESCRIPTION
The zero state for the roles resource is not consistent with the zero states for the other cluster resources. This PR enforces consistency. refs #2121 

Before:
<img width="997" alt="screen shot 2017-09-05 at 2 48 05 pm" src="https://user-images.githubusercontent.com/8570077/30084886-19c715f4-9249-11e7-8d31-9574be1bb27c.png">

After:
<img width="989" alt="screen shot 2017-09-05 at 2 47 57 pm" src="https://user-images.githubusercontent.com/8570077/30084884-168c125e-9249-11e7-9e7f-0f31e28d0211.png">

