### PR TITLE
hide nodePort in internal endpoints when nodePort is not set

### DIFF
--- a/src/app/frontend/common/components/endpoint/internalendpoint.html
+++ b/src/app/frontend/common/components/endpoint/internalendpoint.html
@@ -20,7 +20,7 @@ limitations under the License.
       <kd-middle-ellipsis display-string="{{::$ctrl.endpoint.host}}:{{::port.port}} {{::port.protocol}}">
       </kd-middle-ellipsis>
     </div>
-    <div>
+    <div ng-if="port.nodePort != 0">
       <kd-middle-ellipsis display-string="{{::$ctrl.endpoint.host}}:{{::port.nodePort}} {{::port.protocol}}">
       </kd-middle-ellipsis>
     </div>


### PR DESCRIPTION
### What this PR does

When nodePort is not set for a service, hide the nodePort endpoint rather than display a <service>:0 endpoint.

### How to reproduce it

1. deploy a ClusterIP type service
```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-service1
  labels:
    app: nginx-svc
spec:
  selector:
    app: nginx
  ports:
  - protocol: TCP
    name: http
    port: 30080
    targetPort: 80
  type: ClusterIP
```

2. open Dashboard - Service list
3. check Internal endpoints column of the service above
```
my-service1:30080 TCP
my-service1:0 TCP
```

### How to fix it

Add a ng-if directive for Internal endpoints fields