### PR TITLE
Fix job pod status display

### DIFF
--- a/src/app/backend/resource/job/pods.go
+++ b/src/app/backend/resource/job/pods.go
@@ -93,5 +93,10 @@ func getJobPodInfo(client k8sClient.Interface, job *batch.Job) (*common.PodInfo,
 	}
 
 	podInfo := common.GetPodInfo(job.Status.Active, job.Spec.Completions, pods.Items)
+
+	// This pod info for jobs should be get from job status, similar to kubectl describe logic.
+	podInfo.Running = job.Status.Active
+	podInfo.Succeeded = job.Status.Succeeded
+	podInfo.Failed = job.Status.Failed
 	return &podInfo, nil
 }


### PR DESCRIPTION
Fixes #2459. I am only overriding it since there are some additional info in `PodInfo` structures tha I don't want to loose.

This is the code fragment in `kubectl` that displays this information: https://github.com/kubernetes/kubernetes/blob/ededef24e4b7425784b97cd5d661399592c06ffe/pkg/printers/internalversion/describe.go#L1690