### PR TITLE
style: [kd-info-card-entry] Both keys and values be L-aligned within two columns.

### DIFF
--- a/src/app/frontend/common/components/infocard/infocardentry.html
+++ b/src/app/frontend/common/components/infocard/infocardentry.html
@@ -17,7 +17,7 @@ limitations under the License.
 <div layout="row"
      class="kd-info-card-entry">
   <div ng-if="::$ctrl.title"
-       flex="nogrow">{{$ctrl.title}}:</div>
+       class="kd-info-card-entry-title">{{$ctrl.title}}:</div>
   <div ng-if="::$ctrl.title"
        flex="auto"
        class="kd-info-card-entry-content"

--- a/src/app/frontend/common/components/infocard/infocardentry.scss
+++ b/src/app/frontend/common/components/infocard/infocardentry.scss
@@ -21,6 +21,10 @@
   white-space: nowrap;
 }
 
+.kd-info-card-entry-title {
+  flex: 0 0 160px;
+}
+
 .kd-info-card-entry-content {
   font-weight: $regular-font-weight;
   margin-left: $baseline-grid / 2;


### PR DESCRIPTION
<img width="831" alt="2018-07-02 5 00 08" src="https://user-images.githubusercontent.com/14850134/42154855-6d14ba4c-7e19-11e8-942a-4f687a7f8258.png">

Style issues mentioned in [PR #2980](https://github.com/kubernetes/dashboard/pull/2980), I've solved it.