### PR TITLE
Fix overview button and center toolbar buttons

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -26,11 +26,14 @@ limitations under the License.
     </div>
     <kd-search class="kd-search-bar"></kd-search>
     <div class="kd-global-actions">
-      <md-button ng-click="$ctrl.create()">
+      <md-button ng-click="$ctrl.create()"
+                 class="kd-actionbar-button">
         <md-icon class="kd-global-action-icon">add</md-icon>
         <md-tooltip md-delay="500"
                     md-autohide>
-          [[Create an application or any Kubernetes resource|Tooltip for global action bar create button tooltip.]]
+          <div class="kd-actionbar-button-text">
+            [[Create an application or any Kubernetes resource|Tooltip for global action bar create button tooltip.]]
+          </div>
         </md-tooltip>
         [[Create|Label for global action bar create button.]]
       </md-button>

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -60,7 +60,8 @@ kd-chrome {
 
     .kd-global-action-icon {
       color: $primary;
-      margin-right: .25 * $baseline-grid;
+      margin-top: 0.6 * $baseline-grid;
+      margin-right: $baseline-grid / 4;
     }
   }
 }

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -60,8 +60,8 @@ kd-chrome {
 
     .kd-global-action-icon {
       color: $primary;
-      margin-top: 0.6 * $baseline-grid;
       margin-right: $baseline-grid / 4;
+      margin-top: .6 * $baseline-grid;
     }
   }
 }

--- a/src/app/frontend/common/components/actionbar/actionbar.scss
+++ b/src/app/frontend/common/components/actionbar/actionbar.scss
@@ -50,10 +50,6 @@
   }
 }
 
-.kd-actionbar-icon-button {
-  //margin-right: .25 * $baseline-grid;
-}
-
 .kd-actionbar-divider {
   border-left: 1px solid $foreground-4;
   height: 4 * $baseline-grid;
@@ -66,7 +62,7 @@
   flex-direction: row;
 
   .kd-actionbar-button-text {
-    padding-right: $baseline-grid / 2;
     margin-left: $baseline-grid / 2;
+    padding-right: $baseline-grid / 2;
   }
 }

--- a/src/app/frontend/common/components/actionbar/actionbar.scss
+++ b/src/app/frontend/common/components/actionbar/actionbar.scss
@@ -51,7 +51,7 @@
 }
 
 .kd-actionbar-icon-button {
-  margin-right: .25 * $baseline-grid;
+  //margin-right: .25 * $baseline-grid;
 }
 
 .kd-actionbar-divider {
@@ -66,6 +66,7 @@
   flex-direction: row;
 
   .kd-actionbar-button-text {
-    padding-left: $baseline-grid / 2;
+    padding-right: $baseline-grid / 2;
+    margin-left: $baseline-grid / 2;
   }
 }

--- a/src/app/frontend/common/components/actionbar/actionbar.scss
+++ b/src/app/frontend/common/components/actionbar/actionbar.scss
@@ -60,3 +60,12 @@
   margin-left: 1.5 * $baseline-grid;
   margin-right: $baseline-grid;
 }
+
+.kd-actionbar-button {
+  display: flex;
+  flex-direction: row;
+
+  .kd-actionbar-button-text {
+    padding-left: $baseline-grid / 2;
+  }
+}

--- a/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
+++ b/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="$ctrl.remove()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">delete</md-icon>
+  <md-icon>delete</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     {{::$ctrl.getDeleteTooltip()}}

--- a/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
+++ b/src/app/frontend/common/components/actionbar/actionbardeleteitem.html
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="$ctrl.remove()">
+<md-button ng-click="$ctrl.remove()"
+           class="kd-actionbar-button">
   <md-icon class="kd-actionbar-icon-button">delete</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     {{::$ctrl.getDeleteTooltip()}}
   </md-tooltip>
-  [[Delete|Action 'Delete', which is a button on the actionbar and is there for every resource type.]]
+  <div class="kd-actionbar-button-text">
+    [[Delete|Action 'Delete', which is a button on the actionbar and is there for every resource type.]]
+  </div>
 </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbaredititem.html
+++ b/src/app/frontend/common/components/actionbar/actionbaredititem.html
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="$ctrl.edit()">
+<md-button ng-click="$ctrl.edit()"
+           class="kd-actionbar-button">
   <md-icon class="kd-actionbar-icon-button">edit</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     {{::$ctrl.getEditTooltip()}}
   </md-tooltip>
-  [[Edit|Action 'Edit' for the edit button on the global action bar.]]
+  <div class="kd-actionbar-button-text">
+    [[Edit|Action 'Edit' for the edit button on the global action bar.]]
+  </div>
 </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbaredititem.html
+++ b/src/app/frontend/common/components/actionbar/actionbaredititem.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="$ctrl.edit()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">edit</md-icon>
+  <md-icon>edit</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     {{::$ctrl.getEditTooltip()}}

--- a/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="$ctrl.deployApp()">
+<md-button ng-click="$ctrl.deployApp()"
+           class="kd-actionbar-button">
   <md-icon class="kd-actionbar-icon-button">add</md-icon>
-  [[Deploy app|Label for deploy app button.]]
+  <div class="kd-actionbar-button-text">[[Deploy app|Label for deploy app button.]]</div>
 </md-button>
 
 <md-button ng-click="$ctrl.deployFile()">

--- a/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlistbuttons.html
@@ -16,11 +16,11 @@ limitations under the License.
 
 <md-button ng-click="$ctrl.deployApp()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">add</md-icon>
+  <md-icon>add</md-icon>
   <div class="kd-actionbar-button-text">[[Deploy app|Label for deploy app button.]]</div>
 </md-button>
 
 <md-button ng-click="$ctrl.deployFile()">
-  <md-icon class="kd-actionbar-icon-button">file_upload</md-icon>
+  <md-icon>file_upload</md-icon>
   [[Upload YAML|Label for upload YAML button.]]
 </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbarlogs.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlogs.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="::$ctrl.viewLogs()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">subject</md-icon>
+  <md-icon>subject</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[View logs|Tooltip for the 'logs' button on the action bar.]]

--- a/src/app/frontend/common/components/actionbar/actionbarlogs.html
+++ b/src/app/frontend/common/components/actionbar/actionbarlogs.html
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="::$ctrl.viewLogs()">
+<md-button ng-click="::$ctrl.viewLogs()"
+           class="kd-actionbar-button">
   <md-icon class="kd-actionbar-icon-button">subject</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[View logs|Tooltip for the 'logs' button on the action bar.]]
   </md-tooltip>
-  [[Logs|Tooltip for the 'logs' button on the action bar.]]
+  <div class="kd-actionbar-button-text">[[Logs|Tooltip for the 'logs' button on the action bar.]]</div>
 </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
+++ b/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="$ctrl.goToNamespaceOverview()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">info</md-icon>
+  <md-icon class="kd-actionbar-icon-button">public</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Go to namespace overview page|]]

--- a/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
+++ b/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-href="{{$ctrl.getNamespaceOverviewHref()}}">
-  <md-icon class="kd-actionbar-icon-button">assessment</md-icon>
+<md-button ng-click="$ctrl.goToNamespaceOverview()"
+           class="kd-actionbar-button">
+  <md-icon class="kd-actionbar-icon-button">info</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Go to namespace overview page|]]
   </md-tooltip>
-  [[Overview|]]
+  <div class="kd-actionbar-button-text">[[Overview|]]</div>
 </md-button>

--- a/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
+++ b/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="$ctrl.goToNamespaceOverview()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">public</md-icon>
+  <md-icon>public</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Go to namespace overview page|]]

--- a/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview_component.js
+++ b/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview_component.js
@@ -28,10 +28,7 @@ export class ActionbarNamespaceOverviewController {
     this.state_ = $state;
   }
 
-  /**
-   * @return {string}
-   * @export
-   */
+  /** @export */
   goToNamespaceOverview() {
     this.state_.go(overview, {[namespaceParam]: this.namespace});
   }

--- a/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview_component.js
+++ b/src/app/frontend/common/components/actionbar/actionbarnamespaceoverview_component.js
@@ -32,8 +32,8 @@ export class ActionbarNamespaceOverviewController {
    * @return {string}
    * @export
    */
-  getNamespaceOverviewHref() {
-    return this.state_.href(overview, {[namespaceParam]: this.namespace});
+  goToNamespaceOverview() {
+    this.state_.go(overview, {[namespaceParam]: this.namespace});
   }
 }
 

--- a/src/app/frontend/common/components/actionbar/shell.html
+++ b/src/app/frontend/common/components/actionbar/shell.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <md-button ng-click="::$ctrl.openShell()"
            class="kd-actionbar-button">
-  <md-icon class="kd-actionbar-icon-button">input</md-icon>
+  <md-icon>input</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Exec into Pod|Exec button tooltip located on pod detail page actionbar]]

--- a/src/app/frontend/common/components/actionbar/shell.html
+++ b/src/app/frontend/common/components/actionbar/shell.html
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<md-button ng-click="::$ctrl.openShell()">
+<md-button ng-click="::$ctrl.openShell()"
+           class="kd-actionbar-button">
   <md-icon class="kd-actionbar-icon-button">input</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Exec into Pod|Exec button tooltip located on pod detail page actionbar]]
   </md-tooltip>
-  [[Exec|Execute shell in the container]]
+  <div class="kd-actionbar-button-text">[[Exec|Execute shell in the container]]</div>
 </md-button>

--- a/src/app/frontend/common/components/scale/scale.html
+++ b/src/app/frontend/common/components/scale/scale.html
@@ -23,7 +23,7 @@ limitations under the License.
 
 <md-button ng-if="!$ctrl.isMenuItem()"
            ng-click="$ctrl.handleScaleResourceDialog()">
-  <md-icon class="kd-actionbar-icon-button">linear_scale</md-icon>
+  <md-icon>linear_scale</md-icon>
   <md-tooltip md-delay="500"
               md-autohide>
     [[Edit number of pods|Tooltip for the 'scale' button on the action bar on a resource details view.]]


### PR DESCRIPTION
- Center toolbar icon buttons
- Fix glitch with black text color for a second during page load

I'd also update overview icon. Here are few proposals.

### Current
![zrzut ekranu z 2017-10-18 17-29-58](https://user-images.githubusercontent.com/2285385/31727884-18b67782-b42b-11e7-9d32-625b2a58521d.png)

### Proposals
![zrzut ekranu z 2017-10-18 17-30-11](https://user-images.githubusercontent.com/2285385/31727887-1cea7e3e-b42b-11e7-8c37-dfff38312fe0.png)
![zrzut ekranu z 2017-10-18 17-32-17](https://user-images.githubusercontent.com/2285385/31727889-1df729f8-b42b-11e7-9f12-a739c607e21e.png)
![zrzut ekranu z 2017-10-18 17-34-49](https://user-images.githubusercontent.com/2285385/31727891-1eeea304-b42b-11e7-9eb7-137b97386ce9.png)

## Icon buttons
### Before
![zrzut ekranu z 2017-10-18 17-36-22](https://user-images.githubusercontent.com/2285385/31727928-3bc9b702-b42b-11e7-9493-97346640290d.png)

### After
![zrzut ekranu z 2017-10-18 17-36-13](https://user-images.githubusercontent.com/2285385/31727923-38bba4a8-b42b-11e7-8487-957faa7224f4.png)

