### PR TITLE
Add container for development outside cluster

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -1,0 +1,70 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a Dockerfile for running and building Kubernetes dashboard
+# It installs all deps in the container and adds the dashboard source
+# This way it abstracts all required build tools away and lets the user
+# run gulp tasks on the code with only docker installed
+
+# golang is based on debian:jessie
+FROM golang
+
+# Install Node.js. Go is already installed.
+# A small tweak, apt-get update is already run by the nodejs setup script,
+# so there's no need to run it again.
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
+  && apt-get install -y --no-install-recommends \
+	nodejs \
+	patch \
+	chromium \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+
+# Install dependencies. This will take a while.
+RUN npm install -g npm@latest gulp
+
+# Set environment variable for JavaScript tests.
+ENV CHROME_BIN=/usr/bin/chromium
+
+# Set environment variable for terminal
+ENV TERM=xterm
+
+# Add ${GOPATH}/bin into ${PATH}
+ENV PATH=${GOPATH}/bin:${PATH}
+
+# For testing, etc., to know if this environment is on container.
+ENV K8S_DASHBOARD_CONTAINER=TRUE
+
+# Download a statically linked docker client,
+# so the container is able to build images on the host.
+RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
+	chmod +x /usr/bin/docker
+
+# Install delve for debuging go files.
+RUN go get github.com/derekparker/delve/cmd/dlv
+
+# Volume for source code
+VOLUME ["/go/src/github.com/kubernetes/dashboard"]
+
+# Mount point for kubeconfig
+RUN mkdir -p /root/.kube
+
+# Current directory is always dashboard source directory.
+WORKDIR /go/src/github.com/kubernetes/dashboard
+
+# Expose port for frontend, backend and remote debuging
+EXPOSE 8080 9090 2345
+
+# Run npm command in container. 
+CMD ./aio/develop/npm-command.sh

--- a/aio/develop/npm-command.sh
+++ b/aio/develop/npm-command.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run npm command if K8S_DASHBOARD_NPM_CMD is set,
+# otherwise install and start dashboard.
+if [[ -n "${K8S_DASHBOARD_NPM_CMD}" ]] ; then
+  # Run npm command
+  echo "Run npm '${K8S_DASHBOARD_NPM_CMD}'"
+  npm ${K8S_DASHBOARD_NPM_CMD}
+else
+  # Install dashboard.
+  echo "Install dashboard"
+  npm ci --unsafe-perm
+  # Start dashboard.
+  echo "Start dashboard"
+  npm start
+fi

--- a/aio/develop/run-npm-on-container.sh
+++ b/aio/develop/run-npm-on-container.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This runs npm commands for dashboard in container.
+#
+# To run dashboard on container, simply run `run-npm-command.sh`.
+# To run npm command in container, set K8S_DASHBOARD_NPM_CMD variable
+# like "run check" or run like `run-npm-command.sh run check`.
+
+CD="$(pwd)"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# K8S_DASHBOARD_NPM_CMD will be passed into container and will be used
+# by run-npm-command.sh on container.
+export K8S_DASHBOARD_NPM_CMD=$*
+
+# Build and run container for dashboard
+DASHBOARD_IMAGE_NAME=${K8S_DASHBOARD_CONTAINER_NAME:-"k8s-dashboard-dev-image"}
+K8S_DASHBOARD_SRC=${K8S_DASHBOARD_SRC:-"${CD}"}
+K8S_DASHBOARD_CONTAINER_NAME=${K8S_DASHBOARD_CONTAINER_NAME:-"k8s-dashboard-dev"}
+K8S_DASHBOARD_SRC_ON_CONTAINER=/go/src/github.com/kubernetes/dashboard
+
+echo "Remove existing container ${K8S_DASHBOARD_CONTAINER_NAME}"
+docker rm -f ${K8S_DASHBOARD_CONTAINER_NAME}
+
+# Always test if the image is up-to-date. If nothing has changed since last build,
+# it'll just use the already-built image
+echo "Start building container image for development"
+docker build -t ${DASHBOARD_IMAGE_NAME} -f ${DIR}/Dockerfile ${DIR}/../../
+
+# Run dashboard container for development and expose necessary ports automatically.
+echo "Run container for development"
+docker run \
+	-it \
+	--net=host \
+	--name=${K8S_DASHBOARD_CONTAINER_NAME} \
+	--cap-add=SYS_PTRACE \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v ${K8S_DASHBOARD_SRC}:${K8S_DASHBOARD_SRC_ON_CONTAINER} \
+	-v ${K8S_DASHBOARD_KUBECONFIG}:/root/.kube/config \
+	-e K8S_DASHBOARD_NPM_CMD="${K8S_DASHBOARD_NPM_CMD}" \
+	${DOCKER_RUN_OPTS} \
+	${DASHBOARD_IMAGE_NAME}

--- a/aio/karma.conf.js
+++ b/aio/karma.conf.js
@@ -90,5 +90,21 @@ module.exports = function(config) {
     };
   }
 
+  // Use custom browser configuration when running on container.
+  if (!!process.env.K8S_DASHBOARD_CONTAINER) {
+    configuration.browsers = ['ChromeHeadless'];
+    configuration.customLaunchers = {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--disable-gpu',
+          '--headless',
+          '--no-sandbox',
+          '--remote-debugging-port=9222',
+        ],
+      },
+    };
+  }
+
   config.set(configuration);
 };


### PR DESCRIPTION
To construct thinner development environment outside cluster
with docker, this adds Dockerfile and shell scripts.

This container will run npm command as you like, or install and run 
dashboard. 

Also, this adds chrome driver as headless for testing in container.

The following commands are reviewed in this:
* npm ci
* npm run check
* npm run test:frontend
* npm run test:backend
* npm run start

To run this container:
1. Copy kubeconfig from your cluster, and confirm URL for API server in it.
2. Set filepath for kubeconfig into K8S_DASHBOARD_KUBECONFIG environment variable.
3. Change directory into your dashboard source directory.
4. To install and run dashboard, simply run `aio/develop/run-npm-on-container.sh`.

If you want to run npm command in this container as you like, run like follows:
`aio/develop/run-npm-on-container.sh run check`
`aio/develop/run-npm-on-container.sh run test:backend`
