### PR TITLE
fix: deployment to rs reference

### DIFF
--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -26,17 +26,11 @@ import (
 func FilterDeploymentPodsByOwnerReference(deployment apps.Deployment, allRS []apps.ReplicaSet,
 	allPods []v1.Pod) []v1.Pod {
 	var matchingPods []v1.Pod
-
-	rsTemplate := v1.PodTemplateSpec{
-		ObjectMeta: deployment.Spec.Template.ObjectMeta,
-		Spec:       deployment.Spec.Template.Spec,
-	}
-
-	for _, rs := range allRS {
-		if EqualIgnoreHash(rs.Spec.Template, rsTemplate) {
-			matchingPods = FilterPodsByControllerRef(&rs, allPods)
-		}
-	}
+  for _, rs := range allRS {
+    if metav1.IsControlledBy(&rs, &deployment) {
+      matchingPods = append(matchingPods, FilterPodsByControllerRef(&rs, allPods)...)
+    }
+  }
 
 	return matchingPods
 }


### PR DESCRIPTION
Previously template.ObjectMeta will always be empty, deployment will wrongly reference pod with same template.Spec.

Also
```
 	for _, rs := range allRS {	
		if EqualIgnoreHash(rs.Spec.Template, rsTemplate) {	
			**matchingPods = FilterPodsByControllerRef(&rs, allPods)**	
		}	
	}
```
if two rs has same spec only the last rs will be considered.
