### PR TITLE
Several fixes where Init-containers are mising in the frontend

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -488,6 +488,8 @@
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="1223986507449568472" key="MSG_LOGS_LOGS_3" desc="Footer part for logs card.">to</translation>
+  <translation id="8510779305487405945" key="MSG_LOGS_LOGS_4" desc="Label atop a list of Containers">Containers</translation>
+  <translation id="7432843701863632053" key="MSG_LOGS_LOGS_5" desc="Label atop a list of Init Containers">Init Containers</translation>
   <translation id="3402202863027894322" key="MSG_LOGS_TRUNCATED_WARNING" desc="Error dialog indicating that parts of the log file is missing due to memory constraints.">The middle part of the log file cannot be loaded, because it is too big.</translation>
   <translation id="7594890250973129963" key="MSG_LOGS_ZEROSTATE_TEXT" desc="Text for logs card zerostate in logs page.">The selected container has not logged any messages yet.</translation>
   <translation id="2533795620042066843" key="MSG_MORE_WARNINGS_LABEL" desc="Show more warnings button label.">Show <ph name="COUNT"> more</ph></translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -504,6 +504,8 @@
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="1223986507449568472" key="MSG_LOGS_LOGS_3" desc="Footer part for logs card.">to</translation>
+  <translation id="8510779305487405945" key="MSG_LOGS_LOGS_4" desc="Label atop a list of Containers">Containers</translation>
+  <translation id="7432843701863632053" key="MSG_LOGS_LOGS_5" desc="Label atop a list of Init Containers">Init Containers</translation>
   <translation id="3402202863027894322" key="MSG_LOGS_TRUNCATED_WARNING" desc="Error dialog indicating that parts of the log file is missing due to memory constraints.">大きすぎるため、ログファイルの中間部分は読み込めません。</translation>
   <translation id="7594890250973129963" key="MSG_LOGS_ZEROSTATE_TEXT" desc="Text for logs card zerostate in logs page.">選択されたコンテナにはログにメッセージが記録されていません。</translation>
   <translation id="2533795620042066843" key="MSG_MORE_WARNINGS_LABEL" desc="Show more warnings button label.">Show <ph name="COUNT"> more</ph></translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -486,6 +486,8 @@
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位於</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">日誌範圍從</translation>
   <translation id="1223986507449568472" key="MSG_LOGS_LOGS_3" desc="Footer part for logs card.">到</translation>
+  <translation id="8510779305487405945" key="MSG_LOGS_LOGS_4" desc="Label atop a list of Containers">Containers</translation>
+  <translation id="7432843701863632053" key="MSG_LOGS_LOGS_5" desc="Label atop a list of Init Containers">Init Containers</translation>
   <translation id="3402202863027894322" key="MSG_LOGS_TRUNCATED_WARNING" desc="Error dialog indicating that parts of the log file is missing due to memory constraints.">日誌檔案過大，中間部分無法載入</translation>
   <translation id="7594890250973129963" key="MSG_LOGS_ZEROSTATE_TEXT" desc="Text for logs card zerostate in logs page.">選擇的容器沒有日誌訊息</translation>
   <translation id="2533795620042066843" key="MSG_MORE_WARNINGS_LABEL" desc="Show more warnings button label.">顯示更多 <ph name="COUNT"> 則</ph></translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -488,6 +488,8 @@
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位于</translation>
   <translation id="6208229815004454576" key="MSG_LOGS_LOGS_2" desc="Title prefix for logs card.">日志范围从</translation>
   <translation id="1223986507449568472" key="MSG_LOGS_LOGS_3" desc="Footer part for logs card.">到</translation>
+  <translation id="8510779305487405945" key="MSG_LOGS_LOGS_4" desc="Label atop a list of Containers">Containers</translation>
+  <translation id="7432843701863632053" key="MSG_LOGS_LOGS_5" desc="Label atop a list of Init Containers">Init Containers</translation>
   <translation id="3402202863027894322" key="MSG_LOGS_TRUNCATED_WARNING" desc="Error dialog indicating that parts of the log file is missing due to memory constraints.">日志文件过大，中间部分无法加载</translation>
   <translation id="7594890250973129963" key="MSG_LOGS_ZEROSTATE_TEXT" desc="Text for logs card zerostate in logs page.">所选容器没有日志信息</translation>
   <translation id="2533795620042066843" key="MSG_MORE_WARNINGS_LABEL" desc="Show more warnings button label.">显示更多 <ph name="COUNT"> 条</ph></translation>

--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -73,6 +73,15 @@ func GetContainerImages(podTemplate *v1.PodSpec) []string {
 	return containerImages
 }
 
+// GetInitContainerImages returns init container image strings from the given pod spec.
+func GetInitContainerImages(podTemplate *v1.PodSpec) []string {
+	var initContainerImages []string
+	for _, initContainer := range podTemplate.InitContainers {
+		initContainerImages = append(initContainerImages, initContainer.Image)
+	}
+	return initContainerImages
+}
+
 // GetContainerNames returns the container image name without the version number from the given pod spec.
 func GetContainerNames(podTemplate *v1.PodSpec) []string {
 	var containerNames []string
@@ -80,6 +89,15 @@ func GetContainerNames(podTemplate *v1.PodSpec) []string {
 		containerNames = append(containerNames, container.Name)
 	}
 	return containerNames
+}
+
+// GetInitContainerNames returns the init container image name without the version number from the given pod spec.
+func GetInitContainerNames(podTemplate *v1.PodSpec) []string {
+	var initContainerNames []string
+	for _, initContainer := range podTemplate.InitContainers {
+		initContainerNames = append(initContainerNames, initContainer.Name)
+	}
+	return initContainerNames
 }
 
 // EqualIgnoreHash returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]

--- a/src/app/backend/resource/common/pod_test.go
+++ b/src/app/backend/resource/common/pod_test.go
@@ -127,6 +127,29 @@ func TestGetContainerImages(t *testing.T) {
 	}
 }
 
+func TestGetInitContainerImages(t *testing.T) {
+	cases := []struct {
+		podTemplate *api.PodSpec
+		expected    []string
+	}{
+		{&api.PodSpec{}, nil},
+		{
+			&api.PodSpec{
+				InitContainers: []api.Container{{Image: "initContainer:v3"}, {Image: "initContainer:v4"}},
+			},
+			[]string{"initContainer:v3", "initContainer:v4"},
+		},
+	}
+
+	for _, c := range cases {
+		actual := GetInitContainerImages(c.podTemplate)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetInitContainerImages(%+v) == %+v, expected %+v",
+				c.podTemplate, actual, c.expected)
+		}
+	}
+}
+
 func TestGetContainerNames(t *testing.T) {
 	cases := []struct {
 		podTemplate *api.PodSpec
@@ -145,6 +168,29 @@ func TestGetContainerNames(t *testing.T) {
 		actual := GetContainerNames(c.podTemplate)
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Errorf("GetContainerNames(%+v) == %+v, expected %+v",
+				c.podTemplate, actual, c.expected)
+		}
+	}
+}
+
+func TestGetInitContainerNames(t *testing.T) {
+	cases := []struct {
+		podTemplate *api.PodSpec
+		expected    []string
+	}{
+		{&api.PodSpec{}, nil},
+		{
+			&api.PodSpec{
+				InitContainers: []api.Container{{Name: "initContainer"}, {Name: "initContainer"}},
+			},
+			[]string{"initContainer", "initContainer"},
+		},
+	}
+
+	for _, c := range cases {
+		actual := GetInitContainerNames(c.podTemplate)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetInitContainerNames(%+v) == %+v, expected %+v",
 				c.podTemplate, actual, c.expected)
 		}
 	}

--- a/src/app/backend/resource/container/logs_test.go
+++ b/src/app/backend/resource/container/logs_test.go
@@ -331,7 +331,7 @@ func TestGetLogs(t *testing.T) {
 				LogLines: logs.LogLines{logs.LogLine{
 					Timestamp: "0",
 					Content:   "an error message from api server",
-				},},
+				}},
 				Selection: logs.Selection{
 					ReferencePoint: logs.LogLineId{
 						LogTimestamp: "0",

--- a/src/app/backend/resource/controller/controller.go
+++ b/src/app/backend/resource/controller/controller.go
@@ -34,17 +34,19 @@ import (
 // ResourceOwner is an structure representing resource owner, it may be Replication Controller,
 // Daemon Set, Job etc.
 type ResourceOwner struct {
-	ObjectMeta      api.ObjectMeta `json:"objectMeta"`
-	TypeMeta        api.TypeMeta   `json:"typeMeta"`
-	Pods            common.PodInfo `json:"pods"`
-	ContainerImages []string       `json:"containerImages"`
+	ObjectMeta          api.ObjectMeta `json:"objectMeta"`
+	TypeMeta            api.TypeMeta   `json:"typeMeta"`
+	Pods                common.PodInfo `json:"pods"`
+	ContainerImages     []string       `json:"containerImages"`
+	InitContainerImages []string       `json:"initContainerImages"`
 }
 
 // LogSources is a structure that represents all log files (all combinations of pods and container)
 // from a higher level controller (such as ReplicaSet).
 type LogSources struct {
-	ContainerNames []string `json:"containerNames"`
-	PodNames       []string `json:"podNames"`
+	ContainerNames     []string `json:"containerNames"`
+	InitContainerNames []string `json:"initContainerNames"`
+	PodNames           []string `json:"podNames"`
 }
 
 // ResourceController is an interface, that allows to perform operations on resource controller. To
@@ -110,10 +112,11 @@ func (self JobController) Get(allPods []v1.Pod, allEvents []v1.Event) ResourceOw
 	podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
 
 	return ResourceOwner{
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindJob),
-		ObjectMeta:      api.NewObjectMeta(self.ObjectMeta),
-		Pods:            podInfo,
-		ContainerImages: common.GetContainerImages(&self.Spec.Template.Spec),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindJob),
+		ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+		Pods:                podInfo,
+		ContainerImages:     common.GetContainerImages(&self.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&self.Spec.Template.Spec),
 	}
 }
 
@@ -126,8 +129,9 @@ func (self JobController) UID() types.UID {
 func (self JobController) GetLogSources(allPods []v1.Pod) LogSources {
 	controlledPods := common.FilterPodsForJob(batch.Job(self), allPods)
 	return LogSources{
-		PodNames:       getPodNames(controlledPods),
-		ContainerNames: common.GetContainerNames(&self.Spec.Template.Spec),
+		PodNames:           getPodNames(controlledPods),
+		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
+		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
 }
 
@@ -142,10 +146,11 @@ func (self ReplicaSetController) Get(allPods []v1.Pod, allEvents []v1.Event) Res
 	podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
 
 	return ResourceOwner{
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindReplicaSet),
-		ObjectMeta:      api.NewObjectMeta(self.ObjectMeta),
-		Pods:            podInfo,
-		ContainerImages: common.GetContainerImages(&self.Spec.Template.Spec),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindReplicaSet),
+		ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+		Pods:                podInfo,
+		ContainerImages:     common.GetContainerImages(&self.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&self.Spec.Template.Spec),
 	}
 }
 
@@ -158,8 +163,9 @@ func (self ReplicaSetController) UID() types.UID {
 func (self ReplicaSetController) GetLogSources(allPods []v1.Pod) LogSources {
 	controlledPods := common.FilterPodsByControllerRef(&self, allPods)
 	return LogSources{
-		PodNames:       getPodNames(controlledPods),
-		ContainerNames: common.GetContainerNames(&self.Spec.Template.Spec),
+		PodNames:           getPodNames(controlledPods),
+		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
+		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
 }
 
@@ -175,10 +181,11 @@ func (self ReplicationControllerController) Get(allPods []v1.Pod,
 	podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
 
 	return ResourceOwner{
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindReplicationController),
-		ObjectMeta:      api.NewObjectMeta(self.ObjectMeta),
-		Pods:            podInfo,
-		ContainerImages: common.GetContainerImages(&self.Spec.Template.Spec),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindReplicationController),
+		ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+		Pods:                podInfo,
+		ContainerImages:     common.GetContainerImages(&self.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&self.Spec.Template.Spec),
 	}
 }
 
@@ -191,8 +198,9 @@ func (self ReplicationControllerController) UID() types.UID {
 func (self ReplicationControllerController) GetLogSources(allPods []v1.Pod) LogSources {
 	controlledPods := common.FilterPodsByControllerRef(&self, allPods)
 	return LogSources{
-		PodNames:       getPodNames(controlledPods),
-		ContainerNames: common.GetContainerNames(&self.Spec.Template.Spec),
+		PodNames:           getPodNames(controlledPods),
+		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
+		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
 }
 
@@ -208,10 +216,11 @@ func (self DaemonSetController) Get(allPods []v1.Pod, allEvents []v1.Event) Reso
 	podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
 
 	return ResourceOwner{
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindDaemonSet),
-		ObjectMeta:      api.NewObjectMeta(self.ObjectMeta),
-		Pods:            podInfo,
-		ContainerImages: common.GetContainerImages(&self.Spec.Template.Spec),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindDaemonSet),
+		ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+		Pods:                podInfo,
+		ContainerImages:     common.GetContainerImages(&self.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&self.Spec.Template.Spec),
 	}
 }
 
@@ -224,8 +233,9 @@ func (self DaemonSetController) UID() types.UID {
 func (self DaemonSetController) GetLogSources(allPods []v1.Pod) LogSources {
 	controlledPods := common.FilterPodsByControllerRef(&self, allPods)
 	return LogSources{
-		PodNames:       getPodNames(controlledPods),
-		ContainerNames: common.GetContainerNames(&self.Spec.Template.Spec),
+		PodNames:           getPodNames(controlledPods),
+		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
+		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
 }
 
@@ -240,10 +250,11 @@ func (self StatefulSetController) Get(allPods []v1.Pod, allEvents []v1.Event) Re
 	podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
 
 	return ResourceOwner{
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindStatefulSet),
-		ObjectMeta:      api.NewObjectMeta(self.ObjectMeta),
-		Pods:            podInfo,
-		ContainerImages: common.GetContainerImages(&self.Spec.Template.Spec),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindStatefulSet),
+		ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+		Pods:                podInfo,
+		ContainerImages:     common.GetContainerImages(&self.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&self.Spec.Template.Spec),
 	}
 }
 
@@ -256,8 +267,9 @@ func (self StatefulSetController) UID() types.UID {
 func (self StatefulSetController) GetLogSources(allPods []v1.Pod) LogSources {
 	controlledPods := common.FilterPodsByControllerRef(&self, allPods)
 	return LogSources{
-		PodNames:       getPodNames(controlledPods),
-		ContainerNames: common.GetContainerNames(&self.Spec.Template.Spec),
+		PodNames:           getPodNames(controlledPods),
+		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
+		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
 }
 

--- a/src/app/backend/resource/daemonset/detail.go
+++ b/src/app/backend/resource/daemonset/detail.go
@@ -41,6 +41,9 @@ type DaemonSetDetail struct {
 	// Container image list of the pod template specified by this Daemon Set.
 	ContainerImages []string `json:"containerImages"`
 
+	// Init Container image list of the pod template specified by this Daemon Set.
+	InitContainerImages []string `json:"initContainerImages"`
+
 	// Aggregate information about pods of this daemon set.
 	PodInfo common.PodInfo `json:"podInfo"`
 
@@ -107,6 +110,10 @@ func GetDaemonSetDetail(client k8sClient.Interface, metricClient metricapi.Metri
 
 	for _, container := range daemonSet.Spec.Template.Spec.Containers {
 		daemonSetDetail.ContainerImages = append(daemonSetDetail.ContainerImages, container.Image)
+	}
+
+	for _, initContainer := range daemonSet.Spec.Template.Spec.InitContainers {
+		daemonSetDetail.InitContainerImages = append(daemonSetDetail.InitContainerImages, initContainer.Image)
 	}
 
 	return daemonSetDetail, nil

--- a/src/app/backend/resource/daemonset/list.go
+++ b/src/app/backend/resource/daemonset/list.go
@@ -46,6 +46,9 @@ type DaemonSet struct {
 
 	// Container images of the Daemon Set.
 	ContainerImages []string `json:"containerImages"`
+
+	// InitContainer images of the Daemon Set.
+	InitContainerImages []string `json:"initContainerImages"`
 }
 
 // GetDaemonSetList returns a list of all Daemon Set in the cluster.
@@ -116,10 +119,11 @@ func toDaemonSetList(daemonSets []extensions.DaemonSet, pods []v1.Pod, events []
 		podInfo.Warnings = event.GetPodsEventWarnings(events, matchingPods)
 
 		daemonSetList.DaemonSets = append(daemonSetList.DaemonSets, DaemonSet{
-			ObjectMeta:      api.NewObjectMeta(daemonSet.ObjectMeta),
-			TypeMeta:        api.NewTypeMeta(api.ResourceKindDaemonSet),
-			Pods:            podInfo,
-			ContainerImages: common.GetContainerImages(&daemonSet.Spec.Template.Spec),
+			ObjectMeta:          api.NewObjectMeta(daemonSet.ObjectMeta),
+			TypeMeta:            api.NewTypeMeta(api.ResourceKindDaemonSet),
+			Pods:                podInfo,
+			ContainerImages:     common.GetContainerImages(&daemonSet.Spec.Template.Spec),
+			InitContainerImages: common.GetInitContainerImages(&daemonSet.Spec.Template.Spec),
 		})
 	}
 

--- a/src/app/backend/resource/daemonset/list_test.go
+++ b/src/app/backend/resource/daemonset/list_test.go
@@ -81,7 +81,8 @@ func TestToDaemonSetList(t *testing.T) {
 							MatchLabels: map[string]string{"app": "my-name-1"},
 						},
 						Template: v1.PodTemplateSpec{
-							Spec: v1.PodSpec{Containers: []v1.Container{{Image: "my-container-image-1"}}},
+							Spec: v1.PodSpec{Containers: []v1.Container{{Image: "my-container-image-1"}},
+								InitContainers: []v1.Container{{Image: "my-init-container-image-1"}}},
 						},
 					},
 					Status: extensions.DaemonSetStatus{
@@ -98,7 +99,8 @@ func TestToDaemonSetList(t *testing.T) {
 							MatchLabels: map[string]string{"app": "my-name-2", "ver": "2"},
 						},
 						Template: v1.PodTemplateSpec{
-							Spec: v1.PodSpec{Containers: []v1.Container{{Image: "my-container-image-2"}}},
+							Spec: v1.PodSpec{Containers: []v1.Container{{Image: "my-container-image-2"}},
+								InitContainers: []v1.Container{{Image: "my-init-container-image-2"}}},
 						},
 					},
 					Status: extensions.DaemonSetStatus{
@@ -186,8 +188,9 @@ func TestToDaemonSetList(t *testing.T) {
 							Name:      "my-app-1",
 							Namespace: "namespace-1",
 						},
-						TypeMeta:        api.TypeMeta{Kind: api.ResourceKindDaemonSet},
-						ContainerImages: []string{"my-container-image-1"},
+						TypeMeta:            api.TypeMeta{Kind: api.ResourceKindDaemonSet},
+						ContainerImages:     []string{"my-container-image-1"},
+						InitContainerImages: []string{"my-init-container-image-1"},
 						Pods: common.PodInfo{
 							Desired:   &desired,
 							Failed:    2,
@@ -201,8 +204,9 @@ func TestToDaemonSetList(t *testing.T) {
 							Name:      "my-app-2",
 							Namespace: "namespace-2",
 						},
-						TypeMeta:        api.TypeMeta{Kind: api.ResourceKindDaemonSet},
-						ContainerImages: []string{"my-container-image-2"},
+						TypeMeta:            api.TypeMeta{Kind: api.ResourceKindDaemonSet},
+						ContainerImages:     []string{"my-container-image-2"},
+						InitContainerImages: []string{"my-init-container-image-2"},
 						Pods: common.PodInfo{
 							Desired:  &desired,
 							Warnings: []common.Event{},

--- a/src/app/backend/resource/deployment/list.go
+++ b/src/app/backend/resource/deployment/list.go
@@ -52,6 +52,9 @@ type Deployment struct {
 
 	// Container images of the Deployment.
 	ContainerImages []string `json:"containerImages"`
+
+	// Init Container images of the Deployment.
+	InitContainerImages []string `json:"initContainerImages"`
 }
 
 // GetDeploymentList returns a list of all Deployments in the cluster.
@@ -129,10 +132,11 @@ func toDeploymentList(deployments []extensions.Deployment, pods []v1.Pod, events
 
 		deploymentList.Deployments = append(deploymentList.Deployments,
 			Deployment{
-				ObjectMeta:      api.NewObjectMeta(deployment.ObjectMeta),
-				TypeMeta:        api.NewTypeMeta(api.ResourceKindDeployment),
-				ContainerImages: common.GetContainerImages(&deployment.Spec.Template.Spec),
-				Pods:            podInfo,
+				ObjectMeta:          api.NewObjectMeta(deployment.ObjectMeta),
+				TypeMeta:            api.NewTypeMeta(api.ResourceKindDeployment),
+				ContainerImages:     common.GetContainerImages(&deployment.Spec.Template.Spec),
+				InitContainerImages: common.GetInitContainerImages(&deployment.Spec.Template.Spec),
+				Pods:                podInfo,
 			})
 	}
 

--- a/src/app/backend/resource/job/detail.go
+++ b/src/app/backend/resource/job/detail.go
@@ -42,6 +42,9 @@ type JobDetail struct {
 	// Container images of the Job.
 	ContainerImages []string `json:"containerImages"`
 
+	// Init container images of the Job.
+	InitContainerImages []string `json:"initContainerImages"`
+
 	// List of events related to this Job.
 	EventList common.EventList `json:"eventList"`
 
@@ -89,14 +92,15 @@ func GetJobDetail(client k8sClient.Interface, metricClient metricapi.MetricClien
 func toJobDetail(job *batch.Job, eventList common.EventList, podList pod.PodList, podInfo common.PodInfo,
 	nonCriticalErrors []error) JobDetail {
 	return JobDetail{
-		ObjectMeta:      api.NewObjectMeta(job.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindJob),
-		ContainerImages: common.GetContainerImages(&job.Spec.Template.Spec),
-		PodInfo:         podInfo,
-		PodList:         podList,
-		EventList:       eventList,
-		Parallelism:     job.Spec.Parallelism,
-		Completions:     job.Spec.Completions,
-		Errors:          nonCriticalErrors,
+		ObjectMeta:          api.NewObjectMeta(job.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindJob),
+		ContainerImages:     common.GetContainerImages(&job.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&job.Spec.Template.Spec),
+		PodInfo:             podInfo,
+		PodList:             podList,
+		EventList:           eventList,
+		Parallelism:         job.Spec.Parallelism,
+		Completions:         job.Spec.Completions,
+		Errors:              nonCriticalErrors,
 	}
 }

--- a/src/app/backend/resource/job/list.go
+++ b/src/app/backend/resource/job/list.go
@@ -52,6 +52,9 @@ type Job struct {
 	// Container images of the Job.
 	ContainerImages []string `json:"containerImages"`
 
+	// Init Container images of the Job.
+	InitContainerImages []string `json:"initContainerImages"`
+
 	// number of parallel jobs defined.
 	Parallelism *int32 `json:"parallelism"`
 }
@@ -133,10 +136,11 @@ func toJobList(jobs []batch.Job, pods []v1.Pod, events []v1.Event, nonCriticalEr
 
 func toJob(job *batch.Job, podInfo *common.PodInfo) Job {
 	return Job{
-		ObjectMeta:      api.NewObjectMeta(job.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindJob),
-		ContainerImages: common.GetContainerImages(&job.Spec.Template.Spec),
-		Pods:            *podInfo,
-		Parallelism:     job.Spec.Parallelism,
+		ObjectMeta:          api.NewObjectMeta(job.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindJob),
+		ContainerImages:     common.GetContainerImages(&job.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&job.Spec.Template.Spec),
+		Pods:                *podInfo,
+		Parallelism:         job.Spec.Parallelism,
 	}
 }

--- a/src/app/backend/resource/logs/logs.go
+++ b/src/app/backend/resource/logs/logs.go
@@ -88,6 +88,9 @@ type LogInfo struct {
 	// The name of the container the logs are for.
 	ContainerName string `json:"containerName"`
 
+	// The name of the init container the logs are for.
+	InitContainerName string `json:"initContainerName"`
+
 	// Date of the first log line
 	FromDate LogTimestamp `json:"fromDate"`
 

--- a/src/app/backend/resource/logs/source.go
+++ b/src/app/backend/resource/logs/source.go
@@ -37,8 +37,9 @@ func getLogSourcesFromPod(k8sClient kubernetes.Interface, ns, resourceName strin
 		return controller.LogSources{}, err
 	}
 	return controller.LogSources{
-		ContainerNames: common.GetContainerNames(&pod.Spec),
-		PodNames:       []string{resourceName},
+		ContainerNames:     common.GetContainerNames(&pod.Spec),
+		InitContainerNames: common.GetInitContainerNames(&pod.Spec),
+		PodNames:           []string{resourceName},
 	}, nil
 }
 

--- a/src/app/backend/resource/replicaset/common.go
+++ b/src/app/backend/resource/replicaset/common.go
@@ -34,15 +34,19 @@ type ReplicaSet struct {
 
 	// Container images of the Replica Set.
 	ContainerImages []string `json:"containerImages"`
+
+	// Init Container images of the Replica Set.
+	InitContainerImages []string `json:"initContainerImages"`
 }
 
 // ToReplicaSet converts replica set api object to replica set model object.
 func ToReplicaSet(replicaSet *extensions.ReplicaSet, podInfo *common.PodInfo) ReplicaSet {
 	return ReplicaSet{
-		ObjectMeta:      api.NewObjectMeta(replicaSet.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindReplicaSet),
-		ContainerImages: common.GetContainerImages(&replicaSet.Spec.Template.Spec),
-		Pods:            *podInfo,
+		ObjectMeta:          api.NewObjectMeta(replicaSet.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindReplicaSet),
+		ContainerImages:     common.GetContainerImages(&replicaSet.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&replicaSet.Spec.Template.Spec),
+		Pods:                *podInfo,
 	}
 }
 

--- a/src/app/backend/resource/replicaset/detail.go
+++ b/src/app/backend/resource/replicaset/detail.go
@@ -50,6 +50,9 @@ type ReplicaSetDetail struct {
 	// Container images of the Replica Set.
 	ContainerImages []string `json:"containerImages"`
 
+	// Init Container images of the Replica Set.
+	InitContainerImages []string `json:"initContainerImages"`
+
 	// List of events related to this Replica Set.
 	EventList common.EventList `json:"eventList"`
 
@@ -115,6 +118,7 @@ func toReplicaSetDetail(replicaSet *extensions.ReplicaSet, eventList common.Even
 		ObjectMeta:                  api.NewObjectMeta(replicaSet.ObjectMeta),
 		TypeMeta:                    api.NewTypeMeta(api.ResourceKindReplicaSet),
 		ContainerImages:             common.GetContainerImages(&replicaSet.Spec.Template.Spec),
+		InitContainerImages:         common.GetInitContainerImages(&replicaSet.Spec.Template.Spec),
 		Selector:                    replicaSet.Spec.Selector,
 		PodInfo:                     podInfo,
 		PodList:                     podList,

--- a/src/app/backend/resource/replicationcontroller/common.go
+++ b/src/app/backend/resource/replicationcontroller/common.go
@@ -37,6 +37,9 @@ type ReplicationController struct {
 
 	// Container images of the Replication Controller.
 	ContainerImages []string `json:"containerImages"`
+
+	// Init Container images of the Replication Controller.
+	InitContainerImages []string `json:"initContainerImages"`
 }
 
 // Transforms simple selector map to labels.Selector object that can be used when querying for
@@ -89,10 +92,11 @@ func ToReplicationController(replicationController *v1.ReplicationController,
 	podInfo *common.PodInfo) ReplicationController {
 
 	return ReplicationController{
-		ObjectMeta:      api.NewObjectMeta(replicationController.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindReplicationController),
-		Pods:            *podInfo,
-		ContainerImages: common.GetContainerImages(&replicationController.Spec.Template.Spec),
+		ObjectMeta:          api.NewObjectMeta(replicationController.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindReplicationController),
+		Pods:                *podInfo,
+		ContainerImages:     common.GetContainerImages(&replicationController.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&replicationController.Spec.Template.Spec),
 	}
 }
 

--- a/src/app/backend/resource/replicationcontroller/detail.go
+++ b/src/app/backend/resource/replicationcontroller/detail.go
@@ -42,6 +42,9 @@ type ReplicationControllerDetail struct {
 	// Container image list of the pod template specified by this Replication Controller.
 	ContainerImages []string `json:"containerImages"`
 
+	// Init Container image list of the pod template specified by this Replication Controller.
+	InitContainerImages []string `json:"initContainerImages"`
+
 	// Aggregate information about pods of this replication controller.
 	PodInfo common.PodInfo `json:"podInfo"`
 
@@ -154,6 +157,7 @@ func toReplicationControllerDetail(replicationController *v1.ReplicationControll
 		ServiceList:                 serviceList,
 		HorizontalPodAutoscalerList: hpas,
 		ContainerImages:             common.GetContainerImages(&replicationController.Spec.Template.Spec),
+		InitContainerImages:         common.GetInitContainerImages(&replicationController.Spec.Template.Spec),
 		Errors:                      nonCriticalErrors,
 	}
 }

--- a/src/app/backend/resource/statefulset/detail.go
+++ b/src/app/backend/resource/statefulset/detail.go
@@ -32,12 +32,13 @@ import (
 // StatefulSetDetail is a presentation layer view of Kubernetes Stateful Set resource. This means it is Stateful
 // Set plus additional augmented data we can get from other sources (like services that target the same pods).
 type StatefulSetDetail struct {
-	ObjectMeta      api.ObjectMeta   `json:"objectMeta"`
-	TypeMeta        api.TypeMeta     `json:"typeMeta"`
-	PodInfo         common.PodInfo   `json:"podInfo"`
-	PodList         pod.PodList      `json:"podList"`
-	ContainerImages []string         `json:"containerImages"`
-	EventList       common.EventList `json:"eventList"`
+	ObjectMeta          api.ObjectMeta   `json:"objectMeta"`
+	TypeMeta            api.TypeMeta     `json:"typeMeta"`
+	PodInfo             common.PodInfo   `json:"podInfo"`
+	PodList             pod.PodList      `json:"podList"`
+	ContainerImages     []string         `json:"containerImages"`
+	InitContainerImages []string         `json:"initContainerImages"`
+	EventList           common.EventList `json:"eventList"`
 
 	// List of non-critical errors, that occurred during resource retrieval.
 	Errors []error `json:"errors"`
@@ -78,12 +79,13 @@ func GetStatefulSetDetail(client kubernetes.Interface, metricClient metricapi.Me
 func getStatefulSetDetail(statefulSet *apps.StatefulSet, eventList common.EventList, podList pod.PodList,
 	podInfo common.PodInfo, nonCriticalErrors []error) StatefulSetDetail {
 	return StatefulSetDetail{
-		ObjectMeta:      api.NewObjectMeta(statefulSet.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindStatefulSet),
-		ContainerImages: common.GetContainerImages(&statefulSet.Spec.Template.Spec),
-		PodInfo:         podInfo,
-		PodList:         podList,
-		EventList:       eventList,
-		Errors:          nonCriticalErrors,
+		ObjectMeta:          api.NewObjectMeta(statefulSet.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindStatefulSet),
+		ContainerImages:     common.GetContainerImages(&statefulSet.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&statefulSet.Spec.Template.Spec),
+		PodInfo:             podInfo,
+		PodList:             podList,
+		EventList:           eventList,
+		Errors:              nonCriticalErrors,
 	}
 }

--- a/src/app/backend/resource/statefulset/list.go
+++ b/src/app/backend/resource/statefulset/list.go
@@ -52,6 +52,9 @@ type StatefulSet struct {
 
 	// Container images of the Stateful Set.
 	ContainerImages []string `json:"containerImages"`
+
+	// Init container images of the Stateful Set.
+	InitContainerImages []string `json:"initContainerImages"`
 }
 
 // GetStatefulSetList returns a list of all Stateful Sets in the cluster.
@@ -132,9 +135,10 @@ func toStatefulSetList(statefulSets []apps.StatefulSet, pods []v1.Pod, events []
 
 func toStatefulSet(statefulSet *apps.StatefulSet, podInfo *common.PodInfo) StatefulSet {
 	return StatefulSet{
-		ObjectMeta:      api.NewObjectMeta(statefulSet.ObjectMeta),
-		TypeMeta:        api.NewTypeMeta(api.ResourceKindStatefulSet),
-		ContainerImages: common.GetContainerImages(&statefulSet.Spec.Template.Spec),
-		Pods:            *podInfo,
+		ObjectMeta:          api.NewObjectMeta(statefulSet.ObjectMeta),
+		TypeMeta:            api.NewTypeMeta(api.ResourceKindStatefulSet),
+		ContainerImages:     common.GetContainerImages(&statefulSet.Spec.Template.Spec),
+		InitContainerImages: common.GetInitContainerImages(&statefulSet.Spec.Template.Spec),
+		Pods:                *podInfo,
 	}
 }

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -268,6 +268,7 @@ backendApi.PodInfo;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>
  * }}
  */
 backendApi.ReplicationController;
@@ -278,6 +279,7 @@ backendApi.ReplicationController;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>
  * }}
  */
 backendApi.ReplicaSet;
@@ -289,6 +291,7 @@ backendApi.ReplicaSet;
  *   podInfo: !backendApi.PodInfo,
  *   podList: !backendApi.PodList,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   eventList: !backendApi.EventList,
  *   errors: !Array<!backendApi.Error>
  * }}
@@ -310,6 +313,7 @@ backendApi.ReplicaSetList;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   parallelism: number
  * }}
  */
@@ -322,6 +326,7 @@ backendApi.Job;
  *   podInfo: !backendApi.PodInfo,
  *   podList: !backendApi.PodList,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   eventList: !backendApi.EventList,
  *   parallelism: number,
  *   completions: number
@@ -344,6 +349,7 @@ backendApi.JobList;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>
  * }}
  */
 backendApi.StatefulSet;
@@ -355,6 +361,7 @@ backendApi.StatefulSet;
  *   podInfo: !backendApi.PodInfo,
  *   podList: !backendApi.PodList,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   eventList: !backendApi.EventList,
  *   errors: !Array<!backendApi.Error>
  * }}
@@ -596,6 +603,7 @@ backendApi.FlockerVolumeSource;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>
  * }}
  */
 backendApi.Deployment;
@@ -696,6 +704,7 @@ backendApi.TypeMeta;
  *   typeMeta: !backendApi.TypeMeta,
  *   labelSelector: !Object<string, string>,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   podInfo: !backendApi.PodInfo,
  *   podList: !backendApi.PodList,
  *   serviceList: !backendApi.ServiceList,
@@ -925,6 +934,7 @@ backendApi.ServiceList;
  *  typeMeta: !backendApi.TypeMeta,
  *  labelSelector: !Object<string, string>,
  *  containerImages: !Array<string>,
+ *  initContainerImages: !Array<string>,
  *  podInfo: !backendApi.PodInfo,
  *  podList: !backendApi.PodList,
  *  serviceList: !backendApi.ServiceList,
@@ -941,6 +951,7 @@ backendApi.DaemonSetDetail;
  *  typeMeta: !backendApi.TypeMeta,
  *  pods: !backendApi.PodInfo,
  *  containerImages: !Array<string>,
+ *  initContainerImages: !Array<string>
  * }}
  */
 backendApi.DaemonSet;
@@ -1009,7 +1020,8 @@ backendApi.ReplicationControllerPods;
 /**
  * @typedef {{
  *   podNames: !Array<string>,
- *   containerNames: !Array<string>
+ *   containerNames: !Array<string>,
+ *   initContainerNames: !Array<string>
  * }}
  */
 backendApi.LogSources;
@@ -1027,6 +1039,7 @@ backendApi.LogDetails;
  * @typedef {{
  *   podName: string,
  *   containerName: string,
+ *   initContainerName: string,
  *   fromDate: string,
  *   toDate: string,
  *   truncated: boolean
@@ -1262,6 +1275,7 @@ backendApi.NodeAllocatedResources;
  *   nodeInfo: !backendApi.NodeInfo,
  *   conditions: !backendApi.ConditionList,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>,
  *   podList: !backendApi.PodList,
  *   eventList: !backendApi.EventList,
  *   errors: !Array<!backendApi.Error>
@@ -1392,6 +1406,7 @@ backendApi.StorageClassList;
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
+ *   initContainerImages: !Array<string>
  * }}
  */
 backendApi.Controller;

--- a/src/app/frontend/daemonset/detail/info.html
+++ b/src/app/frontend/daemonset/detail/info.html
@@ -31,6 +31,9 @@ limitations under the License.
       <div ng-repeat="image in $ctrl.daemonSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in $ctrl.daemonSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-info-card-entry>
   </kd-info-card-section>
 

--- a/src/app/frontend/daemonset/list/card.html
+++ b/src/app/frontend/daemonset/list/card.html
@@ -73,6 +73,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.daemonSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.daemonSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-logs-button object-meta="::$ctrl.daemonSet.objectMeta"

--- a/src/app/frontend/deployment/list/card.html
+++ b/src/app/frontend/deployment/list/card.html
@@ -74,6 +74,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.deployment.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.deployment.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-resource-card-menu>

--- a/src/app/frontend/job/detail/info.html
+++ b/src/app/frontend/job/detail/info.html
@@ -31,6 +31,9 @@ limitations under the License.
       <div ng-repeat="image in $ctrl.job.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in $ctrl.job.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-info-card-entry>
     <kd-info-card-entry ng-if="::$ctrl.job.completions"
                         title="[[Completions|Job completions. Appears in details section.]]">

--- a/src/app/frontend/job/list/card.html
+++ b/src/app/frontend/job/list/card.html
@@ -80,6 +80,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.job.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.job.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-logs-button object-meta="::$ctrl.job.objectMeta"

--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -324,7 +324,7 @@ export class LogsController {
    */
   getDownloadLink() {
     let namespace = this.stateParams_.objectNamespace;
-    return `/api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
+    return `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
         this.logsService.getPrevious()}`;
   }
 

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -22,10 +22,20 @@ limitations under the License.
                ng-model="ctrl.container"
                md-on-close="ctrl.onContainerChange(ctrl.container)"
                required>
-      <md-option ng-repeat="item in ctrl.logSources.containerNames"
-                 ng-value="item">
-        <span class="kd-logs-toolbar-text">{{::item}}</span>
-      </md-option>
+      <md-optgroup label="[[Containers|Label atop a list of Containers]]"
+                   class="kd-namespace-select-namespace-list">
+        <md-option ng-repeat="item in ctrl.logSources.containerNames"
+                   ng-value="item">
+          <span class="kd-logs-toolbar-text">{{::item}}</span>
+        </md-option>
+      </md-optgroup>
+      <md-optgroup label="[[Init Containers|Label atop a list of Init Containers]]"
+                   class="kd-namespace-select-namespace-list">
+        <md-option ng-repeat="item in ctrl.logSources.initContainerNames"
+                   ng-value="item">
+          <span class="kd-logs-toolbar-text">{{::item}}</span>
+        </md-option>
+      </md-optgroup>
     </md-select>
     [[in|Title part for logs card.]]
     <md-select class="kd-logs-toolbar-select"

--- a/src/app/frontend/replicaset/detail/info.html
+++ b/src/app/frontend/replicaset/detail/info.html
@@ -26,6 +26,9 @@ limitations under the License.
       <div ng-repeat="image in $ctrl.replicaSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in $ctrl.replicaSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-info-card-entry>
   </kd-info-card-section>
 

--- a/src/app/frontend/replicaset/list/card.html
+++ b/src/app/frontend/replicaset/list/card.html
@@ -81,6 +81,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.replicaSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.replicaSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-logs-button object-meta="::$ctrl.replicaSet.objectMeta"

--- a/src/app/frontend/replicationcontroller/detail/info.html
+++ b/src/app/frontend/replicationcontroller/detail/info.html
@@ -26,6 +26,9 @@ limitations under the License.
       <div ng-repeat="image in $ctrl.replicationController.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in $ctrl.replicationController.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-info-card-entry>
   </kd-info-card-section>
 

--- a/src/app/frontend/replicationcontroller/list/card.html
+++ b/src/app/frontend/replicationcontroller/list/card.html
@@ -78,6 +78,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.replicationController.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.replicationController.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-logs-button object-meta="::$ctrl.replicationController.objectMeta"

--- a/src/app/frontend/statefulset/detail/info.html
+++ b/src/app/frontend/statefulset/detail/info.html
@@ -23,6 +23,9 @@ limitations under the License.
       <div ng-repeat="image in $ctrl.statefulSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in $ctrl.statefulSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-info-card-entry>
   </kd-info-card-section>
 

--- a/src/app/frontend/statefulset/list/card.html
+++ b/src/app/frontend/statefulset/list/card.html
@@ -77,6 +77,9 @@ limitations under the License.
       <div ng-repeat="image in ::$ctrl.statefulSet.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
       </div>
+      <div ng-repeat="image in ::$ctrl.statefulSet.initContainerImages track by $index">
+        <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+      </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">
       <kd-logs-button object-meta="::$ctrl.statefulSet.objectMeta"


### PR DESCRIPTION
- We are now displaying init container info in all the places where regular containers are shown. 

- We are also displaying init containers when looking at pod logs. 
