### PR TITLE
API request logging improvements

### DIFF
--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -108,6 +108,12 @@ func (self *holderBuilder) SetSystemBannerSeverity(systemBannerSeverity string) 
 	return self
 }
 
+// SetLogLevel 'api-log-level' argument of Dashboard binary.
+func (self *holderBuilder) SetAPILogLevel(apiLogLevel string) *holderBuilder {
+	self.holder.apiLogLevel = apiLogLevel
+	return self
+}
+
 // SetAuthenticationMode 'authentication-mode' argument of Dashboard binary.
 func (self *holderBuilder) SetAuthenticationMode(authMode []string) *holderBuilder {
 	self.holder.authenticationMode = authMode

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -41,6 +41,7 @@ type holder struct {
 	kubeConfigFile       string
 	systemBanner         string
 	systemBannerSeverity string
+	apiLogLevel          string
 
 	authenticationMode []string
 
@@ -48,7 +49,7 @@ type holder struct {
 	enableInsecureLogin       bool
 	disableSettingsAuthorizer bool
 
-	disableSkipButton         bool
+	disableSkipButton bool
 }
 
 // GetInsecurePort 'insecure-port' argument of Dashboard binary.
@@ -127,6 +128,11 @@ func (self *holder) GetSystemBanner() string {
 // GetSystemBannerSeverity 'system-banner-severity' argument of Dashboard binary.
 func (self *holder) GetSystemBannerSeverity() string {
 	return self.systemBannerSeverity
+}
+
+// LogLevel 'api-log-level' argument of Dashboard binary.
+func (self *holder) GetAPILogLevel() string {
+	return self.apiLogLevel
 }
 
 // GetAuthenticationMode 'authentication-mode' argument of Dashboard binary.

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -69,6 +69,7 @@ var (
 	argDisableSkip               = pflag.Bool("disable-skip", false, "When enabled, the skip button on the login page will not be shown. Default: false.")
 	argSystemBanner              = pflag.String("system-banner", "", "When non-empty displays message to Dashboard users. Accepts simple HTML tags. Default: ''.")
 	argSystemBannerSeverity      = pflag.String("system-banner-severity", "INFO", "Severity of system banner. Should be one of 'INFO|WARNING|ERROR'. Default: 'INFO'.")
+	argAPILogLevel               = pflag.String("api-log-level", "INFO", "Level of API request logging. Should be one of 'INFO|NONE|DEBUG'. Default: 'INFO'.")
 	argDisableSettingsAuthorizer = pflag.Bool("disable-settings-authorizer", false, "When enabled, Dashboard settings page will not require user to be logged in and authorized to access settings page.")
 )
 
@@ -217,6 +218,7 @@ func initArgHolder() {
 	builder.SetKubeConfigFile(*argKubeConfigFile)
 	builder.SetSystemBanner(*argSystemBanner)
 	builder.SetSystemBannerSeverity(*argSystemBannerSeverity)
+	builder.SetAPILogLevel(*argAPILogLevel)
 	builder.SetAuthenticationMode(*argAuthenticationMode)
 	builder.SetAutoGenerateCertificates(*argAutoGenerateCertificates)
 	builder.SetEnableInsecureLogin(*argEnableInsecureLogin)

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -102,11 +102,16 @@ func formatResponseLog(response *restful.Response, request *restful.Request) str
 // checkSensitiveUrl checks if a string matches against a sensitive URL
 // true if sensitive. false if not.
 func checkSensitiveURL(url *string) bool {
-	var sensitiveUrls = make(map[string]bool)
-	sensitiveUrls["/api/v1/login"] = true
-	sensitiveUrls["/api/v1/csrftoken/login"] = true
+	var s struct{}
+	var sensitiveUrls = make(map[string]struct{})
+	sensitiveUrls["/api/v1/login"] = s
+	sensitiveUrls["/api/v1/csrftoken/login"] = s
 
-	return sensitiveUrls[*url]
+	if _, ok := sensitiveUrls[*url]; ok {
+		return true
+	}
+	return false
+
 }
 
 func metricsFilter(req *restful.Request, resp *restful.Response,

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -83,17 +83,10 @@ func formatRequestLog(request *restful.Request) string {
 		}
 	}
 
-	// Is DEBUG level logging enabled?
-	if args.Holder.GetAPILogLevel() != "DEBUG" {
-		// Great now let's filter out any content from sensitive URLs
-		var sensitive_urls [2]string
-		sensitive_urls[0] = "/api/v1/login"
-		sensitive_urls[1] = "/api/v1/csrftoken/login"
-		for _, a := range sensitive_urls {
-			if a == uri {
-				content = "{ contents hidden }"
-			}
-		}
+	// Is DEBUG level logging enabled? Yes?
+	// Great now let's filter out any content from sensitive URLs
+	if args.Holder.GetAPILogLevel() != "DEBUG" && checkSensitiveURL(&uri) {
+		content = "{ contents hidden }"
 	}
 
 	return fmt.Sprintf(RequestLogString, time.Now().Format(time.RFC3339), request.Request.Proto,
@@ -104,6 +97,16 @@ func formatRequestLog(request *restful.Request) string {
 func formatResponseLog(response *restful.Response, request *restful.Request) string {
 	return fmt.Sprintf(ResponseLogString, time.Now().Format(time.RFC3339),
 		request.Request.RemoteAddr, response.StatusCode())
+}
+
+// checkSensitiveUrl checks if a string matches against a sensitive URL
+// true if sensitive. false if not.
+func checkSensitiveURL(url *string) bool {
+	var sensitiveUrls = make(map[string]bool)
+	sensitiveUrls["/api/v1/login"] = true
+	sensitiveUrls["/api/v1/csrftoken/login"] = true
+
+	return sensitiveUrls[*url]
 }
 
 func metricsFilter(req *restful.Request, resp *restful.Response,


### PR DESCRIPTION
Hey all!

This directly addresses #3174, #3012, and potentially others. 

I created a list of addresses that may potentially have sensitive information that should not be logged. Instead it will only log `{ contents hidden }`. 

However, in some cases (like debugging and development) you still want to see what's being passed along. So I added a new CLI argument to the dashboard called `--api-log-level` with three options: INFO,DEBUG,NONE

The default setting is INFO, which will log everything but sensitive URLs. 
NONE will turn off all request/response logging.
DEBUG will log everything including the contents of sensitive URLs.

I added tests for all this, and also updated `TestFormatRequestLog` to handle more diverse test cases.

Thanks!