### PR TITLE
Remove `golangci-lint` temporarily from `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,6 @@
     "src/**/*.scss": [
       "scssfmt",
       "git add"
-    ],
-    "src/**/*.go": [
-      "golangci-lint run -c .golangci.yml --fix",
-      "git add"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
`golangci-lint` in `lint-staged` does not work as we expected
due to its strage behavior (maybe bug in golangci-lint).
Not to block development, this removes `golangci-lint` temporarily
from `lint-staged` until we understand its behavior perfectly.

Observations will be tracked by #3656.