### PR TITLE
filter /token/refresh contents from logs

### DIFF
--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -106,6 +106,7 @@ func checkSensitiveURL(url *string) bool {
 	var sensitiveUrls = make(map[string]struct{})
 	sensitiveUrls["/api/v1/login"] = s
 	sensitiveUrls["/api/v1/csrftoken/login"] = s
+  sensitiveUrls["/api/v1/token/refresh"] = s
 
 	if _, ok := sensitiveUrls[*url]; ok {
 		return true


### PR DESCRIPTION
Tokens are currently being written to the logs. Add the `/api/v1/token/refresh` url to the map of sensitiveUrls which should be scrubbed from the logs.