### PR TITLE
Fix Dashboard crash after exec into pod when using proxy

### DIFF
--- a/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
@@ -100,12 +100,20 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+        volumeMounts:
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             path: /
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
@@ -101,7 +101,7 @@ spec:
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
         volumeMounts:
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -112,8 +112,7 @@ spec:
           timeoutSeconds: 30
       volumes:
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm.yaml
@@ -98,12 +98,20 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+        volumeMounts:
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             path: /
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm.yaml
@@ -99,7 +99,7 @@ spec:
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
         volumeMounts:
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -110,8 +110,7 @@ spec:
           timeoutSeconds: 30
       volumes:
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-head.yaml
@@ -100,12 +100,20 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+        volumeMounts:
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             path: /
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-head.yaml
@@ -101,7 +101,7 @@ spec:
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
         volumeMounts:
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -112,8 +112,7 @@ spec:
           timeoutSeconds: 30
       volumes:
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard.yaml
@@ -100,7 +100,7 @@ spec:
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
         volumeMounts:
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -111,8 +111,7 @@ spec:
           timeoutSeconds: 30
       volumes:
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/alternative/kubernetes-dashboard.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard.yaml
@@ -99,12 +99,20 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+        volumeMounts:
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             path: /
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -123,6 +123,9 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -134,6 +137,9 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -123,7 +123,7 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -138,8 +138,7 @@ spec:
         secret:
           secretName: kubernetes-dashboard-certs
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -121,7 +121,7 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -136,8 +136,7 @@ spec:
         secret:
           secretName: kubernetes-dashboard-certs
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -121,6 +121,9 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -132,6 +135,9 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -123,6 +123,9 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -134,6 +137,9 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -123,7 +123,7 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -138,8 +138,7 @@ spec:
         secret:
           secretName: kubernetes-dashboard-certs
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard.yaml
@@ -122,7 +122,7 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
-          # Create in-memory volume to store exec logs
+          # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
         livenessProbe:
@@ -137,8 +137,7 @@ spec:
         secret:
           secretName: kubernetes-dashboard-certs
       - name: tmp-volume
-        emptyDir:
-          medium: Memory
+        emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/src/deploy/recommended/kubernetes-dashboard.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard.yaml
@@ -122,6 +122,9 @@ spec:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
+          # Create in-memory volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -133,6 +136,9 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:


### PR DESCRIPTION
Related to #2029 

Dashboard was crashing when trying to exec into pod. This was caused by missing `tmp` directory in the dashboard container. I have added `/tmp` mount that will be stored ~in memory~ on disk. 

Tested on k8s `1.7.7`. Exec works fine when accessing Dashboard using NodePort and kubectl proxy.