### PR TITLE
Add Metrics Scaper object definitions

### DIFF
--- a/src/app/backend/integration/metric/api/types.go
+++ b/src/app/backend/integration/metric/api/types.go
@@ -164,6 +164,36 @@ type Metric struct {
 	Aggregate AggregationMode `json:"aggregation,omitempty"`
 }
 
+// SidecarMetric is a format of data used by our sidecar. This is also the format of data that is being sent by backend API.
+type SidecarMetric struct {
+	// DataPoints is a list of X, Y int64 data points, sorted by X.
+	DataPoints `json:"dataPoints"`
+	// MetricPoints is a list of value, timestamp metrics used for sparklines on a pod list page.
+	MetricPoints []MetricPoint `json:"metricPoints"`
+	// MetricName is the name of metric stored in this struct.
+	MetricName string `json:"metricName"`
+	// Label stores information about identity of resources (UIDS) described by this metric.
+	UIDs []string `json:"uids"`
+}
+
+type SidecarMetricResultList struct {
+	Items []SidecarMetric `json:"items"`
+}
+
+type MetricResultList struct {
+	Items []Metric `json:"items"`
+}
+
+func (metric *SidecarMetric) AddMetricPoint(item MetricPoint) []MetricPoint {
+	metric.MetricPoints = append(metric.MetricPoints, item)
+	return metric.MetricPoints
+}
+
+func (metric *Metric) AddMetricPoint(item MetricPoint) []MetricPoint {
+	metric.MetricPoints = append(metric.MetricPoints, item)
+	return metric.MetricPoints
+}
+
 // String implements stringer interface to allow easy printing
 func (self Metric) String() string {
 	return "{\nDataPoints: " + fmt.Sprintf("%v", self.DataPoints) +


### PR DESCRIPTION
This is an interim PR to add the object definitions required for the Dashboard Scraper integration. This needs to be merged in before the rest of the WIP PR so work can proceed finishing the Scraper container (as the Scraper calls on and requires these definition) 

