### PR TITLE
Bump node.js to 11.x in container for development

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -23,7 +23,7 @@ FROM golang
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,
 # so there's no need to run it again.
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
   && apt-get install -y --no-install-recommends \
 	openjdk-8-jre \
 	nodejs \


### PR DESCRIPTION
In favor of Angular 8, update node.js to 11.x.