### PR TITLE
Download golangci-lint via curl

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "fix:license": "gulp update-license-headers",
     "clean": "rm -rf .go_workspace .tmp coverage dist npm-debug.log",
     "postversion": "node aio/scripts/version.js",
-    "postinstall": "node aio/scripts/version.js && ./node_modules/protractor/bin/webdriver-manager update --gecko=false --versions.standalone=3.141.59 && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint"
+    "postinstall": "node aio/scripts/version.js && ./node_modules/protractor/bin/webdriver-manager update --gecko=false --versions.standalone=3.141.59 && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
In the `package.json` `postinstall`, it downloads a specific version of `golangci-lint` (via `curl`), instead of via `go get`. Coincidentally, that's what's [recommended by the `golangci-lint` team](https://github.com/golangci/golangci-lint/#ci-installation).

Closes #3936 
Closes #3935 