### PR TITLE
fixing issue 3030 pods owning pods on dashboard

### DIFF
--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -58,6 +58,8 @@ func FilterPodsForJob(job batch.Job, pods []v1.Pod) []v1.Pod {
 	return result
 }
 
+
+
 // GetContainerImages returns container image strings from the given pod spec.
 func GetContainerImages(podTemplate *v1.PodSpec) []string {
 	var containerImages []string
@@ -92,6 +94,69 @@ func GetInitContainerNames(podTemplate *v1.PodSpec) []string {
 		initContainerNames = append(initContainerNames, initContainer.Name)
 	}
 	return initContainerNames
+}
+
+// GetNonduplicateContainerImages returns list of container image strings without duplicates
+func GetNonduplicateContainerImages(podList []v1.Pod) []string{
+  var containerImages []string
+  for _, pod := range podList {
+    for _, container := range pod.Spec.Containers {
+      if noStringInSlice(container.Image, containerImages){
+        containerImages = append(containerImages, container.Image)
+      }
+    }
+  }
+  return containerImages
+}
+
+// GetNonduplicateInitContainerImages returns list of init container image strings without duplicates
+func GetNonduplicateInitContainerImages(podList []v1.Pod) []string{
+  var initContainerImages []string
+  for _, pod := range podList {
+    for _, initContainer := range pod.Spec.InitContainers {
+      if noStringInSlice(initContainer.Image, initContainerImages){
+        initContainerImages = append(initContainerImages, initContainer.Image)
+      }
+    }
+  }
+  return initContainerImages
+}
+
+// GetNonduplicateContainerNames returns list of container names strings without duplicates
+func GetNonduplicateContainerNames(podList []v1.Pod) []string{
+  var containerNames []string
+  for _, pod := range podList {
+    for _, container := range pod.Spec.Containers {
+      if noStringInSlice(container.Name, containerNames){
+        containerNames = append(containerNames, container.Name)
+      }
+    }
+  }
+  return containerNames
+}
+
+// GetNonduplicateInitContainerNames returns list of init container names strings without duplicates
+func GetNonduplicateInitContainerNames(podList []v1.Pod) []string{
+  var initContainerNames []string
+  for _, pod := range podList {
+    for _, initContainer := range pod.Spec.InitContainers {
+      if noStringInSlice(initContainer.Name, initContainerNames){
+        initContainerNames = append(initContainerNames, initContainer.Name)
+      }
+    }
+  }
+  return initContainerNames
+}
+
+
+//noStringInSlice checks if string in array
+func noStringInSlice(str string, array []string) bool {
+  for _, alreadystr := range array {
+    if alreadystr == str {
+      return false
+    }
+  }
+  return true
 }
 
 // EqualIgnoreHash returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]

--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -58,8 +58,6 @@ func FilterPodsForJob(job batch.Job, pods []v1.Pod) []v1.Pod {
 	return result
 }
 
-
-
 // GetContainerImages returns container image strings from the given pod spec.
 func GetContainerImages(podTemplate *v1.PodSpec) []string {
 	var containerImages []string
@@ -147,7 +145,6 @@ func GetNonduplicateInitContainerNames(podList []v1.Pod) []string{
   }
   return initContainerNames
 }
-
 
 //noStringInSlice checks if string in array
 func noStringInSlice(str string, array []string) bool {

--- a/src/app/backend/resource/common/pod_test.go
+++ b/src/app/backend/resource/common/pod_test.go
@@ -196,6 +196,28 @@ func TestGetInitContainerNames(t *testing.T) {
 	}
 }
 
+func TestGetNonduplicateInitContainerNames(t *testing.T) {
+  expected :=[]string{"initContainer1", "initContainer2", "initContainer3"}
+  pods := []api.Pod{api.Pod{}, api.Pod{}}
+
+  pods[0] = api.Pod{
+      Spec: api.PodSpec{
+        InitContainers: []api.Container{{Name: "initContainer1"}, {Name: "initContainer2"}},
+      },
+    }
+
+   pods[1] = api.Pod{
+      Spec: api.PodSpec{
+        InitContainers: []api.Container{{Name: "initContainer2"}, {Name: "initContainer3"}},
+      },
+    }
+  actual := GetNonduplicateInitContainerNames(pods)
+    if !reflect.DeepEqual(actual, expected) {
+      t.Errorf("GetNonduplicateInitContainerNames() == %+v, expected %+v",
+        actual, expected)
+    }
+}
+
 func TestFilterPodsForJob(t *testing.T) {
 	cases := []struct {
 		job      batch.Job

--- a/src/app/backend/resource/controller/controller.go
+++ b/src/app/backend/resource/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"fmt"
+
 	"strings"
 
 	"github.com/kubernetes/dashboard/src/app/backend/api"

--- a/src/app/backend/resource/controller/controller.go
+++ b/src/app/backend/resource/controller/controller.go
@@ -16,7 +16,6 @@ package controller
 
 import (
 	"fmt"
-
 	"strings"
 
 	"github.com/kubernetes/dashboard/src/app/backend/api"
@@ -71,6 +70,12 @@ func NewResourceController(ref meta.OwnerReference, namespace string, client cli
 			return nil, err
 		}
 		return JobController(*job), nil
+  case api.ResourceKindPod:
+    pod, err := client.CoreV1().Pods(namespace).Get(ref.Name, meta.GetOptions{})
+    if err != nil {
+      return nil, err
+    }
+    return PodController(*pod), nil
 	case api.ResourceKindReplicaSet:
 		rs, err := client.AppsV1beta2().ReplicaSets(namespace).Get(ref.Name, meta.GetOptions{})
 		if err != nil {
@@ -132,6 +137,38 @@ func (self JobController) GetLogSources(allPods []v1.Pod) LogSources {
 		ContainerNames:     common.GetContainerNames(&self.Spec.Template.Spec),
 		InitContainerNames: common.GetInitContainerNames(&self.Spec.Template.Spec),
 	}
+}
+
+type PodController v1.Pod
+
+// Get is an implementation of Get method from ResourceController interface.
+func (self PodController) Get(allPods []v1.Pod, allEvents[]v1.Event) ResourceOwner {
+  matchingPods := common.FilterPodsByControllerRef(&self, allPods)
+  podInfo := common.GetPodInfo(int32(len(matchingPods)), nil, matchingPods) // Pods should not desire any Pods
+  podInfo.Warnings = event.GetPodsEventWarnings(allEvents, matchingPods)
+
+  return ResourceOwner{
+    TypeMeta:            api.NewTypeMeta(api.ResourceKindPod),
+    ObjectMeta:          api.NewObjectMeta(self.ObjectMeta),
+    Pods:                podInfo,
+    ContainerImages:     common.GetNonduplicateContainerImages(matchingPods),
+    InitContainerImages: common.GetNonduplicateInitContainerImages(matchingPods),
+  }
+}
+
+// UID is an implementation of UID method from ResourceController interface.
+func (self PodController) UID() types.UID {
+  return v1.Pod(self).UID
+}
+
+// GetLogSources is an implementation of the GetLogSources method from ResourceController interface.
+func (self PodController) GetLogSources(allPods []v1.Pod) LogSources {
+  controlledPods := common.FilterPodsByControllerRef(&self, allPods)
+  return LogSources{
+    PodNames:           getPodNames(controlledPods),
+    ContainerNames:     common.GetNonduplicateContainerNames(controlledPods),
+    InitContainerNames: common.GetNonduplicateInitContainerNames(controlledPods),
+  }
 }
 
 // ReplicaSetController is an alias-type for Kubernetes API Replica Set type. It allows to provide

--- a/src/app/backend/resource/controller/controller_test.go
+++ b/src/app/backend/resource/controller/controller_test.go
@@ -20,6 +20,8 @@ import (
 
 	"k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "github.com/kubernetes/dashboard/src/app/backend/api"
+  "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetPodNames(t *testing.T) {
@@ -45,6 +47,32 @@ func TestGetPodNames(t *testing.T) {
 		}
 	}
 
+}
+
+func TestNewResourceController(t *testing.T) {
+  ctrl, err := NewResourceController(
+    meta.OwnerReference {
+      Kind: api.ResourceKindPod,
+      Name: "test-name",
+  }, "default", fake.NewSimpleClientset(&v1.Pod{
+    TypeMeta: meta.TypeMeta{
+      Kind: "pod",
+      APIVersion:"v1",
+    },
+    ObjectMeta: meta.ObjectMeta{
+      Name: "test-name",
+      Namespace: "default",
+    }}))
+  if err != nil {
+    t.Fatal("Returned Error finding pod")
+  }
+  podCtrl, ok := ctrl.(PodController)
+  if !ok {
+    t.Fatal("Returned value is not pod controller")
+  }
+  if podCtrl.Name != "test-name" {
+    t.Fatal("Returned invalid pod name")
+  }
 }
 
 func newPod(name string) v1.Pod {

--- a/src/app/frontend/pod/detail/creatorinfo.html
+++ b/src/app/frontend/pod/detail/creatorinfo.html
@@ -113,7 +113,7 @@ limitations under the License.
           </kd-resource-card-column>
           <kd-resource-card-column>
             <span class="kd-replicase-card-pods-stat">
-        {{::$ctrl.creator.pods.running}} / {{::$ctrl.creator.pods.desired}}
+        {{::$ctrl.creator.pods.running}} <span ng-if="$ctrl.creator.pods.desired != null">/ {{::$ctrl.creator.pods.desired}}</span>
       </span>
           </kd-resource-card-column>
           <kd-resource-card-column>


### PR DESCRIPTION
Fixing Bug 3030: Dashboard recognizes pods owning other pods. Owned-pods have a UI of the owner-pod, which shows all the owner-pod's images and total running pods.