### PR TITLE
Let's not lint the whole k/* directory :)

### DIFF
--- a/aio/scripts/lint-backend.sh
+++ b/aio/scripts/lint-backend.sh
@@ -26,7 +26,7 @@ if [ ! -f ${GOLINT_BIN} ]; then
 fi
 
 # Run checks.
-${GOLINT_BIN} run ../... \
+${GOLINT_BIN} run ./... \
   --no-config \
   --issues-exit-code=0 \
   --deadline=30m \


### PR DESCRIPTION
While I was diving into @shu-mutou's PR #3315 I noticed our golint job runs on the whole k/* directory.

This changes it to only run on the Dashboard's folder. :)