### PR TITLE
Support for viewing completed/inactive CronJob jobs 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,4 +41,5 @@ WORKDIR /dashboard
 COPY ./ ./
 
 # Install dependencies. This will take a while.
+RUN npm install -g npm@latest gulp
 RUN npm install --unsafe-perm

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,5 +41,4 @@ WORKDIR /dashboard
 COPY ./ ./
 
 # Install dependencies. This will take a while.
-RUN npm install -g npm@latest gulp
 RUN npm install --unsafe-perm

--- a/src/app/backend/resource/cronjob/detail_test.go
+++ b/src/app/backend/resource/cronjob/detail_test.go
@@ -65,6 +65,11 @@ func TestGetJobDetail(t *testing.T) {
 					CumulativeMetrics: make([]metricapi.Metric, 0),
 					Errors:            make([]error, 0),
 				},
+				InactiveJobs: job.JobList{
+					Jobs:              make([]job.Job, 0),
+					CumulativeMetrics: make([]metricapi.Metric, 0),
+					Errors:            make([]error, 0),
+				},
 				Events: *event.EmptyEventList,
 				Errors: []error{},
 			},

--- a/src/app/backend/resource/cronjob/detail_test.go
+++ b/src/app/backend/resource/cronjob/detail_test.go
@@ -39,7 +39,7 @@ func TestGetJobDetail(t *testing.T) {
 		{
 			namespace,
 			name,
-			[]string{"get", "get", "list", "list", "list", "list"},
+			[]string{"get", "get", "list", "list", "list", "get", "list", "list", "list", "list"},
 			&batch.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/src/app/backend/resource/cronjob/jobs.go
+++ b/src/app/backend/resource/cronjob/jobs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/job"
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	client "k8s.io/client-go/kubernetes"
@@ -72,23 +71,76 @@ func GetCronJobJobs(client client.Interface, metricClient metricapi.MetricClient
 		return emptyJobList, criticalError
 	}
 
-	jobs.Items = filterJobsByOwnerReferences(cronJob.Status.Active, jobs.Items)
+	jobs.Items = filterJobsByOwnerUID(cronJob.UID, jobs.Items)
+	jobs.Items = filterJobsByState(true, jobs.Items)
 
 	return job.ToJobList(jobs.Items, pods.Items, events.Items, nonCriticalErrors, dsQuery, metricClient), nil
 }
 
-func filterJobsByOwnerReferences(refs []v1.ObjectReference, jobs []batch.Job) (matchingJobs []batch.Job) {
-	m := make(map[types.UID]batch.Job, 0)
-	for _, j := range jobs {
-		m[j.UID] = j // Map job to their UIDs to enable quick access.
+// GetCronJobJobs returns list of jobs owned by cron job.
+func GetCronJobCompletedJobs(client client.Interface, metricClient metricapi.MetricClient,
+	dsQuery *dataselect.DataSelectQuery, namespace, name string) (*job.JobList, error) {
+	var err error
+
+	cronJob, err := client.BatchV1beta1().CronJobs(namespace).Get(name, metaV1.GetOptions{})
+	if err != nil {
+		return emptyJobList, err
 	}
 
-	for _, ref := range refs {
-		matchedJob, hasMatch := m[ref.UID]
-		if hasMatch {
-			matchingJobs = append(matchingJobs, matchedJob)
+	channels := &common.ResourceChannels{
+		JobList:   common.GetJobListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
+		PodList:   common.GetPodListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
+		EventList: common.GetEventListChannel(client, common.NewSameNamespaceQuery(namespace), 1),
+	}
+
+	jobs := <-channels.JobList.List
+	err = <-channels.JobList.Error
+	nonCriticalErrors, criticalError := errors.HandleError(err)
+	if criticalError != nil {
+		return emptyJobList, nil
+	}
+
+	pods := <-channels.PodList.List
+	err = <-channels.PodList.Error
+	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
+	if criticalError != nil {
+		return emptyJobList, criticalError
+	}
+
+	events := <-channels.EventList.List
+	err = <-channels.EventList.Error
+	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
+	if criticalError != nil {
+		return emptyJobList, criticalError
+	}
+
+	jobs.Items = filterJobsByOwnerUID(cronJob.UID, jobs.Items)
+	jobs.Items = filterJobsByState(false, jobs.Items)
+
+	return job.ToJobList(jobs.Items, pods.Items, events.Items, nonCriticalErrors, dsQuery, metricClient), nil
+}
+
+func filterJobsByOwnerUID(UID types.UID, jobs []batch.Job) (matchingJobs []batch.Job) {
+	for _, j := range jobs {
+		for _, i := range j.OwnerReferences {
+			if i.UID == UID {
+				matchingJobs = append(matchingJobs, j)
+				break
+			}
 		}
 	}
+	return
+}
 
+func filterJobsByState(active bool, jobs []batch.Job) (matchingJobs []batch.Job) {
+	for _, j := range jobs {
+		if active && j.Status.Active > 0 {
+			matchingJobs = append(matchingJobs, j)
+		} else if !active && j.Status.Active == 0 {
+			matchingJobs = append(matchingJobs, j)
+		} else {
+			//sup
+		}
+	}
 	return
 }

--- a/src/app/frontend/cronjob/detail/detail.html
+++ b/src/app/frontend/cronjob/detail/detail.html
@@ -30,5 +30,17 @@ limitations under the License.
   </kd-content>
 </kd-content-card>
 
+<kd-content-card>
+  <kd-content>
+    <kd-job-card-list job-list="ctrl.cronJobDetail.inactiveJobs"
+                      job-list-resource="ctrl.jobListResource">
+      <kd-header>[[Inactive Jobs|Inactive Jobs card title, displayed on Cron Job details page.]]</kd-header>
+      <kd-empty-list-text>
+        [[There are currently no inactive Jobs managed by this Cron Job.|]]
+      </kd-empty-list-text>
+    </kd-job-card-list>
+  </kd-content>
+</kd-content-card>
+
 <kd-event-card-list event-list="::ctrl.cronJobDetail.events"
                     event-list-resource="::ctrl.eventsResource"></kd-event-card-list>


### PR DESCRIPTION
Hi all! This directly addresses #2786

I created an additional function that pulls only completed Jobs for a given CronJob.
Next I shimmed in "Inactive Jobs" in the CronJobDetail Type as well as in the Angular page under the "Active Jobs" card.

Tested locally via minikube (v1.10, v1.9, v1.8)

Let me know if there's anything I need to change or fix!