### PR TITLE
[Angular Migration] - Add HPA to deployment details page

### DIFF
--- a/src/app/frontend/common/components/horizontalpodautoscalers/component.ts
+++ b/src/app/frontend/common/components/horizontalpodautoscalers/component.ts
@@ -1,0 +1,65 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HttpParams} from '@angular/common/http';
+import {Component, ComponentFactoryResolver, Input} from '@angular/core';
+import {HorizontalPodAutoscaler, HorizontalPodAutoscalerList} from '@api/backendapi';
+import {StateService} from '@uirouter/core';
+import {Observable} from 'rxjs/Observable';
+
+import {deploymentState} from '../../../resource/workloads/deployment/state';
+import {ResourceListBase} from '../../resources/list';
+import {NamespaceService} from '../../services/global/namespace';
+import {NotificationsService} from '../../services/global/notifications';
+import {EndpointManager, Resource} from '../../services/resource/endpoint';
+import {NamespacedResourceService} from '../../services/resource/resource';
+import {ResourceService} from '../../services/resource/resource';
+import {MenuComponent} from '../list/column/menu/component';
+import {ListGroupIdentifiers, ListIdentifiers} from '../resourcelist/groupids';
+
+@Component({
+  selector: 'kd-horizontalpodautoscalers-list',
+  templateUrl: './template.html',
+})
+
+export class HorizontalPodAutoscalerListComponent extends
+    ResourceListBase<HorizontalPodAutoscalerList, HorizontalPodAutoscaler> {
+  @Input() endpoint = EndpointManager.resource(Resource.horizontalpodautoscaler, true).list();
+
+  constructor(
+      state: StateService,
+      private readonly horizontalpodautoscalerList: ResourceService<HorizontalPodAutoscalerList>,
+      notifications: NotificationsService) {
+    super(deploymentState.name, state, notifications);
+    this.id = ListIdentifiers.horizontalPodAutoScaler;
+    this.groupId = ListGroupIdentifiers.workloads;
+
+    this.registerActionColumn<MenuComponent>('menu', MenuComponent);
+  }
+
+  getResourceObservable(params?: HttpParams): Observable<HorizontalPodAutoscalerList> {
+    return this.horizontalpodautoscalerList.get(this.endpoint, undefined, params);
+  }
+
+  map(horizontalpodautoscalerList: HorizontalPodAutoscalerList): HorizontalPodAutoscaler[] {
+    return horizontalpodautoscalerList.horizontalpodautoscalers;
+  }
+
+  getDisplayColumns(): string[] {
+    return [
+      'name', 'namespace', 'creationTimestamp', 'minReplicas', 'maxReplicas',
+      'currentCPUUtilizationPercentage', 'targetCPUUtilizationPercentage'
+    ];
+  }
+}

--- a/src/app/frontend/common/components/horizontalpodautoscalers/template.html
+++ b/src/app/frontend/common/components/horizontalpodautoscalers/template.html
@@ -1,0 +1,30 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-card role="table" [hidden]="isHidden()">
+	<div title fxLayout="row">Horizontal Pod Autoscaler</div>
+	<div actions>
+		<kd-card-list-filter></kd-card-list-filter>
+	</div>
+
+	<div content [hidden]="showZeroState()">
+		<div kdLoadingSpinner [isLoading]="isLoading"></div>
+	</div>
+
+	<div content>
+    <kd-list-zero-state></kd-list-zero-state>
+  </div>
+</kd-card>

--- a/src/app/frontend/common/components/module.ts
+++ b/src/app/frontend/common/components/module.ts
@@ -43,6 +43,7 @@ import {EndpointListComponent} from './endpoint/cardlist/component';
 import {ExternalEndpointComponent} from './endpoint/external/component';
 import {InternalEndpointComponent} from './endpoint/internal/component';
 import {HiddenPropertyComponent} from './hiddenproperty/component';
+import {HorizontalPodAutoscalerListComponent} from './horizontalpodautoscalers/component';
 import {ResourceLimitListComponent} from './limits/component';
 import {ColumnComponent} from './list/column/component';
 import {MenuComponent} from './list/column/menu/component';
@@ -129,6 +130,7 @@ import {ZeroStateComponent} from './zerostate/component';
     EventListComponent,
     ContainerCardComponent,
     ConditionListComponent,
+    HorizontalPodAutoscalerListComponent,
     CreatorCardComponent,
     PodStatusCardComponent,
     NamespaceSelectorComponent,
@@ -193,6 +195,7 @@ import {ZeroStateComponent} from './zerostate/component';
     EventListComponent,
     ContainerCardComponent,
     ConditionListComponent,
+    HorizontalPodAutoscalerListComponent,
     CreatorCardComponent,
     PodStatusCardComponent,
     NamespaceSelectorComponent,

--- a/src/app/frontend/common/components/resourcelist/groupids.ts
+++ b/src/app/frontend/common/components/resourcelist/groupids.ts
@@ -33,6 +33,7 @@ export enum ListIdentifiers {
   statefulSet = 'statefulSetList',
   event = 'event',
   resource = 'resource',
+  horizontalPodAutoScaler = 'horizontalPodAutoScalerList',
 }
 
 export enum ListGroupIdentifiers {

--- a/src/app/frontend/common/services/resource/endpoint.ts
+++ b/src/app/frontend/common/services/resource/endpoint.ts
@@ -37,6 +37,7 @@ export enum Resource {
   event = 'event',
   container = 'container',
   shell = 'shell',
+  horizontalpodautoscaler = 'horizontalpodautoscaler',
 }
 
 class ResourceEndpoint {

--- a/src/app/frontend/resource/workloads/deployment/detail/template.html
+++ b/src/app/frontend/resource/workloads/deployment/detail/template.html
@@ -235,6 +235,8 @@ limitations under the License.
   </div>
 </kd-card>
 
+<kd-horizontalpodautoscalers-list></kd-horizontalpodautoscalers-list>
+
 <kd-replica-set-list [endpoint]="oldReplicaSetsEndpoint"
                      title="Old Replica Sets"></kd-replica-set-list>
 

--- a/src/app/frontend/typings/backendapi.d.ts
+++ b/src/app/frontend/typings/backendapi.d.ts
@@ -357,6 +357,7 @@ export interface DeploymentDetail extends ResourceDetail {
   revisionHistoryLimit?: number;
   rollingUpdateStrategy?: RollingUpdateStrategy;
   oldReplicaSetList: ReplicaSetList;
+  horizontalpodautoscalers: HorizontalPodAutoscalerList[];
   newReplicaSet: ReplicaSet;
   events: EventList;
 }


### PR DESCRIPTION
Added Horizontal Pod Autoscalers to the deployment details page.  Ref - #3440 

<img width="1424" alt="screen shot 1940-11-23 at 1 59 34 pm" src="https://user-images.githubusercontent.com/6227784/52622005-c7b24300-2ece-11e9-9c4d-aecbe29196a6.png">

Checklist/TODO

- [ ] Verify the required fields to be displayed under HPA
- [ ] Add HPA under the replica sets details page as well
- [ ] Null check: Should we still display the placeholder even if there are no HPA lists for a pod. 
- [ ] Add tests if any 

@maciaszczykm 