### PR TITLE
Use polling instead of watch for secrets

### DIFF
--- a/src/app/backend/sync/api/types.go
+++ b/src/app/backend/sync/api/types.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -51,4 +53,11 @@ type Synchronizer interface {
 type SynchronizerManager interface {
 	// Secret created single secret synchronizer based on name and namespace information.
 	Secret(namespace, name string) Synchronizer
+}
+
+// Poller interface is responsible for periodically polling specific resource.
+type Poller interface {
+	// Poll polls specific resource every 'interval' time. Watch interface is returned in order to use it
+	// in the same way as regular watch on resource.
+	Poll(interval time.Duration) watch.Interface
 }

--- a/src/app/backend/sync/api/types.go
+++ b/src/app/backend/sync/api/types.go
@@ -47,6 +47,8 @@ type Synchronizer interface {
 	// RegisterActionHandler registers callback functions on given event types. They are automatically called by
 	// watcher.
 	RegisterActionHandler(ActionHandlerFunction, ...watch.EventType)
+	// SetPoller allows to set custom poller to synchronize objects.
+	SetPoller(poller Poller)
 }
 
 // SynchronizerManager interface is responsible for creating specific synchronizers.

--- a/src/app/backend/sync/poll/secret.go
+++ b/src/app/backend/sync/poll/secret.go
@@ -19,7 +19,7 @@ type SecretPoller struct {
 	watcher   *PollWatcher
 }
 
-// Poll, polls new secret every 'interval' time and sends it to watcher channel. See Poller for more information.
+// Poll new secret every 'interval' time and send it to watcher channel. See Poller for more information.
 func (self *SecretPoller) Poll(interval time.Duration) watch.Interface {
 	stopCh := make(chan struct{})
 

--- a/src/app/backend/sync/poll/secret.go
+++ b/src/app/backend/sync/poll/secret.go
@@ -1,0 +1,74 @@
+package poll
+
+import (
+	"time"
+
+	syncapi "github.com/kubernetes/dashboard/src/app/backend/sync/api"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// SecretPoller implements Poller interface. See Poller for more information.
+type SecretPoller struct {
+	name      string
+	namespace string
+	client    kubernetes.Interface
+	watcher   *PollWatcher
+}
+
+// Poll, polls new secret every 'interval' time and sends it to watcher channel. See Poller for more information.
+func (self *SecretPoller) Poll(interval time.Duration) watch.Interface {
+	stopCh := make(chan struct{})
+
+	go wait.Until(func() {
+		if self.watcher.IsStopped() {
+			close(stopCh)
+			return
+		}
+
+		self.watcher.eventChan <- self.getSecretEvent()
+	}, interval, stopCh)
+
+	return self.watcher
+}
+
+// Gets secret from API server and transforms it to watch.Event object.
+func (self *SecretPoller) getSecretEvent() watch.Event {
+	secret, err := self.client.CoreV1().Secrets(self.namespace).Get(self.name, v1.GetOptions{})
+	event := watch.Event{
+		Object: secret,
+		Type:   watch.Added,
+	}
+
+	if err != nil {
+		event.Type = watch.Error
+	}
+
+	if self.isNotFoundError(err) {
+		event.Type = watch.Deleted
+	}
+
+	return event
+}
+
+// Checks whether or not given error is a not found error (404).
+func (self *SecretPoller) isNotFoundError(err error) bool {
+	statusErr, ok := err.(*errors.StatusError)
+	if !ok {
+		return false
+	}
+	return statusErr.ErrStatus.Code == 404
+}
+
+// NewSecretPoller returns instance of Poller interface.
+func NewSecretPoller(name, namespace string, client kubernetes.Interface) syncapi.Poller {
+	return &SecretPoller{
+		name:      name,
+		namespace: namespace,
+		client:    client,
+		watcher:   NewPollWatcher(),
+	}
+}

--- a/src/app/backend/sync/poll/secret.go
+++ b/src/app/backend/sync/poll/secret.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package poll
 
 import (

--- a/src/app/backend/sync/poll/secret_test.go
+++ b/src/app/backend/sync/poll/secret_test.go
@@ -51,6 +51,7 @@ func TestNewSecretPoller_Poll(t *testing.T) {
 	case ev := <-watcher.ResultChan():
 		watchEvent = &ev
 	case <-time.After(3 * time.Second):
+		t.Fatal("Timeout while waiting for watcher data.")
 	}
 
 	if watchEvent == nil {

--- a/src/app/backend/sync/poll/secret_test.go
+++ b/src/app/backend/sync/poll/secret_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package poll_test
 
 import (

--- a/src/app/backend/sync/poll/secret_test.go
+++ b/src/app/backend/sync/poll/secret_test.go
@@ -1,0 +1,45 @@
+package poll_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubernetes/dashboard/src/app/backend/sync/poll"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewSecretPoller(t *testing.T) {
+	poller := poll.NewSecretPoller("test-secret", "test-ns", nil)
+
+	if poller == nil {
+		t.Fatal("Expected poller not to be nil.")
+	}
+}
+
+func TestNewSecretPoller_Poll(t *testing.T) {
+	var watchEvent *watch.Event
+	sName := "test-secret"
+	nsName := "test-ns"
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName,
+			Name:      sName,
+		},
+	}
+	client := fake.NewSimpleClientset(event)
+	poller := poll.NewSecretPoller(sName, nsName, client)
+
+	watcher := poller.Poll(1 * time.Second)
+	select {
+	case ev := <-watcher.ResultChan():
+		watchEvent = &ev
+	case <-time.After(3 * time.Second):
+	}
+
+	if watchEvent == nil {
+		t.Fatal("Expected watchEvent not to be nil.")
+	}
+}

--- a/src/app/backend/sync/poll/watcher.go
+++ b/src/app/backend/sync/poll/watcher.go
@@ -1,0 +1,44 @@
+package poll
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Implements watch.Interface
+type PollWatcher struct {
+	eventChan chan watch.Event
+	stopped   bool
+	sync.Mutex
+}
+
+// Stop stops poll watcher and closes event channel.
+func (self *PollWatcher) Stop() {
+	self.Lock()
+	defer self.Unlock()
+	if !self.stopped {
+		close(self.eventChan)
+		self.stopped = true
+	}
+}
+
+// IsStopped returns whether or not watcher was stopped.
+func (self *PollWatcher) IsStopped() bool {
+	return self.stopped
+}
+
+// ResultChan returns result channel that user can watch for incoming events.
+func (self *PollWatcher) ResultChan() <-chan watch.Event {
+	self.Lock()
+	defer self.Unlock()
+	return self.eventChan
+}
+
+// NewPollWatcher creates instance of PollWatcher.
+func NewPollWatcher() *PollWatcher {
+	return &PollWatcher{
+		eventChan: make(chan watch.Event),
+		stopped:   false,
+	}
+}

--- a/src/app/backend/sync/poll/watcher.go
+++ b/src/app/backend/sync/poll/watcher.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package poll
 
 import (

--- a/src/app/backend/sync/poll/watcher_test.go
+++ b/src/app/backend/sync/poll/watcher_test.go
@@ -1,0 +1,15 @@
+package poll_test
+
+import (
+	"testing"
+	"github.com/kubernetes/dashboard/src/app/backend/sync/poll"
+)
+
+func TestNewPollWatcher(t *testing.T) {
+	watcher := poll.NewPollWatcher()
+
+	if watcher == nil {
+		t.Fatal("Expected watcher not to be nil.")
+	}
+}
+

--- a/src/app/backend/sync/poll/watcher_test.go
+++ b/src/app/backend/sync/poll/watcher_test.go
@@ -16,6 +16,7 @@ package poll_test
 
 import (
 	"testing"
+
 	"github.com/kubernetes/dashboard/src/app/backend/sync/poll"
 )
 
@@ -26,4 +27,3 @@ func TestNewPollWatcher(t *testing.T) {
 		t.Fatal("Expected watcher not to be nil.")
 	}
 }
-

--- a/src/app/backend/sync/poll/watcher_test.go
+++ b/src/app/backend/sync/poll/watcher_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package poll_test
 
 import (

--- a/src/app/backend/sync/secret.go
+++ b/src/app/backend/sync/secret.go
@@ -20,16 +20,20 @@ import (
 	"log"
 	"reflect"
 	"sync"
+	"time"
 
 	syncApi "github.com/kubernetes/dashboard/src/app/backend/sync/api"
+	"github.com/kubernetes/dashboard/src/app/backend/sync/poll"
 	"k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
+
+// Time interval between which secret should be resynchronized.
+const secretSyncPeriod = 5 * time.Minute
 
 // Implements Synchronizer interface. See Synchronizer for more information.
 type secretSynchronizer struct {
@@ -167,15 +171,8 @@ func (self *secretSynchronizer) getSecret(obj runtime.Object) *v1.Secret {
 }
 
 func (self *secretSynchronizer) watch(namespace, name string) (watch.Interface, error) {
-	selector, err := fields.ParseSelector(fmt.Sprintf("metadata.name=%s", name))
-	if err != nil {
-		return nil, err
-	}
-
-	return self.client.CoreV1().Secrets(namespace).Watch(metaV1.ListOptions{
-		FieldSelector: selector.String(),
-		Watch:         true,
-	})
+	poller := poll.NewSecretPoller(name, namespace, self.client)
+	return poller.Poll(secretSyncPeriod), nil
 }
 
 func (self *secretSynchronizer) handleEvent(event watch.Event) error {
@@ -212,7 +209,6 @@ func (self *secretSynchronizer) handleEvent(event watch.Event) error {
 func (self *secretSynchronizer) update(secret v1.Secret) {
 	if reflect.DeepEqual(self.secret, &secret) {
 		// Skip update if existing object is the same as new one
-		log.Print("Trying to update secret with same object. Skipping")
 		return
 	}
 

--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Configuration to deploy head version of the Dashboard UI compatible with
-# Kubernetes 1.7.
+# Kubernetes 1.8.
 #
 # Example usage: kubectl create -f <this_file>
 
@@ -45,16 +45,16 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
   namespace: kube-system
 rules:
   # Allow Dashboard to create and watch for changes of 'kubernetes-dashboard-key-holder' secret.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "watch"]
+  verbs: ["create"]
 - apiGroups: [""]
   resources: ["secrets"]
-  # Allow Dashboard to get, update and delete 'kubernetes-dashboard-key-holder' secret.
+  # Allow Dashboard to get, update and delete 'kubernetes-dashboard-key-holder' and 'kubernetes-dashboard-certs' secrets.
   resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
   verbs: ["get", "update", "delete"]
   # Allow Dashboard to get metrics from heapster.
@@ -66,12 +66,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
 subjects:
 - kind: ServiceAccount
   name: kubernetes-dashboard-head
@@ -98,12 +98,6 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard-head
     spec:
-      initContainers:
-      - name: kubernetes-dashboard-init
-        image: kubernetesdashboarddev/kubernetes-dashboard-init-arm:v1.0.1
-        volumeMounts:
-        - name: kubernetes-dashboard-certs
-          mountPath: /certs
       containers:
       - name: kubernetes-dashboard-head
         image: kubernetesdashboarddev/kubernetes-dashboard-arm:head
@@ -113,8 +107,7 @@ spec:
         - containerPort: 8443
           protocol: TCP
         args:
-          - --tls-key-file=/certs/dashboard.key
-          - --tls-cert-file=/certs/dashboard.crt
+          - --auto-generate-certificates
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
@@ -122,7 +115,6 @@ spec:
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
-          readOnly: true
           # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Configuration to deploy head version of the Dashboard UI compatible with
-# Kubernetes 1.7.
+# Kubernetes 1.8.
 #
 # Example usage: kubectl create -f <this_file>
 
@@ -24,7 +24,7 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard-head
-  name: kubernetes-dashboard-certs
+  name: kubernetes-dashboard-certs-head
   namespace: kube-system
 type: Opaque
 
@@ -45,13 +45,13 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
   namespace: kube-system
 rules:
   # Allow Dashboard to create and watch for changes of 'kubernetes-dashboard-key-holder' secret.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "watch"]
+  verbs: ["create"]
 - apiGroups: [""]
   resources: ["secrets"]
   # Allow Dashboard to get, update and delete 'kubernetes-dashboard-key-holder' and 'kubernetes-dashboard-certs' secrets.
@@ -66,12 +66,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kubernetes-dashboard-minimal
+  name: kubernetes-dashboard-minimal-head
 subjects:
 - kind: ServiceAccount
   name: kubernetes-dashboard-head
@@ -98,12 +98,6 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard-head
     spec:
-      initContainers:
-      - name: kubernetes-dashboard-init
-        image: kubernetesdashboarddev/kubernetes-dashboard-init-amd64:v1.0.1
-        volumeMounts:
-        - name: kubernetes-dashboard-certs
-          mountPath: /certs
       containers:
       - name: kubernetes-dashboard-head
         image: kubernetesdashboarddev/kubernetes-dashboard-amd64:head
@@ -113,8 +107,7 @@ spec:
         - containerPort: 8443
           protocol: TCP
         args:
-          - --tls-key-file=/certs/dashboard.key
-          - --tls-cert-file=/certs/dashboard.crt
+          - --auto-generate-certificates
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
@@ -122,7 +115,6 @@ spec:
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs
-          readOnly: true
           # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume


### PR DESCRIPTION
Added polling mechanism that replaced watch on secrets to tighten minimal Dashboard privileges required to start it. Default resync period is set to 5 minutes.