### PR TITLE
Switch user in container for development

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -31,6 +31,10 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
 	patch \
 	chromium \
 	bc \
+	sudo \
+	gosu \
+	nano \
+	less \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean
 
@@ -75,7 +79,7 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 VOLUME ["/go/src/github.com/kubernetes/dashboard"]
 
 # Mount point for kubeconfig
-RUN mkdir -p /root/.kube
+RUN mkdir -p /home/user/.kube
 
 # Current directory is always dashboard source directory.
 WORKDIR /go/src/github.com/kubernetes/dashboard
@@ -83,5 +87,5 @@ WORKDIR /go/src/github.com/kubernetes/dashboard
 # Expose port for frontend, backend and remote debuging
 EXPOSE 8080 9090 2345
 
-# Run npm command in container. 
-CMD ./aio/develop/npm-command.sh
+# Run gosu command in container.
+CMD ./aio/develop/gosu-command.sh

--- a/aio/develop/gosu-command.sh
+++ b/aio/develop/gosu-command.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create and switch user to "user" with same UID and GID as local.
+groupadd -g ${LOCAL_GID} user
+useradd -u ${LOCAL_UID} -g ${LOCAL_GID} -d /home/user user
+chown -R user:user /home/user
+
+# Add user as sudoer without password
+echo "user ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/user
+
+# Execute command with gosu as user
+GOSU="exec /usr/sbin/gosu user"
+
+# Run command if K8S_DASHBOARD_CMD is set,
+# otherwise run `npm ${K8S_DASHBOARD_NPM_CMD}`.
+if [[ -n "${K8S_DASHBOARD_CMD}" ]] ; then
+  # Run npm command
+  echo "Run '${K8S_DASHBOARD_CMD}'"
+  ${GOSU} ${K8S_DASHBOARD_CMD}
+else
+  ${GOSU} aio/develop/npm-command.sh
+fi

--- a/aio/develop/npm-command.sh
+++ b/aio/develop/npm-command.sh
@@ -23,17 +23,20 @@ if [[ -n "${K8S_DASHBOARD_NPM_CMD}" ]] ; then
 else
   # Install dashboard.
   echo "Install dashboard"
-  npm ci --unsafe-perm
+  npm ci
   if [[ "${K8S_OWN_CLUSTER}" != true ]] ; then
     # Stop cluster.
     echo "Stop cluster"
-    npm run cluster:stop
+    sudo npm run cluster:stop
     # Start cluster.
     echo "Start cluster"
-    npm run cluster:start
+    sudo npm run cluster:start
+    # Copy kubeconfig from /root/.kube/config
+    sudo cat /root/.kube/config > kind.kubeconfig
+    sudo chown ${LOCAL_UID}:${LOCAL_GID} kind.kubeconfig
     # Edit kubeconfig for kind
     KIND_CONTAINER_NAME="k8s-cluster-ci-control-plane"
-    KIND_ADDR=$(docker inspect -f='{{.NetworkSettings.IPAddress}}' ${KIND_CONTAINER_NAME})
+    KIND_ADDR=$(sudo docker inspect -f='{{.NetworkSettings.IPAddress}}' ${KIND_CONTAINER_NAME})
     sed -e "s/localhost:[0-9]\+/${KIND_ADDR}:6443/g" kind.kubeconfig > kind.kubeconfig.new
     cat kind.kubeconfig.new > kind.kubeconfig
     rm -f kind.kubeconfig.new

--- a/aio/develop/run-npm-on-container.sh
+++ b/aio/develop/run-npm-on-container.sh
@@ -23,9 +23,16 @@
 CD="$(pwd)"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# User and group ID to execute commands.
+LOCAL_UID=$(id -u)
+LOCAL_GID=$(id -g)
+
 # K8S_DASHBOARD_NPM_CMD will be passed into container and will be used
-# by run-npm-command.sh on container.
-export K8S_DASHBOARD_NPM_CMD=$*
+# by run-npm-command.sh on container. Then the shell sciprt will run `npm`
+# command with K8S_DASHBOAD_NPM_CMD.
+# But if K8S_DASHBOARD_CMD is set, the command in K8S_DASHBOARD_CMD will be
+# executed instead of `npm ${K8S_DASHBOARD_NPM_CMD}`.
+K8S_DASHBOARD_NPM_CMD=$*
 
 # kubeconfig for dashboard.
 # This will be mounted and certain npm command can modify it,
@@ -60,13 +67,15 @@ docker run \
   --cap-add=SYS_PTRACE \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v ${K8S_DASHBOARD_SRC}:${K8S_DASHBOARD_SRC_ON_CONTAINER} \
-  -v ${K8S_DASHBOARD_KUBECONFIG}:/root/.kube/config \
+  -v ${K8S_DASHBOARD_KUBECONFIG}:/home/user/.kube/config \
   -e K8S_DASHBOARD_NPM_CMD="${K8S_DASHBOARD_NPM_CMD}" \
+  -e K8S_DASHBOARD_CMD="${K8S_DASHBOARD_CMD}" \
   -e K8S_OWN_CLUSTER=${K8S_OWN_CLUSTER} \
   -e K8S_DASHBOARD_DEBUG=${K8S_DASHBOARD_DEBUG} \
+  -e LOCAL_UID="${LOCAL_UID}" \
+  -e LOCAL_GID="${LOCAL_GID}" \
   -p 8080:8080 \
   -p 9090:9090 \
   -p 2345:2345 \
   ${DOCKER_RUN_OPTS} \
-  ${DASHBOARD_IMAGE_NAME} \
-  ${K8S_DASHBOARD_CMD}
+  ${DASHBOARD_IMAGE_NAME}


### PR DESCRIPTION
In container for development, switch user from "root" to "user" who have same UID as local before running commands.

Also, install `nano` for `git commit` in container.