### PR TITLE
Fix logging in when using kubectl proxy

### DIFF
--- a/src/app/frontend/common/auth/service.js
+++ b/src/app/frontend/common/auth/service.js
@@ -64,7 +64,11 @@ export class AuthService {
    * @private
    */
   setTokenCookie_(token) {
+    // This will only work for HTTPS connection
     this.cookies_.put(this.tokenCookieName_, token, {secure: true});
+    // This will only work when accessing Dashboard at 'localhost' or '127.0.0.1'
+    this.cookies_.put(this.tokenCookieName_, token, {domain: 'localhost'});
+    this.cookies_.put(this.tokenCookieName_, token, {domain: '127.0.0.1'});
   }
 
   /**


### PR DESCRIPTION
Note in [Accessing Dashboard](https://github.com/kubernetes/dashboard/wiki/Accessing-Dashboard---1.7.X-and-above#kubectl-proxy) guide describes this change.

It makes sure that our token will not be saved unless Dashboard is accessed over HTTPS or locally (`127.0.0.1` or `localhost` domains) using `kubectl proxy`. Exposing Dashboard using `kubectl proxy --address ip ...` will not allow to log in.