### PR TITLE
fix: namespace param should be checked in onEnter hook

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,31 +1,30 @@
 {
   "env": {
     "production": {
-      "presets": [["env",
-        {
-          "targets": {
-            "browsers": [
-              ">1%",
-              "last 4 versions",
-              "not ie < 11"
-            ]
-          },
-          "useBuiltIns": true
-        }
+      "presets": [
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": [">1%", "last 4 versions", "not ie < 11"]
+            },
+            "useBuiltIns": true
+          }
         ]
       ]
     },
     "development": {
-      "presets": [["env", {"targets": {"node": 8}, "useBuiltIns": true}]],
+      "presets": [["env", { "targets": { "node": 8 }, "useBuiltIns": true }]]
     },
     "test": {
       "presets": ["env"],
       "plugins": [
-        ["istanbul", {
-          "exclude": [
-            "**/*_test.js"
-          ]
-        }]
+        [
+          "istanbul",
+          {
+            "exclude": ["**/*_test.js"]
+          }
+        ]
       ]
     }
   }

--- a/src/app/externs/uirouter.js
+++ b/src/app/externs/uirouter.js
@@ -48,6 +48,13 @@ kdUiRouter.$transitions.prototype.onStart = function(criteria, callback, options
  * @param {Function} callback
  * @param {Object=} options
  */
+kdUiRouter.$transitions.prototype.onEnter = function(criteria, callback, options) {};
+
+/**
+ * @param {Object} criteria
+ * @param {Function} callback
+ * @param {Object=} options
+ */
 kdUiRouter.$transitions.prototype.onBefore = function(criteria, callback, options) {};
 
 /**

--- a/src/app/frontend/common/namespace/module.js
+++ b/src/app/frontend/common/namespace/module.js
@@ -35,28 +35,29 @@ export default angular
 
 /**
  * Ensures that namespaceParam is present in the URL.
- * @param {!angular.Scope} $rootScope
  * @param {!angular.$location} $location
  * @param {!kdUiRouter.$transitions} $transitions
  * @param {!kdUiRouter.$state} $state
  * @ngInject
  */
-function ensureNamespaceParamPresent($rootScope, $location, $transitions, $state) {
+function ensureNamespaceParamPresent($location, $transitions, $state) {
   /**
    * Helper function which replaces namespace URL search param when the given namespace is
    * undefined.
    * @param {string|undefined} namespace
+   * @returns {boolean}
    */
   function replaceUrlIfNeeded(namespace) {
     if (namespace === undefined && !!$state.transition &&
         $state.transition.to().name !== loginState) {
       $location.search(namespaceParam, DEFAULT_NAMESPACE);
       $location.replace();
+      return false;
     }
+    return true;
   }
 
-  $rootScope.$watch(() => $location.search()[namespaceParam], replaceUrlIfNeeded);
-  $transitions.onSuccess({}, () => {
-    replaceUrlIfNeeded($location.search()[namespaceParam]);
+  $transitions.onEnter({}, () => {
+    return replaceUrlIfNeeded($location.search()[namespaceParam]);
   });
 }

--- a/src/test/frontend/common/namespace/component_test.js
+++ b/src/test/frontend/common/namespace/component_test.js
@@ -57,6 +57,7 @@ describe('Namespace select component ', () => {
 
     kdFutureStateService.params = {namespace: 'non-existing-namespace'};
     scope.$digest();
+
     expect(ctrl.selectedNamespace).toBe('non-existing-namespace');
 
     state.go('fakeState', new StateParams('non-existing-namespace2'));


### PR DESCRIPTION
Related issue:
https://github.com/kubernetes/dashboard/issues/2974


The issue is related to how app is initialized:

1. user hits `k8s-ui.com`
2. app load default state, with namespace = `''`
3. `kubernetesDashboard.common.namespace` module 's `run` method checks `ensureNamespaceParamPresent`. Since no namespace presents in the url, the app then reload with namespace = `'default'`

By changing the hook from onSuccess to onEnter, overview state (and any other state) will always success with a non empty namespace.