### PR TITLE
Reorganize `docs/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters.
 
 ## Getting Started
 
-**IMPORTANT:** Read the [Access Control](
-https://github.com/kubernetes/dashboard/wiki/Access-control) guide before performing any further steps. The default Dashboard deployment contains a minimal set of RBAC privileges needed to run.
+**IMPORTANT:** Read the [Access Control](docs/user/access-control/README.md) guide before performing any further steps. The default Dashboard deployment contains a minimal set of RBAC privileges needed to run.
 
 To deploy Dashboard, execute following command:
 
@@ -33,25 +32,20 @@ Now access Dashboard at:
 http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/).
 
 ## Create An Authentication Token (RBAC)
-To find out how to create sample user and log in follow [Creating sample user](https://github.com/kubernetes/dashboard/wiki/Creating-sample-user) guide.
+To find out how to create sample user and log in follow [Creating sample user](docs/user/access-control/creating-sample-user.md) guide.
 
 **NOTE:**
 * Kubeconfig Authentication method does not support external identity providers or certificate-based authentication. 
 * Dashboard can only be accessed over HTTPS
-* [Heapster](https://github.com/kubernetes/heapster/) has to be running in the cluster for the metrics
-and graphs to be available. Read more about it in [Integrations](
-https://github.com/kubernetes/dashboard/wiki/Integrations) guide.
+* [Heapster](https://github.com/kubernetes/heapster/) has to be running in the cluster for the metrics and graphs to be available. Read more about it in [Integrations](docs/user/integrations.md) guide.
 
 ## Documentation
 
-Dashboard documentation can be found on [Wiki](https://github.com/kubernetes/dashboard/wiki) pages which contains:
+Dashboard documentation can be found on [docs](docs/README.md) directory which contains:
 
-* Common: Entry-level overview
-* User Guide: [Installation](https://github.com/kubernetes/dashboard/wiki/Installation), [Accessing Dashboard](
-https://github.com/kubernetes/dashboard/wiki/Accessing-dashboard) and more for users
-* Developer Guide: [Getting Started](https://github.com/kubernetes/dashboard/wiki/Getting-started), [Dependency
-Management](https://github.com/kubernetes/dashboard/wiki/Dependency-management) and more for anyone interested in
-contributing
+* [Common](docs/common/README.md): Entry-level overview
+* [User Guide](docs/user/README.md): [Installation](docs/user/installation.md), [Accessing Dashboard](docs/user/accessing-dashboard/README.md) and more for users
+* [Developer Guide](docs/developer/README.md): [Getting Started](docs/developer/getting-started.md), [Dependency Management](docs/developer/dependency-management.md) and more for anyone interested in contributing
 
 ## Community, discussion, contribution, and support
 
@@ -63,6 +57,11 @@ You can reach the maintainers of this project at:
 * [**kubernetes-sig-ui mailing list** ](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
 * [**Issue tracker**](https://github.com/kubernetes/dashboard/issues)
 * [**SIG info**](https://github.com/kubernetes/community/tree/master/sig-ui)
+* [**Roles**](ROLES.md)
+
+### Contribution
+
+Learn how to start contribution on the [Contributing Guidline](CONTRIBUTING.md)
 
 ### Code of conduct
 
@@ -71,3 +70,6 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ## License
 
 [Apache License 2.0](https://github.com/kubernetes/dashboard/blob/master/LICENSE)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Kubernetes Dashboard documentation
+
+___TO BE ADDED___
+
+## Index
+
+### [Common](common/README.md)
+
+* [FAQ](common/faq.md)
+* [Roadmap](common/roadmap.md)
+* [Dashboard arguments](common/dashboard-arguments.md)
+
+### [User Guide](user/README.md)
+
+* [Installation](user/installation.md)
+* [Certificate management](user/certificate-management.md)
+* [Accessing Dashboard](user/accessing-dashboard.md)
+  * [1.7.x and above](user/accessing-dashboard/1.7.x-and-above.md)
+  * [1.6.x and below](user/accessing-dashboard/1.6.x-and-below.md)
+* [Access control](user/access-control.md)
+  * [Creating sample user](user/access-control/creating-sample-user.md)
+* [Integrations](user/integrations.md)
+* [Labels](user/labels.md)
+
+### [Developer Guide](developer/README.md)
+
+* [Getting started](developer/getting-started.md)
+* [Release procedures](developer/release-procedures.md)
+* [Dependency management](developer/dependency-management.md)
+* [Architecture](developer/architecture.md)
+* [Code conventions](developer/code-conventions.md)
+* [Text conventions](developer/text-conventions.md)
+* [Internationalization](developer/internationalization.md)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -1,0 +1,8 @@
+# Common
+
+* [FAQ](faq.md)
+* [Roadmap](roadmap.md)
+* [Dashboard arguments](dashboard-arguments.md)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/common/dashboard-arguments.md
+++ b/docs/common/dashboard-arguments.md
@@ -1,0 +1,6 @@
+# Dashboard arguments
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/common/faq.md
+++ b/docs/common/faq.md
@@ -1,0 +1,6 @@
+# FAQ
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/common/roadmap.md
+++ b/docs/common/roadmap.md
@@ -1,0 +1,6 @@
+# Roadmap
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,12 @@
+# Developer guide
+
+* [Getting started](getting-started.md)
+* [Release procedures](release-procedures.md)
+* [Dependency management](dependency-management.md)
+* [Architecture](architecture.md)
+* [Code conventions](code-conventions.md)
+* [Text conventions](text-conventions.md)
+* [Internationalization](internationalization.md)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/code-conventions.md
+++ b/docs/developer/code-conventions.md
@@ -1,0 +1,6 @@
+# Code conventions
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/dependency-management.md
+++ b/docs/developer/dependency-management.md
@@ -1,0 +1,6 @@
+# Dependency management
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -1,0 +1,6 @@
+# Getting started
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/internationalization.md
+++ b/docs/developer/internationalization.md
@@ -1,0 +1,6 @@
+# Internationarization
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/release-procedures.md
+++ b/docs/developer/release-procedures.md
@@ -1,0 +1,6 @@
+# Release procedures
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/developer/text-conventions.md
+++ b/docs/developer/text-conventions.md
@@ -1,0 +1,6 @@
+# Text conventions
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,14 @@
+# User guide
+
+* [Installation](installation.md)
+* [Certificate management](certificate-management.md)
+* [Accessing Dashboard](accessing-dashboard/README.md)
+  * [1.7.x and above](accessing-dashboard/1.7.x-and-above.md)
+  * [1.6.x and below](accessing-dashboard/1.6.x-and-below.md)
+* [Access control](access-control/README.md)
+  * [Creating sample user](access-control/creating-sample-user.md)
+* [Integrations](integrations.md)
+* [Labels](labels.md)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/access-control/README.md
+++ b/docs/user/access-control/README.md
@@ -1,0 +1,6 @@
+# Access control
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/access-control/creating-sample-user.md
+++ b/docs/user/access-control/creating-sample-user.md
@@ -1,0 +1,6 @@
+# Creating sample user
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/accessing-dashboard/1.6.x-and-below.md
+++ b/docs/user/accessing-dashboard/1.6.x-and-below.md
@@ -1,0 +1,6 @@
+# Accessing Dashboard 1.6.x and below
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/accessing-dashboard/1.7.x-and-above.md
+++ b/docs/user/accessing-dashboard/1.7.x-and-above.md
@@ -1,0 +1,6 @@
+# Accessing Dashboard 1.7.x and above
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/accessing-dashboard/README.md
+++ b/docs/user/accessing-dashboard/README.md
@@ -1,0 +1,9 @@
+# Accessing Dashboard
+
+___TO BE ADDED___
+
+* [1.7.x and above](1.7.x-and-above.md)
+* [1.6.x and below](1.6.x-and-below.md)
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/certificate-management.md
+++ b/docs/user/certificate-management.md
@@ -1,0 +1,6 @@
+# Certificate management
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,0 +1,6 @@
+# Installation
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/integrations.md
+++ b/docs/user/integrations.md
@@ -1,0 +1,6 @@
+# Integrations
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -1,0 +1,6 @@
+# Labels
+
+___TO BE ADDED___
+
+----
+_Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_


### PR DESCRIPTION
To migrate wiki contents into `docs/`, prepare directory and file structures.
Contents of each pages would be added as latest in subsequent PRs.

First step to migrate wiki #4008 