### PR TITLE
Fix styling

### DIFF
--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -272,6 +272,6 @@
   }
 
   .mat-drawer-side {
-    border-right: none;
+    border-right: 0;
   }
 }

--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 @import '~@angular/material/theming';
 
 @mixin kd-theme($theme) {

--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 @import '~@angular/material/theming';
 
 @mixin kd-theme($theme) {
@@ -58,6 +57,15 @@
   * {
     &::-webkit-scrollbar-thumb {
       background-color: $border;
+    }
+
+    // Only show the scrollbar on hover, but always enable scrolling.
+    .kd-nav {
+      & > *:not(:hover) {
+        &::-webkit-scrollbar-thumb {
+          background-color: transparent !important;
+        }
+      }
     }
   }
 
@@ -260,5 +268,9 @@
         color: mat-color($primary-palette, lighter);
       }
     }
+  }
+
+  .mat-drawer-side {
+    border-right: none;
   }
 }

--- a/src/app/frontend/chrome/nav/style.scss
+++ b/src/app/frontend/chrome/nav/style.scss
@@ -26,13 +26,6 @@
     margin: $baseline-grid $baseline-grid (2 * $baseline-grid) 0;
   }
 
-  // Only show the scrollbar on hover, but always enable scrolling.
-  &:not(:hover) {
-    &::-webkit-scrollbar-thumb {
-      background-color: transparent;
-    }
-  }
-
   // Children of kd-nav should not shrink to prevent layout issues on IE.
   & > * {
     flex-shrink: 0;

--- a/src/app/frontend/common/components/chips/template.html
+++ b/src/app/frontend/common/components/chips/template.html
@@ -16,15 +16,15 @@ limitations under the License.
 
 <mat-chip-list>
   <ng-container *ngFor="let key of keys; let i = index">
-    <mat-chip *ngIf="isVisible(i)">
-
+    <mat-chip *ngIf="isVisible(i)"
+              [disableRipple]="true">
       <ng-container *ngIf="isTooLong(map[key])">
-        <a href
+        <a class="kd-clickable"
            (click)="openChipDialog(key, map[key])">{{key}}</a>
       </ng-container>
 
       <ng-container *ngIf="!isTooLong(map[key])">
-        <span>
+        <ng-container>
           {{key}}
           <ng-container *ngIf="map[key]">:&nbsp;</ng-container>
           <ng-container *ngIf="map[key]">
@@ -36,7 +36,7 @@ limitations under the License.
             </ng-container>
             <ng-container *ngIf="!isHref(map[key])">{{map[key]}}</ng-container>
           </ng-container>
-        </span>
+        </ng-container>
       </ng-container>
 
     </mat-chip>
@@ -45,9 +45,10 @@ limitations under the License.
             (click)="toggleView()"
             color="primary"
             class="kd-clickable"
-            [selected]="true">
-    <span *ngIf="isShowingAll">Show less</span>
-    <span *ngIf="!isShowingAll">Show all</span>
+            [selected]="true"
+            [disableRipple]="true">
+    <ng-container *ngIf="isShowingAll">Show less</ng-container>
+    <ng-container *ngIf="!isShowingAll">Show all</ng-container>
   </mat-chip>
-  <span *ngIf="keys.length === 0">-</span>
+  <ng-container *ngIf="keys.length === 0">-</ng-container>
 </mat-chip-list>

--- a/src/app/frontend/index.scss
+++ b/src/app/frontend/index.scss
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 @import './dark';
 @import './light';

--- a/src/app/frontend/index.scss
+++ b/src/app/frontend/index.scss
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 @import './dark';
 @import './light';
@@ -74,7 +73,19 @@ code {
 .mat-chip {
   box-shadow: none !important;
   font-weight: $regular-font-weight;
+  height: fit-content !important;
   transition: none !important;
+  word-break: break-all !important;
+}
+
+.mat-standard-chip {
+  &:hover::after {
+    opacity: 0 !important;
+  }
+
+  &:focus::after {
+    opacity: 0 !important;
+  }
 }
 
 .mat-header-row,


### PR DESCRIPTION
A couple of styling fixes that came up:
 - chip opacity was changing on hover (disabled)
 - when clicking on a chip it was selected and its' color was changing (fixed)
 - when clicking on a chip that was supposed to open a dialog, the user was redirected to a default view (fixed)
 - scrollbar on navbar was visible at all times (now only on hover)