### PR TITLE
Fix incorrect desired number of pods for DaemonSets 

### DIFF
--- a/src/app/backend/resource/daemonset/list.go
+++ b/src/app/backend/resource/daemonset/list.go
@@ -116,11 +116,10 @@ func toDaemonSetList(daemonSets []apps.DaemonSet, pods []v1.Pod, events []v1.Eve
 	daemonSets = FromCells(dsCells)
 	daemonSetList.ListMeta = api.ListMeta{TotalItems: filteredTotal}
 
-	for _, daemonSet := range daemonSets {
-		desired := daemonSet.Status.DesiredNumberScheduled
+	for i, daemonSet := range daemonSets {
 		matchingPods := common.FilterPodsByControllerRef(&daemonSet, pods)
 		podInfo := common.GetPodInfo(daemonSet.Status.CurrentNumberScheduled,
-			&desired, matchingPods)
+			&daemonSets[i].Status.DesiredNumberScheduled, matchingPods)
 		podInfo.Warnings = event.GetPodsEventWarnings(events, matchingPods)
 
 		daemonSetList.DaemonSets = append(daemonSetList.DaemonSets, DaemonSet{

--- a/src/app/backend/resource/daemonset/list.go
+++ b/src/app/backend/resource/daemonset/list.go
@@ -117,9 +117,10 @@ func toDaemonSetList(daemonSets []apps.DaemonSet, pods []v1.Pod, events []v1.Eve
 	daemonSetList.ListMeta = api.ListMeta{TotalItems: filteredTotal}
 
 	for _, daemonSet := range daemonSets {
+		desired := daemonSet.Status.DesiredNumberScheduled
 		matchingPods := common.FilterPodsByControllerRef(&daemonSet, pods)
 		podInfo := common.GetPodInfo(daemonSet.Status.CurrentNumberScheduled,
-			&daemonSet.Status.DesiredNumberScheduled, matchingPods)
+			&desired, matchingPods)
 		podInfo.Warnings = event.GetPodsEventWarnings(events, matchingPods)
 
 		daemonSetList.DaemonSets = append(daemonSetList.DaemonSets, DaemonSet{

--- a/src/app/backend/resource/daemonset/list_test.go
+++ b/src/app/backend/resource/daemonset/list_test.go
@@ -173,6 +173,8 @@ func TestToDaemonSetList(t *testing.T) {
 	events := []v1.Event{}
 	controller := true
 	var desired int32 = 1
+	var desire2 int32 = 2
+	var desire3 int32 = 3
 	validPodMeta := metaV1.ObjectMeta{
 		Namespace: "namespace-1",
 		OwnerReferences: []metaV1.OwnerReference{
@@ -228,7 +230,7 @@ func TestToDaemonSetList(t *testing.T) {
 						},
 					},
 					Status: apps.DaemonSetStatus{
-						DesiredNumberScheduled: desired,
+						DesiredNumberScheduled: desire3,
 					},
 				},
 				{
@@ -247,6 +249,24 @@ func TestToDaemonSetList(t *testing.T) {
 					},
 					Status: apps.DaemonSetStatus{
 						DesiredNumberScheduled: desired,
+					},
+				},
+				{
+					ObjectMeta: metaV1.ObjectMeta{
+						Name:      "my-app-3",
+						Namespace: "namespace-3",
+					},
+					Spec: apps.DaemonSetSpec{
+						Selector: &metaV1.LabelSelector{
+							MatchLabels: map[string]string{"app": "my-name-3", "ver": "3"},
+						},
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{Containers: []v1.Container{{Image: "my-container-image-3"}},
+								InitContainers: []v1.Container{{Image: "my-init-container-image-3"}}},
+						},
+					},
+					Status: apps.DaemonSetStatus{
+						DesiredNumberScheduled: desire2,
 					},
 				},
 			},
@@ -322,7 +342,7 @@ func TestToDaemonSetList(t *testing.T) {
 			},
 			},
 			&DaemonSetList{
-				ListMeta:          api.ListMeta{TotalItems: 2},
+				ListMeta:          api.ListMeta{TotalItems: 3},
 				CumulativeMetrics: make([]metricapi.Metric, 0),
 				DaemonSets: []DaemonSet{
 					{
@@ -334,7 +354,7 @@ func TestToDaemonSetList(t *testing.T) {
 						ContainerImages:     []string{"my-container-image-1"},
 						InitContainerImages: []string{"my-init-container-image-1"},
 						Pods: common.PodInfo{
-							Desired:   &desired,
+							Desired:   &desire3,
 							Failed:    2,
 							Pending:   1,
 							Running:   1,
@@ -351,6 +371,18 @@ func TestToDaemonSetList(t *testing.T) {
 						InitContainerImages: []string{"my-init-container-image-2"},
 						Pods: common.PodInfo{
 							Desired:  &desired,
+							Warnings: []common.Event{},
+						},
+					}, {
+						ObjectMeta: api.ObjectMeta{
+							Name:      "my-app-3",
+							Namespace: "namespace-3",
+						},
+						TypeMeta:            api.TypeMeta{Kind: api.ResourceKindDaemonSet},
+						ContainerImages:     []string{"my-container-image-3"},
+						InitContainerImages: []string{"my-init-container-image-3"},
+						Pods: common.PodInfo{
+							Desired:  &desire2,
 							Warnings: []common.Event{},
 						},
 					},


### PR DESCRIPTION
Hi all! This directly addresses #2809 

There may be a better solution for it, but this was a short and sweet one. It seems there's a race condition when looping through the list of DaemonSets. 

I was able to replicate the bug locally and on a separate cluster I have access to. 

Tested locally via minikube (v1.10, v1.9, v1.8)

Let me know if there's anything I need to change or fix!