### PR TITLE
User customizeable links for persistentvolume

### DIFF
--- a/src/app/backend/resource/persistentvolume/detail_test.go
+++ b/src/app/backend/resource/persistentvolume/detail_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes/dashboard/src/app/backend/api"
+	"github.com/kubernetes/dashboard/src/app/backend/userlinks"
 	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -67,6 +68,8 @@ func TestGetPersistentVolumeDetail(t *testing.T) {
 						Path: "my-path",
 					},
 				},
+				Errors:    []error{},
+				UserLinks: []userlinks.UserLink{},
 			},
 		},
 	}

--- a/src/app/backend/userlinks/userlinks.go
+++ b/src/app/backend/userlinks/userlinks.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Kubernetes Dashboard Authors.
+// Copyright 2017 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/backend/userlinks/userlinks.go
+++ b/src/app/backend/userlinks/userlinks.go
@@ -1,0 +1,83 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userlinks
+
+import (
+	"encoding/json"
+	"log"
+	"net/url"
+
+	"github.com/kubernetes/dashboard/src/app/backend/api"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sClient "k8s.io/client-go/kubernetes"
+)
+
+const (
+	annotationObj = "alpha.dashboard.kubernetes.io/links"
+)
+
+// UserLink is an optional annotation attached to the pod or service resource objects.
+type UserLink struct {
+	// Description is the key specified in the annotationObj set
+	Description string `json:"description"`
+	// Link is the value specified in the annotationObj set
+	Link string `json:"link"`
+	// Link status
+	IsURLValid bool `json:"isURLValid"`
+	// Is it a proxyURL
+	IsProxyURL bool `json:"isProxyURL"`
+}
+
+// GetUserLinks delegates getting of user links based on passed in resource kind (ResourceKindService, ResourceKindPod)
+func GetUserLinks(client k8sClient.Interface, namespace, name, resource string) (userLinks []UserLink, err error) {
+	log.Printf("Getting %s resource in %s namespace", name, namespace)
+
+	switch {
+	case resource == api.ResourceKindPersistentVolume:
+		return getPersistentVolumeLinks(client, namespace, name)
+	default:
+		log.Printf("Unknown resource types %T!\n", resource)
+	}
+	return
+}
+
+// getPersistentVolumeLinks get userlinks for persistentvolume
+func getPersistentVolumeLinks(client k8sClient.Interface, namespace, name string) ([]UserLink, error) {
+	userLinks := []UserLink{}
+	persistentVolume, err := client.CoreV1().PersistentVolumes().Get(name, metaV1.GetOptions{})
+
+	if err != nil || len(persistentVolume.Annotations[annotationObj]) == 0 {
+		return userLinks, err
+	}
+
+	m := map[string]string{}
+	err = json.Unmarshal([]byte(persistentVolume.Annotations[annotationObj]), &m)
+	if err != nil {
+		return userLinks, err
+	}
+
+	for key, uri := range m {
+		userLink := new(UserLink)
+		userLink.Description = key
+		if _, err := url.ParseRequestURI(uri); err != nil {
+			userLink.Link = "Invalid User Link: " + uri
+		} else {
+			userLink.Link = uri
+			userLink.IsURLValid = true
+		}
+		userLinks = append(userLinks, *userLink)
+	}
+	return userLinks, err
+}

--- a/src/app/backend/userlinks/userlinks_test.go
+++ b/src/app/backend/userlinks/userlinks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Kubernetes Dashboard Authors.
+// Copyright 2017 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/backend/userlinks/userlinks_test.go
+++ b/src/app/backend/userlinks/userlinks_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 The Kubernetes Dashboard Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userlinks
+
+import (
+	"reflect"
+	"testing"
+
+	"strconv"
+
+	"sort"
+
+	"github.com/kubernetes/dashboard/src/app/backend/api"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetUserLinksForPersistentVolume(t *testing.T) {
+	cases := []struct {
+		persistentVolume          *v1.PersistentVolume
+		namespace, name, resource string
+		expected                  []UserLink
+	}{
+		{
+			persistentVolume: &v1.PersistentVolume{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "pv-1", Namespace: "ns-1",
+					Annotations: map[string]string{
+						"alpha.dashboard.kubernetes.io/links": "{" +
+							strconv.Quote("absolute_path") + ":" +
+							strconv.Quote("http://monitoring.com/debug/requests") + "," +
+							strconv.Quote("invalid") + ":" +
+							strconv.Quote("://www.logs.com/click/here") + "}"},
+				}},
+			namespace: "ns-1", name: "pv-1", resource: api.ResourceKindPersistentVolume,
+			expected: []UserLink{
+				UserLink{Description: "absolute_path", Link: "http://monitoring.com/debug/requests", IsURLValid: true},
+				UserLink{Description: "invalid", Link: "Invalid User Link: ://www.logs.com/click/here", IsURLValid: false}},
+		},
+	}
+
+	for _, c := range cases {
+
+		fakeClient := fake.NewSimpleClientset(c.persistentVolume)
+		actual, _ := GetUserLinks(fakeClient, c.namespace, c.name, c.resource)
+
+		// since order of the "actual" slice cannot be predicted we sort both slice so that the correct indices are compared
+		sort.Slice(actual, func(i, j int) bool {
+			return actual[i].Description < actual[j].Description
+		})
+		sort.Slice(c.expected, func(i, j int) bool {
+			return c.expected[i].Description < c.expected[j].Description
+		})
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("GetUserLinksForPersistentVolume(client,%#v, %#v) == \ngot: %#v, \nexpected %#v",
+				c.namespace, c.name, actual, c.expected)
+		}
+	}
+}

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -475,6 +475,8 @@ backendApi.PersistentVolumeList;
  *   capacity: Object<string, string>,
  *   message: string,
  *   persistentVolumeSource: backendApi.PersistentVolumeSource,
+ *   userLinks: !Array<!backendApi.UserLinks>,
+ *   errors: !Array<!backendApi.Error>,
  * }}
  */
 backendApi.PersistentVolumeDetail;
@@ -920,6 +922,16 @@ backendApi.Role;
  * }}
  */
 backendApi.RoleList;
+
+/**
+ * @typedef {{
+ *  description: string,
+ *  link: string,
+ *  isURLValid: string,
+ *  isProxyURL: string
+ * }}
+ */
+backendApi.UserLinks;
 
 /**
  * @typedef {{

--- a/src/app/frontend/common/components/module.js
+++ b/src/app/frontend/common/components/module.js
@@ -36,6 +36,7 @@ import {serializedReferenceComponent} from './serializedreference/component';
 import {sparklineComponent} from './sparkline/component';
 import {toggleHiddenTextComponent} from './togglehiddentext/component';
 import uploadFileDirective from './uploadfile/directive';
+import {userLinksComponent} from './userlinks/component';
 import {warningsComponent} from './warnings/component';
 import warnThresholdDirective from './warnthreshold/directive';
 import {zeroStateComponent} from './zerostate/component';
@@ -72,6 +73,7 @@ export default angular
     .component('kdWarnings', warningsComponent)
     .component('kdConditionList', conditionListComponent)
     .component('kdScaleButton', scaleButtonComponent)
+    .component('kdUserLinks', userLinksComponent)
     .component('kdPodWarnings', podWarningsComponent)
     .component('kdCapacity', capacityComponent)
     .directive('kdWarnThreshold', warnThresholdDirective)

--- a/src/app/frontend/common/components/userlinks/component.js
+++ b/src/app/frontend/common/components/userlinks/component.js
@@ -1,0 +1,26 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Returns directive definition object for the component that displays the user links
+ * (type {backendApi.UserLinks})
+ * @return {!angular.Component}
+ */
+export const userLinksComponent = {
+  templateUrl: 'common/components/userlinks/userlinks.html',
+  bindings: {
+    /** {!Array<!backendApi.UserLinks>} */
+    'userlinks': '<',
+  },
+};

--- a/src/app/frontend/common/components/userlinks/userlinks.html
+++ b/src/app/frontend/common/components/userlinks/userlinks.html
@@ -1,0 +1,41 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+   External endpoints are shown with link, to make it easy to access the deployed application.
+   This is important because the text might be ellipsised and copy & past not possible. The
+   Link is always shown independent of the endpoint capabilities to support HTTP.
+-->
+<div>
+  <div ng-repeat="link in ::$ctrl.userlinks">
+    <div ng-switch
+         on="link.valid">
+      <div ng-switch-when="false">
+        {{::link.description}} - {{::link.link}}
+      </div>
+      <div ng-switch-default>
+        <a href="{{::link.link}}"
+           target="_blank"
+           layout
+           layout-align="start center">
+          <kd-middle-ellipsis display-string="{{::link.description}} - {{::link.link}}">
+          </kd-middle-ellipsis>
+          <md-icon class="kd-endpoint-icon">open_in_new</md-icon>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/frontend/persistentvolume/detail/info.html
+++ b/src/app/frontend/persistentvolume/detail/info.html
@@ -56,4 +56,10 @@ limitations under the License.
       <div ng-hide="::$ctrl.persistentVolume.message">-</div>
     </kd-info-card-entry>
   </kd-info-card-section>
+  <kd-info-card-section name="[[User links|Subtitle 'User links' at the top of the column about user links attached to resource objects annotations, (right) at the pv detail view.]]"
+    ng-if="::$ctrl.persistentVolume.userLinks.length">
+    <kd-info-card-entry>
+      <kd-user-links userlinks="::$ctrl.persistentVolume.userLinks"></kd-user-links>
+    </kd-info-card-entry>
+  </kd-info-card-section>
 </kd-info-card>


### PR DESCRIPTION
The commit on this PR add the user customizable links support for persistentvolume.

Closed the old PR #2544 which I created for the same functionality,
This PR adds only external links for persistentvolume, this does not have any userlinks support for pod and service like PR #2544 does. 

This is useful for us in scenarios like show link to prometheus/grafana - that can provide detailed metrics on the storage. 

preview of the change
![screenshot from 2018-01-08 14-48-32](https://user-images.githubusercontent.com/31731825/34666158-f5834a1c-f488-11e7-9261-795721c17e80.png)

Any suggestions will be greatly appreciated.