### PR TITLE
Use blue as primary color for dark theme

### DIFF
--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -18,12 +18,12 @@
 $kd-dark-palette-primary: (
   50: #fff, // Primary toolbar buttons.
   100: #fff,
-  200: #d47f16,
+  200: #326de6,
   300: #9575cd,
   400: #7e57c2,
-  500: #d47f16,
+  500: #326de6,
   600: #5e35b1,
-  700: #d47f16,
+  700: #326de6,
   800: #4527a0,
   900: #311b92,
   A100: #b388ff,


### PR DESCRIPTION
<img width="1829" alt="zrzut ekranu 2019-02-21 o 13 01 20" src="https://user-images.githubusercontent.com/2823399/53167722-15b6fd00-35d9-11e9-8d39-fe35b1b42bec.png">

It is my proposal to close #3418 and #3176.