### PR TITLE
fix bug: dashboard crashed by terminal with the panic "invalid memory address or nil pointer dereference”

### DIFF
--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -170,8 +170,8 @@ func handleTerminalSession(session sockjs.Session) {
 	}
 
 	terminalSession.sockJSSession = session
-	terminalSession.bound <- nil
 	terminalSessions[msg.SessionID] = terminalSession
+	terminalSession.bound <- nil
 }
 
 // CreateAttachHandler is called from main for /api/sockjs


### PR DESCRIPTION
the variable "terminalSessions[msg.SessionID]" maybe still nil when use it in function "WaitForTerminal", because sometime it's used before assigned, then it will trigger panic "invalid memory address or nil pointer dereference"