### PR TITLE
Kubernates logo link

### DIFF
--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,12 +17,14 @@ limitations under the License.
 <md-toolbar class="kd-toolbar">
   <div class="md-toolbar-tools kd-toolbar-tools">
     <div class="kd-logo-bar">
-      <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
-               class="kd-toolbar-logo">
-      </md-icon>
-      <md-icon md-svg-icon="assets/images/kubernetes-logo-text.svg"
-               class="kd-toolbar-logo-text">
-      </md-icon>
+      <a href="/">
+        <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
+                class="kd-toolbar-logo">
+        </md-icon>
+        <md-icon md-svg-icon="assets/images/kubernetes-logo-text.svg"
+                class="kd-toolbar-logo-text">
+        </md-icon>
+      </a>
     </div>
     <kd-search class="kd-search-bar"></kd-search>
     <div class="kd-global-actions">

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,7 +17,7 @@ limitations under the License.
 <md-toolbar class="kd-toolbar">
   <div class="md-toolbar-tools kd-toolbar-tools">
     <div class="kd-logo-bar">
-      <a href="/">
+      <a ui-sref="overview" class="kd-toolbar-logo-link">
         <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
                 class="kd-toolbar-logo">
         </md-icon>

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,7 +17,7 @@ limitations under the License.
 <md-toolbar class="kd-toolbar">
   <div class="md-toolbar-tools kd-toolbar-tools">
     <div class="kd-logo-bar">
-      <a ui-sref="overview" class="kd-toolbar-logo-link">
+      <a ui-sref="{{$ctrl.overviewState()}}" class="kd-toolbar-logo-link">
         <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
                 class="kd-toolbar-logo">
         </md-icon>

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -17,7 +17,7 @@ limitations under the License.
 <md-toolbar class="kd-toolbar">
   <div class="md-toolbar-tools kd-toolbar-tools">
     <div class="kd-logo-bar">
-      <a ui-sref="{{$ctrl.overviewState()}}" class="kd-toolbar-logo-link">
+      <a ui-sref="{{$ctrl.getOverviewStateName()}}" class="kd-toolbar-logo-link">
         <md-icon md-svg-icon="assets/images/kubernetes-logo.svg"
                 class="kd-toolbar-logo">
         </md-icon>

--- a/src/app/frontend/chrome/chrome.scss
+++ b/src/app/frontend/chrome/chrome.scss
@@ -22,14 +22,16 @@
   width: 4 * $baseline-grid;
 }
 
-.kd-toolbar-logo {
-  @extend %kd-toolbar-logo-placeholder;
-}
+.kd-toolbar-logo-link {
+  .kd-toolbar-logo {
+    @extend %kd-toolbar-logo-placeholder;
+  }
 
-.kd-toolbar-logo-text {
-  @extend %kd-toolbar-logo-placeholder;
-  min-width: 14 * $baseline-grid;
-  width: 14 * $baseline-grid;
+  .kd-toolbar-logo-text {
+    @extend %kd-toolbar-logo-placeholder;
+    min-width: 14 * $baseline-grid;
+    width: 14 * $baseline-grid;
+  }
 }
 
 .kd-middle-ellipsised-link {

--- a/src/app/frontend/chrome/component.js
+++ b/src/app/frontend/chrome/component.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {deployAppStateName} from '../deploy/state';
+import {stateName as overviewState} from '../overview/state';
 
 import {actionbarViewName, fillContentConfig} from './state';
 
@@ -101,6 +102,13 @@ export class ChromeController {
    */
   create() {
     this.state_.go(deployAppStateName);
+  }
+
+  /**
+   * @export
+   */
+  overviewState() {
+    return overviewState;
   }
 }
 

--- a/src/app/frontend/chrome/component.js
+++ b/src/app/frontend/chrome/component.js
@@ -105,9 +105,10 @@ export class ChromeController {
   }
 
   /**
+   * @return {string}
    * @export
    */
-  overviewState() {
+  getOverviewStateName() {
     return overviewState;
   }
 }


### PR DESCRIPTION
Made Kubernates logo a link to dashboard home page. This helps dashboard users to go to home page directly from any other page.