### PR TITLE
Update outdated devel doc 

### DIFF
--- a/docs/devel/getting-started.md
+++ b/docs/devel/getting-started.md
@@ -16,8 +16,8 @@ logic and fetches raw data from the various Kubernetes APIs.
 Make sure the following software is installed and added to the `$PATH` variable:
 
 * Docker (1.10+)
-* go (1.7+)
-* nodejs (5.1.1+)
+* go (1.8.3+)
+* nodejs (6.10.3+)
 * npm (3+)
 * java (7+)
 * gulp (3.9+)

--- a/docs/devel/requirements-installation.md
+++ b/docs/devel/requirements-installation.md
@@ -4,52 +4,24 @@ These instructions are an elaboration on how to install the requirements listed 
 
 Before you begin please make sure you can connect to your Linux machine and login. Command line instructions for Linux will be shown starting with `$`; you should only type the text following the `$`.
 
+This has been tested on:
+* Ubuntu 16.04.
+* Ubuntu 14.04.
+
 ## Initial System Setup
 
-Based on instructions from: https://docs.docker.com/engine/installation/linux/ubuntulinux/
-
-This will update and upgrade Linux.
-
+First update and upgrade Linux on your node:
 ```shell
 $ sudo apt-get update
 $ sudo apt-get upgrade
 ```
 
-### Check
-
+Install some programs that we'll need later on, and verify that they're there:
 ```shell
-$ uname -r
+$ sudo apt-get install curl git make g++
 ```
 
-You should get `3.2.0-23-generic` or something similar depending on what the current version is.
-
-
-```shell
-$ lsb_release -a
-```
-
-^ You should get a response like:
-
-```log
-No LSB modules are available.
-Distributor ID: Ubuntu
-Description:    Ubuntu 12.04.5 LTS
-Release:        12.04
-Codename:       precise
-```
-
-
-## Install Helpful Programs
-
-Install some programs that we'll need later on, and verify that they're there.
-
-```shell
-$ sudo apt-get install curl
-$ sudo apt-get install git
-```
-
-if you are fedora (install npm3)
-
+if you are fedora (install npm3):
 ```shell
 sudo dnf install -y fedora-repos-rawhide
 sudo dnf install -y --enablerepo rawhide nodejs libuv --best --allowerasing
@@ -57,15 +29,37 @@ sudo dnf install -y --enablerepo rawhide nodejs libuv --best --allowerasing
 
 ### Check
 
+Use the following command to check which kernel version your server is currently running:
+```shell
+$ uname -r
+```
+> You should get `3.13.0-129-generic` or something similar depending on what the current version is.
+
+Use this in the terminal to show the details about the installed Ubuntu "version":
+```shell
+$ lsb_release -a
+```
+
+^ You should get a response like:
+```log
+No LSB modules are available.
+Distributor ID:	Ubuntu
+Description:	Ubuntu 14.04.5 LTS
+Release:	14.04
+Codename:	trusty
+```
+
+Use the following command to check `git` and `curl` version:
 ```shell
 $ curl --version
 $ git --version
 ```
 
-These instructions were last tested with curl `7.22.0`, and git `1.7.9.5`.
+These instructions were last tested with curl `7.35.0+`, and git `1.9.1+`.
 
 ## Get Vagrant on Linux
 
+To install Vagrant using `apt-get`:
 ```shell
 $ sudo apt-get install vagrant
 $ vagrant --version
@@ -73,44 +67,40 @@ $ export KUBERNETES_PROVIDER=vagrant
 $ echo "export KUBERNETES_PROVIDER=vagrant" >> ~/.profile
 ```
 
-These instructions are using vagrant version 1.0.1.
+These instructions are using vagrant version `1.4.3+`.
 
 ## Install Docker
 
-Based on instructions from: https://docs.docker.com/engine/installation/linux/ubuntulinux/
+Based on instructions from: https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/.
 
 ### Setup
 
+Use the following command to set up the repository:
 ```shell
 $ sudo apt-get install apt-transport-https ca-certificates
-$ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 ```
 
 Create a docker.list file with one command:
-
 ```shell
-$ sudo bash -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" > /etc/apt/sources.list.d/docker.list'
+$ echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+$(lsb_release -cs) \
+stable" | sudo tee /etc/apt/sources.list.d/docker.list
 ```
 
+To get Docker package version:
 ```shell
 $ sudo apt-get update
 $ sudo apt-get purge lxc-docker
-$ apt-cache policy docker-engine
-```
-
-### Only needed for Ubuntu Precise 12.04
-
-```shell
-$ sudo apt-get update
-$ sudo apt-get install linux-image-generic-lts-trusty
-$ sudo reboot
+$ apt-cache policy docker-ce
 ```
 
 ### Do the Docker install
 
+To install latest version of Docker:
 ```shell
 $ sudo apt-get update
-$ sudo apt-get install docker-engine
+$ sudo apt-get install docker-ce
 $ sudo service docker start
 $ sudo docker run hello-world
 ```
@@ -119,7 +109,7 @@ You should receive a message that includes: `This message shows that your instal
 
 ### Configure Docker for your user
 
-Based on instructions from https://docs.docker.com/engine/installation/linux/ubuntulinux/#create-a-docker-group
+Based on instructions from https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/.
 
 The example below uses "username" as a placeholder. Please substitute with the user you are logged in as, which can be seen by using `$ id`.
 If you are running Linux in a VM using Vagrant, your username will be "vagrant".
@@ -132,6 +122,7 @@ $ sudo reboot
 
 #### Check
 
+To run Docker without `sudo` command:
 ```shell
 $ docker run hello-world
 ```
@@ -147,27 +138,28 @@ For an additional check you can run these commands:
 
 ## Install Go
 
-The instructions below are for install a specific version of Go (1.8 for linux amd64). If you want the latest Go version or have a different system, then you can get the latest download URL from https://golang.org/dl/
+The instructions below are for install a specific version of Go (1.8.3 for linux amd64). If you want the latest Go version or have a different system, then you can get the latest download URL from https://golang.org/dl/.
 
 ```shell
-$ wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
-$ sudo tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
+$ wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
+$ sudo tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz
 $ export PATH=$PATH:/usr/local/go/bin
 $ echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile
 ```
 
 ### Check
 
+To get Go version:
 ```shell
 $ go version
 $ echo $PATH
 ```
 
-The Go version should return something like `go version go1.8 linux/amd64`. Note that if you already had Go installed, ensure that `GO15VENDOREXPERIMENT` is unset.
+The Go version should return something like `go version go1.8.3 linux/amd64`. Note that if you already had Go installed, ensure that `GO15VENDOREXPERIMENT` is unset.
 
 ## Install Node and NPM
 
-For some reason doing `sudo apt-get install nodejs` gives a much older version, so instead we will get the more recent version:
+For some reason doing `sudo apt-get install nodejs` gives a much older version, so instead we will get the more recent version.
 
 ```shell
 $ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
@@ -176,35 +168,39 @@ $ sudo apt-get install -y nodejs
 
 ### Check
 
+To get Node.js version:
 ```shell
 $ node -v
 $ npm -v
 ```
 
-The last time these instructions were updated, this returned `v6.3.1` and `3.10.3` respectively, but later versions will probably also work.
+The last time these instructions were updated, this returned `v6.11.3` and `3.10.10` respectively, but later versions will probably also work.
 
 ## Install Java runtime
 
+To install OpenJDK 7, execute the following command:
 ```shell
 $ sudo apt-get install openjdk-7-jre
 ```
+> Use `Ubuntu 16.04` need to change `openjdk-7-jre`to` openjdk-8-jre`.
 
-if you are fedora
-
+if you are fedora:
 ```shell
 $ sudo dnf install java-1.8.0-openjdk
 ```
 
 ### Check
 
+To get Java version:
 ```shell
 $ java -version
 ```
 
-Should return `java version "1.7.0_101"`.
+Should return `java version "1.7.0_151"`.
 
-## Install Gulp using npm
+## Install Gulp
 
+To install Gulp using npm:
 ```shell
 $ sudo npm install --global gulp-cli
 $ sudo npm install --global gulp
@@ -212,12 +208,12 @@ $ sudo npm install --global gulp
 
 ### Check
 
+To get Gulp version:
 ```shell
 $ gulp -v
 ```
 
 Should return `CLI version 3.9.1` and `Local version 3.9.1`.
-
 
 ## Get Kubernetes
 
@@ -238,9 +234,10 @@ $ git clone https://github.com/kubernetes/kubernetes.git
 
 ## Install Other Dashboard Dependencies Automatically with NPM
 
+To install the dependencies:
 ```shell
 $ cd ~/dashboard
-$ npm install
+$ npm i
 ```
 
 This will install all the dependencies that are in the `package.json` file in the dashboard repo. *This could take a while.*
@@ -251,14 +248,15 @@ Run the script included with the dashboard that checks out the latest Kubernetes
 
 ```shell
 $ cd ~/dashboard   
-   
+
 # Start cluster at first, because the dashboard need apiserver-host for requesting.
-$ gulp local-up-cluster   
-  
+$ gulp local-up-cluster --heapsterServerHost 'http://localhost:8082'
+
 # Run script to build docker image with name "kubernetes-dashboard-build-image ", and then start a container.
 # The parameter "serve" is necessary, otherwise, there will be a gulp task error.
 $ sudo build/run-gulp-in-docker.sh serve
 ```
+
 If you need append ENV variables to container, you should edit the Dockerfile.
 
 ```Dockerfile
@@ -266,9 +264,8 @@ ENV http_proxy="http://username:passowrd@10.0.58.88:8080/"
 ENV https_proxy="http://username:password@10.0.58.88:8080/"
 ```
 
-If you need to stop the cluster you can run `$ docker kill $(docker ps -aq)`, 
+If you need to stop the cluster you can run `$ docker kill $(docker ps -aq)`,
 and the dashboard container is stopped also.
-
 
 ### Check
 


### PR DESCRIPTION
The doc [Getting Started](https://github.com/kubernetes/dashboard/blob/master/docs/devel/getting-started.md) and [Requirements Installation](https://github.com/kubernetes/dashboard/blob/master/docs/devel/requirements-installation.md) looks outdated. We need update the doc to help developers build a local environment to test the development results.

This has been tested on `Ubuntu 14.04` and `Ubuntu 16.04`, both test result as below.

cc @floreks, @maciaszczykm 

### Kubernetes Dashboard dev on Ubuntu 14.04
```sh
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.5 LTS
Release:	14.04
Codename:	trusty

$ gulp local-up-cluster --heapsterServerHost 'http://localhost:8082'
[15:43:44] Requiring external module babel-register
[15:43:48] Using gulpfile ~/dashboard/gulpfile.babel.js
[15:43:48] Starting 'spawn-cluster'...
[15:43:48] Starting 'wait-for-cluster'...
[15:43:48] Starting 'wait-for-heapster'...
[15:43:49] Waiting for a Kubernetes cluster at http://localhost:8080...
[15:43:49] Waiting for a Heapster ...
[15:43:50] Finished 'spawn-cluster' after 1.97 s
[15:43:50] Heapster is up and running.
[15:43:50] Finished 'wait-for-heapster' after 2.05 s
[15:43:59] Waiting for a Kubernetes cluster at http://localhost:8080...
[15:44:00] Kubernetes cluster is up and running.
[15:44:00] Finished 'wait-for-cluster' after 12 s
[15:44:00] Starting 'local-up-cluster'...
[15:44:00] Finished 'local-up-cluster' after 4.52 μs

$ kubectl get no
NAME        STATUS    AGE       VERSION
127.0.0.1   Ready     13m       v1.5.4

$ export KUBE_DASHBOARD_APISERVER_HOST="http://127.0.0.1:8080"
$ gulp serve
[15:54:48] Requiring external module babel-register
[15:54:52] Using gulpfile ~/dashboard/gulpfile.babel.js
[15:54:52] Starting 'clean-packaged-backend-source'...
[15:54:52] Starting 'kill-backend'...
[15:54:52] Finished 'kill-backend' after 165 μs
[15:54:52] Starting 'locales-for-backend:dev'...
[15:54:52] Starting 'set-dev-node-env'...
[15:54:52] Finished 'set-dev-node-env' after 50 μs
[15:54:52] Starting 'scripts'...
[15:54:53] Starting 'styles'...
[15:54:53] Starting 'buildExistingI18nCache'...
[15:54:53] Finished 'clean-packaged-backend-source' after 472 ms
[15:54:53] Starting 'package-backend-source'...
[15:54:53] Finished 'buildExistingI18nCache' after 708 ms
[15:54:53] Starting 'angular-templates'...
[15:54:54] Finished 'locales-for-backend:dev' after 1.63 s
[15:55:08] Finished 'scripts' after 16 s
[15:55:09] Finished 'styles' after 16 s
[15:55:09] Starting 'index'...
[15:55:09] Finished 'index' after 156 ms
[15:55:09] Finished 'angular-templates' after 16 s
[15:55:09] Starting 'watch'...
[15:55:10] Finished 'watch' after 791 ms
[15:55:10] Finished 'package-backend-source' after 17 s
[15:55:10] Starting 'link-vendor'...
[15:55:10] Finished 'link-vendor' after 399 μs
[15:55:10] Starting 'package-backend'...
[15:55:10] Finished 'package-backend' after 4.59 μs
[15:55:10] Starting 'backend'...
[15:56:13] Finished 'backend' after 1.03 min
[15:56:13] Starting 'spawn-backend'...
[15:56:13] Finished 'spawn-backend' after 19 ms
[15:56:13] Starting 'serve'...
[HPM] Proxy created: /api  ->  http://localhost:9091
[15:56:13] Finished 'serve' after 40 ms
2017/09/11 15:56:13 Starting overwatch
2017/09/11 15:56:13 Using apiserver-host location: http://127.0.0.1:8080
2017/09/11 15:56:13 Skipping in-cluster config
2017/09/11 15:56:13 Using random key for csrf signing
2017/09/11 15:56:13 No request provided. Skipping authorization
2017/09/11 15:56:13 Successful initial request to the apiserver, version: v1.5.4
2017/09/11 15:56:13 New synchronizer has been registered: kubernetes-dashboard-key-holder-kube-system. Starting
2017/09/11 15:56:13 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kube-system
2017/09/11 15:56:13 Generating JWE encryption key
[BS] [BrowserSync SPA] Running...
[Browsersync] Access URLs:
 ---------------------------------------
       Local: http://localhost:9090/
    External: http://172.22.132.23:9090/
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://172.22.132.23:3001
 ---------------------------------------
[Browsersync] Serving files from: /home/ubuntu/dashboard/.tmp/serve
[Browsersync] Serving files from: /home/ubuntu/dashboard/src/app
2017/09/11 15:56:13 Storing encryption key in a secret
2017/09/11 15:56:13 Creating in-cluster Heapster client
2017/09/11 15:56:13 Could not enable metric client: Health check failed: the server could not find the requested resource (get services heapster). Continuing.
2017/09/11 15:56:13 Serving insecurely on HTTP port: 9091

$ sudo build/run-gulp-in-docker.sh serve
Sending build context to Docker daemon  56.77MB
Step 1/8 : FROM golang
 ---> 8eed12823af5
Step 2/8 : RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -   && apt-get install -y --no-install-recommends 	openjdk-8-jre 	nodejs 	&& rm -rf /var/lib/apt/lists/* 	&& apt-get clean
 ---> Using cache
 ---> 174365f4142b
Step 3/8 : RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker &&     chmod +x /usr/bin/docker
 ---> Using cache
 ---> 590eaaf50bdb
Step 4/8 : WORKDIR /dashboard
 ---> Using cache
 ---> fcf96e06075d
Step 5/8 : COPY package.json bower.json ./
 ---> Using cache
 ---> d81e3115e189
Step 6/8 : COPY build/postinstall.sh build/
 ---> Using cache
 ---> 5c7333033ca8
Step 7/8 : RUN npm install --unsafe-perm
 ---> Using cache
 ---> 83b02484edbd
Step 8/8 : COPY ./ ./
 ---> Using cache
 ---> 1b2c3774279b
Successfully built 1b2c3774279b
Successfully tagged kubernetes-dashboard-build-image:latest
[16:12:18] Requiring external module babel-register
[16:12:24] Using gulpfile /dashboard/gulpfile.babel.js
[16:12:24] Starting 'clean-packaged-backend-source'...
[16:12:24] Starting 'kill-backend'...
[16:12:24] Finished 'kill-backend' after 163 μs
[16:12:24] Starting 'locales-for-backend:dev'...
[16:12:24] Starting 'set-dev-node-env'...
[16:12:24] Finished 'set-dev-node-env' after 48 μs
[16:12:24] Starting 'scripts'...
[16:12:24] Starting 'styles'...
[16:12:24] Starting 'buildExistingI18nCache'...
[16:12:24] Finished 'clean-packaged-backend-source' after 489 ms
[16:12:24] Starting 'package-backend-source'...
[16:12:25] Finished 'buildExistingI18nCache' after 739 ms
[16:12:25] Starting 'angular-templates'...
[16:12:25] Finished 'locales-for-backend:dev' after 1.43 s
[16:12:39] Finished 'scripts' after 15 s
[16:12:40] Finished 'styles' after 15 s
[16:12:40] Starting 'index'...
[16:12:40] Finished 'index' after 186 ms
[16:12:40] Finished 'angular-templates' after 15 s
[16:12:40] Starting 'watch'...
[16:12:41] Finished 'watch' after 1.22 s
[16:12:41] Finished 'package-backend-source' after 17 s
[16:12:41] Starting 'link-vendor'...
[16:12:41] Finished 'link-vendor' after 534 μs
[16:12:41] Starting 'package-backend'...
[16:12:41] Finished 'package-backend' after 4.84 μs
[16:12:41] Starting 'backend'...
[16:13:36] Finished 'backend' after 54 s
[16:13:36] Starting 'spawn-backend'...
[16:13:36] Finished 'spawn-backend' after 27 ms
[16:13:36] Starting 'serve'...
[HPM] Proxy created: /api  ->  http://localhost:9091
[16:13:36] Finished 'serve' after 37 ms
2017/09/11 16:13:36 Starting overwatch
2017/09/11 16:13:36 Using apiserver-host location: http://localhost:8080
2017/09/11 16:13:36 Skipping in-cluster config
2017/09/11 16:13:36 Using random key for csrf signing
2017/09/11 16:13:36 No request provided. Skipping authorization
2017/09/11 16:13:36 Successful initial request to the apiserver, version: v1.5.4
2017/09/11 16:13:36 New synchronizer has been registered: kubernetes-dashboard-key-holder-kube-system. Starting
2017/09/11 16:13:36 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kube-system
2017/09/11 16:13:36 Initializing secret synchronizer synchronously using secret kubernetes-dashboard-key-holder from namespace kube-system
2017/09/11 16:13:36 Initializing JWE encryption key from synchronized object
2017/09/11 16:13:36 Trying to update secret with same object. Skipping
2017/09/11 16:13:36 Creating in-cluster Heapster client
2017/09/11 16:13:36 Could not enable metric client: Health check failed: the server could not find the requested resource (get services heapster). Continuing.
2017/09/11 16:13:36 Serving insecurely on HTTP port: 9091
[BS] [BrowserSync SPA] Running...
[Browsersync] Access URLs:
 ---------------------------------------
       Local: http://localhost:9090/
    External: http://172.22.132.23:9090/
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://172.22.132.23:3001
 ---------------------------------------
[Browsersync] Serving files from: /dashboard/.tmp/serve
[Browsersync] Serving files from: /dashboard/src/app
```

### Kubernetes Dashboard dev on Ubuntu 16.04
```sh
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.3 LTS
Release:	16.04
Codename:	xenial

$ gulp local-up-cluster --heapsterServerHost 'http://localhost:8082'
[16:47:07] Requiring external module babel-register
[16:47:08] Using gulpfile ~/dashboard/gulpfile.babel.js
[16:47:08] Starting 'spawn-cluster'...
[16:47:08] Starting 'wait-for-cluster'...
[16:47:08] Starting 'wait-for-heapster'...
[16:47:09] Waiting for a Kubernetes cluster at http://localhost:8080...
[16:47:09] Waiting for a Heapster ...
[16:47:10] Finished 'spawn-cluster' after 1.58 s
[16:47:10] Heapster is up and running.
[16:47:10] Finished 'wait-for-heapster' after 2.02 s
[16:47:18] Kubernetes cluster is up and running.
[16:47:18] Finished 'wait-for-cluster' after 10 s
[16:47:18] Starting 'local-up-cluster'...
[16:47:18] Finished 'local-up-cluster' after 1.45 μs

$ kubectl get no
NAME        STATUS    AGE       VERSION
127.0.0.1   Ready     1m        v1.5.4

$ export KUBE_DASHBOARD_APISERVER_HOST="http://127.0.0.1:8080"
$ gulp serve
[16:48:29] Requiring external module babel-register
[16:48:30] Using gulpfile ~/dashboard/gulpfile.babel.js
[16:48:30] Starting 'clean-packaged-backend-source'...
[16:48:30] Starting 'kill-backend'...
[16:48:30] Finished 'kill-backend' after 64 μs
[16:48:30] Starting 'locales-for-backend:dev'...
[16:48:30] Starting 'set-dev-node-env'...
[16:48:30] Finished 'set-dev-node-env' after 19 μs
[16:48:30] Starting 'scripts'...
[16:48:30] Starting 'styles'...
[16:48:30] Starting 'buildExistingI18nCache'...
[16:48:30] Finished 'clean-packaged-backend-source' after 190 ms
[16:48:30] Starting 'package-backend-source'...
[16:48:31] Finished 'buildExistingI18nCache' after 256 ms
[16:48:31] Starting 'angular-templates'...
[16:48:31] Finished 'locales-for-backend:dev' after 501 ms
[16:48:35] Finished 'scripts' after 5.15 s
[16:48:36] Finished 'styles' after 5.3 s
[16:48:36] Starting 'index'...
[16:48:36] Finished 'index' after 60 ms
[16:48:36] Finished 'angular-templates' after 5.18 s
[16:48:36] Starting 'watch'...
[16:48:36] Finished 'watch' after 382 ms
[16:48:36] Finished 'package-backend-source' after 5.77 s
[16:48:36] Starting 'link-vendor'...
[16:48:36] Finished 'link-vendor' after 118 μs
[16:48:36] Starting 'package-backend'...
[16:48:36] Finished 'package-backend' after 1.11 μs
[16:48:36] Starting 'backend'...
[16:49:01] Finished 'backend' after 25 s
[16:49:01] Starting 'spawn-backend'...
[16:49:01] Finished 'spawn-backend' after 8.21 ms
[16:49:01] Starting 'serve'...
[HPM] Proxy created: /api  ->  http://localhost:9091
[16:49:01] Finished 'serve' after 15 ms
2017/09/11 16:49:01 Starting overwatch
2017/09/11 16:49:01 Using apiserver-host location: http://127.0.0.1:8080
2017/09/11 16:49:01 Skipping in-cluster config
2017/09/11 16:49:01 Using random key for csrf signing
2017/09/11 16:49:01 No request provided. Skipping authorization
2017/09/11 16:49:01 Successful initial request to the apiserver, version: v1.5.4
2017/09/11 16:49:01 New synchronizer has been registered: kubernetes-dashboard-key-holder-kube-system. Starting
2017/09/11 16:49:01 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kube-system
2017/09/11 16:49:01 Generating JWE encryption key
[BS] [BrowserSync SPA] Running...
[Browsersync] Access URLs:
 ---------------------------------------
       Local: http://localhost:9090/
    External: http://172.22.132.24:9090/
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://172.22.132.24:3001
 ---------------------------------------
[Browsersync] Serving files from: /home/ubuntu/dashboard/.tmp/serve
[Browsersync] Serving files from: /home/ubuntu/dashboard/src/app
2017/09/11 16:49:01 Storing encryption key in a secret
2017/09/11 16:49:01 Creating in-cluster Heapster client
2017/09/11 16:49:01 Could not enable metric client: Health check failed: the server could not find the requested resource (get services heapster). Continuing.

$ sudo build/run-gulp-in-docker.sh serve
Sending build context to Docker daemon  56.77MB
Step 1/8 : FROM golang
 ---> 8eed12823af5
Step 2/8 : RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -   && apt-get install -y --no-install-recommends 	openjdk-8-jre 	nodejs 	&& rm -rf /var/lib/apt/lists/* 	&& apt-get clean
 ---> Using cache
 ---> ddcaf3ee263a
Step 3/8 : RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker &&     chmod +x /usr/bin/docker
 ---> Using cache
 ---> f0fdeaae2e36
Step 4/8 : WORKDIR /dashboard
 ---> Using cache
 ---> b0835040a3a3
Step 5/8 : COPY package.json bower.json ./
 ---> Using cache
 ---> c0a6de9ce4a6
Step 6/8 : COPY build/postinstall.sh build/
 ---> Using cache
 ---> ac25ff47754a
Step 7/8 : RUN npm install --unsafe-perm
 ---> Using cache
 ---> 22e3b8717842
Step 8/8 : COPY ./ ./
 ---> Using cache
 ---> d5373dc2ca53
Successfully built d5373dc2ca53
Successfully tagged kubernetes-dashboard-build-image:latest
[17:04:08] Requiring external module babel-register
[17:04:10] Using gulpfile /dashboard/gulpfile.babel.js
[17:04:10] Starting 'clean-packaged-backend-source'...
[17:04:10] Starting 'kill-backend'...
[17:04:10] Finished 'kill-backend' after 84 μs
[17:04:10] Starting 'locales-for-backend:dev'...
[17:04:10] Starting 'set-dev-node-env'...
[17:04:10] Finished 'set-dev-node-env' after 39 μs
[17:04:10] Starting 'scripts'...
[17:04:10] Starting 'styles'...
[17:04:10] Starting 'buildExistingI18nCache'...
[17:04:10] Finished 'clean-packaged-backend-source' after 184 ms
[17:04:10] Starting 'package-backend-source'...
[17:04:10] Finished 'buildExistingI18nCache' after 254 ms
[17:04:10] Starting 'angular-templates'...
[17:04:11] Finished 'locales-for-backend:dev' after 499 ms
[17:04:15] Finished 'scripts' after 5.14 s
[17:04:15] Finished 'styles' after 5.28 s
[17:04:15] Starting 'index'...
[17:04:16] Finished 'index' after 65 ms
[17:04:16] Finished 'angular-templates' after 5.15 s
[17:04:16] Starting 'watch'...
[17:04:16] Finished 'watch' after 328 ms
[17:04:16] Finished 'package-backend-source' after 5.71 s
[17:04:16] Starting 'link-vendor'...
[17:04:16] Finished 'link-vendor' after 319 μs
[17:04:16] Starting 'package-backend'...
[17:04:16] Finished 'package-backend' after 1.9 μs
[17:04:16] Starting 'backend'...
[17:04:39] Finished 'backend' after 23 s
[17:04:39] Starting 'spawn-backend'...
[17:04:39] Finished 'spawn-backend' after 12 ms
[17:04:39] Starting 'serve'...
[HPM] Proxy created: /api  ->  http://localhost:9091
[17:04:39] Finished 'serve' after 15 ms
2017/09/11 17:04:39 Starting overwatch
2017/09/11 17:04:39 Using apiserver-host location: http://localhost:8080
2017/09/11 17:04:39 Skipping in-cluster config
2017/09/11 17:04:39 Using random key for csrf signing
2017/09/11 17:04:39 No request provided. Skipping authorization
2017/09/11 17:04:39 Successful initial request to the apiserver, version: v1.5.4
2017/09/11 17:04:39 New synchronizer has been registered: kubernetes-dashboard-key-holder-kube-system. Starting
2017/09/11 17:04:39 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kube-system
2017/09/11 17:04:39 Initializing secret synchronizer synchronously using secret kubernetes-dashboard-key-holder from namespace kube-system
2017/09/11 17:04:39 Initializing JWE encryption key from synchronized object
2017/09/11 17:04:39 Trying to update secret with same object. Skipping
2017/09/11 17:04:39 Creating in-cluster Heapster client
2017/09/11 17:04:39 Could not enable metric client: Health check failed: the server could not find the requested resource (get services heapster). Continuing.
2017/09/11 17:04:39 Serving insecurely on HTTP port: 9091
[BS] [BrowserSync SPA] Running...
[Browsersync] Access URLs:
 ---------------------------------------
       Local: http://localhost:9090/
    External: http://172.22.132.24:9090/
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://172.22.132.24:3001
 ---------------------------------------
[Browsersync] Serving files from: /dashboard/.tmp/serve
[Browsersync] Serving files from: /dashboard/src/app
```