### PR TITLE
change maintainer to label

### DIFF
--- a/src/deploy/Dockerfile
+++ b/src/deploy/Dockerfile
@@ -18,7 +18,7 @@
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
 FROM scratch
-MAINTAINER Piotr Bryk <bryk@google.com>
+LABEL maintainer "Piotr Bryk <bryk@google.com>"
 
 # Add all files from current working directory to the root of the image, i.e., copy dist directory
 # layout to the root directory.


### PR DESCRIPTION
i changed maintainer to label, since the former is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

All the best,
Benjamin