### PR TITLE
Remove "mijajasinksi" from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,7 +9,6 @@ aliases:
     - konryd
     - ianlewis
     - cupofcat
-    - mijajasinksi
     - bryk
     - floreks
     - maciaszczykm


### PR DESCRIPTION
It's not a valid GitHub account.... o_O Doing updates to our group membership in k/org and this was discovered. 