### PR TITLE
Improve container for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage/
 
 # npm debug log:
 npm-debug.log
+
+# kubeconfig for cluster made by kind
+kind.kubeconfig*

--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -25,9 +25,11 @@ FROM golang
 # so there's no need to run it again.
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
   && apt-get install -y --no-install-recommends \
+	openjdk-8-jre \
 	nodejs \
 	patch \
 	chromium \
+	bc \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean
 
@@ -48,8 +50,19 @@ ENV K8S_DASHBOARD_CONTAINER=TRUE
 
 # Download a statically linked docker client,
 # so the container is able to build images on the host.
-RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
+RUN curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz > /tmp/docker.tgz && \
+	cd /tmp/ && \
+	tar xzvf docker.tgz && \
+	rm docker.tgz && \
+	mv /tmp/docker/docker /usr/bin/docker && \
+	rm -rf /tmp/docker/ && \
 	chmod +x /usr/bin/docker
+
+# Install golangci for ckecking or fixing go format.
+# `npm ci` installs golangci, but this installation is needed
+# for running `npm run check` singlely, like
+# `aio/develop/run-npm-on-container.sh run check`.
+RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # Install delve for debuging go files.
 RUN go get github.com/derekparker/delve/cmd/dlv

--- a/aio/develop/npm-command.sh
+++ b/aio/develop/npm-command.sh
@@ -24,6 +24,20 @@ else
   # Install dashboard.
   echo "Install dashboard"
   npm ci --unsafe-perm
+  if [[ "${K8S_OWN_CLUSTER}" != true ]] ; then
+    # Stop cluster.
+    echo "Stop cluster"
+    npm run cluster:stop
+    # Start cluster.
+    echo "Start cluster"
+    npm run cluster:start
+    # Edit kubeconfig for kind
+    KIND_CONTAINER_NAME="k8s-cluster-ci-control-plane"
+    KIND_ADDR=$(docker inspect -f='{{.NetworkSettings.IPAddress}}' ${KIND_CONTAINER_NAME})
+    sed -e "s/localhost:[0-9]\+/${KIND_ADDR}:6443/g" kind.kubeconfig > kind.kubeconfig.new
+    cat kind.kubeconfig.new > kind.kubeconfig
+    rm -f kind.kubeconfig.new
+  fi
   # Start dashboard.
   echo "Start dashboard"
   npm start

--- a/aio/protractor.conf.js
+++ b/aio/protractor.conf.js
@@ -58,7 +58,7 @@ function createConfig() {
   } else {
     config.capabilities = {
       'browserName': 'chrome',
-      'chromeOptions': {'args': ['--headless', '--disable-gpu', '--window-size=800,600']},
+      'chromeOptions': {'args': ['--headless', '--disable-gpu', '--no-sandbox', '--window-size=800,600']},
     };
   }
 

--- a/aio/scripts/conf.sh
+++ b/aio/scripts/conf.sh
@@ -54,3 +54,30 @@ RESET_STYLE=`tput sgr0`
 
 function say { echo -e "${INFO_STYLE}${BOLD_STYLE}$@${RESET_STYLE}"; }
 function saye { echo -e "${ERROR_STYLE}${BOLD_STYLE}$@${RESET_STYLE}"; }
+
+function ensure-cache {
+  say "\nMaking sure that ${CACHE_DIR} directory exists"
+  mkdir -p ${CACHE_DIR}
+}
+
+function download-kind {
+  KIND_URL="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${ARCH}-amd64"
+  say "\nDownloading kind ${KIND_URL} if it is not cached"
+  wget -nc -O ${KIND_BIN} ${KIND_URL}
+  chmod +x ${KIND_BIN}
+  ${KIND_BIN} version
+}
+
+function ensure-kubeconfig {
+  say "\nMaking sure that kubeconfig file exists and will be used by Dashboard"
+  mkdir -p ${HOME}/.kube
+  touch ${HOME}/.kube/config
+
+  # Let's back up the kubeconfig so we don't totally blow it away
+  # I learned from personal experience. It made me sad. :(
+  # ${HOME}/.kube/config is mounted in container for development,
+  # so we can not `mv` or `rm` it.
+  cp ${HOME}/.kube/config ${HOME}/.kube/config-unkind
+
+  cat $(${KIND_BIN} get kubeconfig-path --name="k8s-cluster-ci") > $HOME/.kube/config
+}

--- a/aio/scripts/start-cluster.sh
+++ b/aio/scripts/start-cluster.sh
@@ -17,31 +17,6 @@
 ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
 . "${ROOT_DIR}/aio/scripts/conf.sh"
 
-function ensure-cache {
-  say "\nMaking sure that ${CACHE_DIR} directory exists"
-  mkdir -p ${CACHE_DIR}
-}
-
-function download-kind {
-  KIND_URL="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${ARCH}-amd64"
-  say "\nDownloading kind ${KIND_URL} if it is not cached"
-  wget -nc -O ${KIND_BIN} ${KIND_URL}
-  chmod +x ${KIND_BIN}
-  ${KIND_BIN} version
-}
-
-function ensure-kubeconfig {
-  say "\nMaking sure that kubeconfig file exists and will be used by Dashboard"
-  mkdir -p ${HOME}/.kube
-  touch ${HOME}/.kube/config
-
-  # Let's back up the kubeconfig so we don't totally blow it away
-  # I learned from personal experience. It made me sad. :(
-  mv ${HOME}/.kube/config ${HOME}/.kube/config-unkind 
-  
-  cat $(${KIND_BIN} get kubeconfig-path --name="k8s-cluster-ci") > $HOME/.kube/config
-}
-
 function start-ci-heapster {
   say "\nRunning heapster in standalone mode"
   docker run --net=host -d k8s.gcr.io/heapster-amd64:${HEAPSTER_VERSION} \

--- a/aio/scripts/stop-cluster.sh
+++ b/aio/scripts/stop-cluster.sh
@@ -1,7 +1,30 @@
-. "./aio/scripts/conf.sh"
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Import config.
+ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
+. "${ROOT_DIR}/aio/scripts/conf.sh"
+
+ensure-cache
+download-kind
 
 ${KIND_BIN} delete cluster --name="k8s-cluster-ci"
 
 # Restore the original kubeconfig and all's right
 # with the world.
-mv ${HOME}/.kube/config-unkind ${HOME}/.kube/config
+# ${HOME}/.kube/config is mounted in container for development,
+# so we can not `mv` or `rm` it.
+cat ${HOME}/.kube/config-unkind > ${HOME}/.kube/config
+rm -f ${HOME}/.kube/config-unkind


### PR DESCRIPTION
Setting up environment inside container and enabling to run more npm commands for dashboard.

Also, changed default command for the container from only `npm start` to `npm run cluster:start` before start. It means this script creates k8s cluster in another container using `kind`, so we don't need to install k8s cluster independently before running dashboard.

Enabled npm commands are follows:
* build
* test:e2e
* cluster:start
* cluster:stop