### PR TITLE
Use settingsApi.SettingsManager in CreateHTTPAPIHandler

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -108,7 +108,7 @@ func main() {
 	authManager := initAuthManager(clientManager)
 
 	// Init settings manager
-	settingsManager := settings.NewSettingsManager(clientManager)
+	settingsManager := settings.NewSettingsManager()
 
 	// Init system banner manager
 	systemBannerManager := systembanner.NewSystemBannerManager(args.Holder.GetSystemBanner(),

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -56,6 +56,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/storageclass"
 	"github.com/kubernetes/dashboard/src/app/backend/scaling"
 	"github.com/kubernetes/dashboard/src/app/backend/settings"
+	settingsApi "github.com/kubernetes/dashboard/src/app/backend/settings/api"
 	"github.com/kubernetes/dashboard/src/app/backend/systembanner"
 	"github.com/kubernetes/dashboard/src/app/backend/validation"
 	"golang.org/x/net/xsrftoken"
@@ -85,7 +86,7 @@ type TerminalResponse struct {
 
 // CreateHTTPAPIHandler creates a new HTTP handler that handles all requests to the API of the backend.
 func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clientapi.ClientManager,
-	authManager authApi.AuthManager, sManager settings.SettingsManager,
+	authManager authApi.AuthManager, sManager settingsApi.SettingsManager,
 	sbManager systembanner.SystemBannerManager) (
 
 	http.Handler, error) {
@@ -108,7 +109,7 @@ func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clie
 	authHandler := auth.NewAuthHandler(authManager)
 	authHandler.Install(apiV1Ws)
 
-	settingsHandler := settings.NewSettingsHandler(sManager)
+	settingsHandler := settings.NewSettingsHandler(sManager, cManager)
 	settingsHandler.Install(apiV1Ws)
 
 	systemBannerHandler := systembanner.NewSystemBannerHandler(sbManager)

--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -45,7 +45,7 @@ func getTokenManager() authApi.TokenManager {
 func TestCreateHTTPAPIHandler(t *testing.T) {
 	cManager := client.NewClientManager("", "http://localhost:8080")
 	authManager := auth.NewAuthManager(cManager, getTokenManager(), authApi.AuthenticationModes{}, true)
-	sManager := settings.NewSettingsManager(cManager)
+	sManager := settings.NewSettingsManager()
 	sbManager := systembanner.NewSystemBannerManager("Hello world!", "INFO")
 	_, err := CreateHTTPAPIHandler(nil, cManager, authManager, sManager, sbManager)
 	if err != nil {

--- a/src/app/backend/settings/api/types.go
+++ b/src/app/backend/settings/api/types.go
@@ -43,9 +43,9 @@ const (
 // SettingsManager is used for user settings management.
 type SettingsManager interface {
 	// GetGlobalSettings gets current global settings from config map.
-	GetGlobalSettings(client kubernetes.Interface) (s *Settings)
+	GetGlobalSettings(client kubernetes.Interface) (s Settings)
 	// SaveGlobalSettings saves provided global settings in config map.
-	SaveGlobalSettings(client kubernetes.Interface, s *Settings)
+	SaveGlobalSettings(client kubernetes.Interface, s *Settings) error
 }
 
 // Settings is a single instance of settings without context.

--- a/src/app/backend/settings/handler.go
+++ b/src/app/backend/settings/handler.go
@@ -26,7 +26,8 @@ import (
 
 // SettingsHandler manages all endpoints related to settings management.
 type SettingsHandler struct {
-	manager SettingsManager
+	manager       api.SettingsManager
+	clientManager clientapi.ClientManager
 }
 
 // Install creates new endpoints for settings management.
@@ -51,7 +52,7 @@ func (self *SettingsHandler) handleSettingsGlobalCanI(request *restful.Request, 
 		verb = http.MethodGet
 	}
 
-	canI := self.manager.clientManager.CanI(request, clientapi.ToSelfSubjectAccessReview(
+	canI := self.clientManager.CanI(request, clientapi.ToSelfSubjectAccessReview(
 		args.Holder.GetNamespace(),
 		api.SettingsConfigMapName,
 		api.ConfigMapKindName,
@@ -66,7 +67,7 @@ func (self *SettingsHandler) handleSettingsGlobalCanI(request *restful.Request, 
 }
 
 func (self *SettingsHandler) handleSettingsGlobalGet(request *restful.Request, response *restful.Response) {
-	client, err := self.manager.clientManager.Client(request)
+	client, err := self.clientManager.Client(request)
 	if err != nil {
 		kdErrors.HandleInternalError(response, err)
 		return
@@ -83,7 +84,7 @@ func (self *SettingsHandler) handleSettingsGlobalSave(request *restful.Request, 
 		return
 	}
 
-	client, err := self.manager.clientManager.Client(request)
+	client, err := self.clientManager.Client(request)
 	if err != nil {
 		kdErrors.HandleInternalError(response, err)
 		return
@@ -97,6 +98,6 @@ func (self *SettingsHandler) handleSettingsGlobalSave(request *restful.Request, 
 }
 
 // NewSettingsHandler creates SettingsHandler.
-func NewSettingsHandler(manager SettingsManager) SettingsHandler {
-	return SettingsHandler{manager: manager}
+func NewSettingsHandler(manager api.SettingsManager, clientManager clientapi.ClientManager) SettingsHandler {
+	return SettingsHandler{manager: manager, clientManager: clientManager}
 }

--- a/src/app/backend/settings/handler_test.go
+++ b/src/app/backend/settings/handler_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {
-	iHandler := NewSettingsHandler(NewSettingsManager(nil))
+	iHandler := NewSettingsHandler(NewSettingsManager(), nil)
 	ws := new(restful.WebService)
 	iHandler.Install(ws)
 

--- a/src/app/backend/settings/manager.go
+++ b/src/app/backend/settings/manager.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 
 	"github.com/kubernetes/dashboard/src/app/backend/args"
-	clientapi "github.com/kubernetes/dashboard/src/app/backend/client/api"
 	"github.com/kubernetes/dashboard/src/app/backend/settings/api"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,16 +28,14 @@ import (
 
 // SettingsManager is a structure containing all settings manager members.
 type SettingsManager struct {
-	settings      map[string]api.Settings
-	rawSettings   map[string]string
-	clientManager clientapi.ClientManager
+	settings    map[string]api.Settings
+	rawSettings map[string]string
 }
 
 // NewSettingsManager creates new settings manager.
-func NewSettingsManager(clientManager clientapi.ClientManager) SettingsManager {
-	return SettingsManager{
-		settings:      make(map[string]api.Settings),
-		clientManager: clientManager,
+func NewSettingsManager() api.SettingsManager {
+	return &SettingsManager{
+		settings: make(map[string]api.Settings),
 	}
 }
 

--- a/src/app/backend/settings/manager_test.go
+++ b/src/app/backend/settings/manager_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNewSettingsManager(t *testing.T) {
-	sm := NewSettingsManager(nil)
+	sm := NewSettingsManager().(*SettingsManager)
 
 	if len(sm.settings) > 0 {
 		t.Error("new settings manager should have no settings set")
@@ -31,7 +31,7 @@ func TestNewSettingsManager(t *testing.T) {
 }
 
 func TestSettingsManager_GetGlobalSettings(t *testing.T) {
-	sm := NewSettingsManager(nil)
+	sm := NewSettingsManager()
 	client := fake.NewSimpleClientset(api.GetDefaultSettingsConfigMap(""))
 	gs := sm.GetGlobalSettings(client)
 
@@ -41,7 +41,7 @@ func TestSettingsManager_GetGlobalSettings(t *testing.T) {
 }
 
 func TestSettingsManager_SaveGlobalSettings(t *testing.T) {
-	sm := NewSettingsManager(nil)
+	sm := NewSettingsManager()
 	client := fake.NewSimpleClientset(api.GetDefaultSettingsConfigMap(""))
 	defaults := api.GetDefaultSettings()
 	err := sm.SaveGlobalSettings(client, &defaults)


### PR DESCRIPTION
Currently the CreateHTTPAPIHandler requires a settings.SettingsManager instead of an api.SettingsManager, which means you can't provide a different implementation if you want to embed the Handler with a different SettingsManager. The SettingsManager interface wasn't actually used anywhere and was out of sync with the implementation, so I've updated the interface to match.

The SettingsManager took in a clientManager, which was only used by the SettingsHandler. This PR moves the clientManager to the SettingsHandler.