### PR TITLE
Support spec variable in detail pod page.

### DIFF
--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -775,7 +775,7 @@ backendApi.EnvVar;
 /**
  * @typedef {{
  *   configMapKeyRef: backendApi.ConfigMapKeyRef,
- *   secretKeyRef: backendApi.SecretKeyRef
+ *   secretKeyRef: backendApi.SecretKeyRef,
  *   fieldRef: backendApi.fieldRef
  * }}
  */

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -776,6 +776,7 @@ backendApi.EnvVar;
  * @typedef {{
  *   configMapKeyRef: backendApi.ConfigMapKeyRef,
  *   secretKeyRef: backendApi.SecretKeyRef
+ *   fieldRef: backendApi.fieldRef
  * }}
  */
 backendApi.EnvVarSource;
@@ -795,6 +796,14 @@ backendApi.ConfigMapKeyRef;
  * }}
  */
 backendApi.SecretKeyRef;
+
+/**
+ * @typedef {{
+ *   apiVersion: string,
+ *   fieldPath: string,
+ * }}
+ */
+backendApi.fieldRef;
 
 /**
  * @typedef {{

--- a/src/app/frontend/pod/detail/containerinfo.html
+++ b/src/app/frontend/pod/detail/containerinfo.html
@@ -45,7 +45,7 @@ limitations under the License.
                ng-if="!$ctrl.isSecret(env)">{{::env.value}}</pre>
           </span>
           <span ng-if="::!$ctrl.isHref(env)">
-                {{::env.name}}:&nbsp;<span class="kd-env-value">{{::env.value}}</span>
+                {{::env.name}}:&nbsp;<span class="kd-env-value">{{::$ctrl.getFieldRefValue(env)}}</span>
           </span>
         </div>
       </div>

--- a/src/app/frontend/pod/detail/containerinfo_component.js
+++ b/src/app/frontend/pod/detail/containerinfo_component.js
@@ -120,7 +120,7 @@ class ContainerInfoController {
    */
   getFieldRefValue(env) {
     if (env.valueFrom && env.valueFrom.fieldRef.apiVersion && env.valueFrom.fieldRef.fieldPath) {
-      return `(${env.valueFrom.fieldRef.apiVersion} : ${env.valueFrom.fieldRef.fieldPath})`;
+      return `(${env.valueFrom.fieldRef.apiVersion}:${env.valueFrom.fieldRef.fieldPath})`;
     }
     return env.value;
   }

--- a/src/app/frontend/pod/detail/containerinfo_component.js
+++ b/src/app/frontend/pod/detail/containerinfo_component.js
@@ -120,7 +120,7 @@ class ContainerInfoController {
    */
   getFieldRefValue(env) {
     if (env.valueFrom && env.valueFrom.fieldRef.apiVersion && env.valueFrom.fieldRef.fieldPath) {
-      return '(' + env.valueFrom.fieldRef.apiVersion + ':' + env.valueFrom.fieldRef.fieldPath + ')';
+      return `(${env.valueFrom.fieldRef.apiVersion} : ${env.valueFrom.fieldRef.fieldPath})`;
     }
     return env.value;
   }

--- a/src/app/frontend/pod/detail/containerinfo_component.js
+++ b/src/app/frontend/pod/detail/containerinfo_component.js
@@ -115,6 +115,18 @@ class ContainerInfoController {
 
   /**
    * @param {!backendApi.EnvVar} env
+   * @return {string}
+   * @export
+   */
+  getFieldRefValue(env) {
+    if (env.valueFrom && env.valueFrom.fieldRef.apiVersion && env.valueFrom.fieldRef.fieldPath) {
+      return '(' + env.valueFrom.fieldRef.apiVersion + ':' + env.valueFrom.fieldRef.fieldPath + ')';
+    }
+    return env.value;
+  }
+
+  /**
+   * @param {!backendApi.EnvVar} env
    * @return {boolean}
    * @export
    */

--- a/src/test/frontend/pod/detail/containerinfo_component_test.js
+++ b/src/test/frontend/pod/detail/containerinfo_component_test.js
@@ -35,4 +35,9 @@ describe('Container info component', () => {
     let cmkr = {name: 'foo', key: 'bar'};
     expect(ctrl.getEnvConfigMapHref(cmkr)).toBe('#!/configmap/foo-namespace/foo');
   });
+
+  it('must show values from the spec', () => {
+    let spec = {valueFrom: {fieldRef: {apiVersion: 'v1', fieldPath: 'spec.nodeName'}}};
+    expect(ctrl.getFieldRefValue(spec)).toBe('(v1:spec.nodeName)');
+  });
 });


### PR DESCRIPTION
Issue: https://github.com/kubernetes/dashboard/issues/2936

Now it is impossible to understand the importance of the variable indicated from the `valueFrom.fieldRef.fieldPath`

docs: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

#### before: 
<img width="500" alt="screen shot 2018-04-05 at 18 23 12" src="https://user-images.githubusercontent.com/579213/38375299-952a1eb0-38fe-11e8-996e-c925fc2a3546.png">

#### after:
<img width="525" alt="screen shot 2018-04-05 at 18 22 43" src="https://user-images.githubusercontent.com/579213/38375312-9a21262a-38fe-11e8-97c6-5f3cf8d0d170.png">