### PR TITLE
pvc listing and details

### DIFF
--- a/src/app/frontend/common/components/resourcelist/persistentvolumeclaim/template.html
+++ b/src/app/frontend/common/components/resourcelist/persistentvolumeclaim/template.html
@@ -82,8 +82,8 @@ limitations under the License.
       <ng-container matColumnDef="capacity">
         <mat-header-cell *matHeaderCellDef>Capacity</mat-header-cell>
         <mat-cell *matCellDef="let pvc">
-          <ng-container *ngIf="pvc.capacity">{{pvc.capacity}}</ng-container>
-          <ng-container *ngIf="!pvc.capacity">-</ng-container>
+          <ng-container *ngIf="pvc?.capacity?.storage">{{pvc.capacity.storage}}</ng-container>
+          <ng-container *ngIf="!pvc?.capacity?.storage">-</ng-container>
         </mat-cell>
       </ng-container>
 
@@ -97,8 +97,8 @@ limitations under the License.
       <ng-container matColumnDef="storagecl">
         <mat-header-cell *matHeaderCellDef>Storage Class</mat-header-cell>
         <mat-cell *matCellDef="let pvc">
-          <ng-container *ngIf="pvc.storageClass">{{pvc.capacity}}</ng-container>
-          <ng-container *ngIf="!pvc.storageClass">-</ng-container>
+          <ng-container *ngIf="pvc?.storageClass">{{pvc.storageClass}}</ng-container>
+          <ng-container *ngIf="!pvc?.storageClass">-</ng-container>
         </mat-cell>
       </ng-container>
 

--- a/src/app/frontend/resource/config/persistentvolumeclaim/detail/template.html
+++ b/src/app/frontend/resource/config/persistentvolumeclaim/detail/template.html
@@ -14,5 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<kd-object-meta [initialized]="isInitialized"
+<kd-object-meta [initialized]="isInitialized" 
                 [objectMeta]="persistentVolumeClaim?.objectMeta"></kd-object-meta>
+
+<kd-card [initialized]="isInitialized">
+  <div title>Persistent Volume Claim information</div>
+  <div content *ngIf="isInitialized" fxLayout="row wrap">
+    <kd-property *ngIf="persistentVolumeClaim?.status">
+      <div key>Status</div>
+      <div value>{{persistentVolumeClaim.status}}</div>
+    </kd-property>
+    <kd-property *ngIf="persistentVolumeClaim?.storageClass">
+        <div key>Storage Class</div>
+        <div value>{{persistentVolumeClaim.storageClass}}</div>
+    </kd-property>
+    <kd-property *ngIf="persistentVolumeClaim?.capacity?.storage">
+        <div key>Capacity</div>
+        <div value>{{persistentVolumeClaim.capacity.storage}}</div>
+    </kd-property>
+    <kd-property *ngIf="persistentVolumeClaim?.capacity?.storage">
+        <div key>Access Modes</div>
+        <div value><kd-chips [map]="persistentVolumeClaim.accessModes"></kd-chips></div>
+    </kd-property>
+  </div>
+</kd-card>

--- a/src/app/frontend/typings/backendapi.d.ts
+++ b/src/app/frontend/typings/backendapi.d.ts
@@ -227,6 +227,7 @@ export interface Node extends Resource { ready: string; }
 
 export interface PersistentVolume extends Resource {
   capacity: StringMap;
+  storageClass: string;
   accessModes: string[];
   reclaimPolicy: string;
   status: string;


### PR DESCRIPTION
- Adds fields in listing for persistent volume claims.
- Adds details when viewing persistent volume claims. 

**Screens**

In listing
<img width="1384" alt="screen shot 2018-11-07 at 16 22 17" src="https://user-images.githubusercontent.com/3543381/48141075-60bb3780-e2aa-11e8-9ef5-bf97be962fac.png">

In details view
<img width="1078" alt="screen shot 2018-11-07 at 16 22 27" src="https://user-images.githubusercontent.com/3543381/48141093-6a449f80-e2aa-11e8-94ad-d6b450702a44.png">

**kubectl equivalent**
```
~/Projects/src/github.com/rctl/dashboard [ng-migration-rctl] $ kubectl get pvc
NAME            STATUS    VOLUME        CAPACITY   ACCESS MODES   STORAGECLASS   AGE
test-volume     Bound     test-volume   1Mi        RWX                           9d
test-volume-2   Pending                                           test           50m
```

**Test plan**

```
~/Projects/src/github.com/rctl/dashboard [ng-migration-rctl] $ npm run test
[...]
Chrome 70.0.3538 (Mac OS X 10.13.6): Executed 7 of 7 SUCCESS (4.199 secs / 4.034 secs)
TOTAL: 7 SUCCESS
TOTAL: 7 SUCCESS
TOTAL: 7 SUCCESS
```