### PR TITLE
Reverted mixup of ARM and AMD64 version of dashboard deployment manifest

### DIFF
--- a/aio/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/aio/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -90,7 +90,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard

--- a/aio/deploy/recommended/kubernetes-dashboard-arm.yaml
+++ b/aio/deploy/recommended/kubernetes-dashboard-arm.yaml
@@ -70,6 +70,7 @@ rules:
   resources: ["services/proxy"]
   resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
   verbs: ["get"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -89,7 +90,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
@@ -108,7 +109,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        image: k8s.gcr.io/kubernetes-dashboard-arm:v1.10.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/aio/deploy/recommended/kubernetes-dashboard.yaml
+++ b/aio/deploy/recommended/kubernetes-dashboard.yaml
@@ -70,7 +70,7 @@ rules:
   resources: ["services/proxy"]
   resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
   verbs: ["get"]
-  
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/aio/deploy/recommended/kubernetes-dashboard.yaml
+++ b/aio/deploy/recommended/kubernetes-dashboard.yaml
@@ -70,7 +70,6 @@ rules:
   resources: ["services/proxy"]
   resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
   verbs: ["get"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -90,7 +89,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
@@ -109,7 +108,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-arm:v1.10.1
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/aio/deploy/recommended/kubernetes-dashboard.yaml
+++ b/aio/deploy/recommended/kubernetes-dashboard.yaml
@@ -70,6 +70,7 @@ rules:
   resources: ["services/proxy"]
   resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
   verbs: ["get"]
+  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Apparently something went wrong in https://github.com/kubernetes/dashboard/commit/7c73bacd64d5fc1e80561d355a4e0dd3c33f984b, as the ARM and AMD64 version were mixed up. This PR fixes that.