### PR TITLE
Fix license header check for html

### DIFF
--- a/build/check.js
+++ b/build/check.js
@@ -47,6 +47,9 @@ const ignoredLicenseCheckFiles = ['fieldpath'];
 function getLicenseFileFilter(...ext) {
   let ignorePattern =
       ignoredLicenseCheckFiles.length > 0 ? `!(${ignoredLicenseCheckFiles.join()})` : '';
+  if (ext.length === 1) {
+    return `**/${ignorePattern}*.${ext}`;
+  }
   return `**/${ignorePattern}*.{${ext.join()}}`;
 }
 

--- a/src/app/frontend/about/about.html
+++ b/src/app/frontend/about/about.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/controlpanel/controlpanel.html
+++ b/src/app/frontend/chrome/controlpanel/controlpanel.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/nav/hamburger.html
+++ b/src/app/frontend/chrome/nav/hamburger.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/nav/nav.html
+++ b/src/app/frontend/chrome/nav/nav.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/nav/navitem.html
+++ b/src/app/frontend/chrome/nav/navitem.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/nav/rolenav.html
+++ b/src/app/frontend/chrome/nav/rolenav.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/nav/thirdpartyresourcenav.html
+++ b/src/app/frontend/chrome/nav/thirdpartyresourcenav.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/chrome/search/search.html
+++ b/src/app/frontend/chrome/search/search.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/cluster/cluster.html
+++ b/src/app/frontend/cluster/cluster.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbar.html
+++ b/src/app/frontend/common/components/actionbar/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
+++ b/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbardetailbuttons.html
+++ b/src/app/frontend/common/components/actionbar/actionbardetailbuttons.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbaredititem.html
+++ b/src/app/frontend/common/components/actionbar/actionbaredititem.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/actionbarlogs.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlogs.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/actionbar/shell.html
+++ b/src/app/frontend/common/components/actionbar/shell.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/allocatedresourceschart/allocatedresourceschart.html
+++ b/src/app/frontend/common/components/allocatedresourceschart/allocatedresourceschart.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/annotations/annotations.html
+++ b/src/app/frontend/common/components/annotations/annotations.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
+++ b/src/app/frontend/common/components/annotations/lastappliedconfiguration.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
+++ b/src/app/frontend/common/components/breadcrumbs/breadcrumbs.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/conditions/conditionslist.html
+++ b/src/app/frontend/common/components/conditions/conditionslist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/contentcard/contentcard.html
+++ b/src/app/frontend/common/components/contentcard/contentcard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/endpoint/externalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/externalendpoint.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/endpoint/internalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/internalendpoint.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/graph/graph.html
+++ b/src/app/frontend/common/components/graph/graph.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/graph/graphcard.html
+++ b/src/app/frontend/common/components/graph/graphcard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/infocard/infocard.html
+++ b/src/app/frontend/common/components/infocard/infocard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/infocard/infocardentry.html
+++ b/src/app/frontend/common/components/infocard/infocardentry.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/infocard/infocardsection.html
+++ b/src/app/frontend/common/components/infocard/infocardsection.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/labels/labels.html
+++ b/src/app/frontend/common/components/labels/labels.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/podwarnings/podwarnings.html
+++ b/src/app/frontend/common/components/podwarnings/podwarnings.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/logsbutton.html
+++ b/src/app/frontend/common/components/resourcecard/logsbutton.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecard.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardcolumn.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardcolumn.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardcolumns.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardcolumns.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecarddeletemenuitem.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecarddeletemenuitem.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardeditmenuitem.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardeditmenuitem.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardfooter.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardheadercolumn.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardheadercolumn.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardheadercolumns.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardlist.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfilter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfilter.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistfooter.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistheader.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistheader.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardlistpagination.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcecard/resourcecardmenu.html
+++ b/src/app/frontend/common/components/resourcecard/resourcecardmenu.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/resourcedetail/infocard.html
+++ b/src/app/frontend/common/components/resourcedetail/infocard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/scale/scale.html
+++ b/src/app/frontend/common/components/scale/scale.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/serializedreference/serializedreference.html
+++ b/src/app/frontend/common/components/serializedreference/serializedreference.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/sparkline/sparkline.html
+++ b/src/app/frontend/common/components/sparkline/sparkline.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/togglehiddentext/togglehiddentext.html
+++ b/src/app/frontend/common/components/togglehiddentext/togglehiddentext.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/uploadfile/uploadfile.html
+++ b/src/app/frontend/common/components/uploadfile/uploadfile.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/warnings/warnings.html
+++ b/src/app/frontend/common/components/warnings/warnings.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/zerostate/zerostate.html
+++ b/src/app/frontend/common/components/zerostate/zerostate.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/namespace/namespaceselect.html
+++ b/src/app/frontend/common/namespace/namespaceselect.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/pagination/pagination.html
+++ b/src/app/frontend/common/pagination/pagination.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/resource/deleteresource.html
+++ b/src/app/frontend/common/resource/deleteresource.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/resource/editresource.html
+++ b/src/app/frontend/common/resource/editresource.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/scaling/scaleresource.html
+++ b/src/app/frontend/common/scaling/scaleresource.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/config/config.html
+++ b/src/app/frontend/config/config.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/detail/actionbar.html
+++ b/src/app/frontend/configmap/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/detail/detail.html
+++ b/src/app/frontend/configmap/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/detail/info.html
+++ b/src/app/frontend/configmap/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/list/card.html
+++ b/src/app/frontend/configmap/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/list/cardlist.html
+++ b/src/app/frontend/configmap/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/configmap/list/list.html
+++ b/src/app/frontend/configmap/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/detail/actionbar.html
+++ b/src/app/frontend/daemonset/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/detail/detail.html
+++ b/src/app/frontend/daemonset/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/detail/info.html
+++ b/src/app/frontend/daemonset/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/list/card.html
+++ b/src/app/frontend/daemonset/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/list/cardlist.html
+++ b/src/app/frontend/daemonset/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/daemonset/list/list.html
+++ b/src/app/frontend/daemonset/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/createnamespace.html
+++ b/src/app/frontend/deploy/createnamespace.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/createsecret.html
+++ b/src/app/frontend/deploy/createsecret.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/deploy.html
+++ b/src/app/frontend/deploy/deploy.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/deployfromfile.html
+++ b/src/app/frontend/deploy/deployfromfile.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/deployfromsettings.html
+++ b/src/app/frontend/deploy/deployfromsettings.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/deploylabel.html
+++ b/src/app/frontend/deploy/deploylabel.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/environmentvariables.html
+++ b/src/app/frontend/deploy/environmentvariables.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/helpsection/helpsection.html
+++ b/src/app/frontend/deploy/helpsection/helpsection.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/helpsection/userhelp.html
+++ b/src/app/frontend/deploy/helpsection/userhelp.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/portmappings.html
+++ b/src/app/frontend/deploy/portmappings.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deploy/upload.html
+++ b/src/app/frontend/deploy/upload.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/detail/actionbar.html
+++ b/src/app/frontend/deployment/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/detail/detail.html
+++ b/src/app/frontend/deployment/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/detail/info.html
+++ b/src/app/frontend/deployment/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/list/card.html
+++ b/src/app/frontend/deployment/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/list/cardlist.html
+++ b/src/app/frontend/deployment/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/deployment/list/list.html
+++ b/src/app/frontend/deployment/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/discovery/discovery.html
+++ b/src/app/frontend/discovery/discovery.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/endpoint/cardlist.html
+++ b/src/app/frontend/endpoint/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/error/internalerror.html
+++ b/src/app/frontend/error/internalerror.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/events/cardlist.html
+++ b/src/app/frontend/events/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/detail/actionbar.html
+++ b/src/app/frontend/horizontalpodautoscaler/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/detail/detail.html
+++ b/src/app/frontend/horizontalpodautoscaler/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/detail/info.html
+++ b/src/app/frontend/horizontalpodautoscaler/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/list/card.html
+++ b/src/app/frontend/horizontalpodautoscaler/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/list/cardlist.html
+++ b/src/app/frontend/horizontalpodautoscaler/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/horizontalpodautoscaler/list/list.html
+++ b/src/app/frontend/horizontalpodautoscaler/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/detail/actionbar.html
+++ b/src/app/frontend/ingress/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/detail/detail.html
+++ b/src/app/frontend/ingress/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/detail/info.html
+++ b/src/app/frontend/ingress/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/list/card.html
+++ b/src/app/frontend/ingress/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/list/cardlist.html
+++ b/src/app/frontend/ingress/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/ingress/list/list.html
+++ b/src/app/frontend/ingress/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/detail/actionbar.html
+++ b/src/app/frontend/job/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/detail/detail.html
+++ b/src/app/frontend/job/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/detail/info.html
+++ b/src/app/frontend/job/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/list/card.html
+++ b/src/app/frontend/job/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/list/cardlist.html
+++ b/src/app/frontend/job/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/job/list/list.html
+++ b/src/app/frontend/job/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/login/basic.html
+++ b/src/app/frontend/login/basic.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/login/kubeconfig.html
+++ b/src/app/frontend/login/kubeconfig.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/login/login.html
+++ b/src/app/frontend/login/login.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/login/options.html
+++ b/src/app/frontend/login/options.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/login/token.html
+++ b/src/app/frontend/login/token.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/namespace/detail/detail.html
+++ b/src/app/frontend/namespace/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/namespace/detail/info.html
+++ b/src/app/frontend/namespace/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/namespace/list/card.html
+++ b/src/app/frontend/namespace/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/namespace/list/cardlist.html
+++ b/src/app/frontend/namespace/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/namespace/list/list.html
+++ b/src/app/frontend/namespace/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/detail/allocatedresources.html
+++ b/src/app/frontend/node/detail/allocatedresources.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/detail/detail.html
+++ b/src/app/frontend/node/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/detail/info.html
+++ b/src/app/frontend/node/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/list/card.html
+++ b/src/app/frontend/node/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/list/cardlist.html
+++ b/src/app/frontend/node/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/node/list/list.html
+++ b/src/app/frontend/node/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/overview/overview.html
+++ b/src/app/frontend/overview/overview.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/detail/actionbar.html
+++ b/src/app/frontend/persistentvolume/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/detail/detail.html
+++ b/src/app/frontend/persistentvolume/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/detail/info.html
+++ b/src/app/frontend/persistentvolume/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/detail/sourceinfo.html
+++ b/src/app/frontend/persistentvolume/detail/sourceinfo.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/list/card.html
+++ b/src/app/frontend/persistentvolume/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/list/cardlist.html
+++ b/src/app/frontend/persistentvolume/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolume/list/list.html
+++ b/src/app/frontend/persistentvolume/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/detail/actionbar.html
+++ b/src/app/frontend/persistentvolumeclaim/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/detail/detail.html
+++ b/src/app/frontend/persistentvolumeclaim/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/detail/info.html
+++ b/src/app/frontend/persistentvolumeclaim/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/list/card.html
+++ b/src/app/frontend/persistentvolumeclaim/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/list/cardlist.html
+++ b/src/app/frontend/persistentvolumeclaim/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/persistentvolumeclaim/list/list.html
+++ b/src/app/frontend/persistentvolumeclaim/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/detail/actionbar.html
+++ b/src/app/frontend/pod/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/detail/containerinfo.html
+++ b/src/app/frontend/pod/detail/containerinfo.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/detail/creatorinfo.html
+++ b/src/app/frontend/pod/detail/creatorinfo.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/detail/detail.html
+++ b/src/app/frontend/pod/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/detail/info.html
+++ b/src/app/frontend/pod/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/list/card.html
+++ b/src/app/frontend/pod/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/list/cardlist.html
+++ b/src/app/frontend/pod/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/pod/list/list.html
+++ b/src/app/frontend/pod/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/detail/actionbar.html
+++ b/src/app/frontend/replicaset/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/detail/detail.html
+++ b/src/app/frontend/replicaset/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/detail/info.html
+++ b/src/app/frontend/replicaset/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/list/card.html
+++ b/src/app/frontend/replicaset/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/list/cardlist.html
+++ b/src/app/frontend/replicaset/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicaset/list/list.html
+++ b/src/app/frontend/replicaset/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/detail/actionbar.html
+++ b/src/app/frontend/replicationcontroller/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/detail/detail.html
+++ b/src/app/frontend/replicationcontroller/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/detail/info.html
+++ b/src/app/frontend/replicationcontroller/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/list/card.html
+++ b/src/app/frontend/replicationcontroller/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/list/cardlist.html
+++ b/src/app/frontend/replicationcontroller/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/list/cardmenu.html
+++ b/src/app/frontend/replicationcontroller/list/cardmenu.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/replicationcontroller/list/list.html
+++ b/src/app/frontend/replicationcontroller/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/resourcelimit/detail/detail.html
+++ b/src/app/frontend/resourcelimit/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/resourcequota/detail/detail.html
+++ b/src/app/frontend/resourcequota/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/resourcequota/detail/status.html
+++ b/src/app/frontend/resourcequota/detail/status.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/role/list/card.html
+++ b/src/app/frontend/role/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/role/list/cardlist.html
+++ b/src/app/frontend/role/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/role/list/list.html
+++ b/src/app/frontend/role/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/search/search.html
+++ b/src/app/frontend/search/search.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/detail/actionbar.html
+++ b/src/app/frontend/secret/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/detail/detail.html
+++ b/src/app/frontend/secret/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/detail/info.html
+++ b/src/app/frontend/secret/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/list/card.html
+++ b/src/app/frontend/secret/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/list/cardlist.html
+++ b/src/app/frontend/secret/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/secret/list/list.html
+++ b/src/app/frontend/secret/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/detail/actionbar.html
+++ b/src/app/frontend/service/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/detail/detail.html
+++ b/src/app/frontend/service/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/detail/info.html
+++ b/src/app/frontend/service/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/list/card.html
+++ b/src/app/frontend/service/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/list/cardlist.html
+++ b/src/app/frontend/service/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/service/list/list.html
+++ b/src/app/frontend/service/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/shell/shell.html
+++ b/src/app/frontend/shell/shell.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/detail/actionbar.html
+++ b/src/app/frontend/statefulset/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/detail/detail.html
+++ b/src/app/frontend/statefulset/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/detail/info.html
+++ b/src/app/frontend/statefulset/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/list/card.html
+++ b/src/app/frontend/statefulset/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/list/cardlist.html
+++ b/src/app/frontend/statefulset/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/statefulset/list/list.html
+++ b/src/app/frontend/statefulset/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/detail/actionbar.html
+++ b/src/app/frontend/storageclass/detail/actionbar.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/detail/detail.html
+++ b/src/app/frontend/storageclass/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/detail/info.html
+++ b/src/app/frontend/storageclass/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/list/card.html
+++ b/src/app/frontend/storageclass/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/list/cardlist.html
+++ b/src/app/frontend/storageclass/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/storageclass/list/list.html
+++ b/src/app/frontend/storageclass/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/detail/detail.html
+++ b/src/app/frontend/thirdpartyresource/detail/detail.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/detail/info.html
+++ b/src/app/frontend/thirdpartyresource/detail/info.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/detail/objectcard.html
+++ b/src/app/frontend/thirdpartyresource/detail/objectcard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/detail/objectlist.html
+++ b/src/app/frontend/thirdpartyresource/detail/objectlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/list/card.html
+++ b/src/app/frontend/thirdpartyresource/list/card.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/list/cardlist.html
+++ b/src/app/frontend/thirdpartyresource/list/cardlist.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/thirdpartyresource/list/list.html
+++ b/src/app/frontend/thirdpartyresource/list/list.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/workloads/workloads.html
+++ b/src/app/frontend/workloads/workloads.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
License header check for HTML files was not active. 

Adapted pattern to handle single entries 

See:
https://www.npmjs.com/package/multimatch
"{} allows for a comma-separated list of "or" expressions"

In case of html, it was interpreted as expression.