### PR TITLE
Fix download filename for firefox

### DIFF
--- a/src/app/backend/handler/download.go
+++ b/src/app/backend/handler/download.go
@@ -22,7 +22,7 @@ import (
 )
 
 func handleDownload(response *restful.Response, result io.ReadCloser, filename string) {
-	header := fmt.Sprintf("attachment; filename='%v'", filename)
+	header := fmt.Sprintf("attachment; filename=\"%v\"", filename)
 	response.AddHeader("Content-Disposition", header)
 
 	defer result.Close()


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dashboard/issues/2439

Tested on Chrome and Firefox. Also read the spec. Should be fine.