### PR TITLE
Remove asterisk from login view input fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6490,9 +6490,9 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20171112.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20171112.0.0.tgz",
-      "integrity": "sha1-eHENtO+J/1QGOdgA5tWffLfPLZg=",
+      "version": "20171203.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20171203.0.0.tgz",
+      "integrity": "sha1-gpW5QFo145HB2I0IJYBo4x0TEaE=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -6501,9 +6501,9 @@
       }
     },
     "google-closure-library": {
-      "version": "20171112.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20171112.0.0.tgz",
-      "integrity": "sha1-bGb+srdNgwmz1wUK90MGowDQGTM=",
+      "version": "20171203.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20171203.0.0.tgz",
+      "integrity": "sha1-50ZFFT4w8Wl/nRmbxbLMmYhPkuo=",
       "dev": true
     },
     "got": {

--- a/src/app/frontend/common/components/uploadfile/uploadfile.html
+++ b/src/app/frontend/common/components/uploadfile/uploadfile.html
@@ -25,7 +25,8 @@ limitations under the License.
       <input id="textInput"
              ng-model="fileName"
              ng-readonly="true"
-             required>
+             required
+             md-no-asterisk>
     </md-input-container>
   </div>
   <md-button id="uploadButton"

--- a/src/app/frontend/login/basic.html
+++ b/src/app/frontend/login/basic.html
@@ -19,7 +19,8 @@ limitations under the License.
     <label>[[Username|'Username' field label shown on login page for basic auth]]</label>
     <input ng-model="$ctrl.username"
            ng-change="$ctrl.onUsernameUpdate()"
-           required>
+           required
+           md-no-asterisk>
   </md-input-container>
 
   <md-input-container class="md-block">
@@ -27,6 +28,7 @@ limitations under the License.
     <input type="password"
            ng-model="$ctrl.password"
            ng-change="$ctrl.onPasswordUpdate()"
-           required>
+           required
+           md-no-asterisk>
   </md-input-container>
 </div>

--- a/src/app/frontend/login/token.html
+++ b/src/app/frontend/login/token.html
@@ -20,6 +20,7 @@ limitations under the License.
     <input ng-model="$ctrl.token"
            ng-change="$ctrl.onTokenUpdate()"
            required
-           type="password">
+           type="password"
+           md-no-asterisk>
   </md-input-container>
 </div>


### PR DESCRIPTION
Applied suggestion from https://github.com/kubernetes/dashboard/issues/2641#issuecomment-349622463.

Closes #2641. For now, this is all we can do. We can revisit adding full support for password managers if their logic will be updated. Also we are still considering complete redesign of login view. In case it will happen we will keep in mind supporting password managers.