### PR TITLE
Fix high cpu usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ## Local copies of dependencies that should stay on developers' local machines
 node_modules/
-bower_components/
 
 ## Build and test artifacts
 .go_workspace/

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,17 @@
     "@uirouter/angularjs": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.6.tgz",
-      "integrity": "sha512-wpC7t+wv5wM+jRr2nd80q4CxXl/igMKHkgYO2DHTC/ZSW+dBWkKEn2+H6AGMBrpKiEOfkjCokA43fqog10tQkQ=="
+      "integrity": "sha512-wpC7t+wv5wM+jRr2nd80q4CxXl/igMKHkgYO2DHTC/ZSW+dBWkKEn2+H6AGMBrpKiEOfkjCokA43fqog10tQkQ==",
+      "requires": {
+        "@uirouter/core": "5.0.6"
+      },
+      "dependencies": {
+        "@uirouter/core": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.6.tgz",
+          "integrity": "sha512-JnnXn3mhSdUa4YwUJ0ZKpPZ6b4l1TBRKKqGAFN/xnbjj0upaYErP56n5Rc6XV+arQmjKEg8Y/Mn0yW3TefYYCw=="
+        }
+      }
     },
     "@uirouter/core": {
       "version": "5.0.7",

--- a/src/app/backend/sync/secret.go
+++ b/src/app/backend/sync/secret.go
@@ -65,7 +65,11 @@ func (self *secretSynchronizer) Start() {
 		defer close(self.errChan)
 		for {
 			select {
-			case ev := <-watcher.ResultChan():
+			case ev, ok := <-watcher.ResultChan():
+				if !ok {
+					self.errChan <- fmt.Errorf("%s watch ended with timeout", self.Name())
+					return
+				}
 				if err := self.handleEvent(ev); err != nil {
 					self.errChan <- err
 					return


### PR DESCRIPTION
## Changes
- Fixes #2401 
- Remove `bower_components/` from `.gitignore`.
- Update `package-lock.json`

For anyone interested in actual cause and fix. Below you can find a description of the problem.

## Cause
Profiling `dashboard` binary showed function that caused high CPU usage.
```bash
(pprof) top
29440ms of 29990ms total (98.17%)
Showing top 10 nodes out of 12 (cum >= 560ms)
      flat  flat%   sum%        cum   cum%
    7620ms 25.41% 25.41%    29990ms   100%  github.com/kubernetes/dashboard/src/app/backend/sync.(*secretSynchronizer).Start.func1
(pprof) peek
29990ms of 29990ms total (  100%)
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                           29990ms   100% |   runtime.goexit
    7620ms 25.41% 25.41%    29990ms   100%                | github.com/kubernetes/dashboard/src/app/backend/sync.(*secretSynchronizer).Start.func1
                                           13840ms 61.87% |   runtime.chanrecv1
                                            7980ms 35.67% |   github.com/kubernetes/dashboard/src/app/backend/sync.(*secretSynchronizer).handleEvent
                                             550ms  2.46% |   github.com/kubernetes/dashboard/vendor/k8s.io/apimachinery/pkg/watch.(*StreamWatcher).ResultChan
```

Compared to other functions, goroutine started in `secretSynchronizer.Start` method took most CPU time.
```golang
for {
	select {
	case ev, ok := <-watcher.ResultChan():
		if err := self.handleEvent(ev); err != nil {
			self.errChan <- err
			return
		}
	}
}
```

The problem was that after some time kubernetes watcher times out without any reason and `ResultChan` is closed. That caused infinite `for` loop. Given that it was running in another goroutine, dashboard was still responsive.

## Fix
Simple check if channel was closed did the trick.
```golang
case ev, ok := <-watcher.ResultChan():
	if !ok {
		self.errChan <- fmt.Errorf("%s watch ended with timeout", self.Name())
		return
	}
...
```