### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ $ kubectl proxy
 ```
 Now access Dashboard at:
 
-[`http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`](
-http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/).
+[`http://localhost:8001/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy`](http://localhost:8001/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy).
 
 ## Create An Authentication Token (RBAC)
 To find out how to create sample user and log in follow [Creating sample user](https://github.com/kubernetes/dashboard/wiki/Creating-sample-user) guide.


### PR DESCRIPTION
Corrected the url for kubernetes web ui. in the documentation it is listed as:
http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernete-dashboard:/proxy/

but it throws an error on the browser:
Error: 'tls: oversized record received with length 20527'
Trying to reach: 'https://172.17.0.3:9090/'

The correct url should be:
http://localhost:8001/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy