### PR TITLE
Fix the package has no installation candidate issue

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,7 +25,7 @@ FROM golang
 # so there's no need to run it again
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y --no-install-recommends \
-	openjdk-7-jre \
+	openjdk-8-jre \
 	nodejs \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean


### PR DESCRIPTION
Fixes issue #2338. I have tested already on Ubuntu 16.04, the output message as below:
```sh
$ build/run-gulp-in-docker.sh serve
Sending build context to Docker daemon  56.71MB
Step 1/8 : FROM golang
 ---> 5e2f23f821ca
Step 2/8 : RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -   && apt-get install -y --no-install-recommends 	openjdk-8-jre 	nodejs 	&& rm -rf /var/lib/apt/lists/* 	&& apt-get clean
 ---> Using cache
 ---> af3779b4ecf9
Step 3/8 : RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker &&     chmod +x /usr/bin/docker
 ---> Using cache
 ---> c67ef4a3b7fb
Step 4/8 : WORKDIR /dashboard
 ---> Using cache
 ---> da916eb4e90c
Step 5/8 : COPY package.json bower.json ./
 ---> Using cache
 ---> 217f1f52256c
Step 6/8 : COPY build/postinstall.sh build/
 ---> Using cache
 ---> 66ff02b37853
Step 7/8 : RUN npm install --unsafe-perm
 ---> Using cache
 ---> 2bb32b8d1c21
Step 8/8 : COPY ./ ./
 ---> Using cache
 ---> f59a41a75752
Successfully built f59a41a75752
Successfully tagged kubernetes-dashboard-build-image:latest
[02:54:24] Requiring external module babel-register
[02:54:26] Using gulpfile /dashboard/gulpfile.babel.js
[02:54:26] Starting 'clean-packaged-backend-source'...
[02:54:26] Starting 'kill-backend'...
[02:54:26] Finished 'kill-backend' after 95 μs
[02:54:26] Starting 'locales-for-backend:dev'...
[02:54:26] Starting 'set-dev-node-env'...
[02:54:26] Finished 'set-dev-node-env' after 20 μs
[02:54:26] Starting 'scripts'...
[02:54:26] Starting 'styles'...
[02:54:26] Starting 'buildExistingI18nCache'...
[02:54:26] Finished 'clean-packaged-backend-source' after 183 ms
[02:54:26] Starting 'package-backend-source'...
[02:54:27] Finished 'buildExistingI18nCache' after 251 ms
[02:54:27] Starting 'angular-templates'...
[02:54:27] Finished 'locales-for-backend:dev' after 505 ms
[02:54:31] Finished 'scripts' after 5.2 s
[02:54:32] Finished 'styles' after 5.34 s
[02:54:32] Starting 'index'...
[02:54:32] Finished 'index' after 66 ms
[02:54:32] Finished 'angular-templates' after 5.22 s
[02:54:32] Starting 'watch'...
[02:54:32] Finished 'watch' after 329 ms
[02:54:32] Finished 'package-backend-source' after 5.77 s
[02:54:32] Starting 'link-vendor'...
[02:54:32] Finished 'link-vendor' after 159 μs
[02:54:32] Starting 'package-backend'...
[02:54:32] Finished 'package-backend' after 1.3 μs
[02:54:32] Starting 'backend'...
[02:54:55] Finished 'backend' after 23 s
[02:54:55] Starting 'spawn-backend'...
[02:54:55] Finished 'spawn-backend' after 13 ms
[02:54:55] Starting 'serve'...
[HPM] Proxy created: /api  ->  http://localhost:9091
[02:54:55] Finished 'serve' after 15 ms
2017/09/06 02:54:55 Starting overwatch
2017/09/06 02:54:55 Using apiserver-host location: http://localhost:8080
2017/09/06 02:54:55 Skipping in-cluster config
2017/09/06 02:54:55 Using random key for csrf signing
2017/09/06 02:54:55 No request provided. Skipping authorization
2017/09/06 02:54:55 Error while initializing connection to Kubernetes apiserver. This most likely means that the cluster is misconfigured (e.g., it has invalid apiserver certificates or service accounts configuration) or the --apiserver-host param points to a server that does not exist. Reason: Get http://localhost:8080/version: dial tcp 127.0.0.1:8080: getsockopt: connection refused
Refer to the troubleshooting guide for more information: https://github.com/kubernetes/dashboard/blob/master/docs/user-guide/troubleshooting.md
[BS] [BrowserSync SPA] Running...
[Browsersync] Access URLs:
 --------------------------------------
       Local: http://localhost:9090/
    External: http://172.20.3.230:9090/
 --------------------------------------
          UI: http://localhost:3001
 UI External: http://172.20.3.230:3001
 --------------------------------------
[Browsersync] Serving files from: /dashboard/.tmp/serve
[Browsersync] Serving files from: /dashboard/src/app
```