### PR TITLE
Include Init Containers in Logs

### DIFF
--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -79,6 +79,9 @@ func GetContainerNames(podTemplate *v1.PodSpec) []string {
 	for _, container := range podTemplate.Containers {
 		containerNames = append(containerNames, container.Name)
 	}
+	for _, container := range podTemplate.InitContainers {
+		containerNames = append(containerNames, container.Name)
+	}
 	return containerNames
 }
 

--- a/src/app/backend/resource/common/pod_test.go
+++ b/src/app/backend/resource/common/pod_test.go
@@ -135,9 +135,10 @@ func TestGetContainerNames(t *testing.T) {
 		{&api.PodSpec{}, nil},
 		{
 			&api.PodSpec{
-				Containers: []api.Container{{Name: "container"}, {Name: "container"}},
+				Containers:     []api.Container{{Name: "container"}, {Name: "container"}},
+				InitContainers: []api.Container{{Name: "init-container-1"}, {Name: "init-container-2"}},
 			},
-			[]string{"container", "container"},
+			[]string{"container", "container", "init-container-1", "init-container-2"},
 		},
 	}
 


### PR DESCRIPTION
Fix for #2358.

This change updates the `GetContainerNames` function to also include Init Containers; the impact of this being you can now view the Logs of Init Containers.

<img width="368" alt="screen shot 2017-09-12 at 9 36 18 pm" src="https://user-images.githubusercontent.com/10828/30323947-879765ca-9802-11e7-8626-ee15ae795cd9.png">

(copy-migrations and run-migrations are both init-containers)