### PR TITLE
Bash script syntax improvements

### DIFF
--- a/aio/scripts/build.sh
+++ b/aio/scripts/build.sh
@@ -130,5 +130,5 @@ copy::supported-locales
 copy::dockerfile
 
 END=$(date +%s.%N)
-TOOK=$(echo "$END - $START" | bc)
+TOOK=$(echo "${END} - ${START}" | bc)
 say "\nBuild finished successfully after ${TOOK}s"

--- a/aio/scripts/start-cluster.sh
+++ b/aio/scripts/start-cluster.sh
@@ -31,8 +31,8 @@ function download-minikube {
 
 function ensure-kubeconfig {
   say "\nMaking sure that kubeconfig file exists and will be used by Dashboard"
-  mkdir -p $HOME/.kube
-  touch $HOME/.kube/config
+  mkdir -p ${HOME}/.kube
+  touch ${HOME}/.kube/config
 }
 
 function configure-minikube {
@@ -59,7 +59,7 @@ function start-ci-heapster {
   for i in {1..150}
   do
     HEAPSTER_STATUS=$(curl -sb -H "Accept: application/json" "127.0.0.1:${HEAPSTER_PORT}/healthz")
-    if [ "$HEAPSTER_STATUS" == "ok" ]; then
+    if [ "${HEAPSTER_STATUS}" == "ok" ]; then
       break
     fi
     sleep 2


### PR DESCRIPTION
Updated the bash scripts variable usage to use `"${foo}"` instead of `$foo`.
Related to https://github.com/kubernetes/kubernetes/issues/73082

https://wiki.bash-hackers.org/syntax/pe#simple_usage