### PR TITLE
Enable `golangci-lint` in `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "src/**/*.scss": [
       "scssfmt",
       "git add"
+    ],
+    "src/**/*.go": [
+      "golangci-lint run -c .golangci.yml --fix src/app/backend/...",
+      "git add"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
`golangci-lint` on `lint-staged` does not work as we expected and their documents.
Fixed to work them by observations of their actual behavior.

Fixes #3656