### PR TITLE
Update webdriver-manager to 12.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17178,9 +17178,9 @@
       }
     },
     "webdriver-manager": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.2.tgz",
-      "integrity": "sha512-aSUcjNguve9Rxd+Hh3UaXXsdU2hMDdYAFBzaKGSxXj9Y8WffPqBvXmfpjULTUAwdcadXdVnRRzlbpymXzP8ltw==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.4.tgz",
+      "integrity": "sha512-aNUzdimlHSl3EotUTdE2QwP9sBUjZgWPCy8C+m1wMmF9jBDKuO/24nnpr2O25Db8dYtsjvj9drPTpSIGqRrNnQ==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tslint": "5.12.0",
     "typescript": "3.1.6",
     "webpack-dev-server": "3.3.1",
-    "webdriver-manager": "12.1.2"
+    "webdriver-manager": "12.1.4"
   },
   "engines": {
     "node": ">=8.0.0",


### PR DESCRIPTION
There were still flaky e2e tests. This seems to fix it across all platforms I can test.