### PR TITLE
Add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+approvers:
+  - sig-ui-leads
+  - dashboard-maintainers
+  - dashboard-admins

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,22 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+aliases:
+  sig-ui-leads:
+    - danielromlein
+    - floreks
+  dashboard-maintainers:
+    - konryd
+    - ianlewis
+    - cupofcat
+    - mijajasinksi
+    - bryk
+    - floreks
+    - maciaszczykm
+    - rf232
+    - danielromlein
+    - pewu
+    - cheld
+    - olekzabl
+    - mhenc
+  dashboard-admins:
+    - bryk


### PR DESCRIPTION
Contents based on github teams that have write or admin
access to this repo, plus the assumption that sig-ui owns
this repo

ref: https://github.com/kubernetes/dashboard/issues/2747