### PR TITLE
Show light-colored scrollbar in dark logs mode

### DIFF
--- a/src/app/frontend/logs/style.scss
+++ b/src/app/frontend/logs/style.scss
@@ -40,6 +40,10 @@ $content-background: #fff;
 .kd-logs-text-color-invert {
   background-color: $logs-color-black;
   color: $logs-color-white;
+
+  ::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.5);
+  }
 }
 
 .kd-logs-text-color {
@@ -149,6 +153,7 @@ $content-background: #fff;
   position: absolute;
   right: 0;
   top: 57px;
+  background-color: inherit;
 }
 
 .kd-virtual-repeat-sizer {

--- a/src/app/frontend/logs/style.scss
+++ b/src/app/frontend/logs/style.scss
@@ -21,6 +21,8 @@ $logs-color-white: #fff;
 $emphasis: #000;
 $content-background: #fff;
 
+$scrollbar-color-light: rgba(255, 255, 255, .5);
+
 .kd-logs-header-text {
   line-height: $baseline-grid * 5.25;
   white-space: nowrap;
@@ -42,7 +44,7 @@ $content-background: #fff;
   color: $logs-color-white;
 
   ::-webkit-scrollbar-thumb {
-    background-color: rgba(255, 255, 255, 0.5);
+    background-color: $scrollbar-color-light;
   }
 }
 
@@ -144,6 +146,7 @@ $content-background: #fff;
 
 .kd-log-view-container {
   -webkit-overflow-scrolling: touch;
+  background-color: inherit;
   bottom: 50px;
   box-sizing: border-box;
   left: 0;
@@ -153,7 +156,6 @@ $content-background: #fff;
   position: absolute;
   right: 0;
   top: 57px;
-  background-color: inherit;
 }
 
 .kd-virtual-repeat-sizer {

--- a/src/app/frontend/logs/template.html
+++ b/src/app/frontend/logs/template.html
@@ -104,11 +104,11 @@ limitations under the License.
     </div>
 
     <div content
-         class="kd-log-view">
+         class="kd-log-view"
+         [ngClass]="{'kd-logs-text-color-invert': logService?.getInverted(), 'kd-logs-text-color': !logService?.getInverted()}">
       <div kdLoadingSpinner
            [isLoading]="isLoading"></div>
-      <div class="kd-log-view-container"
-           [ngClass]="{'kd-logs-text-color-invert': logService?.getInverted(), 'kd-logs-text-color': !logService?.getInverted()}">
+      <div class="kd-log-view-container">
         <div class="kd-virtual-repeat-sizer"></div>
         <div *ngFor="let item of logsSet"
              class="kd-logs-element"


### PR DESCRIPTION
This PR updates the Logs viewer to show a light-colored scrollbar in inverted (dark) mode.
Fixes #3557

![ezgif-5-f2f3c2a4ebd1](https://user-images.githubusercontent.com/11166933/52522435-b0cce000-2c85-11e9-8d8e-992a130ac8e3.gif)