### PR TITLE
fix: fix circular dependencies issues and enable serve without AoT

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "concurrently \"npm run start:backend\" \"npm run start:frontend\"",
     "start:https": "concurrently \"npm run start:backend:https\" \"npm run start:frontend:https\"",
-    "start:frontend": "ng serve --aot --proxy-config aio/proxy.conf.json --host=0.0.0.0",
+    "start:frontend": "ng serve --proxy-config aio/proxy.conf.json --host=0.0.0.0",
     "start:frontend:https": "ng serve --aot --proxy-config aio/https-proxy.conf.json --ssl --host=0.0.0.0",
     "start:backend": "gulp serve --kubeconfig $npm_package_config_kubeconfig",
     "start:backend:https": "gulp serve --kubeconfig $npm_package_config_kubeconfig --autoGenerateCerts true --defaultCertDir $npm_package_config_kubeconfig_dir",

--- a/src/app/frontend/common/components/module.ts
+++ b/src/app/frontend/common/components/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 
 import {SharedModule} from '../../shared.module';
-import {ResourceModule} from '../services/resource/module';
 
 import {ActionbarComponent} from './actionbar/component';
 import {ActionbarDetailActionsComponent} from './actionbar/detailactions/component';
@@ -75,7 +74,6 @@ import {ZeroStateComponent} from './zerostate/component';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
   ],
   declarations: [
     AllocationChartComponent,

--- a/src/app/frontend/common/dialogs/module.ts
+++ b/src/app/frontend/common/dialogs/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 
 import {SharedModule} from '../../shared.module';
 import {ComponentsModule} from '../components/module';
-import {ResourceModule} from '../services/resource/module';
 
 import {AlertDialog} from './alert/dialog';
 import {DeleteResourceDialog} from './deleteresource/dialog';
@@ -25,7 +24,6 @@ import {EditResourceDialog} from './editresource/dialog';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
   ],
   declarations: [

--- a/src/app/frontend/common/services/global/module.ts
+++ b/src/app/frontend/common/services/global/module.ts
@@ -15,8 +15,6 @@
 import {HTTP_INTERCEPTORS} from '@angular/common/http';
 import {APP_INITIALIZER, Injector, NgModule} from '@angular/core';
 
-import {DialogsModule} from '../../dialogs/module';
-
 import {ActionbarService} from './actionbar';
 import {AssetsService} from './assets';
 import {AuthService} from './authentication';
@@ -36,9 +34,6 @@ import {TitleService} from './title';
 import {VerberService} from './verber';
 
 @NgModule({
-  imports: [
-    DialogsModule,
-  ],
   providers: [
     AuthorizerService, AssetsService, BreadcrumbsService, LocalSettingsService,
     GlobalSettingsService, ConfigService, TitleService, AuthService, CsrfTokenService,

--- a/src/app/frontend/common/services/resource/resource.ts
+++ b/src/app/frontend/common/services/resource/resource.ts
@@ -29,6 +29,13 @@ export class ResourceService<T> extends ResourceBase<T> {
 
     return this.http_.get<T>(endpoint, {params});
   }
+
+  /**
+   * We need to provide HttpClient here since the base is not annotated with @Injectable
+   */
+  constructor(http: HttpClient) {
+    super(http);
+  }
 }
 
 @Injectable()

--- a/src/app/frontend/core.module.ts
+++ b/src/app/frontend/core.module.ts
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {HttpClientModule} from '@angular/common/http';
 import {Inject, NgModule, Optional, SkipSelf} from '@angular/core';
 import {CookieService} from 'ngx-cookie-service';
 
+import {DialogsModule} from './common/dialogs/module';
 import {GlobalServicesModule} from './common/services/global/module';
+import {ResourceModule} from './common/services/resource/module';
 import {CONFIG, CONFIG_DI_TOKEN} from './index.config';
 
 @NgModule({
   providers: [{provide: CONFIG_DI_TOKEN, useValue: CONFIG}, CookieService],
-  imports: [HttpClientModule, GlobalServicesModule]
+  imports: [GlobalServicesModule, DialogsModule, ResourceModule]
 })
 export class CoreModule {
   /* make sure CoreModule is imported only by one NgModule the RootModule */

--- a/src/app/frontend/index.module.ts
+++ b/src/app/frontend/index.module.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {HttpClientModule} from '@angular/common/http';
 import {NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -57,6 +58,7 @@ import {settingsFutureState} from './settings/state';
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
+    HttpClientModule,
     CoreModule,
     ChromeModule,
     LoginModule,

--- a/src/app/frontend/overview/module.ts
+++ b/src/app/frontend/overview/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../common/components/module';
-import {ResourceModule} from '../common/services/resource/module';
 import {SharedModule} from '../shared.module';
 import {OverviewComponent} from './component';
 import {overviewState} from './state';
@@ -24,7 +23,6 @@ import {overviewState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({states: [overviewState]}),
   ],

--- a/src/app/frontend/polyfills.ts
+++ b/src/app/frontend/polyfills.ts
@@ -54,7 +54,7 @@
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /** IE10 and IE11 requires the following for the Reflect API. */
-// import 'core-js/es6/reflect';
+import 'core-js/es7/reflect';
 
 import 'hammerjs';
 

--- a/src/app/frontend/resource/cluster/clusterrole/module.ts
+++ b/src/app/frontend/resource/cluster/clusterrole/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ClusterRoleDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {clusterRoleState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({
       states: [

--- a/src/app/frontend/resource/cluster/module.ts
+++ b/src/app/frontend/resource/cluster/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../common/components/module';
-import {ResourceModule} from '../../common/services/resource/module';
 import {SharedModule} from '../../shared.module';
 import {ClusterComponent} from './component';
 import {clusterState} from './state';
@@ -24,7 +23,6 @@ import {clusterState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({states: [clusterState]}),
   ],

--- a/src/app/frontend/resource/cluster/namespace/module.ts
+++ b/src/app/frontend/resource/cluster/namespace/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ActionbarComponent} from './detail/actionbar/component';
@@ -30,7 +29,6 @@ import {namespaceState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({
       states: [
         namespaceState,

--- a/src/app/frontend/resource/cluster/node/module.ts
+++ b/src/app/frontend/resource/cluster/node/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {NodeDetailComponent} from './detail/component';
@@ -29,7 +28,6 @@ import {nodeState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [nodeState, nodeListState, nodeDetailState]}),
   ],
   declarations: [NodeListComponent, NodeDetailComponent],

--- a/src/app/frontend/resource/cluster/persistentvolume/module.ts
+++ b/src/app/frontend/resource/cluster/persistentvolume/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {PersistentVolumeDetailComponent} from './detail/component';
@@ -29,7 +28,6 @@ import {persistentVolumeState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({
       states: [

--- a/src/app/frontend/resource/cluster/storageclass/module.ts
+++ b/src/app/frontend/resource/cluster/storageclass/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {StorageClassDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {storageClassState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({
       states: [

--- a/src/app/frontend/resource/config/configmap/module.ts
+++ b/src/app/frontend/resource/config/configmap/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ConfigMapDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {configMapState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({states: [configMapState, configMapListState, configMapDetailState]}),
   ],

--- a/src/app/frontend/resource/config/module.ts
+++ b/src/app/frontend/resource/config/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../common/components/module';
-import {ResourceModule} from '../../common/services/resource/module';
 import {SharedModule} from '../../shared.module';
 
 import {ConfigComponent} from './component';
@@ -26,7 +25,6 @@ import {configState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [configState]}),
   ],
   declarations: [ConfigComponent],

--- a/src/app/frontend/resource/config/persistentvolumeclaim/module.ts
+++ b/src/app/frontend/resource/config/persistentvolumeclaim/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {PersistentVolumeClaimDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {persistentVolumeClaimState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({
       states: [

--- a/src/app/frontend/resource/config/secret/module.ts
+++ b/src/app/frontend/resource/config/secret/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {SecretDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {secretState} from './state';
 @NgModule({
   imports: [
     SharedModule,
-    ResourceModule,
     ComponentsModule,
     UIRouterModule.forChild({states: [secretState, secretListState, secretDetailState]}),
   ],

--- a/src/app/frontend/resource/discovery/ingress/module.ts
+++ b/src/app/frontend/resource/discovery/ingress/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {IngressDetailComponent} from './detail/component';
@@ -29,7 +28,6 @@ import {ingressState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({
       states: [
         ingressState,

--- a/src/app/frontend/resource/discovery/module.ts
+++ b/src/app/frontend/resource/discovery/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../common/components/module';
-import {ResourceModule} from '../../common/services/resource/module';
 import {SharedModule} from '../../shared.module';
 
 import {DiscoveryComponent} from './component';
@@ -26,7 +25,6 @@ import {discoveryState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [discoveryState]}),
   ],
   declarations: [DiscoveryComponent],

--- a/src/app/frontend/resource/discovery/service/module.ts
+++ b/src/app/frontend/resource/discovery/service/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ServiceDetailComponent} from './detail/component';
@@ -29,7 +28,6 @@ import {serviceState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({
       states: [
         serviceState,

--- a/src/app/frontend/resource/workloads/cronjob/module.ts
+++ b/src/app/frontend/resource/workloads/cronjob/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 
 import {SharedModule} from '../../../shared.module';
 import {CronJobDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {cronJobState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [cronJobState, cronJobListState, cronJobDetailState]}),
   ],
   declarations: [CronJobList, CronJobDetailComponent],

--- a/src/app/frontend/resource/workloads/daemonset/module.ts
+++ b/src/app/frontend/resource/workloads/daemonset/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ActionbarComponent} from './detail/actionbar/component';
@@ -30,7 +29,6 @@ import {daemonSetState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [daemonSetState, daemonSetListState, daemonSetDetailState]}),
   ],
   declarations: [DaemonSetList, DaemonSetDetailComponent, ActionbarComponent],

--- a/src/app/frontend/resource/workloads/deployment/module.ts
+++ b/src/app/frontend/resource/workloads/deployment/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 
 import {ActionbarComponent} from './detail/actionbar/component';
@@ -30,7 +29,6 @@ import {deploymentState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild(
         {states: [deploymentState, deploymentListState, deploymentDetailState]}),
   ],

--- a/src/app/frontend/resource/workloads/job/module.ts
+++ b/src/app/frontend/resource/workloads/job/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 import {JobDetailComponent} from './detail/component';
 import {jobDetailState} from './detail/state';
@@ -27,7 +26,6 @@ import {jobState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [jobState, jobListState, jobDetailState]}),
   ],
   declarations: [JobList, JobDetailComponent],

--- a/src/app/frontend/resource/workloads/module.ts
+++ b/src/app/frontend/resource/workloads/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../common/components/module';
-import {ResourceModule} from '../../common/services/resource/module';
 import {SharedModule} from '../../shared.module';
 
 import {WorkloadsComponent} from './component';
@@ -26,7 +25,6 @@ import {workloadsState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [workloadsState]}),
   ],
   declarations: [WorkloadsComponent],

--- a/src/app/frontend/resource/workloads/pod/module.ts
+++ b/src/app/frontend/resource/workloads/pod/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 import {SharedModule} from '../../../shared.module';
 import {PodDetailComponent} from './detail/component';
 import {podDetailState} from './detail/state';
@@ -28,7 +27,6 @@ import {podState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [podState, podListState, podDetailState]}),
   ],
   declarations: [PodList, PodDetailComponent],

--- a/src/app/frontend/resource/workloads/replicaset/module.ts
+++ b/src/app/frontend/resource/workloads/replicaset/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 
 import {SharedModule} from '../../../shared.module';
 import {ReplicaSetDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {replicaSetState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild(
         {states: [replicaSetState, replicaSetListState, replicaSetDetailState]}),
   ],

--- a/src/app/frontend/resource/workloads/replicationcontroller/module.ts
+++ b/src/app/frontend/resource/workloads/replicationcontroller/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 
 import {SharedModule} from '../../../shared.module';
 import {ReplicationControllerDetailComponent} from '../replicationcontroller/detail/component';
@@ -28,7 +27,6 @@ import {replicationControllerState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({
       states: [
         replicationControllerState, replicationControllerListState, replicationControllerDetailState

--- a/src/app/frontend/resource/workloads/statefulset/module.ts
+++ b/src/app/frontend/resource/workloads/statefulset/module.ts
@@ -15,7 +15,6 @@
 import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 import {ComponentsModule} from '../../../common/components/module';
-import {ResourceModule} from '../../../common/services/resource/module';
 
 import {SharedModule} from '../../../shared.module';
 import {StatefulSetDetailComponent} from './detail/component';
@@ -28,7 +27,6 @@ import {statefulSetState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild(
         {states: [statefulSetState, statefulSetListState, statefulSetDetailState]}),
   ],

--- a/src/app/frontend/search/module.ts
+++ b/src/app/frontend/search/module.ts
@@ -16,7 +16,6 @@ import {NgModule} from '@angular/core';
 import {UIRouterModule} from '@uirouter/angular';
 
 import {ComponentsModule} from '../common/components/module';
-import {ResourceModule} from '../common/services/resource/module';
 import {SharedModule} from '../shared.module';
 
 import {SearchComponent} from './component';
@@ -26,7 +25,6 @@ import {searchState} from './state';
   imports: [
     SharedModule,
     ComponentsModule,
-    ResourceModule,
     UIRouterModule.forChild({states: [searchState]}),
   ],
   declarations: [


### PR DESCRIPTION
Before the PR, the app is served with `--aot` option and the local dev recompilation is time consuming and annoying. After I turned off --aot, I found that the app has some circular dependency issues.

The issue is mainly caused by that the global service module and dialog module has some indirect imports between each other. A safer way is to move the dialog module to the parent of global service module, thus global service module and dialog module would have the same level of import paths.

Also resource service module is not necessarily imported by many features since it is a provider only module.

After the PR, we can develop the Angular branch without `--aot` option, and the recompilation should be significantly improved. 