### PR TITLE
Fix bug: display job as failed if job backoff limit has reached

### DIFF
--- a/src/app/backend/resource/job/list_test.go
+++ b/src/app/backend/resource/job/list_test.go
@@ -112,6 +112,10 @@ func TestGetJobListFromChannels(t *testing.T) {
 						},
 						Status: batch.JobStatus{
 							Active: 7,
+							Conditions: []batch.JobCondition{{
+								Type:   batch.JobFailed,
+								Status: v1.ConditionTrue,
+							}},
 						},
 					},
 				},
@@ -165,6 +169,9 @@ func TestGetJobListFromChannels(t *testing.T) {
 						Failed:   2,
 						Warnings: []common.Event{},
 					},
+					JobStatus: JobStatus{
+						Status: JobStatusRunning,
+					},
 				}, {
 					ObjectMeta: api.ObjectMeta{
 						Name:              "rs-name",
@@ -178,6 +185,9 @@ func TestGetJobListFromChannels(t *testing.T) {
 						Desired:  &completions,
 						Failed:   2,
 						Warnings: []common.Event{},
+					},
+					JobStatus: JobStatus{
+						Status: JobStatusFailed,
 					},
 				}},
 				Errors: []error{},

--- a/src/app/backend/resource/workload/workload_test.go
+++ b/src/app/backend/resource/workload/workload_test.go
@@ -159,6 +159,9 @@ func TestGetWorkloadsFromChannels(t *testing.T) {
 					Warnings: []common.Event{},
 					Desired:  &replicas,
 				},
+				JobStatus: job.JobStatus{
+					Status: job.JobStatusRunning,
+				},
 			}},
 			[]cronjob.CronJob{{
 				ObjectMeta: api.ObjectMeta{

--- a/src/app/externs/backendapi.js
+++ b/src/app/externs/backendapi.js
@@ -314,12 +314,21 @@ backendApi.ReplicaSetList;
 
 /**
  * @typedef {{
+ *   status: !string,
+ *   message: string
+ * }}
+ */
+backendApi.JobStatus;
+
+/**
+ * @typedef {{
  *   objectMeta: !backendApi.ObjectMeta,
  *   typeMeta: !backendApi.TypeMeta,
  *   pods: !backendApi.PodInfo,
  *   containerImages: !Array<string>,
  *   initContainerImages: !Array<string>,
- *   parallelism: number
+ *   parallelism: number,
+ *   jobStatus: !backendApi.JobStatus
  * }}
  */
 backendApi.Job;

--- a/src/app/frontend/job/list/card.html
+++ b/src/app/frontend/job/list/card.html
@@ -17,6 +17,12 @@ limitations under the License.
 <kd-resource-card object-meta="$ctrl.job.objectMeta"
                   type-meta="$ctrl.job.typeMeta">
   <kd-resource-card-status layout="row">
+    <md-icon class="material-icons kd-error" ng-if="::$ctrl.isFailed()">
+      error
+      <md-tooltip md-delay="500" md-autohide>
+        {{::$ctrl.job.jobStatus.message}}
+      </md-tooltip>
+    </md-icon>
     <md-icon class="material-icons md-warn"
              ng-if="::$ctrl.hasWarnings()">
       error

--- a/src/app/frontend/job/list/card_component.js
+++ b/src/app/frontend/job/list/card_component.js
@@ -64,7 +64,16 @@ class JobCardController {
    * @export
    */
   hasWarnings() {
-    return this.job.pods.warnings.length > 0;
+    return this.job.pods.warnings.length > 0 && !this.isFailed();
+  }
+
+  /**
+   * Checks if job status is failed.
+   * @return {boolean}
+   * @export
+   */
+  isFailed() {
+    return this.job.jobStatus.status === 'Failed';
   }
 
   /**
@@ -82,7 +91,7 @@ class JobCardController {
    * @export
    */
   isSuccess() {
-    return !this.isPending() && !this.hasWarnings();
+    return !this.isPending() && !this.hasWarnings() && !this.isFailed();
   }
 }
 

--- a/src/test/frontend/job/list/card_component_test.js
+++ b/src/test/frontend/job/list/card_component_test.js
@@ -61,6 +61,9 @@ describe('Job card', () => {
           },
         ],
       },
+      jobStatus: {
+        status: 'Running',
+      },
     };
 
     // then
@@ -72,6 +75,9 @@ describe('Job card', () => {
     ctrl.job = {
       pods: {
         warnings: [],
+      },
+      jobStatus: {
+        status: 'Completed',
       },
     };
 
@@ -87,6 +93,9 @@ describe('Job card', () => {
          pods: {
            warnings: [],
            pending: 1,
+         },
+         jobStatus: {
+           status: 'Running',
          },
        };
 
@@ -106,6 +115,9 @@ describe('Job card', () => {
           },
         ],
       },
+      jobStatus: {
+        status: 'Running',
+      },
     };
 
     // then
@@ -120,6 +132,9 @@ describe('Job card', () => {
       pods: {
         warnings: [],
         pending: 0,
+      },
+      jobStatus: {
+        status: 'Running',
       },
     };
 


### PR DESCRIPTION
Pull request resolves #2788: job list API returns an inferred job status; the job card component renders error icon if job status is failed.