### PR TITLE
target node version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,7 @@
       ]
     },
     "development": {
-      "presets": [["env", {"targets": {"node": 8}, "useBuiltIns": true}]],
+      "presets": [["env", {"targets": {"node": "current"}, "useBuiltIns": true}]],
     },
     "test": {
       "presets": ["env"],


### PR DESCRIPTION
https://github.com/kubernetes/dashboard/issues/2937

target node verison set a fixed number is not reasonable.the version number should be set to fit platform.nodejs high version compatible with low version.