### PR TITLE
fix: add lock to terminalSessions to avoid panic when concurrent access

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -378,9 +378,9 @@ func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clie
 		apiV1Ws.GET("/cronjob/{namespace}/{name}/event").
 			To(apiHandler.handleGetCronJobEvents).
 			Writes(common.EventList{}))
-  apiV1Ws.Route(
-    apiV1Ws.PUT("/cronjob/{namespace}/{name}/trigger").
-      To(apiHandler.handleTriggerCronJob))
+	apiV1Ws.Route(
+		apiV1Ws.PUT("/cronjob/{namespace}/{name}/trigger").
+			To(apiHandler.handleTriggerCronJob))
 
 	apiV1Ws.Route(
 		apiV1Ws.POST("/namespace").
@@ -1316,11 +1316,11 @@ func (apiHandler *APIHandler) handleExecShell(request *restful.Request, response
 		return
 	}
 
-	terminalSessions[sessionId] = TerminalSession{
+	terminalSessions.Set(sessionId, TerminalSession{
 		id:       sessionId,
 		bound:    make(chan error),
 		sizeChan: make(chan remotecommand.TerminalSize),
-	}
+	})
 	go WaitForTerminal(k8sClient, cfg, request, sessionId)
 	response.WriteHeaderAndEntity(http.StatusOK, TerminalResponse{Id: sessionId})
 }
@@ -2106,20 +2106,20 @@ func (apiHandler *APIHandler) handleGetCronJobEvents(request *restful.Request, r
 }
 
 func (apiHandler *APIHandler) handleTriggerCronJob(request *restful.Request, response *restful.Response) {
-  k8sClient, err := apiHandler.cManager.Client(request)
-  if err != nil {
-    kdErrors.HandleInternalError(response, err)
-    return
-  }
+	k8sClient, err := apiHandler.cManager.Client(request)
+	if err != nil {
+		kdErrors.HandleInternalError(response, err)
+		return
+	}
 
-  namespace := request.PathParameter("namespace")
-  name := request.PathParameter("name")
-  err = cronjob.TriggerCronJob(k8sClient, namespace, name)
-  if err != nil {
-    kdErrors.HandleInternalError(response, err)
-    return
-  }
-  response.WriteHeader(http.StatusOK)
+	namespace := request.PathParameter("namespace")
+	name := request.PathParameter("name")
+	err = cronjob.TriggerCronJob(k8sClient, namespace, name)
+	if err != nil {
+		kdErrors.HandleInternalError(response, err)
+		return
+	}
+	response.WriteHeader(http.StatusOK)
 }
 
 func (apiHandler *APIHandler) handleGetStorageClassList(request *restful.Request, response *restful.Response) {

--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sync"
 
 	restful "github.com/emicklei/go-restful"
 	"gopkg.in/igm/sockjs-go.v2/sockjs"
@@ -131,16 +132,37 @@ func (t TerminalSession) Toast(p string) error {
 	return nil
 }
 
+// SessionMap stores a map of all TerminalSession objects and a lock to avoid concurrent conflict
+type SessionMap struct {
+	Sessions map[string]TerminalSession
+	Lock     sync.RWMutex
+}
+
+// Get return a given terminalSession by sessionId
+func (sm SessionMap) Get(sessionId string) TerminalSession {
+	sm.Lock.RLock()
+	defer sm.Lock.RUnlock()
+	return sm.Sessions[sessionId]
+}
+
+// Set store a TerminalSession to SessionMap
+func (sm SessionMap) Set(sessionId string, session TerminalSession) {
+	sm.Lock.Lock()
+	defer sm.Lock.Unlock()
+	sm.Sessions[sessionId] = session
+}
+
 // Close shuts down the SockJS connection and sends the status code and reason to the client
 // Can happen if the process exits or if there is an error starting up the process
 // For now the status code is unused and reason is shown to the user (unless "")
-func (t TerminalSession) Close(status uint32, reason string) {
-	t.sockJSSession.Close(status, reason)
+func (sm SessionMap) Close(sessionId string, status uint32, reason string) {
+	sm.Lock.Lock()
+	defer sm.Lock.Unlock()
+	sm.Sessions[sessionId].sockJSSession.Close(status, reason)
+	delete(sm.Sessions, sessionId)
 }
 
-// terminalSessions stores a map of all TerminalSession objects
-// FIXME: this structure needs locking
-var terminalSessions = make(map[string]TerminalSession)
+var terminalSessions = SessionMap{Sessions: make(map[string]TerminalSession)}
 
 // handleTerminalSession is Called by net/http for any new /api/sockjs connections
 func handleTerminalSession(session sockjs.Session) {
@@ -149,7 +171,6 @@ func handleTerminalSession(session sockjs.Session) {
 		err             error
 		msg             TerminalMessage
 		terminalSession TerminalSession
-		ok              bool
 	)
 
 	if buf, err = session.Recv(); err != nil {
@@ -167,13 +188,13 @@ func handleTerminalSession(session sockjs.Session) {
 		return
 	}
 
-	if terminalSession, ok = terminalSessions[msg.SessionID]; !ok {
+	if terminalSession = terminalSessions.Get(msg.SessionID); terminalSession.id == "" {
 		log.Printf("handleTerminalSession: can't find session '%s'", msg.SessionID)
 		return
 	}
 
 	terminalSession.sockJSSession = session
-	terminalSessions[msg.SessionID] = terminalSession
+	terminalSessions.Set(msg.SessionID, terminalSession)
 	terminalSession.bound <- nil
 }
 
@@ -253,31 +274,31 @@ func WaitForTerminal(k8sClient kubernetes.Interface, cfg *rest.Config, request *
 	shell := request.QueryParameter("shell")
 
 	select {
-	case <-terminalSessions[sessionId].bound:
-		close(terminalSessions[sessionId].bound)
+	case <-terminalSessions.Get(sessionId).bound:
+		close(terminalSessions.Get(sessionId).bound)
 
 		var err error
 		validShells := []string{"bash", "sh", "powershell", "cmd"}
 
 		if isValidShell(validShells, shell) {
 			cmd := []string{shell}
-			err = startProcess(k8sClient, cfg, request, cmd, terminalSessions[sessionId])
+			err = startProcess(k8sClient, cfg, request, cmd, terminalSessions.Get(sessionId))
 		} else {
 			// No shell given or it was not valid: try some shells until one succeeds or all fail
 			// FIXME: if the first shell fails then the first keyboard event is lost
 			for _, testShell := range validShells {
 				cmd := []string{testShell}
-				if err = startProcess(k8sClient, cfg, request, cmd, terminalSessions[sessionId]); err == nil {
+				if err = startProcess(k8sClient, cfg, request, cmd, terminalSessions.Get(sessionId)); err == nil {
 					break
 				}
 			}
 		}
 
 		if err != nil {
-			terminalSessions[sessionId].Close(2, err.Error())
+			terminalSessions.Close(sessionId, 2, err.Error())
 			return
 		}
 
-		terminalSessions[sessionId].Close(1, "Process exited")
+		terminalSessions.Close(sessionId, 1, "Process exited")
 	}
 }


### PR DESCRIPTION
When there are simultaneously exec api calls, the dashboard may panic duo to current access to terminalSessions map.
Use a RWMutex to avoid this panic