### PR TITLE
Fix FilterPodsForJob in backend

### DIFF
--- a/src/app/backend/resource/common/pod.go
+++ b/src/app/backend/resource/common/pod.go
@@ -46,12 +46,21 @@ func FilterPodsByControllerRef(owner metav1.Object, allPods []v1.Pod) []v1.Pod {
 	return matchingPods
 }
 
+// FilterPodsForJob returns a list of pods that matches to a job controller's selector
 func FilterPodsForJob(job batch.Job, pods []v1.Pod) []v1.Pod {
 	result := make([]v1.Pod, 0)
 	for _, pod := range pods {
-		if pod.Namespace == job.Namespace && pod.Labels["controller-uid"] ==
-			job.Spec.Selector.MatchLabels["controller-uid"] {
-			result = append(result, pod)
+		if pod.Namespace == job.Namespace {
+			selectorMatch := true
+			for key, value := range job.Spec.Selector.MatchLabels {
+				if pod.Labels[key] != value {
+					selectorMatch = false
+					break
+				}
+			}
+			if selectorMatch {
+				result = append(result, pod)
+			}
 		}
 	}
 

--- a/src/app/backend/resource/job/list_test.go
+++ b/src/app/backend/resource/job/list_test.go
@@ -126,6 +126,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					{
 						ObjectMeta: metaV1.ObjectMeta{
 							Namespace: "rs-namespace",
+							Labels:	   map[string]string{"foo": "bar"},
 							OwnerReferences: []metaV1.OwnerReference{
 								{
 									Name:       "rs-name",
@@ -166,7 +167,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  &completions,
-						Failed:   2,
+						Failed:   1,
 						Warnings: []common.Event{},
 					},
 					JobStatus: JobStatus{
@@ -183,7 +184,7 @@ func TestGetJobListFromChannels(t *testing.T) {
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  &completions,
-						Failed:   2,
+						Failed:   1,
 						Warnings: []common.Event{},
 					},
 					JobStatus: JobStatus{


### PR DESCRIPTION
The current implementation `FilterPodsForJob` in backend assumes the job controller uses automatically generated selector, which doesn't work if `manualSelector: true`.
This commit implements the `MatchLabels` expression in job controller `Selector` and fixes the issue.