### PR TITLE
Include gulp and updated npm in build/Dockerfile for easier development

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,4 +41,5 @@ WORKDIR /dashboard
 COPY ./ ./
 
 # Install dependencies. This will take a while.
+RUN npm install -g npm@latest gulp
 RUN npm install --unsafe-perm


### PR DESCRIPTION
Hi all!

I wanted to start contributing more to this repo but found that spinning up a development environment wasn't that easy (for reference I'm on OSX and had a couple others follow the docs and run into trouble)

What this does is simple: update NPM and install Gulp. This should not affect anything else the container is used for. What this does is allow people to more easily spin up and use the container to run as their dev environment without invoking Gulp (instead Gulp is used within the container)

From there, spinning up a dev environment is as easy as:

```
docker build -t kubernetes-dashboard-build-image build/
docker run --rm -e KUBE_DASHBOARD_APISERVER_HOST=http://192.168.2.1:8080 -p 3001:3001 -p 9090:9090 -p 9091:9091 -ti -v $(pwd):/app kubernetes-dashboard-build-image gulp serve
kubectl proxy --port=8080 --accept-hosts='^.*$'
```

Once this (hopefully) gets merged, I'd like to update the Getting Started documentation to reflect this as a more streamlined way to spin up a development environment. :)

Thanks!