### PR TITLE
Fix logs download

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -183,6 +183,7 @@ function compileES6(translation) {
     path.join(conf.paths.externs, 'graph.js'),
     path.join(conf.paths.externs, 'errors.js'),
     path.join(conf.paths.externs, 'file.js'),
+    path.join(conf.paths.externs, 'filesaver.js'),
   ];
 
   let closureCompilerConfig = {

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -512,11 +512,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">Please select the kubeconfig file that you have created to configure access to the cluster. To find out more about how to configure and use kubeconfig file, please refer to the &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; section.</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">Enter token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
-  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
-  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
-  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
-  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="Log file download dialog title.">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="Log file download dialog info.">Please wait until download has finished.</translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="Log file download dialog download status info.">Downloaded: </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="Log file download dialog \'Save\' button.">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="Log file download dialog \'Abort\' button.">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">Show previous logs</translation>

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -512,6 +512,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">Please select the kubeconfig file that you have created to configure access to the cluster. To find out more about how to configure and use kubeconfig file, please refer to the &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; section.</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">Enter token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
+  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">Show previous logs</translation>

--- a/i18n/messages-en.xtb
+++ b/i18n/messages-en.xtb
@@ -514,7 +514,7 @@
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
   <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
   <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
   <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
   <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -518,6 +518,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">Please select the kubeconfig file that you have created to configure access to the cluster. To find out more about how to configure and use kubeconfig file, please refer to the &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; section.</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">Enter token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
+  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">Show previous logs</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -518,11 +518,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">Please select the kubeconfig file that you have created to configure access to the cluster. To find out more about how to configure and use kubeconfig file, please refer to the &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; section.</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">Enter token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
-  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
-  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
-  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
-  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="Log file download dialog title.">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="Log file download dialog info.">Please wait until download has finished.</translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="Log file download dialog download status info.">Downloaded: </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="Log file download dialog \'Save\' button.">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="Log file download dialog \'Abort\' button.">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">in</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">Show previous logs</translation>

--- a/i18n/messages-ja.xtb
+++ b/i18n/messages-ja.xtb
@@ -520,7 +520,7 @@
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">Authentication failed. Please try again.</translation>
   <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
   <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
   <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
   <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">Logs from</translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -510,11 +510,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">請選擇你建立的 kubeconfig 檔案，來設定存取叢集。請參閱 &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; 小節，來了解更多關於如何設定與使用 kubeconfig 檔案的資訊。</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">輸入 Token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">認證失敗，請再嘗試一次</translation>
-  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
-  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
-  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
-  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="Log file download dialog title.">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="Log file download dialog info.">Please wait until download has finished.</translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="Log file download dialog download status info.">Downloaded: </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="Log file download dialog \'Save\' button.">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="Log file download dialog \'Abort\' button.">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日誌</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位於</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">顯示先前日誌</translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -512,7 +512,7 @@
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">認證失敗，請再嘗試一次</translation>
   <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
   <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
   <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
   <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日誌</translation>

--- a/i18n/messages-zh-tw.xtb
+++ b/i18n/messages-zh-tw.xtb
@@ -510,6 +510,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">請選擇你建立的 kubeconfig 檔案，來設定存取叢集。請參閱 &lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;Configure Access to Multiple Clusters&lt;/a&gt; 小節，來了解更多關於如何設定與使用 kubeconfig 檔案的資訊。</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">輸入 Token</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">認證失敗，請再嘗試一次</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
+  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日誌</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位於</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">顯示先前日誌</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -513,7 +513,7 @@
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">验证失败，请重试</translation>
   <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
   <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
   <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
   <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日志</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -397,8 +397,7 @@
   <translation id="1706523109425956587" key="MSG_DEPLOY_UPLOAD_3" desc="The text is used as a \'Learn more\' link text besides the file upload on the deploy page.">了解更多</translation>
   <translation id="2854540335199012536" key="MSG_DEPLOY_UPLOAD_4" desc="User help for the YAML/JSON file upload form on the deploy page.">选择一个 YAML 或 JSON 文件，文件中包含需要部署在当前（左侧菜单）命名空间的资源</translation>
   <translation id="7869641598803414323" key="MSG_DESIRED_PODS_MSG" desc="Satisfies a way to make normal binding in angularjs to pass in google closure compiler.">
-    需要 <ph name="DESIRED_PODS"> 个</ph>
-  </translation>
+    需要 <ph name="DESIRED_PODS"> 个</ph></translation>
   <translation id="4942061082776173364" key="MSG_ENCRYPTION_KEY_CHANGED" desc="Text shown when saved token could not be decrypted by backend.">会话过期，请重新登录</translation>
   <translation id="778882191405410811" key="MSG_ENDPOINTS_WARNING_LABEL" desc="Label 'Warning' for the endpoint selection drop-down.">警告</translation>
   <translation id="4983649641173165689" key="MSG_ENDPOINT_CARDLIST_0" desc="Label which appears above the list of such objects.">端点</translation>
@@ -512,6 +511,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">请选择您已配置用来访问集群的 kubeconfig 文件，请浏览&lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;配置对多个集群的访问&lt;/a&gt;一节，了解更多关于如何配置和使用 kubeconfig 文件的信息</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">输入令牌</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">验证失败，请重试</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
+  <translation id="9071411568337764822" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="kdMemory }}|">Downloaded: {{ $ctrl.loaded </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日志</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位于</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">显示更早日志</translation>

--- a/i18n/messages-zh.xtb
+++ b/i18n/messages-zh.xtb
@@ -511,11 +511,11 @@
   <translation id="5295755962056443196" key="MSG_LOGIN_LOGIN_7" desc="(no description provided)">请选择您已配置用来访问集群的 kubeconfig 文件，请浏览&lt;a href='https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/'&gt;配置对多个集群的访问&lt;/a&gt;一节，了解更多关于如何配置和使用 kubeconfig 文件的信息</translation>
   <translation id="7931742467615349833" key="MSG_LOGIN_TOKEN_0" desc="\'Token\' field label shown on login page for token auth">输入令牌</translation>
   <translation id="1813585001229142426" key="MSG_LOGIN_UNAUTHORIZED_ERROR" desc="Text shown when unauthorized user tries to log in.">验证失败，请重试</translation>
-  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="(no description provided)">Downloading log file</translation>
-  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="(no description provided)">Please wait until download has finished.</translation>
-  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="(no description provided)">Downloaded: </translation>
-  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="(no description provided)">Save</translation>
-  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="(no description provided)">Abort</translation>
+  <translation id="6905890758241326832" key="MSG_LOGS_DOWNLOAD_DIALOG_0" desc="Log file download dialog title.">Downloading log file</translation>
+  <translation id="7920142392085872110" key="MSG_LOGS_DOWNLOAD_DIALOG_1" desc="Log file download dialog info.">Please wait until download has finished.</translation>
+  <translation id="3238335709642538928" key="MSG_LOGS_DOWNLOAD_DIALOG_2" desc="Log file download dialog download status info.">Downloaded: </translation>
+  <translation id="2306078941708704664" key="MSG_LOGS_DOWNLOAD_DIALOG_3" desc="Log file download dialog \'Save\' button.">Save</translation>
+  <translation id="6309042137906110314" key="MSG_LOGS_DOWNLOAD_DIALOG_4" desc="Log file download dialog \'Abort\' button.">Abort</translation>
   <translation id="4722922095699681308" key="MSG_LOGS_LOGS_0" desc="Title prefix for logs card.">容器日志</translation>
   <translation id="6855662924451585032" key="MSG_LOGS_LOGS_1" desc="Title part for logs card.">位于</translation>
   <translation id="6427964323602885868" key="MSG_LOGS_LOGS_10" desc="Tooltip for button that switches to showing the previous logs.">显示更早日志</translation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-dashboard",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -224,6 +224,15 @@
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/angular-cookies/-/angular-cookies-1.6.6.tgz",
       "integrity": "sha1-MRZC2v28T/fNaSILiSW4g1n7oUg="
+    },
+    "angular-file-saver": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/angular-file-saver/-/angular-file-saver-1.1.3.tgz",
+      "integrity": "sha1-3K7AaVIU8iakyq/IwW0hqaYffRs=",
+      "requires": {
+        "blob-tmp": "1.0.0",
+        "file-saver": "1.3.3"
+      }
     },
     "angular-jsoneditor": {
       "version": "0.0.2",
@@ -1469,6 +1478,11 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
+    },
+    "blob-tmp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/blob-tmp/-/blob-tmp-1.0.0.tgz",
+      "integrity": "sha1-3oJJHiIv8TVMd6k+6OTqLIlUQnM="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -5811,6 +5825,11 @@
       "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-5.0.0.tgz",
       "integrity": "sha512-MIMzBjsXrH20bF4TAF24U6MWsqXP4K8Pu/Xj+wX9oh3xKgRfRZ2Z0IPMPMfkVNbO6QeLKmGIyOpW2hVv/AipBA==",
       "dev": true
+    },
+    "file-saver": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.3.tgz",
+      "integrity": "sha1-zdTETTqiZOrC9o7BZbx5HDSvEjI="
     },
     "file-type": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "angular-aria": "~1.6.6",
     "angular-clipboard": "~1.6.2",
     "angular-cookies": "~1.6.6",
+    "angular-file-saver": "^1.1.3",
     "angular-jsoneditor": "~0.0.2",
     "angular-material": "~1.1.5",
     "angular-messages": "~1.6.6",

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -2260,12 +2260,12 @@ func (apiHandler *APIHandler) handleLogFile(request *restful.Request, response *
 	containerID := request.PathParameter("container")
 	usePreviousLogs := request.QueryParameter("previous") == "true"
 
-	filename, logStream, err := container.GetLogFile(k8sClient, namespace, podID, containerID, usePreviousLogs)
+	logStream, err := container.GetLogFile(k8sClient, namespace, podID, containerID, usePreviousLogs)
 	if err != nil {
 		handleInternalError(response, err)
 		return
 	}
-	handleDownload(response, logStream, filename)
+	handleDownload(response, logStream)
 }
 
 // parseNamespacePathParameter parses namespace selector for list pages in path parameter.

--- a/src/app/backend/handler/download.go
+++ b/src/app/backend/handler/download.go
@@ -15,16 +15,13 @@
 package handler
 
 import (
-	"fmt"
 	"io"
 
-	restful "github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful"
 )
 
-func handleDownload(response *restful.Response, result io.ReadCloser, filename string) {
-	header := fmt.Sprintf("attachment; filename=\"%v\"", filename)
-	response.AddHeader("Content-Disposition", header)
-
+func handleDownload(response *restful.Response, result io.ReadCloser) {
+	response.AddHeader(restful.HEADER_ContentType, "text/plain")
 	defer result.Close()
 	_, err := io.Copy(response, result)
 	if err != nil {

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -15,7 +15,6 @@
 package container
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -114,16 +113,15 @@ func readRawLogs(client kubernetes.Interface, namespace, podID string, logOption
 
 // GetLogFile returns a stream to the log file which can be piped directly to the response. This avoids out of memory
 // issues. Previous indicates to read archived logs created by log rotation or container crash
-func GetLogFile(client kubernetes.Interface, namespace, podID string, container string, usePreviousLogs bool) (string, io.ReadCloser, error) {
+func GetLogFile(client kubernetes.Interface, namespace, podID string, container string, usePreviousLogs bool) (io.ReadCloser, error) {
 	logOptions := &v1.PodLogOptions{
 		Container:  container,
 		Follow:     false,
 		Previous:   usePreviousLogs,
 		Timestamps: false,
 	}
-	filename := fmt.Sprintf("logs-from-%v-in-%v.txt", container, podID)
 	logStream, err := openStream(client, namespace, podID, logOptions)
-	return filename, logStream, err
+	return logStream, err
 }
 
 func openStream(client kubernetes.Interface, namespace, podID string, logOptions *v1.PodLogOptions) (io.ReadCloser, error) {

--- a/src/app/externs/filesaver.js
+++ b/src/app/externs/filesaver.js
@@ -12,36 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../../variables';
+/**
+ * @fileoverview Externs for angular-file-saver module
+ *
+ * @externs
+ */
 
-.kd-download-dialog {
-  display: grid;
-  grid-template-columns: $baseline-grid auto $baseline-grid;
-  grid-gap: 2 * $baseline-grid;
-  grid-auto-rows: minmax(2 * $baseline-grid, auto);
-}
+const kdFileApi = {};
 
-.kd-download-progress {
-  padding-top: .5 * $baseline-grid;
-}
+/** @constructor */
+kdFileApi.FileSaver = function() {};
 
-.kd-download-progress-bar {
-  margin-top: $baseline-grid;
-  grid-column: 2;
-  grid-row: 2;
-}
-
-.kd-download-info {
-  grid-column: 2;
-  grid-row: 1;
-}
-
-.kd-download-buttons {
-  grid-column: 2;
-  grid-row: 3;
-
-  .md-button {
-    margin-left: 0;
-    margin-bottom: 2 * $baseline-grid;
-  }
-}
+/**
+ * @param {Blob} data
+ * @param {string} filename
+ * @param {boolean} [disableAutoBom]
+ */
+kdFileApi.FileSaver.prototype.saveAs = function(data, filename, disableAutoBom) {};

--- a/src/app/frontend/common/filters/memory.js
+++ b/src/app/frontend/common/filters/memory.js
@@ -16,7 +16,7 @@
 const base = 1024;
 
 /** Names of the suffixes where I-th name is for base^I suffix. */
-const powerSuffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
+const powerSuffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
 
 /**
  * Returns filter function that formats memory in bytes.

--- a/src/app/frontend/common/filters/memory.js
+++ b/src/app/frontend/common/filters/memory.js
@@ -16,7 +16,7 @@
 const base = 1024;
 
 /** Names of the suffixes where I-th name is for base^I suffix. */
-const powerSuffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+const powerSuffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
 
 /**
  * Returns filter function that formats memory in bytes.

--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {showDownloadDialog} from "./download/dialog";
-
 const logsPerView = 100;
 const maxLogSize = 2e9;
 // Load logs from the beginning of the log file. This matters only if the log file is too large to
@@ -25,11 +23,7 @@ const endOfLogFile = 'end';
 const oldestTimestamp = 'oldest';
 const newestTimestamp = 'newest';
 
-/**
- * Controller for the logs view.
- *
- * @final
- */
+/** @final */
 export class LogsController {
   /**
    * @param {!./service.LogsService} logsService
@@ -39,9 +33,12 @@ export class LogsController {
    * @param {!angular.$interval} $interval
    * @param {!../common/errorhandling/dialog.ErrorDialog} errorDialog
    * @param {!../common/settings/service.SettingsService} kdSettingsService
+   * @param {!./download/service.DownloadService} kdDownloadService
    * @ngInject
    */
-  constructor(logsService, $sce, $document, $resource, $interval, errorDialog, kdSettingsService, kdDownloadService) {
+  constructor(
+      logsService, $sce, $document, $resource, $interval, errorDialog, kdSettingsService,
+      kdDownloadService) {
     /** @private {!angular.$sce} */
     this.sce_ = $sce;
 
@@ -111,6 +108,7 @@ export class LogsController {
     /** @private {!../common/settings/service.SettingsService} */
     this.settingsService_ = kdSettingsService;
 
+    /** @private {!./download/service.DownloadService} */
     this.downloadService_ = kdDownloadService;
   }
 
@@ -291,8 +289,10 @@ export class LogsController {
    */
   downloadLog() {
     let namespace = this.stateParams_.objectNamespace;
-    let logUrl = `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${this.logsService.getPrevious()}`;
-    this.downloadService_.startDownload(logUrl, this.logsService.getLogFileName(this.pod, this.container));
+    let logUrl = `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
+        this.logsService.getPrevious()}`;
+    this.downloadService_.download(
+        logUrl, this.logsService.getLogFileName(this.pod, this.container));
   }
 
   /**

--- a/src/app/frontend/logs/component.js
+++ b/src/app/frontend/logs/component.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {showDownloadDialog} from "./download/dialog";
+
 const logsPerView = 100;
 const maxLogSize = 2e9;
 // Load logs from the beginning of the log file. This matters only if the log file is too large to
@@ -39,7 +41,7 @@ export class LogsController {
    * @param {!../common/settings/service.SettingsService} kdSettingsService
    * @ngInject
    */
-  constructor(logsService, $sce, $document, $resource, $interval, errorDialog, kdSettingsService) {
+  constructor(logsService, $sce, $document, $resource, $interval, errorDialog, kdSettingsService, kdDownloadService) {
     /** @private {!angular.$sce} */
     this.sce_ = $sce;
 
@@ -108,6 +110,8 @@ export class LogsController {
 
     /** @private {!../common/settings/service.SettingsService} */
     this.settingsService_ = kdSettingsService;
+
+    this.downloadService_ = kdDownloadService;
   }
 
   $onInit() {
@@ -282,14 +286,13 @@ export class LogsController {
   }
 
   /**
-   * Return the link to download the log file
+   * Initiate logs download.
    * @export
-   * @return {string}
    */
-  getDownloadLink() {
+  downloadLog() {
     let namespace = this.stateParams_.objectNamespace;
-    return `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${
-        this.logsService.getPrevious()}`;
+    let logUrl = `api/v1/log/file/${namespace}/${this.pod}/${this.container}?previous=${this.logsService.getPrevious()}`;
+    this.downloadService_.startDownload(logUrl, this.logsService.getLogFileName(this.pod, this.container));
   }
 
   /**
@@ -347,7 +350,7 @@ const i18n = {
   /** @export {string} @desc Text for logs card zerostate in logs page. */
   MSG_LOGS_ZEROSTATE_TEXT: goog.getMsg('The selected container has not logged any messages yet.'),
   /**
-     @export {string} @desc Error dialog indicating that parts of the log file is missing due to memory constraints.
+   @export {string} @desc Error dialog indicating that parts of the log file is missing due to memory constraints.
    */
   MSG_LOGS_TRUNCATED_WARNING:
       goog.getMsg('The middle part of the log file cannot be loaded, because it is too big.'),

--- a/src/app/frontend/logs/download/dialog.html
+++ b/src/app/frontend/logs/download/dialog.html
@@ -1,9 +1,25 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <div class="kd-download-dialog">
   <div class="kd-download-info">
-    <h3>Downloading log file</h3>
-    Please wait until download has finished.
+    <h3>[[Downloading log file|]]</h3>
+    [[Please wait until download has finished.|]]
     <div class="kd-download-progress">
-      Downloaded: {{ $ctrl.loaded | kdMemory }}
+      [[Downloaded: {{ $ctrl.loaded | kdMemory }}|]]
     </div>
   </div>
 
@@ -16,8 +32,10 @@
     <md-button class="md-primary md-raised "
                ng-disabled="!$ctrl.hasDownloadFinished()"
                ng-click="$ctrl.save()">
-      Save
+      [[Save|]]
     </md-button>
-    <md-button ng-click="$ctrl.abort()">Abort</md-button>
+    <md-button ng-click="$ctrl.abort()">
+      [[Abort|]]
+    </md-button>
   </div>
 </div>

--- a/src/app/frontend/logs/download/dialog.html
+++ b/src/app/frontend/logs/download/dialog.html
@@ -16,10 +16,10 @@ limitations under the License.
 
 <div class="kd-download-dialog">
   <div class="kd-download-info">
-    <h3>[[Downloading log file|]]</h3>
-    [[Please wait until download has finished.|]]
+    <h3>[[Downloading log file|Log file download dialog title.]]</h3>
+    [[Please wait until download has finished.|Log file download dialog info.]]
     <div class="kd-download-progress">
-      [[Downloaded: |]] {{ $ctrl.loaded | kdMemory }}
+      [[Downloaded: |Log file download dialog download status info.]] {{ $ctrl.loaded | kdMemory }}
     </div>
   </div>
 
@@ -32,10 +32,10 @@ limitations under the License.
     <md-button class="md-primary md-raised "
                ng-disabled="!$ctrl.hasDownloadFinished()"
                ng-click="$ctrl.save()">
-      [[Save|]]
+      [[Save|Log file download dialog 'Save' button.]]
     </md-button>
     <md-button ng-click="$ctrl.abort()">
-      [[Abort|]]
+      [[Abort|Log file download dialog 'Abort' button.]]
     </md-button>
   </div>
 </div>

--- a/src/app/frontend/logs/download/dialog.html
+++ b/src/app/frontend/logs/download/dialog.html
@@ -1,0 +1,23 @@
+<div class="kd-download-dialog">
+  <div class="kd-download-info">
+    <h3>Downloading log file</h3>
+    Please wait until download has finished.
+    <div class="kd-download-progress">
+      Downloaded: {{ $ctrl.loaded | kdMemory }}
+    </div>
+  </div>
+
+  <md-progress-linear md-mode="{{$ctrl.getDownloadMode()}}"
+                      value="100"
+                      class="kd-download-progress-bar">
+  </md-progress-linear>
+
+  <div class="kd-download-buttons">
+    <md-button class="md-primary md-raised "
+               ng-disabled="!$ctrl.hasDownloadFinished()"
+               ng-click="$ctrl.save()">
+      Save
+    </md-button>
+    <md-button ng-click="$ctrl.abort()">Abort</md-button>
+  </div>
+</div>

--- a/src/app/frontend/logs/download/dialog.html
+++ b/src/app/frontend/logs/download/dialog.html
@@ -19,7 +19,7 @@ limitations under the License.
     <h3>[[Downloading log file|]]</h3>
     [[Please wait until download has finished.|]]
     <div class="kd-download-progress">
-      [[Downloaded: {{ $ctrl.loaded | kdMemory }}|]]
+      [[Downloaded: |]] {{ $ctrl.loaded | kdMemory }}
     </div>
   </div>
 

--- a/src/app/frontend/logs/download/dialog.js
+++ b/src/app/frontend/logs/download/dialog.js
@@ -1,94 +1,138 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+/** @const {number} */
 const PROGRESS_UPDATE_TIMEOUT = 500;
 
 /** @final */
 class DownloadDialogController {
   /**
-   * @param downloadUrl
-   * @param fileName
-   * @param FileSaver
-   * @param $mdDialog
-   * @param $q
-   * @param kdDownloadService
-   * @param $timeout
+   * @param {string} downloadUrl
+   * @param {string} fileName
+   * @param {!kdFileApi.FileSaver} FileSaver
+   * @param {!md.$dialog} $mdDialog
+   * @param {!angular.$q} $q
+   * @param {!./service.DownloadService} kdDownloadService
+   * @param {!angular.$timeout} $timeout
    * @ngInject
    */
   constructor(downloadUrl, fileName, FileSaver, $mdDialog, $q, kdDownloadService, $timeout) {
+    /** @private {string} */
     this.downloadUrl_ = downloadUrl;
-
+    /** @private {string} */
     this.fileName_ = fileName;
-
+    /** @export {number} */
     this.loaded = 0;
-
-    this.lastLoaded = 0;
-
+    /** @private {number} */
+    this.lastLoaded_ = 0;
+    /** @private {boolean} */
     this.finished = false;
-
+    /** @private {!kdFileApi.FileSaver} */
     this.fileSaver_ = FileSaver;
-
+    /** @private {Blob} */
     this.data;
-
+    /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
-
+    /** @private {!angular.$q.Deferred} */
     this.canceler_ = $q.defer();
-
+    /** @private {./service.DownloadService} */
     this.downloadService_ = kdDownloadService;
-
+    /** @private {angular.$timeout} */
     this.timeout_ = $timeout;
-
+    /** @private {angular.$q.Promise|undefined} */
     this.progressUpdateTimeoutFinished_;
   }
 
+  /** @export */
   $onInit() {
-    this.downloadService_.downloadFile(this.downloadUrl_, this.progressUpdateCallback.bind(this), this.canceler_)
-        .then(this.downloadFinishedCallback.bind(this))
+    this.downloadService_
+        .downloadFile(this.downloadUrl_, this.progressUpdateCallback_.bind(this), this.canceler_)
+        .then(this.downloadFinishedCallback_.bind(this))
         // Silence the error as we are handling abort in abort function
         .catch(() => {});
   }
 
-  progressUpdateCallback(event) {
-    this.lastLoaded = event.loaded;
+  /**
+   * @param {Object} event
+   * @private
+   */
+  progressUpdateCallback_(event) {
+    this.lastLoaded_ = event.loaded;
 
-    if(this.progressUpdateTimeoutFinished_) {
+    if (this.progressUpdateTimeoutFinished_) {
       return;
     }
 
     this.progressUpdateTimeoutFinished_ = this.timeout_(() => {
       this.progressUpdateTimeoutFinished_ = undefined;
-      this.updateProgress(event.loaded);
+      this.updateProgress_(event.loaded);
     }, PROGRESS_UPDATE_TIMEOUT);
   }
 
-  downloadFinishedCallback(response) {
+  /**
+   * @param {!angular.$http.Response} response
+   * @private
+   */
+  downloadFinishedCallback_(response) {
     this.data = response.data;
     this.finished = true;
     this.timeout_.cancel(this.progressUpdateTimeoutFinished_);
-    this.loaded = this.lastLoaded;
+    this.loaded = this.lastLoaded_;
   }
 
-  updateProgress(loaded) {
+  /**
+   * @param {number} loaded
+   * @private
+   */
+  updateProgress_(loaded) {
     this.loaded = loaded;
   }
 
+  /**
+   * @return {boolean}
+   * @export
+   */
   hasDownloadFinished() {
     return this.finished;
   }
 
+  /** @export */
   save() {
     this.fileSaver_.saveAs(this.data, this.fileName_);
     this.mdDialog_.hide();
   }
 
+  /** @export */
   abort() {
     this.canceler_.resolve();
     this.mdDialog_.hide();
   }
 
+  /**
+   * @return {string}
+   * @export
+   */
   getDownloadMode() {
     return this.finished ? 'determinate' : 'indeterminate';
   }
 }
 
+/**
+ * @param {!md.$dialog} mdDialog
+ * @param {string} downloadUrl
+ * @param {string} fileName
+ */
 export function showDownloadDialog(mdDialog, downloadUrl, fileName) {
   return mdDialog.show({
     controller: DownloadDialogController,

--- a/src/app/frontend/logs/download/dialog.js
+++ b/src/app/frontend/logs/download/dialog.js
@@ -16,7 +16,7 @@
 const PROGRESS_UPDATE_TIMEOUT = 500;
 
 /** @final */
-class DownloadDialogController {
+export class DownloadDialogController {
   /**
    * @param {string} downloadUrl
    * @param {string} fileName

--- a/src/app/frontend/logs/download/dialog.js
+++ b/src/app/frontend/logs/download/dialog.js
@@ -142,6 +142,6 @@ export function showDownloadDialog(mdDialog, downloadUrl, fileName) {
       'fileName': fileName,
     },
     templateUrl: 'logs/download/dialog.html',
-    escapeToClose: false
-  })
+    escapeToClose: false,
+  });
 }

--- a/src/app/frontend/logs/download/dialog.js
+++ b/src/app/frontend/logs/download/dialog.js
@@ -1,0 +1,103 @@
+
+const PROGRESS_UPDATE_TIMEOUT = 500;
+
+/** @final */
+class DownloadDialogController {
+  /**
+   * @param downloadUrl
+   * @param fileName
+   * @param FileSaver
+   * @param $mdDialog
+   * @param $q
+   * @param kdDownloadService
+   * @param $timeout
+   * @ngInject
+   */
+  constructor(downloadUrl, fileName, FileSaver, $mdDialog, $q, kdDownloadService, $timeout) {
+    this.downloadUrl_ = downloadUrl;
+
+    this.fileName_ = fileName;
+
+    this.loaded = 0;
+
+    this.lastLoaded = 0;
+
+    this.finished = false;
+
+    this.fileSaver_ = FileSaver;
+
+    this.data;
+
+    this.mdDialog_ = $mdDialog;
+
+    this.canceler_ = $q.defer();
+
+    this.downloadService_ = kdDownloadService;
+
+    this.timeout_ = $timeout;
+
+    this.progressUpdateTimeoutFinished_;
+  }
+
+  $onInit() {
+    this.downloadService_.downloadFile(this.downloadUrl_, this.progressUpdateCallback.bind(this), this.canceler_)
+        .then(this.downloadFinishedCallback.bind(this))
+        // Silence the error as we are handling abort in abort function
+        .catch(() => {});
+  }
+
+  progressUpdateCallback(event) {
+    this.lastLoaded = event.loaded;
+
+    if(this.progressUpdateTimeoutFinished_) {
+      return;
+    }
+
+    this.progressUpdateTimeoutFinished_ = this.timeout_(() => {
+      this.progressUpdateTimeoutFinished_ = undefined;
+      this.updateProgress(event.loaded);
+    }, PROGRESS_UPDATE_TIMEOUT);
+  }
+
+  downloadFinishedCallback(response) {
+    this.data = response.data;
+    this.finished = true;
+    this.timeout_.cancel(this.progressUpdateTimeoutFinished_);
+    this.loaded = this.lastLoaded;
+  }
+
+  updateProgress(loaded) {
+    this.loaded = loaded;
+  }
+
+  hasDownloadFinished() {
+    return this.finished;
+  }
+
+  save() {
+    this.fileSaver_.saveAs(this.data, this.fileName_);
+    this.mdDialog_.hide();
+  }
+
+  abort() {
+    this.canceler_.resolve();
+    this.mdDialog_.hide();
+  }
+
+  getDownloadMode() {
+    return this.finished ? 'determinate' : 'indeterminate';
+  }
+}
+
+export function showDownloadDialog(mdDialog, downloadUrl, fileName) {
+  return mdDialog.show({
+    controller: DownloadDialogController,
+    controllerAs: '$ctrl',
+    locals: {
+      'downloadUrl': downloadUrl,
+      'fileName': fileName,
+    },
+    templateUrl: 'logs/download/dialog.html',
+    escapeToClose: false
+  })
+}

--- a/src/app/frontend/logs/download/dialog.scss
+++ b/src/app/frontend/logs/download/dialog.scss
@@ -1,0 +1,33 @@
+@import '../../variables';
+
+.kd-download-dialog {
+  display: grid;
+  grid-template-columns: $baseline-grid 50 * $baseline-grid $baseline-grid;
+  grid-gap: 2 * $baseline-grid;
+  grid-auto-rows: minmax(2 * $baseline-grid, auto);
+}
+
+.kd-download-progress {
+  padding-top: .5 * $baseline-grid;
+}
+
+.kd-download-progress-bar {
+  margin-top: $baseline-grid;
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.kd-download-info {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.kd-download-buttons {
+  grid-column: 2;
+  grid-row: 3;
+
+  .md-button {
+    margin-left: 0;
+    margin-bottom: 2 * $baseline-grid;
+  }
+}

--- a/src/app/frontend/logs/download/dialog.scss
+++ b/src/app/frontend/logs/download/dialog.scss
@@ -16,9 +16,9 @@
 
 .kd-download-dialog {
   display: grid;
-  grid-template-columns: $baseline-grid auto $baseline-grid;
-  grid-gap: 2 * $baseline-grid;
   grid-auto-rows: minmax(2 * $baseline-grid, auto);
+  grid-gap: 2 * $baseline-grid;
+  grid-template-columns: $baseline-grid auto $baseline-grid;
 }
 
 .kd-download-progress {
@@ -26,9 +26,9 @@
 }
 
 .kd-download-progress-bar {
-  margin-top: $baseline-grid;
   grid-column: 2;
   grid-row: 2;
+  margin-top: $baseline-grid;
 }
 
 .kd-download-info {
@@ -41,7 +41,7 @@
   grid-row: 3;
 
   .md-button {
-    margin-left: 0;
     margin-bottom: 2 * $baseline-grid;
+    margin-left: 0;
   }
 }

--- a/src/app/frontend/logs/download/service.js
+++ b/src/app/frontend/logs/download/service.js
@@ -1,0 +1,36 @@
+/** @final */
+import {showDownloadDialog} from "./dialog";
+
+export class DownloadService {
+  /**
+   * @ngInject
+   */
+  constructor($http, $mdDialog, $timeout, FileSaver) {
+    /** @private {!angular.$resource} */
+    this.http_ = $http;
+
+    this.mdDialog_ = $mdDialog;
+
+    this.timeout_ = $timeout;
+
+    this.fileSaver_ = FileSaver;
+  }
+
+  /**
+   * @param {string} url
+   * @param {!function(Object)} progressUpdateFn
+   * @param {!angular.$q} canceler
+   * @return {!angular.$q.Promise}
+   */
+  downloadFile(url, progressUpdateFn, canceler) {
+    return this.http_.get(url, {
+      responseType: 'blob',
+      timeout: canceler.promise,
+      onProgress: (event) => {progressUpdateFn(event)}
+    });
+  }
+
+  startDownload(url, fileName) {
+    showDownloadDialog(this.mdDialog_, url, fileName);
+  }
+}

--- a/src/app/frontend/logs/download/service.js
+++ b/src/app/frontend/logs/download/service.js
@@ -43,8 +43,8 @@ export class DownloadService {
       responseType: 'blob',
       timeout: canceler.promise,
       onProgress: (event) => {
-        progressUpdateFn(event)
-      }
+        progressUpdateFn(event);
+      },
     });
   }
 

--- a/src/app/frontend/logs/download/service.js
+++ b/src/app/frontend/logs/download/service.js
@@ -1,36 +1,61 @@
-/** @final */
-import {showDownloadDialog} from "./dialog";
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+/** @final */
+import {showDownloadDialog} from './dialog';
+
+/** @final */
 export class DownloadService {
   /**
+   * @param {!angular.$http} $http
+   * @param {!md.$dialog} $mdDialog
    * @ngInject
    */
-  constructor($http, $mdDialog, $timeout, FileSaver) {
-    /** @private {!angular.$resource} */
+  constructor($http, $mdDialog) {
+    /** @private {!angular.$http} */
     this.http_ = $http;
-
+    /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
-
-    this.timeout_ = $timeout;
-
-    this.fileSaver_ = FileSaver;
   }
 
   /**
+   * Raw file download function that returns promise which is resolved when file is saved in
+   * browser's cache and is available as response.data of type Blob.
+   *
    * @param {string} url
    * @param {!function(Object)} progressUpdateFn
-   * @param {!angular.$q} canceler
+   * @param {!angular.$q.Deferred} canceler
    * @return {!angular.$q.Promise}
    */
   downloadFile(url, progressUpdateFn, canceler) {
     return this.http_.get(url, {
       responseType: 'blob',
       timeout: canceler.promise,
-      onProgress: (event) => {progressUpdateFn(event)}
+      onProgress: (event) => {
+        progressUpdateFn(event)
+      }
     });
   }
 
-  startDownload(url, fileName) {
+  /**
+   * Download function that triggers download dialog. It handles download of file provided in url
+   * and allows to save it under provided file name.
+   *
+   * @param {string} url
+   * @param {string} fileName
+   */
+  download(url, fileName) {
     showDownloadDialog(this.mdDialog_, url, fileName);
   }
 }

--- a/src/app/frontend/logs/logs.html
+++ b/src/app/frontend/logs/logs.html
@@ -108,7 +108,7 @@ limitations under the License.
         </md-tooltip>
       </md-button>
       <md-button class="kd-logs-toolbar-button"
-                 ng-href="{{ctrl.getDownloadLink()}}">
+                 ng-click="ctrl.downloadLog()">
         <md-icon class="kd-logs-icon">file_download</md-icon>
         <md-tooltip md-delay="500"
                     md-autohide>

--- a/src/app/frontend/logs/module.js
+++ b/src/app/frontend/logs/module.js
@@ -29,6 +29,7 @@ export default angular
         [
           'ngResource',
           'ngFileSaver',
+          'ngMaterial',
           'ui.router',
           settingsServiceModule.name,
         ])

--- a/src/app/frontend/logs/module.js
+++ b/src/app/frontend/logs/module.js
@@ -48,6 +48,8 @@ export default angular
  * @param {!function(*, string)} $delegate
  * @param {!angular.$injector} $injector
  * @return {!function(*, string)}
+ * @export
+ * @ngInject
  */
 function httpProgressUpdateDecorator($delegate, $injector) {
   return (method, url) => {

--- a/src/app/frontend/logs/service.js
+++ b/src/app/frontend/logs/service.js
@@ -17,9 +17,7 @@
  * @final
  */
 export class LogsService {
-  /**
-   * @ngInject
-   */
+  /** @ngInject */
   constructor() {
     /** @private {boolean} */
     this.inverted_ = true;
@@ -95,5 +93,14 @@ export class LogsService {
    */
   getPrevious() {
     return this.previous_;
+  }
+
+  /**
+   * @param {string} pod
+   * @param {string} container
+   * @return {string}
+   */
+  getLogFileName(pod, container) {
+    return `logs-from-${container}-in-${pod}.txt`;
   }
 }

--- a/src/test/frontend/logs/download/dialog_test.js
+++ b/src/test/frontend/logs/download/dialog_test.js
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {DownloadDialogController} from 'logs/download/dialog';
 import LogsModule from 'logs/module';
 

--- a/src/test/frontend/logs/download/dialog_test.js
+++ b/src/test/frontend/logs/download/dialog_test.js
@@ -1,0 +1,94 @@
+import {DownloadDialogController} from 'logs/download/dialog';
+import LogsModule from 'logs/module';
+
+describe('Download dialog controller ', () => {
+  let ctrl;
+  let downloadService;
+  let httpBackend;
+  let mdDialog;
+  let fileSaver;
+
+  let downloadUrl = 'api/v1/log/file/test';
+  let fileName = 'test.txt';
+
+  beforeEach(() => {
+    angular.mock.module(LogsModule.name);
+    angular.mock.inject(($controller, kdDownloadService, $httpBackend, $mdDialog, FileSaver) => {
+      downloadService = kdDownloadService;
+      httpBackend = $httpBackend;
+      mdDialog = $mdDialog;
+      fileSaver = FileSaver;
+      ctrl = $controller(DownloadDialogController, {
+        downloadUrl: downloadUrl,
+        fileName: fileName,
+        kdDownloadService: downloadService,
+        $mdDialog: mdDialog,
+        FileSaver: fileSaver,
+      });
+    });
+  });
+
+  it('should create controller', () => {
+    expect(ctrl).toBeDefined();
+  });
+
+  it('should trigger file download on init', () => {
+    // given
+    spyOn(downloadService, 'downloadFile').and.callThrough();
+
+    // when
+    ctrl.$onInit();
+
+    // then
+    expect(downloadService.downloadFile).toHaveBeenCalled();
+  });
+
+  it('should enable save button once download has finished', () => {
+    // given
+    httpBackend.whenGET(downloadUrl).respond({});
+
+    // when
+    ctrl.$onInit();
+    httpBackend.flush();
+
+    // then
+    expect(ctrl.hasDownloadFinished()).toBeTruthy();
+  });
+
+  it('should change progress bar mode after download has finished', () => {
+    // given
+    httpBackend.whenGET(downloadUrl).respond({});
+    expect(ctrl.getDownloadMode()).toEqual('indeterminate');
+
+    // when
+    ctrl.$onInit();
+    httpBackend.flush();
+
+    // then
+    expect(ctrl.getDownloadMode()).toEqual('determinate');
+  });
+
+  it('should hide the dialog on abort', () => {
+    // given
+    spyOn(mdDialog, 'hide');
+
+    // when
+    ctrl.abort();
+
+    // then
+    expect(mdDialog.hide).toHaveBeenCalled();
+  });
+
+  it('should trigger file save and close the dialog', () => {
+    // given
+    spyOn(mdDialog, 'hide');
+    spyOn(fileSaver, 'saveAs');
+
+    // when
+    ctrl.save();
+
+    // then
+    expect(mdDialog.hide).toHaveBeenCalled();
+    expect(fileSaver.saveAs).toHaveBeenCalled();
+  });
+});

--- a/src/test/frontend/logs/download/service_test.js
+++ b/src/test/frontend/logs/download/service_test.js
@@ -1,3 +1,17 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import LogsModule from 'logs/module';
 
 describe('Download service ', () => {

--- a/src/test/frontend/logs/download/service_test.js
+++ b/src/test/frontend/logs/download/service_test.js
@@ -1,0 +1,47 @@
+import LogsModule from 'logs/module';
+
+describe('Download service ', () => {
+  let service;
+  let httpBackend;
+  let q;
+  let mdDialog;
+
+  beforeEach(() => {
+    angular.mock.module(LogsModule.name);
+    angular.mock.inject((kdDownloadService, $httpBackend, $q) => {
+      service = kdDownloadService;
+      mdDialog = service.mdDialog_;
+      httpBackend = $httpBackend;
+      q = $q;
+    });
+  });
+
+  it('should download file', () => {
+    // given
+    let url = 'api/v1/log/file/test';
+    let response = {data: 'mockData'};
+    httpBackend.whenGET(url).respond({
+      data: response.data,
+    });
+
+    // when
+    service.downloadFile(url, () => {}, q.defer()).then((file) => {
+      // then
+      expect(file.data).toEqual(response);
+    });
+    httpBackend.flush();
+  });
+
+  it('should open download dialog', () => {
+    // given
+    let url = 'api/v1/log/file/test';
+    let fileName = 'test.txt';
+    spyOn(mdDialog, 'show');
+
+    // when
+    service.download(url, fileName);
+
+    // then
+    expect(mdDialog.show).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #2640 and issue mentioned in https://github.com/kubernetes/dashboard/issues/2631#issuecomment-349075045.

## Changes
- Redesign logs download functionality
- Add download progress dialog
- Download file to browser's cache first then save to disk

## Todo
- [x] Add documentation
- [x] Add tests

## Preview
Tested in:
Firefox 57.0.1
Chrome 63.0.3239.84

Also tested download of big files 500 MB+. Everything works correctly. Still browser's cache will be a limitation here so I believe that it will not be possible to download very big files (10GB+).

![peek 2017-12-08 15-47](https://user-images.githubusercontent.com/2285385/33770811-3aac0934-dc2f-11e7-8a4a-4ae2146a542d.gif)
