### PR TITLE
Make environment variables defined in envFrom shown in pod detail page

### DIFF
--- a/src/app/backend/resource/pod/detail.go
+++ b/src/app/backend/resource/pod/detail.go
@@ -213,57 +213,8 @@ func extractContainerInfo(containerList []v1.Container, pod *v1.Pod, configMaps 
 			}
 			vars = append(vars, variable)
 		}
+		vars = append(vars, evalEnvFrom(container, configMaps, secrets)...)
 
-		for _, envFromVar := range container.EnvFrom {
-			switch {
-			case envFromVar.ConfigMapRef != nil:
-				name := envFromVar.ConfigMapRef.LocalObjectReference.Name
-				for _, configMap := range configMaps.Items {
-					if configMap.ObjectMeta.Name == name {
-						for key, value := range configMap.Data {
-							valueFrom := &v1.EnvVarSource{
-								ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: name,
-									},
-									Key: key,
-								},
-							}
-							variable := EnvVar{
-								Name:      envFromVar.Prefix + key,
-								Value:     value,
-								ValueFrom: valueFrom,
-							}
-							vars = append(vars, variable)
-						}
-						break
-					}
-				}
-			case envFromVar.SecretRef != nil:
-				name := envFromVar.SecretRef.LocalObjectReference.Name
-				for _, secret := range secrets.Items {
-					if secret.ObjectMeta.Name == name {
-						for key, value := range secret.Data {
-							valueFrom := &v1.EnvVarSource{
-								SecretKeyRef: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: name,
-									},
-									Key: key,
-								},
-							}
-							variable := EnvVar{
-								Name:      envFromVar.Prefix + key,
-								Value:     base64.StdEncoding.EncodeToString(value),
-								ValueFrom: valueFrom,
-							}
-							vars = append(vars, variable)
-						}
-						break
-					}
-				}
-			}
-		}
 		containers = append(containers, Container{
 			Name:     container.Name,
 			Image:    container.Image,
@@ -292,6 +243,61 @@ func toPodDetail(pod *v1.Pod, metrics []metricapi.Metric, configMaps *v1.ConfigM
 		EventList:      *events,
 		Errors:         nonCriticalErrors,
 	}
+}
+
+func evalEnvFrom(container v1.Container, configMaps *v1.ConfigMapList, secrets *v1.SecretList) []EnvVar {
+	vars := make([]EnvVar, 0)
+	for _, envFromVar := range container.EnvFrom {
+		switch {
+		case envFromVar.ConfigMapRef != nil:
+			name := envFromVar.ConfigMapRef.LocalObjectReference.Name
+			for _, configMap := range configMaps.Items {
+				if configMap.ObjectMeta.Name == name {
+					for key, value := range configMap.Data {
+						valueFrom := &v1.EnvVarSource{
+							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: name,
+								},
+								Key: key,
+							},
+						}
+						variable := EnvVar{
+							Name:      envFromVar.Prefix + key,
+							Value:     value,
+							ValueFrom: valueFrom,
+						}
+						vars = append(vars, variable)
+					}
+					break
+				}
+			}
+		case envFromVar.SecretRef != nil:
+			name := envFromVar.SecretRef.LocalObjectReference.Name
+			for _, secret := range secrets.Items {
+				if secret.ObjectMeta.Name == name {
+					for key, value := range secret.Data {
+						valueFrom := &v1.EnvVarSource{
+							SecretKeyRef: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: name,
+								},
+								Key: key,
+							},
+						}
+						variable := EnvVar{
+							Name:      envFromVar.Prefix + key,
+							Value:     base64.StdEncoding.EncodeToString(value),
+							ValueFrom: valueFrom,
+						}
+						vars = append(vars, variable)
+					}
+					break
+				}
+			}
+		}
+	}
+	return vars
 }
 
 // evalValueFrom evaluates environment value from given source. For more details check:


### PR DESCRIPTION
Fix #2343 

This commit create EnvVars from every item in referenced ConfigMap or Secret, then add them to the container info. 

The following is an example.

![pod_detail](https://user-images.githubusercontent.com/489448/30755211-6752236e-9f8b-11e7-8762-afdf7af36b52.png)

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: env-variables
spec:
  containers:
  - name: test
    image: gcr.io/google_containers/busybox
    command: [ "sh", "-c"]
    args:
    - while true; do
        echo -en '\n';
        printenv CONST_USER;
        printenv CONFIG_USER;
        printenv SECRET_USER;
        printenv TEST_FROM_CONFIG_USER;
        printenv TEST_FROM_CONFIG_TITLE;
        printenv FROM_SECRET_USER;
        printenv FROM_SECRET_TITLE;
        sleep 10;
      done;
    env:
    - name: CONST_USER
      value: alice
    - name: CONFIG_USER
      valueFrom:
        configMapKeyRef:
          name: config-env
          key: username
    - name: SECRET_USER
      valueFrom:
        secretKeyRef:
          name: secret-env
          key: username
    envFrom:
      - prefix: TEST_
        configMapRef:
          name: config-env-from
      - secretRef:
          name: secret-env-from
---
kind: ConfigMap
apiVersion: v1
metadata:
  name: config-env
data:
  username: bob
---
kind: Secret
apiVersion: v1
metadata:
  name: secret-env
data:
  username: Y2hhcmxpZQ==
---
kind: ConfigMap
apiVersion: v1
metadata:
  name: config-env-from
data:
  FROM_CONFIG_USER: david
  FROM_CONFIG_TITLE: programmer
---
kind: Secret
apiVersion: v1
metadata:
  name: secret-env-from
data:
  FROM_SECRET_USER: ZXZl
  FROM_SECRET_JOB: ZGVzaWduZXI=
```
