### PR TITLE
Update deployment YAMLs with latest init container version

### DIFF
--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -100,7 +100,7 @@ spec:
     spec:
       initContainers:
       - name: kubernetes-dashboard-init
-        image: kubernetesdashboarddev/kubernetes-dashboard-init-arm:v1.0.0
+        image: kubernetesdashboarddev/kubernetes-dashboard-init-arm:v1.0.1
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs

--- a/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -100,7 +100,7 @@ spec:
     spec:
       initContainers:
       - name: kubernetes-dashboard-init
-        image: gcr.io/google_containers/kubernetes-dashboard-init-arm:v1.0.0
+        image: gcr.io/google_containers/kubernetes-dashboard-init-arm:v1.0.1
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -100,7 +100,7 @@ spec:
     spec:
       initContainers:
       - name: kubernetes-dashboard-init
-        image: kubernetesdashboarddev/kubernetes-dashboard-init-amd64:v1.0.0
+        image: kubernetesdashboarddev/kubernetes-dashboard-init-amd64:v1.0.1
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs

--- a/src/deploy/recommended/kubernetes-dashboard.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard.yaml
@@ -101,7 +101,7 @@ spec:
     spec:
       initContainers:
       - name: kubernetes-dashboard-init
-        image: gcr.io/google_containers/kubernetes-dashboard-init-amd64:v1.0.0
+        image: gcr.io/google_containers/kubernetes-dashboard-init-amd64:v1.0.1
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs


### PR DESCRIPTION
I have built and pushed updated init containers `v1.0.1` to my DockerHub. @rf232 could you merge this PR and reupload them to gcr?

[AMD64](https://hub.docker.com/r/floreks/kubernetes-dashboard-init-amd64/tags/)
[ARM](https://hub.docker.com/r/floreks/kubernetes-dashboard-init-arm/tags/)