### PR TITLE
Specify version for GO image and golangci-lint for develop container

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -18,7 +18,8 @@
 # run gulp tasks on the code with only docker installed
 
 # golang is based on debian:jessie
-FROM golang
+# Specify version to clarify which version we use.
+FROM golang:1.12
 
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,
@@ -65,7 +66,7 @@ RUN curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-18.0
 # `npm ci` installs golangci, but this installation is needed
 # for running `npm run check` singlely, like
 # `aio/develop/run-npm-on-container.sh run check`.
-RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 
 # Install delve for debuging go files.
 RUN go get github.com/go-delve/delve/cmd/dlv


### PR DESCRIPTION
To clarify versions which we use in container, specify them.