### PR TITLE
Breadcrumbs are missing after page refresh

### DIFF
--- a/src/app/frontend/common/components/breadcrumbs/component.ts
+++ b/src/app/frontend/common/components/breadcrumbs/component.ts
@@ -33,6 +33,7 @@ export class BreadcrumbsComponent implements OnInit {
   constructor(private readonly _router: Router, private readonly _activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
+    this._initBreadcrumbs();
     this._registerNavigationHook();
   }
 

--- a/src/app/frontend/common/components/breadcrumbs/component.ts
+++ b/src/app/frontend/common/components/breadcrumbs/component.ts
@@ -33,7 +33,7 @@ export class BreadcrumbsComponent implements OnInit {
   constructor(private readonly _router: Router, private readonly _activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
-    this._initBreadcrumbs();
+    // this._initBreadcrumbs();
     this._registerNavigationHook();
   }
 

--- a/src/app/frontend/common/components/breadcrumbs/component.ts
+++ b/src/app/frontend/common/components/breadcrumbs/component.ts
@@ -33,7 +33,7 @@ export class BreadcrumbsComponent implements OnInit {
   constructor(private readonly _router: Router, private readonly _activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
-    // this._initBreadcrumbs();
+    this._initBreadcrumbs();
     this._registerNavigationHook();
   }
 


### PR DESCRIPTION
adding init breadcrumbs in ngOnInit because events does not triggered on refresh.
 
/cc maciaszczykm

Fixes #3952