### PR TITLE
Secret Volume Mode

### DIFF
--- a/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm-head.yaml
@@ -142,6 +142,7 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+          defaultMode: 0600
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head

--- a/src/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -140,6 +140,7 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+          defaultMode: 0600
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard

--- a/src/deploy/recommended/kubernetes-dashboard-head.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard-head.yaml
@@ -142,6 +142,7 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+          defaultMode: 0600
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head

--- a/src/deploy/recommended/kubernetes-dashboard.yaml
+++ b/src/deploy/recommended/kubernetes-dashboard.yaml
@@ -141,6 +141,7 @@ spec:
       - name: kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
+          defaultMode: 0600
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard


### PR DESCRIPTION
The pod will error when using the `--auto-generate-certificates` flag
while trying to write the cert file. This is because a secret's volume mode is set to `0400` by default.  See
[docs](https://kubernetes.io/docs/concepts/configuration/secret/)