### PR TITLE
Issue 2330

### DIFF
--- a/build/serve.js
+++ b/build/serve.js
@@ -135,6 +135,7 @@ function serveDevelopmentMode() {
  * development artifacts.
  */
 gulp.task('serve', ['spawn-backend', 'watch'], serveDevelopmentMode);
+gulp.task('serve:no-backend', ['watch'], serveDevelopmentMode);
 
 /**
  * Serves the application in development mode.

--- a/src/app/frontend/common/components/middleellipsis/component.js
+++ b/src/app/frontend/common/components/middleellipsis/component.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Kubernetes Dashboard Authors.
+// Copyright 2017 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/middleellipsis/component.js
+++ b/src/app/frontend/common/components/middleellipsis/component.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Kubernetes Authors.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,28 +13,35 @@
 // limitations under the License.
 
 /**
+ * Controller for tooltips used for words that are too long for angular UI.
  * @final
  */
-class MiddleEllipsisController {
+export default class MiddleEllipsisController {
   /**
    * Constructs middle ellipsis controller.
    * @ngInject
+   * @param {!angular.JQLite} $element
    */
-  constructor() {
-    /** @export {string} Initialized from the scope. */
-    this.displayString;
+  constructor($element) {
+    /** @private {!angular.JQLite} */
+    this.element_ = $element;
+  }
+
+  /**
+   * Checks if text length is equal to surrounding container.
+   * @returns {boolean}
+   * @export
+   */
+  isTruncated() {
+    let cOfsWidth = this.element_[0].querySelector('.kd-middleellipsis-displayStr').offsetWidth;
+    return cOfsWidth > this.element_[0].offsetWidth;
   }
 }
-
 /**
  * Middle ellipsis component definition.
- *
  * @type {!angular.Component}
  */
 export const middleEllipsisComponent = {
-  bindings: {
-    'displayString': '@',
-  },
   controller: MiddleEllipsisController,
   controllerAs: 'ellipsisCtrl',
   templateUrl: 'common/components/middleellipsis/middleellipsis.html',

--- a/src/app/frontend/common/components/middleellipsis/component.js
+++ b/src/app/frontend/common/components/middleellipsis/component.js
@@ -25,6 +25,9 @@ export default class MiddleEllipsisController {
   constructor($element) {
     /** @private {!angular.JQLite} */
     this.element_ = $element;
+
+    /** @export {string} Initialized from the scope. */
+    this.displayString;
   }
 
   /**
@@ -42,6 +45,9 @@ export default class MiddleEllipsisController {
  * @type {!angular.Component}
  */
 export const middleEllipsisComponent = {
+  bindings: {
+    'displayString': '@',
+  },
   controller: MiddleEllipsisController,
   controllerAs: 'ellipsisCtrl',
   templateUrl: 'common/components/middleellipsis/middleellipsis.html',

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Dashboard Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -18,7 +18,7 @@ limitations under the License.
 <div class="kd-middleellipsis">
   <span class="kd-middleellipsis-displayStr">{{ellipsisCtrl.displayString}}</span>
 <md-tooltip ng-if="ellipsisCtrl.isTruncated()">
-{{ellipsisCtrl.disgplayString}}
+{{ellipsisCtrl.displayString}}
 </md-tooltip>
 </div>
 </div>

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -17,7 +17,7 @@ limitations under the License.
 <div class="kd-middleellipsis2">
 <div class="kd-middleellipsis">
   <span class="kd-middleellipsis-displayStr">{{ellipsisCtrl.displayString}}</span>
-<md-tooltip ng-if="ellipsisCtrl.isTruncated()">
+<md-tooltip md-delay="500" ng-if="ellipsisCtrl.isTruncated()">
 {{ellipsisCtrl.displayString}}
 </md-tooltip>
 </div>

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.html
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Dashboard Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,4 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<span class="kd-middleellipsis">{{ellipsisCtrl.displayString}}</span>
+<div class="kd-middleellipsis2">
+<div class="kd-middleellipsis">
+  <span class="kd-middleellipsis-displayStr">{{ellipsisCtrl.displayString}}</span>
+<md-tooltip ng-if="ellipsisCtrl.isTruncated()">
+{{ellipsisCtrl.disgplayString}}
+</md-tooltip>
+</div>
+</div>

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
@@ -1,16 +1,16 @@
-// Copyright 2017 The Kubernetes Dashboard Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+ //Copyright 2017 The Kubernetes Authors.
+ //
+ //Licensed under the Apache License, Version 2.0 (the "License");
+ //you may not use this file except in compliance with the License.
+ //You may obtain a copy of the License at
+ //
+ //    http://www.apache.org/licenses/LICENSE-2.0
+ //
+ //Unless required by applicable law or agreed to in writing, software
+ //distributed under the License is distributed on an "AS IS" BASIS,
+ //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ //See the License for the specific language governing permissions and
+ //limitations under the License.
 
 .kd-middleellipsis {
   overflow: hidden;

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
@@ -1,4 +1,4 @@
-// Copyright 2017 The Kubernetes Authors.
+// Copyright 2017 The Kubernetes Dashboard Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,3 +17,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.kd-middleellipsis2 {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: bottom;
+}
+

--- a/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
+++ b/src/app/frontend/common/components/middleellipsis/middleellipsis.scss
@@ -1,16 +1,16 @@
- //Copyright 2017 The Kubernetes Authors.
- //
- //Licensed under the Apache License, Version 2.0 (the "License");
- //you may not use this file except in compliance with the License.
- //You may obtain a copy of the License at
- //
- //    http://www.apache.org/licenses/LICENSE-2.0
- //
- //Unless required by applicable law or agreed to in writing, software
- //distributed under the License is distributed on an "AS IS" BASIS,
- //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- //See the License for the specific language governing permissions and
- //limitations under the License.
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 .kd-middleellipsis {
   overflow: hidden;

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
@@ -23,7 +23,8 @@ describe('Middle ellipsis controller', () => {
     angular.mock.module(componentsModule.name);
 
     angular.mock.inject(($componentController) => {
-      element = angular.element('<div style="width: 1px;"><span class="kd-middleellipsis-displayStr">slfjdligjlfijfijhfih</span> </div>');
+      element = angular.element(
+          '<div style="width: 1px;"><span class="kd-middleellipsis-displayStr">Hello World!</span> </div>');
       document.body.appendChild(element[0]);
       ctrl = $componentController('kdMiddleEllipsis', {$element: element});
     });

--- a/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
+++ b/src/test/frontend/common/components/middleellipsis/middleellipsis_controller_test.js
@@ -15,20 +15,30 @@
 import componentsModule from 'common/components/module';
 
 describe('Middle ellipsis controller', () => {
-  /**
-   * @type {!MiddleEllipsisController}
-   */
+  /** @type {!MiddleEllipsisController} */
   let ctrl;
-
+  let element;
+  /** @type {!angular.JQLite} */
   beforeEach(() => {
     angular.mock.module(componentsModule.name);
 
-    angular.mock.inject(($componentController, $rootScope) => {
-      ctrl = $componentController('kdMiddleEllipsis', {$scope: $rootScope});
+    angular.mock.inject(($componentController) => {
+      element = angular.element('<div style="width: 1px;"><span class="kd-middleellipsis-displayStr">slfjdligjlfijfijhfih</span> </div>');
+      document.body.appendChild(element[0]);
+      ctrl = $componentController('kdMiddleEllipsis', {$element: element});
     });
   });
 
   it('should initialize controller', () => {
     expect(ctrl).not.toBeNull();
+  });
+
+  it('checks if isTruncated logic works', () => {
+    expect(ctrl.isTruncated()).toBeTruthy();
+  });
+
+
+  afterEach(() => {
+    document.body.removeChild(element[0]);
   });
 });


### PR DESCRIPTION
Continuation of issue: https://github.com/kubernetes/dashboard/pull/2330. 

- Fixed logic so length is taken from span instead of a "hacky" workaround. 
- Removed unnecessary functions.
- documented code based of JSDocs.
