### PR TITLE
Fix logs download button

### DIFF
--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -324,7 +324,7 @@ export class LogsController {
    */
   getDownloadLink() {
     let namespace = this.stateParams_.objectNamespace;
-    return `/api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
+    return `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
         this.logsService.getPrevious()}`;
   }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dashboard/issues/2408

Download link for logs not working in latest version when using kubectl proxy.

The generated URL removed the proxy prefix. Tested the fix inside the cluster with kubectl proxy. Should work