### PR TITLE
Enable frontend test in docker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,15 +20,19 @@
 # golang is based on debian:jessie
 FROM golang
 
-# Install Java and Node.js. Go is already installed.
+# Install Java, Node.js and Chromium browser. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script, so there's no need to run it again.
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
   && apt-get install -y --no-install-recommends \
 	openjdk-8-jre \
 	nodejs \
 	patch \
+	chromium \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean
+
+# Set environment variable for JavaScript tests.
+ENV CHROME_BIN=/usr/bin/chromium
 
 # Download a statically linked docker client, so the container is able to build images on the host.
 RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \

--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -138,7 +138,10 @@ module.exports = function(config) {
     // Limit concurrency to not exhaust saucelabs resources for the CI user.
     configuration.concurrency = 1;
   } else {
-    configuration.browsers = ['Chrome'];
+    configuration.browsers = ['ChromeHeadlessNoSandbox'];
+    configuration.customLaunchers = {
+      ChromeHeadlessNoSandbox: {base: 'ChromeHeadless', flags: ['--no-sandbox']},
+    };
   }
 
   // Convert all JS code written ES2017 with modules to ES5 bundles that browsers can digest.


### PR DESCRIPTION
To enable frontend test in docker container, add chromium into
container and change browser to 'ChromeHeadless'.