### PR TITLE
manually specify webdriver-manager to support chrome 74

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17049,6 +17049,99 @@
         "selenium-webdriver": "^3.0.1"
       }
     },
+    "webdriver-manager": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.2.tgz",
+      "integrity": "sha512-aSUcjNguve9Rxd+Hh3UaXXsdU2hMDdYAFBzaKGSxXj9Y8WffPqBvXmfpjULTUAwdcadXdVnRRzlbpymXzP8ltw==",
+      "dev": true,
+      "requires": {
+        "adm-zip": "^0.4.9",
+        "chalk": "^1.1.1",
+        "del": "^2.2.0",
+        "glob": "^7.0.3",
+        "ini": "^1.3.4",
+        "minimist": "^1.2.0",
+        "q": "^1.4.1",
+        "request": "^2.87.0",
+        "rimraf": "^2.5.2",
+        "semver": "^5.3.0",
+        "xml2js": "^0.4.17"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
+          "requires": {
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "webpack": {
       "version": "4.29.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "ts-node": "8.1.0",
     "tslint": "5.12.0",
     "typescript": "3.1.6",
-    "webpack-dev-server": "3.3.1"
+    "webpack-dev-server": "3.3.1",
+    "webdriver-manager": "12.1.2"
   },
   "engines": {
     "node": ">=8.0.0",


### PR DESCRIPTION
The new version of `webdriver-manager` supports Chrome 74. That paired with @floreks other fix means e2e tests aren't flaking anymore. 

The Protractor Greenkeeper PR is going to be the canary to review these fixes. Once Angular-CLI supports the new Protractor release, I'll see what we can clean up.