### PR TITLE
Typo fix in returned messages: containe->contain/retrun->return

### DIFF
--- a/src/test/frontend/common/docker/dockerimagereference_test.js
+++ b/src/test/frontend/common/docker/dockerimagereference_test.js
@@ -73,7 +73,7 @@ describe('DokcerImageReference', () => {
     expect(result).toEqual('1');
   });
 
-  it('should return empty string when containerImage is not empty and does not containe `:`' +
+  it('should return empty string when containerImage is not empty and does not contain `:`' +
          ' delimiter after `/` delimiter',
      () => {
        // given
@@ -100,7 +100,7 @@ describe('DokcerImageReference', () => {
      });
 
   it('should return part of the string after last `:` delimiter when containerImage is not empty' +
-         ' and containe two `:` delimiters',
+         ' and contain two `:` delimiters',
      () => {
        // given
        let reference = 'private.registry:5000/test:image:1';
@@ -147,7 +147,7 @@ describe('DokcerImageReference', () => {
        expect(result).toEqual('');
      });
 
-  it('should retrun empty when containerImage is `::`', () => {
+  it('should return empty when containerImage is `::`', () => {
     // given
     let reference = '::';
 
@@ -158,7 +158,7 @@ describe('DokcerImageReference', () => {
     expect(result).toEqual('');
   });
 
-  it('should retrun empty when containerImage is not empty and ends with `:` delimiter', () => {
+  it('should return empty when containerImage is not empty and ends with `:` delimiter', () => {
     // given
     let reference = 'test:';
 
@@ -169,7 +169,7 @@ describe('DokcerImageReference', () => {
     expect(result).toEqual('');
   });
 
-  it('should retrun empty when containerImage is not empty and ends with `/` delimiter', () => {
+  it('should return empty when containerImage is not empty and ends with `/` delimiter', () => {
     // given
     let reference = 'test/';
 


### PR DESCRIPTION
Two typos in returned messages:
containe->contain
retrun->return