### PR TITLE
Display long image names in tooltip

### DIFF
--- a/src/app/frontend/deployment/list/card.html
+++ b/src/app/frontend/deployment/list/card.html
@@ -73,9 +73,11 @@ limitations under the License.
     <kd-resource-card-column>
       <div ng-repeat="image in ::$ctrl.deployment.containerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+        <md-tooltip md-delay="500" md-autohide>{{::image}}</md-tooltip>
       </div>
       <div ng-repeat="image in ::$ctrl.deployment.initContainerImages track by $index">
         <kd-middle-ellipsis display-string="{{::image}}"></kd-middle-ellipsis>
+        <md-tooltip md-delay="500" md-autohide>{{::image}}</md-tooltip>
       </div>
     </kd-resource-card-column>
     <kd-resource-card-column class="kd-row-layout-column kd-icon-column">


### PR DESCRIPTION
As `middleellipsis` cuts off longer image names in the deployment list. Important context gets missing in the overview (container version, ...). Adding a tooltip with the full name allows details on the image.