### PR TITLE
Fix golanci-lint for pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "git add"
     ],
     "src/**/*.go": [
-      "golangci-lint run -c .golangci.yml --fix src/app/backend/...",
+      "golangci-lint run -c .golangci.yml --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
Previously, we add `src/app/backend/...` at the end of `golangci-lint` command to run it for pre-commit.
But we do not need to take such tricky way for now.

Fixes #3918