### PR TITLE
#3861 Remove the border of the graphs in the dark theme

### DIFF
--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -106,4 +106,8 @@ $kd-dark-theme: mat-dark-theme($kd-dark-theme-primary, $kd-dark-theme-accent, $k
   .kd-cross-line-primary {
     stroke: $accent;
   }
+
+  .c3-chart-arc path {
+    stroke: none;
+  }  
 }

--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -107,6 +107,7 @@ $kd-dark-theme: mat-dark-theme($kd-dark-theme-primary, $kd-dark-theme-accent, $k
     stroke: $accent;
   }
 
+  // this removes the border of the graphs
   .c3-chart-arc path {
     stroke: none;
   }  

--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -110,5 +110,5 @@ $kd-dark-theme: mat-dark-theme($kd-dark-theme-primary, $kd-dark-theme-accent, $k
   // this removes the border of the graphs
   .c3-chart-arc path {
     stroke: none;
-  }  
+  }
 }


### PR DESCRIPTION
In the dark theme of the kubernetes dashboard, we are seeing white borders around the graphs. This PR is created to remove it.

Before:
<img width="1389" alt="Screenshot 2019-06-07 at 17 05 21" src="https://user-images.githubusercontent.com/15198929/59117796-94486800-8946-11e9-8829-2cf80580c14d.png">

After:
<img width="1393" alt="Screenshot 2019-06-07 at 17 04 20" src="https://user-images.githubusercontent.com/15198929/59117811-9c080c80-8946-11e9-92ef-bafcad589f6f.png">
