### PR TITLE
Fix namespace change dialog actions

### DIFF
--- a/src/app/frontend/common/namespace/component.js
+++ b/src/app/frontend/common/namespace/component.js
@@ -187,7 +187,7 @@ export class NamespaceSelectController {
    * @private
    */
   handleNamespaceChangeDialog_(toParams) {
-    showNamespaceChangeInfoDialog(this.mdDialog_, toParams.objectNamespace);
+    showNamespaceChangeInfoDialog(this.mdDialog_, toParams.objectNamespace, toParams.namespace);
   }
 
   /**

--- a/src/app/frontend/common/namespace/dialog.html
+++ b/src/app/frontend/common/namespace/dialog.html
@@ -20,7 +20,7 @@ limitations under the License.
     <h4 class="md-title">[[Change namespace?|]]</h4>
     <div class="kd-namespace-change-dialog-text">[[Selected resource is in a different namespace than currently selected.|]]</div>
     <div class="kd-namespace-change-dialog-text">
-      [[Do you want to change namespace from <i>{{$ctrl.currentNamespace()}}</i> to <i>{{::$ctrl.newNamespace}}</i>?|]]
+      [[Do you want to change namespace from <i>{{$ctrl.currentNamespace}}</i> to <i>{{::$ctrl.newNamespace}}</i>?|]]
     </div>
     <md-dialog-actions layout="row">
       <md-button ng-click="$ctrl.changeNamespace()"

--- a/src/app/frontend/common/namespace/dialog.js
+++ b/src/app/frontend/common/namespace/dialog.js
@@ -19,12 +19,13 @@ import {stateName as overview} from '../../overview/state';
 export class NamespaceChangeInfoDialogController {
   /**
    * @param {!md.$dialog} $mdDialog
+   * @param {string} currentNamespace
    * @param {string} newNamespace
    * @param {!./../state/service.FutureStateService} kdFutureStateService
    * @param {!kdUiRouter.$state} $state
    * @ngInject
    */
-  constructor($mdDialog, newNamespace, kdFutureStateService, $state) {
+  constructor($mdDialog, currentNamespace, newNamespace, kdFutureStateService, $state) {
     /** @private {!md.$dialog} */
     this.mdDialog_ = $mdDialog;
 
@@ -33,6 +34,9 @@ export class NamespaceChangeInfoDialogController {
 
     /** @private {!kdUiRouter.$state} */
     this.state_ = $state;
+
+    /** @export {string} */
+    this.currentNamespace = currentNamespace;
 
     /** @export {string} */
     this.newNamespace = newNamespace;
@@ -45,21 +49,13 @@ export class NamespaceChangeInfoDialogController {
    */
   cancel() {
     this.mdDialog_.cancel();
-    this.state_.go(overview, {[namespaceParam]: this.currentNamespace()});
+    this.state_.go(this.futureStateService_.state, {[namespaceParam]: this.currentNamespace});
   }
 
   /** @export */
   changeNamespace() {
     this.mdDialog_.hide();
-    this.state_.go(this.futureStateService_.state, {[namespaceParam]: this.newNamespace});
-  }
-
-  /**
-   * @return {string}
-   * @export
-   */
-  currentNamespace() {
-    return this.state_.params[namespaceParam];
+    this.state_.go(overview, {[namespaceParam]: this.newNamespace});
   }
 }
 
@@ -67,16 +63,18 @@ export class NamespaceChangeInfoDialogController {
  * Displays new namespace change info dialog.
  *
  * @param {!md.$dialog} mdDialog
+ * @param {string} currentNamespace
  * @param {string} newNamespace
  * @return {!angular.$q.Promise}
  */
-export function showNamespaceChangeInfoDialog(mdDialog, newNamespace) {
+export function showNamespaceChangeInfoDialog(mdDialog, currentNamespace, newNamespace) {
   return mdDialog.show({
     controller: NamespaceChangeInfoDialogController,
     controllerAs: '$ctrl',
     clickOutsideToClose: false,
     templateUrl: 'common/namespace/dialog.html',
     locals: {
+      'currentNamespace': currentNamespace,
       'newNamespace': newNamespace,
     },
   });

--- a/src/test/frontend/common/namespace/dialog_test.js
+++ b/src/test/frontend/common/namespace/dialog_test.js
@@ -33,54 +33,43 @@ describe('Namespace change info dialog ', () => {
     angular.mock.module(chromeModule.name);
 
     angular.mock.inject(($state, _kdFutureStateService_, $mdDialog) => {
-      ctrl = new NamespaceChangeInfoDialogController($mdDialog, '', _kdFutureStateService_, $state);
+      ctrl = new NamespaceChangeInfoDialogController(
+          $mdDialog, '', '', _kdFutureStateService_, $state);
       state = $state;
       kdFutureStateService = _kdFutureStateService_;
       mdDialog = $mdDialog;
     });
   });
 
-  it('should cancel state change and redirect to overview page of current namespace', () => {
+  it('should cancel state change and reload current page', () => {
     // given
     let currentNamespace = 'namespace-1';
     spyOn(mdDialog, 'cancel');
     spyOn(state, 'go');
-    state.params[namespaceParam] = currentNamespace;
+    let futureState = {name: overview};
+    kdFutureStateService.state = futureState;
+    ctrl.currentNamespace = currentNamespace;
 
     // when
     ctrl.cancel();
 
     // then
     expect(mdDialog.cancel).toHaveBeenCalled();
-    expect(state.go).toHaveBeenCalledWith(overview, {[namespaceParam]: currentNamespace});
+    expect(state.go).toHaveBeenCalledWith(futureState, {[namespaceParam]: currentNamespace});
   });
 
-  it('should change namespace and reload current page', () => {
+  it('should change namespace and redirect to overview page of current namespace', () => {
     // given
     let newNamespace = 'namespace-2';
-    let futureState = {name: overview};
     spyOn(mdDialog, 'hide');
     spyOn(state, 'go');
     ctrl.newNamespace = newNamespace;
-    kdFutureStateService.state = futureState;
 
     // when
     ctrl.changeNamespace();
 
     // then
     expect(mdDialog.hide).toHaveBeenCalled();
-    expect(state.go).toHaveBeenCalledWith(futureState, {[namespaceParam]: newNamespace});
-  });
-
-  it('should return current selected namespace', () => {
-    // given
-    let currentNamespace = 'namespace-1';
-    state.params[namespaceParam] = currentNamespace;
-
-    // when
-    let result = ctrl.currentNamespace();
-
-    // then
-    expect(result).toEqual(currentNamespace);
+    expect(state.go).toHaveBeenCalledWith(overview, {[namespaceParam]: newNamespace});
   });
 });


### PR DESCRIPTION
The change namespace dialog actions seemed to be reversed for the user-expected behaviour (#2784). That is fixed in this PR.