### PR TITLE
hide request info for sensitive urls

### DIFF
--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -103,25 +103,38 @@ func TestMapUrlToResource(t *testing.T) {
 }
 
 func TestFormatRequestLog(t *testing.T) {
-	req, err := http.NewRequest("PUT", "/api/v1/pod", bytes.NewReader([]byte("{}")))
-	if err != nil {
-		t.Error("Cannot mockup request")
-	}
 	cases := []struct {
-		request  *restful.Request
+		method   string
+		uri      string
+		content  *bytes.Reader
 		expected string
 	}{
 		{
-			&restful.Request{
-				Request: req,
-			},
+			"PUT",
+			"/api/v1/pod",
+			bytes.NewReader([]byte("{}")),
 			"Incoming HTTP/1.1 PUT /api/v1/pod request",
 		},
+		{
+			"POST",
+			"/api/v1/login",
+			bytes.NewReader([]byte("{}")),
+			"Incoming HTTP/1.1 POST /api/v1/login request from : { contents hidden }",
+		},
 	}
+
 	for _, c := range cases {
-		actual := formatRequestLog(c.request)
+		req, err := http.NewRequest(c.method, c.uri, c.content)
+		if err != nil {
+			t.Error("Cannot mockup request")
+		}
+
+		var restfulRequest restful.Request
+		restfulRequest.Request = req
+
+		actual := formatRequestLog(&restfulRequest)
 		if !strings.Contains(actual, c.expected) {
-			t.Errorf("formatRequestLog(%#v) returns %#v, expected to contain %#v", c.request, actual, c.expected)
+			t.Errorf("formatRequestLog(%#v) returns %#v, expected to contain %#v", req, actual, c.expected)
 		}
 	}
 }

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -67,12 +67,23 @@ func formatRequestLog(request *restful.Request) string {
 	}
 
 	content := "{}"
+
 	entity := make(map[string]interface{})
 	request.ReadEntity(&entity)
 	if len(entity) > 0 {
 		bytes, err := json.MarshalIndent(entity, "", "  ")
 		if err == nil {
 			content = string(bytes)
+		}
+	}
+
+	// Great now let's filter out any content from sensitive URLs
+	var sensitive_urls [2]string
+	sensitive_urls[0] = "/api/v1/login"
+	sensitive_urls[1] = "/api/v1/csrftoken/login"
+	for _, a := range sensitive_urls {
+		if a == uri {
+			content = "{ contents hidden }"
 		}
 	}
 


### PR DESCRIPTION
Hey all! This directly addresses #3012 amongst other dupes.

I created an array of URLs that we would deem "sensitive". We would therefore not log any request variables for these URLs. I've tentatively added the two login endpoints.

I also updated the tests to:
- More easily add additional cases based on URL / Method
- Ensure those URLs will log "{ contents hidden}" rather than the contents.

Critiques and comments are welcome. :)

Thanks!