### PR TITLE
Bump golangci-lint to 1.15.0 and add go linter for pre-commit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+# golangci-lint configuration file.
+# Read more at: https://github.com/golangci/golangci-lint#config-file
+
+run:
+  deadline: 30m
+  issues-exit-code: 1
+  tests: true
+linters:
+  disable-all: true
+  enable:
+    - gocyclo
+    - goimports
+    - govet
+    - ineffassign
+    - misspell

--- a/aio/scripts/lint-backend.sh
+++ b/aio/scripts/lint-backend.sh
@@ -22,7 +22,7 @@ ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
 
 # Make sure that all required tools are available.
 if [ ! -f ${GOLINT_BIN} ]; then
-    curl -sfL ${GOLINT_URL} | sh -s -- -b ${CACHE_DIR} v1.12.3
+    curl -sfL ${GOLINT_URL} | sh -s -- -b ${CACHE_DIR} v1.15.0
 fi
 
 # Need to check source files under GOPATH
@@ -31,12 +31,4 @@ if [ ${TRAVIS} ]; then
 fi
 
 # Run checks.
-${GOLINT_BIN} run ./... \
-  --no-config \
-  --deadline=30m \
-  --disable-all \
-  --enable=govet \
-  --enable=gocyclo \
-  --enable=misspell \
-  --enable=ineffassign \
-  --enable=goimports
+${GOLINT_BIN} run -c ${ROOT_DIR}/.golangci.yml ./...

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check:frontend:html": "./aio/scripts/format.sh --html --check",
     "check:license": "gulp check-license-headers",
     "fix": "concurrently \"npm run fix:backend\" \"npm run fix:frontend\" \"npm run fix:license\"",
-    "fix:backend": "goimports -w src/app/backend",
+    "fix:backend": "golangci-lint run -c .golangci.yml --fix src/app/backend/...",
     "fix:frontend": "concurrently \"npm run fix:frontend:ts\" \"npm run fix:frontend:scss\" \"npm run fix:frontend:html\"",
     "fix:frontend:ts": "gts fix",
     "fix:frontend:scss": "scssfmt -r 'src/**/*.scss'",
@@ -49,7 +49,7 @@
     "fix:license": "gulp update-license-headers",
     "clean": "rm -rf .go_workspace .tmp coverage dist npm-debug.log",
     "postversion": "node aio/scripts/version.js",
-    "postinstall": "node aio/scripts/version.js && ./node_modules/protractor/bin/webdriver-manager update --gecko=false && go get golang.org/x/tools/cmd/goimports"
+    "postinstall": "node aio/scripts/version.js && ./node_modules/protractor/bin/webdriver-manager update --gecko=false"
   },
   "husky": {
     "hooks": {
@@ -63,6 +63,10 @@
     ],
     "src/**/*.scss": [
       "scssfmt",
+      "git add"
+    ],
+    "src/**/*.go": [
+      "golangci-lint run -c .golangci.yml --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
Newly added auto-fix feature for goimports into golangci-lint 1.15.0.
So we can use this for fixing go format in our tasks, i.e. pre-commit, check:backend and fix:backend.

Also, added config file for golangci-lint as `.golangci.yml`.

Standalone goimports installation was removed in favor of this.