### PR TITLE
Fix resource editor

### DIFF
--- a/src/app/frontend/common/components/textinput/component.ts
+++ b/src/app/frontend/common/components/textinput/component.ts
@@ -18,6 +18,7 @@ import 'brace/mode/json';
 import 'brace/mode/yaml';
 import 'brace/theme/idle_fingers';
 import 'brace/theme/textmate';
+import 'brace/worker/json';
 
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 

--- a/src/app/frontend/polyfills.ts
+++ b/src/app/frontend/polyfills.ts
@@ -33,3 +33,9 @@ import 'rxjs/Rx';
 
 // Needed for unit testing.
 import 'core-js/es7/reflect';
+
+/* tslint:disable */
+// Global variable is required by some 3rd party libraries such as 'ace-ui'.
+// It was removed in Angular 6.X, more info can be found here:
+// https://github.com/angular/angular-cli/issues/9827#issuecomment-369578814
+(window as any).global = window;


### PR DESCRIPTION
During YAML editing error was thrown whenever validation failed and dialog was unresponsive. Additionally, I have fixed worker support for JSON, so during editing, it will be showing lines that are not passing validation.