### PR TITLE
Bump go version to 1.10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       - SAUCE_USERNAME=k8s-dashboard-ci
 
 before_script:
-  - eval "$(gimme 1.8.3)"
+  - eval "$(gimme 1.10.3)"
   - docker --version
 
 script:

--- a/build/gocommand.js
+++ b/build/gocommand.js
@@ -35,7 +35,7 @@ const env = lodash.merge(process.env, {GOPATH: sourceGopath, PATH: devPath});
 /**
  * Minimum required Go Version
  */
-const minGoVersion = '1.8.3';
+const minGoVersion = '1.10.3';
 
 /**
  * Spawns a Go process after making sure all Go prerequisites are

--- a/src/app/backend/integration/manager_test.go
+++ b/src/app/backend/integration/manager_test.go
@@ -58,14 +58,14 @@ func TestIntegrationManager_GetState(t *testing.T) {
 			"Server provided and using in-cluster heapster",
 			"http://127.0.0.1:8080", "", &api.IntegrationState{
 				Connected: false,
-				Error:     errors.New("Get http://127.0.0.1:8080/api/v1/namespaces/kube-system/services/heapster/proxy/healthz: dial tcp 127.0.0.1:8080: getsockopt: connection refused"),
+				Error:     errors.New("Get http://127.0.0.1:8080/api/v1/namespaces/kube-system/services/heapster/proxy/healthz: dial tcp 127.0.0.1:8080: connect: connection refused"),
 			}, nil,
 		},
 		{
 			"Server provided and using external heapster",
 			"http://127.0.0.1:8080", "http://127.0.0.1:8081", &api.IntegrationState{
 				Connected: false,
-				Error:     errors.New("Get http://127.0.0.1:8081/healthz: dial tcp 127.0.0.1:8081: getsockopt: connection refused"),
+				Error:     errors.New("Get http://127.0.0.1:8081/healthz: dial tcp 127.0.0.1:8081: connect: connection refused"),
 			}, nil,
 		},
 	}


### PR DESCRIPTION
We uses Ubuntu 16.04.5 image in CI, and the image uses go 1.10.3.
So we should bump up the go version on prerequisites by changing
minGoVersion constant and "Getting started" wiki.