### PR TITLE
Switch to proxy subresource

### DIFF
--- a/src/app/backend/integration/manager_test.go
+++ b/src/app/backend/integration/manager_test.go
@@ -58,7 +58,7 @@ func TestIntegrationManager_GetState(t *testing.T) {
 			"Server provided and using in-cluster heapster",
 			"http://127.0.0.1:8080", "", &api.IntegrationState{
 				Connected: false,
-				Error:     errors.New("Get http://127.0.0.1:8080/api/v1/proxy/namespaces/kube-system/services/heapster/healthz: dial tcp 127.0.0.1:8080: getsockopt: connection refused"),
+				Error:     errors.New("Get http://127.0.0.1:8080/api/v1/namespaces/kube-system/services/heapster/proxy/healthz: dial tcp 127.0.0.1:8080: getsockopt: connection refused"),
 			}, nil,
 		},
 		{

--- a/src/app/backend/integration/metric/heapster/restclient.go
+++ b/src/app/backend/integration/metric/heapster/restclient.go
@@ -42,20 +42,22 @@ type inClusterHeapsterClient struct {
 
 // Get creates request to given path.
 func (c inClusterHeapsterClient) Get(path string) RequestInterface {
-	return c.client.Get().Prefix("proxy").
+	return c.client.Get().
 		Namespace("kube-system").
 		Resource("services").
 		Name("heapster").
+		SubResource("proxy").
 		Suffix("/api/v1/" + path)
 }
 
 // HealthCheck does a health check of the application.
 // Returns nil if connection to application can be established, error object otherwise.
 func (self inClusterHeapsterClient) HealthCheck() error {
-	_, err := self.client.Get().Prefix("proxy").
+	_, err := self.client.Get().
 		Namespace("kube-system").
 		Resource("services").
 		Name("heapster").
+		SubResource("proxy").
 		Suffix("/healthz").
 		DoRaw()
 	return err

--- a/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm-head.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/alternative/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-arm.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/alternative/kubernetes-dashboard-head.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard-head.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/alternative/kubernetes-dashboard.yaml
+++ b/src/deploy/alternative/kubernetes-dashboard.yaml
@@ -56,6 +56,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -67,6 +67,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -67,6 +67,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -67,6 +67,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/src/deploy/recommended/kubernetes-dashboard.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard.yaml
@@ -67,6 +67,10 @@ rules:
   resources: ["services"]
   resourceNames: ["heapster"]
   verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The root proxy API path has been deprecated since 1.2 and does not allow for fine-grained verb access control.

This switches the dashboard to use the service proxy subresource