### PR TITLE
Fixing asset path resolution

### DIFF
--- a/src/app/backend/handler/localehandler_test.go
+++ b/src/app/backend/handler/localehandler_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -69,6 +70,8 @@ func TestGetSupportedLocales(t *testing.T) {
 }
 
 func TestDetermineLocale(t *testing.T) {
+	assetsDir := getAssetsDir()
+	defaultDir := filepath.Join(assetsDir, defaultLocaleDir)
 	cases := []struct {
 		handler           *LocaleHandler
 		createDir         bool
@@ -105,7 +108,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"ja",
-			"./public/ja",
+			filepath.Join(assetsDir, "ja"),
 		},
 		{
 			&LocaleHandler{
@@ -113,7 +116,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"ja,en-US;q=0.8,en;q=0.6",
-			"./public/ja",
+			filepath.Join(assetsDir, "ja"),
 		},
 		{
 			&LocaleHandler{
@@ -121,7 +124,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"af,ja,en-US;q=0.8,en;q=0.6",
-			"./public/ja",
+			filepath.Join(assetsDir, "ja"),
 		},
 		{
 			&LocaleHandler{
@@ -129,7 +132,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"af,en-US;q=0.8,en;q=0.6",
-			"./public/en",
+			filepath.Join(assetsDir, "en"),
 		},
 		{
 			&LocaleHandler{
@@ -145,7 +148,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"en",
-			"./public/en",
+			filepath.Join(assetsDir, "en"),
 		},
 		{
 			&LocaleHandler{
@@ -153,7 +156,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"zh",
-			"./public/zh",
+			filepath.Join(assetsDir, "zh"),
 		},
 		{
 			&LocaleHandler{
@@ -161,7 +164,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"zh-cn",
-			"./public/zh",
+			filepath.Join(assetsDir, "zh"),
 		},
 		{
 			&LocaleHandler{
@@ -169,7 +172,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"ar",
-			"./public/en",
+			filepath.Join(assetsDir, "en"),
 		},
 		{
 			&LocaleHandler{
@@ -177,7 +180,7 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"ar-bh",
-			"./public/en",
+			filepath.Join(assetsDir, "en"),
 		},
 		{
 			&LocaleHandler{
@@ -185,24 +188,24 @@ func TestDetermineLocale(t *testing.T) {
 			},
 			true,
 			"af,zh-HK,zh;q=0.8,en;q=0.6",
-			"./public/zh",
+			filepath.Join(assetsDir, "zh"),
 		},
 	}
 
 	for _, c := range cases {
 		func() {
 			if c.createDir {
-				err := os.Mkdir("./public", 0777)
+				err := os.Mkdir(assetsDir, 0777)
 				if err != nil {
 					t.Fatalf("%s", err)
 				}
 				for _, lang := range c.handler.SupportedLocales {
-					err = os.Mkdir("./public/"+lang.String(), 0777)
+					err = os.Mkdir(filepath.Join(assetsDir, lang.String()), 0777)
 					if err != nil {
 						t.Fatalf("%s", err)
 					}
 				}
-				defer os.RemoveAll("./public")
+				defer os.RemoveAll(assetsDir)
 			}
 			actual := c.handler.determineLocalizedDir(c.acceptLanguageKey)
 			if !reflect.DeepEqual(actual, c.expected) {


### PR DESCRIPTION
 - When determining the path of the localized frontend assets, do
not look in current working directory, use the directory of the
executable. (Resolves symlinks to determine the directory of
the executable.)