### PR TITLE
Added tooltip for Timestamp icon on Logs page

### DIFF
--- a/src/app/frontend/logs/template.html
+++ b/src/app/frontend/logs/template.html
@@ -64,7 +64,7 @@ limitations under the License.
           'kd-logs-size-icon': !logService.getCompact()}">text_fields</mat-icon>
         </button>
         <button mat-icon-button
-                matTooltip="Show timestamp"
+                matTooltip="Show timestamps"
                 (click)="onShowTimestamp()">
           <mat-icon>{{logService.getShowTimestamp() ? 'timer' : 'timer_off'}}</mat-icon>
         </button>

--- a/src/app/frontend/logs/template.html
+++ b/src/app/frontend/logs/template.html
@@ -64,6 +64,7 @@ limitations under the License.
           'kd-logs-size-icon': !logService.getCompact()}">text_fields</mat-icon>
         </button>
         <button mat-icon-button
+                matTooltip="Show timestamp"
                 (click)="onShowTimestamp()">
           <mat-icon>{{logService.getShowTimestamp() ? 'timer' : 'timer_off'}}</mat-icon>
         </button>


### PR DESCRIPTION
This PR adds a tooltip to the 'Show Timestamp' button on the logs page.
Accessibility fix.