### PR TITLE
Don't claim copyright for future years

### DIFF
--- a/build/conf.js
+++ b/build/conf.js
@@ -64,6 +64,10 @@ const version = {
    * Version name of the head release of the project.
    */
   head: 'head',
+  /**
+   * Year of last source change of the project
+   */
+  year: '2018',
 };
 
 /**

--- a/build/script.js
+++ b/build/script.js
@@ -242,7 +242,7 @@ function patchBuildInformation() {
                   patterns: [
                     {match: 'BUILD_GIT_COMMIT', replacement: commit},
                     {match: 'BUILD_DASHBOARD_VERSION', replacement: conf.deploy.version.release},
-                    {match: 'BUILD_YEAR', replacement: new Date().getFullYear()},
+                    {match: 'BUILD_YEAR', replacement: conf.deploy.version.year},
                   ],
                 }));
 }


### PR DESCRIPTION
When building the kubernetes-dashboard openSUSE package
in future years, files differed because they contained
something like
this.latestCopyrightYear="2033"

See https://reproducible-builds.org/ for why this matters.

And https://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated suggests that expiry should not be a concern anyway.

https://github.com/kubernetes/kubernetes/pull/59172 fixed this for kubernetes.