### PR TITLE
Add namespace change info dialog

### DIFF
--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -122,9 +122,9 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">Dismiss all</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">There is nothing to display here</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">You can &lt;a href="{{::$ctrl.getStateHref()}}"&gt;deploy a containerized app&lt;/a&gt;, select other namespace or &lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;take the Dashboard Tour &lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt; to learn more.</translation>
-  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="4149717000499670158" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Change namespace?</translation>
   <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
-  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="6445329193254792187" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to change namespace?</translation>
   <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
   <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">Namespace</translation>

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -122,6 +122,11 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">Dismiss all</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">There is nothing to display here</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">You can &lt;a href="{{::$ctrl.getStateHref()}}"&gt;deploy a containerized app&lt;/a&gt;, select other namespace or &lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;take the Dashboard Tour &lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt; to learn more.</translation>
+  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
+  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
+  <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">Namespace</translation>
   <translation id="5174603006239796789" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_1" desc="Text describing what namespace selector is">Selector for namespaces</translation>
   <translation id="7324783266461564175" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_2" desc="Text for dropdown item that indicates that no namespace was selected.">All namespaces</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -126,6 +126,11 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">Dismiss all</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="(no description provided)">表示するものがありません</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">&lt;a href="{{::$ctrl.getStateHref()}}"&gt;コンテナアプリを配備&lt;/a&gt;、他のネームスペースを選択、もっと知るために&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;ダッシュボードツアーに出る&lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt; が可能です。</translation>
+  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
+  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
+  <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">ネームスペース</translation>
   <translation id="5174603006239796789" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_1" desc="Text describing what namespace selector is">ネームスペースセレクター</translation>
   <translation id="7324783266461564175" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_2" desc="Text for dropdown item that indicates that no namespace was selected.">すべてのネームスペース</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -126,9 +126,9 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">Dismiss all</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="(no description provided)">表示するものがありません</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">&lt;a href="{{::$ctrl.getStateHref()}}"&gt;コンテナアプリを配備&lt;/a&gt;、他のネームスペースを選択、もっと知るために&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;ダッシュボードツアーに出る&lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt; が可能です。</translation>
-  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="4149717000499670158" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Change namespace?</translation>
   <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
-  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="6445329193254792187" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to change namespace?</translation>
   <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
   <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">ネームスペース</translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -122,9 +122,9 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">忽略全部</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">無內容可顯示</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">您可以&lt;a href="{{::$ctrl.getStateHref()}}"&gt;部署容器化應用程式&lt;/a&gt;、查看其他命名空間，或&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;瀏覽儀表板概覽 &lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt;來了解更多.</translation>
-  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="4149717000499670158" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Change namespace?</translation>
   <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
-  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="6445329193254792187" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to change namespace?</translation>
   <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
   <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">命名空間</translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -122,6 +122,11 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">忽略全部</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">無內容可顯示</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">您可以&lt;a href="{{::$ctrl.getStateHref()}}"&gt;部署容器化應用程式&lt;/a&gt;、查看其他命名空間，或&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;瀏覽儀表板概覽 &lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt;來了解更多.</translation>
+  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
+  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
+  <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">命名空間</translation>
   <translation id="5174603006239796789" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_1" desc="Text describing what namespace selector is">所選的命名空間標籤</translation>
   <translation id="7324783266461564175" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_2" desc="Text for dropdown item that indicates that no namespace was selected.">全部命名空間</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -122,9 +122,9 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">忽略所有</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">无内容显示</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">现在就&lt;a href="{{::$ctrl.getStateHref()}}"&gt;部署容器应用&lt;/a&gt;、查看其它命名空间，或&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;浏览控制面板概览&lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt;来了解更多</translation>
-  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="4149717000499670158" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Change namespace?</translation>
   <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
-  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="6445329193254792187" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to change namespace?</translation>
   <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
   <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">命名空间</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -122,6 +122,11 @@
   <translation id="7328790086203280450" key="MSG_COMMON_COMPONENTS_WARNINGS_WARNINGS_1" desc="Tooltip for all warning dismissal button.">忽略所有</translation>
   <translation id="6941584785589389821" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_0" desc="Title text which appears on zero state view.">无内容显示</translation>
   <translation id="8000678649572976545" key="MSG_COMMON_COMPONENTS_ZEROSTATE_ZEROSTATE_1" desc="Description for a zero state page.">现在就&lt;a href="{{::$ctrl.getStateHref()}}"&gt;部署容器应用&lt;/a&gt;、查看其它命名空间，或&lt;a href="http://kubernetes.io/docs/user-guide/ui/" target="_blank"&gt;浏览控制面板概览&lt;i class="material-icons kd-zerostate-icon"&gt;open_in_new&lt;/i&gt;&lt;/a&gt;来了解更多</translation>
+  <translation id="7888842010310161957" key="MSG_COMMON_NAMESPACE_DIALOG_0" desc="(no description provided)">Namespace change</translation>
+  <translation id="1716771106236346382" key="MSG_COMMON_NAMESPACE_DIALOG_1" desc="(no description provided)">Selected resource is in a different namespace than currently selected.</translation>
+  <translation id="5178069190760665737" key="MSG_COMMON_NAMESPACE_DIALOG_2" desc="(no description provided)">Do you want to switch namespace?</translation>
+  <translation id="5902174388191116331" key="MSG_COMMON_NAMESPACE_DIALOG_3" desc="(no description provided)">Yes</translation>
+  <translation id="7374326576991357026" key="MSG_COMMON_NAMESPACE_DIALOG_4" desc="(no description provided)">No</translation>
   <translation id="4492076728105331074" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_0" desc="Title for namespace select.">命名空间</translation>
   <translation id="5174603006239796789" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_1" desc="Text describing what namespace selector is">所选的命名空间标签</translation>
   <translation id="7324783266461564175" key="MSG_COMMON_NAMESPACE_NAMESPACESELECT_2" desc="Text for dropdown item that indicates that no namespace was selected.">所有命名空间</translation>

--- a/src/app/externs/uirouter.js
+++ b/src/app/externs/uirouter.js
@@ -90,7 +90,7 @@ kdUiRouter.$state = function() {};
 kdUiRouter.$state.prototype.defaultErrorHandler = function(callback) {};
 
 /**
- * @param {string|!ui.router.State} to
+ * @param {string|!ui.router.State|!ui.router.$state} to
  * @param {?ui.router.StateParams=} opt_toParams
  * @param {!ui.router.StateOptions=} opt_options
  * @return {!angular.$q.Promise}

--- a/src/app/frontend/common/components/graph/graphcard.html
+++ b/src/app/frontend/common/components/graph/graphcard.html
@@ -17,7 +17,7 @@ limitations under the License.
 <kd-content-card ng-if="$ctrl.shouldShowGraph()">
   <kd-title>{{$ctrl.graphTitle}}
     <span ng-if="::$ctrl.graphInfo">
-      <md-icon md-font-library="material-icons">info</md-icon>
+      <md-icon class="kd-graph-card-icon">info_outline</md-icon>
       <md-tooltip md-delay="500" md-autohide>
         {{::$ctrl.graphInfo}}
       </md-tooltip>

--- a/src/app/frontend/common/components/graph/graphcard.scss
+++ b/src/app/frontend/common/components/graph/graphcard.scss
@@ -27,3 +27,7 @@ kd-graph-card {
     }
   }
 }
+
+.kd-graph-card-icon {
+  line-height: 2.5 * $baseline-grid;
+}

--- a/src/app/frontend/common/namespace/component.js
+++ b/src/app/frontend/common/namespace/component.js
@@ -42,11 +42,10 @@ export class NamespaceSelectController {
    * @param {!ui.router.$state} $state
    * @param {!angular.Scope} $scope
    * @param {!./../state/service.FutureStateService} kdFutureStateService
-   * @param {!./../components/breadcrumbs/service.BreadcrumbsService} kdBreadcrumbsService
    * @param {!md.$dialog} $mdDialog
    * @ngInject
    */
-  constructor($resource, $state, $scope, kdFutureStateService, kdBreadcrumbsService, $mdDialog) {
+  constructor($resource, $state, $scope, kdFutureStateService, $mdDialog) {
     /**
      * Initialized with all namespaces on first open.
      * @export {!Array<string>}
@@ -79,9 +78,6 @@ export class NamespaceSelectController {
 
     /** @private {!./../state/service.FutureStateService}} */
     this.futureStateService_ = kdFutureStateService;
-
-    /** @private {!./../components/breadcrumbs/service.BreadcrumbsService}} */
-    this.kdBreadcrumbsService_ = kdBreadcrumbsService;
 
     /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;

--- a/src/app/frontend/common/namespace/component.js
+++ b/src/app/frontend/common/namespace/component.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {namespaceParam} from '../../chrome/state';
+import {showNamespaceChangeInfoDialog} from './dialog';
 
 /**
  * Internal key for empty selection. To differentiate empty string from nulls.
@@ -42,9 +43,10 @@ export class NamespaceSelectController {
    * @param {!angular.Scope} $scope
    * @param {!./../state/service.FutureStateService} kdFutureStateService
    * @param {!./../components/breadcrumbs/service.BreadcrumbsService} kdBreadcrumbsService
+   * @param {!md.$dialog} $mdDialog
    * @ngInject
    */
-  constructor($resource, $state, $scope, kdFutureStateService, kdBreadcrumbsService) {
+  constructor($resource, $state, $scope, kdFutureStateService, kdBreadcrumbsService, $mdDialog) {
     /**
      * Initialized with all namespaces on first open.
      * @export {!Array<string>}
@@ -81,6 +83,9 @@ export class NamespaceSelectController {
     /** @private {!./../components/breadcrumbs/service.BreadcrumbsService}} */
     this.kdBreadcrumbsService_ = kdBreadcrumbsService;
 
+    /** @private {!md.$dialog} */
+    this.mdDialog_ = $mdDialog;
+
     /** @export */
     this.i18n = i18n;
   }
@@ -108,18 +113,6 @@ export class NamespaceSelectController {
   shouldRedirect_(toParams) {
     return toParams && toParams.namespace && toParams.objectNamespace &&
         toParams.namespace !== '_all' && toParams.namespace !== toParams.objectNamespace;
-  }
-
-  /**
-   * Redirects to parent state. It should be list state, because redirect takes place when user
-   * is detail state.
-   *
-   * @param {Object<string, string>} toParams
-   * @private
-   */
-  redirectToParentState_(toParams) {
-    this.state_.go(
-        this.kdBreadcrumbsService_.getParentStateName(this.state_['$current']), toParams);
   }
 
   /**
@@ -156,8 +149,16 @@ export class NamespaceSelectController {
     }
 
     if (this.shouldRedirect_(toParams)) {
-      this.redirectToParentState_(toParams);
+      this.handleNamespaceChangeDialog_(toParams);
     }
+  }
+
+  /**
+   * @param {Object<string, string>} toParams
+   * @private
+   */
+  handleNamespaceChangeDialog_(toParams) {
+    showNamespaceChangeInfoDialog(this.mdDialog_, toParams.objectNamespace);
   }
 
   /**

--- a/src/app/frontend/common/namespace/component.js
+++ b/src/app/frontend/common/namespace/component.js
@@ -98,7 +98,7 @@ export class NamespaceSelectController {
   }
 
   /**
-   *  Redirect should happen if user is on details page (toParams.objectNamespace), not all
+   *  Dialog should be shown if user is on details page (toParams.objectNamespace), not all
    *  namespaces are selected (toParams.namespace !== "_all") and current object namespace is
    *  different than selected namespace (toParams.namespace !== toParams.objectNamespace).
    *
@@ -106,7 +106,7 @@ export class NamespaceSelectController {
    * @return {boolean}
    * @private
    */
-  shouldRedirect_(toParams) {
+  shouldShowNamespaceChangeDialog_(toParams) {
     return toParams && toParams.namespace && toParams.objectNamespace &&
         toParams.namespace !== '_all' && toParams.namespace !== toParams.objectNamespace;
   }
@@ -144,7 +144,7 @@ export class NamespaceSelectController {
       this.selectedNamespace = DEFAULT_NAMESPACE;
     }
 
-    if (this.shouldRedirect_(toParams)) {
+    if (this.shouldShowNamespaceChangeDialog_(toParams)) {
       this.handleNamespaceChangeDialog_(toParams);
     }
   }

--- a/src/app/frontend/common/namespace/dialog.html
+++ b/src/app/frontend/common/namespace/dialog.html
@@ -17,9 +17,9 @@ limitations under the License.
 <md-dialog aria-label="Change namespace"
            layout="column">
   <md-dialog-content layout-padding>
-    <h4 class="md-title">[[Namespace change|]]</h4>
+    <h4 class="md-title">[[Change namespace?|]]</h4>
     <div class="kd-namespace-change-dialog-text">[[Selected resource is in a different namespace than currently selected.|]]</div>
-    <div class="kd-namespace-change-dialog-text">[[Do you want to switch namespace?|]]</div>
+    <div class="kd-namespace-change-dialog-text">[[Do you want to change namespace?|]]</div>
 
     <md-dialog-actions layout="row">
       <md-button ng-click="$ctrl.changeNamespace()"

--- a/src/app/frontend/common/namespace/dialog.html
+++ b/src/app/frontend/common/namespace/dialog.html
@@ -1,0 +1,30 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<md-dialog aria-label="Change namespace"
+           layout="column">
+  <md-dialog-content layout-padding>
+    <h4 class="md-title">[[Namespace change|]]</h4>
+    <div class="kd-namespace-change-dialog-text">[[Selected resource is in a different namespace than currently selected.|]]</div>
+    <div class="kd-namespace-change-dialog-text">[[Do you want to switch namespace?|]]</div>
+
+    <md-dialog-actions layout="row">
+      <md-button ng-click="$ctrl.changeNamespace()"
+                 class="md-primary">[[Yes|]]</md-button>
+      <md-button ng-click="$ctrl.cancel()">[[No|]]</md-button>
+    </md-dialog-actions>
+  </md-dialog-content>
+</md-dialog>

--- a/src/app/frontend/common/namespace/dialog.js
+++ b/src/app/frontend/common/namespace/dialog.js
@@ -1,0 +1,79 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {namespaceParam} from '../../chrome/state';
+import {stateName as overview} from '../../overview/state';
+
+/** @final */
+class NamespaceChangeInfoDialogController {
+  /**
+   * @param {!md.$dialog} $mdDialog
+   * @param {string} newNamespace
+   * @param {!./../state/service.FutureStateService} kdFutureStateService
+   * @param {!ui.router.$state} $state
+   * @param {!../history/service.HistoryService} kdHistoryService
+   * @ngInject
+   */
+  constructor($mdDialog, newNamespace, kdFutureStateService, $state, kdHistoryService) {
+    /** @private {!md.$dialog} */
+    this.mdDialog_ = $mdDialog;
+
+    /** @private {!./../state/service.FutureStateService}} */
+    this.futureStateService_ = kdFutureStateService;
+
+    /** @private {!ui.router.$state} */
+    this.state_ = $state;
+
+    /** @private {string} */
+    this.newNamespace_ = newNamespace;
+
+    /** @private {!../history/service.HistoryService} */
+    this.kdHistoryService_ = kdHistoryService;
+  }
+
+  /**
+   * Cancels namespace change and redirects to last state.
+   *
+   * @export
+   */
+  cancel() {
+    this.mdDialog_.cancel();
+    this.kdHistoryService_.back(overview);
+  }
+
+  /** @export */
+  changeNamespace() {
+    this.mdDialog_.hide();
+    this.state_.go(this.futureStateService_.state, {[namespaceParam]: this.newNamespace_});
+  }
+}
+
+/**
+ * Displays new namespace change info dialog.
+ *
+ * @param {!md.$dialog} mdDialog
+ * @param {string} newNamespace
+ * @return {!angular.$q.Promise}
+ */
+export function showNamespaceChangeInfoDialog(mdDialog, newNamespace) {
+  return mdDialog.show({
+    controller: NamespaceChangeInfoDialogController,
+    controllerAs: '$ctrl',
+    clickOutsideToClose: false,
+    templateUrl: 'common/namespace/dialog.html',
+    locals: {
+      'newNamespace': newNamespace,
+    },
+  });
+}

--- a/src/app/frontend/common/namespace/dialog.js
+++ b/src/app/frontend/common/namespace/dialog.js
@@ -21,7 +21,7 @@ class NamespaceChangeInfoDialogController {
    * @param {!md.$dialog} $mdDialog
    * @param {string} newNamespace
    * @param {!./../state/service.FutureStateService} kdFutureStateService
-   * @param {!ui.router.$state} $state
+   * @param {!kdUiRouter.$state} $state
    * @param {!../history/service.HistoryService} kdHistoryService
    * @ngInject
    */
@@ -32,7 +32,7 @@ class NamespaceChangeInfoDialogController {
     /** @private {!./../state/service.FutureStateService}} */
     this.futureStateService_ = kdFutureStateService;
 
-    /** @private {!ui.router.$state} */
+    /** @private {!kdUiRouter.$state} */
     this.state_ = $state;
 
     /** @private {string} */

--- a/src/app/frontend/common/namespace/dialog.scss
+++ b/src/app/frontend/common/namespace/dialog.scss
@@ -1,0 +1,20 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../../variables';
+
+.kd-namespace-change-dialog-text {
+  padding-bottom: $baseline-grid / 2;
+  padding-top: 0;
+}

--- a/src/app/frontend/node/detail/detail.html
+++ b/src/app/frontend/node/detail/detail.html
@@ -34,7 +34,8 @@ limitations under the License.
   <kd-content>
     <kd-pod-card-list pod-list="::ctrl.nodeDetail.podList"
                       pod-list-resource="::ctrl.podListResource"
-                      with-statuses="true">
+                      with-statuses="true"
+                      show-namespaces="true">
       <kd-empty-list-text>
         [[There are currently no Pods scheduled on this Node.|Text for pods card zerostate in node details page.]]
       </kd-empty-list-text>

--- a/src/app/frontend/node/detail/detail.html
+++ b/src/app/frontend/node/detail/detail.html
@@ -34,8 +34,7 @@ limitations under the License.
   <kd-content>
     <kd-pod-card-list pod-list="::ctrl.nodeDetail.podList"
                       pod-list-resource="::ctrl.podListResource"
-                      with-statuses="true"
-                      show-namespaces="true">
+                      with-statuses="true">
       <kd-empty-list-text>
         [[There are currently no Pods scheduled on this Node.|Text for pods card zerostate in node details page.]]
       </kd-empty-list-text>

--- a/src/app/frontend/pod/list/card_component.js
+++ b/src/app/frontend/pod/list/card_component.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {StateParams} from '../../common/resource/resourcedetail';
-import {stateName as logsStateName, StateParams as LogsStateParams} from '../../logs/state';
 import {stateName} from '../../pod/detail/state';
 
 /**
@@ -25,7 +24,7 @@ export class PodCardController {
    * @param {!ui.router.$state} $state
    * @param {!../../common/namespace/service.NamespaceService} kdNamespaceService
    */
-  constructor($state, $interpolate, kdNamespaceService) {
+  constructor($state, kdNamespaceService) {
     /** @private {!../../common/namespace/service.NamespaceService} */
     this.kdNamespaceService_ = kdNamespaceService;
 
@@ -80,16 +79,6 @@ export class PodCardController {
    */
   isFailed() {
     return this.pod.podStatus.status === 'failed';
-  }
-
-  /**
-   * @return {string}
-   * @export
-   */
-  getPodLogsHref() {
-    return this.state_.href(
-        logsStateName,
-        new LogsStateParams(this.pod.objectMeta.namespace, this.pod.objectMeta.name, 'pod'));
   }
 
   /**

--- a/src/test/frontend/common/namespace/namespaceselect_component_test.js
+++ b/src/test/frontend/common/namespace/namespaceselect_component_test.js
@@ -137,28 +137,4 @@ describe('Namespace select component ', () => {
     scope.$digest();
     expect(ctrl.selectedNamespace).toBe('default');
   });
-
-  it('should redirect if on details page of object from different namespace', () => {
-    let toParams = {
-      namespace: 'chosen-namespace',
-      objectNamespace: 'different-namespace',
-    };
-    expect(ctrl.shouldRedirect_(toParams)).toBeTruthy();
-  });
-
-  it('should not redirect if all namespaces are selected', () => {
-    let toParams = {
-      namespace: '_all',
-      objectNamespace: 'different-namespace',
-    };
-    expect(ctrl.shouldRedirect_(toParams)).toBeFalsy();
-  });
-
-  it('should not redirect if same namespaces are selected', () => {
-    let toParams = {
-      namespace: 'namespace',
-      objectNamespace: 'namespace',
-    };
-    expect(ctrl.shouldRedirect_(toParams)).toBeFalsy();
-  });
 });


### PR DESCRIPTION
Fixes #2300

Added dialog that will be displayed in case user wants to access resource being in a different namespace than currently selected one.

In case user clicks `Yes` state will be reloaded with new namespace selected, otherwise user will be taken to last page or overview page of currently selected namespace if no last page was found.

![zrzut ekranu z 2017-10-16 15-48-52](https://user-images.githubusercontent.com/2285385/31615339-8cfb2532-b289-11e7-8b00-a5410b09b507.png)
