### PR TITLE
Set user-agent for client-go and add --version flag

### DIFF
--- a/build/backend.js
+++ b/build/backend.js
@@ -35,6 +35,9 @@ gulp.task('backend', ['package-backend'], function(doneFn) {
         'build',
         // Install dependencies to speed up subsequent compilations.
         '-i',
+        // record version info into src/version/version.go
+        '-ldflags',
+        conf.recordVersionExpression,
         '-o',
         path.join(conf.paths.serve, conf.backend.binaryName),
         conf.backend.mainPackageName,
@@ -116,6 +119,9 @@ function backendProd(outputBinaryPathsAndArchs) {
             '-a',
             '-installsuffix',
             'cgo',
+            // record version info into src/version/version.go
+            '-ldflags',
+            conf.recordVersionExpression,
             '-o',
             path,
             conf.backend.mainPackageName,

--- a/build/conf.js
+++ b/build/conf.js
@@ -76,6 +76,12 @@ const imageNameBase = 'kubernetes-dashboard';
  */
 export default {
   /**
+   * the expression of recording version info into src/app/backend/client/manager.go
+   */
+  recordVersionExpression:
+      `-X github.com/kubernetes/dashboard/src/app/backend/client.Version=${version.release}`,
+
+  /**
    * Configuration for container registry to push images to.
    */
   containerRegistry: containerRegistry,

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -42,7 +42,12 @@ const (
 	DefaultCmdConfigName = "kubernetes"
 	// Header name that contains token used for authorization. See TokenManager for more information.
 	JWETokenHeader = "jweToken"
+	// Default http header for user-agent
+	DefaultUserAgent = "dashboard"
 )
+
+// VERSION of this binary
+var Version = "UNKNOWN"
 
 // ClientManager is responsible for initializing and creating clients to communicate with
 // kubernetes apiserver on demand
@@ -188,6 +193,7 @@ func (self *clientManager) initConfig(cfg *rest.Config) {
 	cfg.QPS = DefaultQPS
 	cfg.Burst = DefaultBurst
 	cfg.ContentType = DefaultContentType
+	cfg.UserAgent = DefaultUserAgent + "/" + Version
 }
 
 // Returns rest Config based on provided apiserverHost and kubeConfigPath flags. If both are


### PR DESCRIPTION
Set user-agent for client-go.

before
```
client="dashboard/v1.7.1 (linux/amd64) kubernetes/$Format"
```
after
```
client="dashboard/v1.7.1"
```
And add `--version` flag
```
root@vv-node1:~# docker exec -it 956c8bc970cd /dashboard --version
2017/11/09 08:42:28 Starting overwatch
dashboard v1.7.1
```