### PR TITLE
Enable check:backend task on Travis CI and add goimports check

### DIFF
--- a/aio/scripts/lint-backend.sh
+++ b/aio/scripts/lint-backend.sh
@@ -25,13 +25,18 @@ if [ ! -f ${GOLINT_BIN} ]; then
     curl -sfL ${GOLINT_URL} | sh -s -- -b ${CACHE_DIR} v1.12.3
 fi
 
+# Need to check source files under GOPATH
+if [ ${TRAVIS} ]; then
+    cd ${GOPATH}/src/github.com/kubernetes/dashboard/src/app/backend/
+fi
+
 # Run checks.
 ${GOLINT_BIN} run ./... \
   --no-config \
-  --issues-exit-code=0 \
   --deadline=30m \
   --disable-all \
   --enable=govet \
   --enable=gocyclo \
   --enable=misspell \
-  --enable=ineffassign
+  --enable=ineffassign \
+  --enable=goimports

--- a/src/app/backend/resource/job/list_test.go
+++ b/src/app/backend/resource/job/list_test.go
@@ -140,7 +140,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					{
 						ObjectMeta: metaV1.ObjectMeta{
 							Namespace: "rs-namespace",
-							Labels:	   map[string]string{"foo": "bar"},
+							Labels:    map[string]string{"foo": "bar"},
 							OwnerReferences: []metaV1.OwnerReference{
 								{
 									Name:       "rs-name-running-pod",


### PR DESCRIPTION
`check:backend` task always return success even if linters reported errors now.
And golangci-lint does not work properly for checking source code outside `${GOPATH}`.

Removed `--issue-exit-code=0` option for `golangci-lint` and change directory into `${GOPAHT}/src/github.com/kubernetes/dashboard` before run `golangci-lint` on Travis CI.

Also, added `enable=goimports` option for `golangci-lint` and applied "goimports -w src/app/backend".
