### PR TITLE
Make deployment files consistent

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -223,7 +223,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
   name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
@@ -231,7 +231,7 @@ spec:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
 
 ---
 
@@ -239,22 +239,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper
+      k8s-app: dashboard-metrics-scraper
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper
+        k8s-app: dashboard-metrics-scraper
     spec:
       containers:
-        - name: kubernetes-metrics-scraper
+        - name: dashboard-metrics-scraper
           image: kubernetesui/metrics-scraper:v1.0.0
           ports:
             - containerPort: 8000

--- a/aio/deploy/alternative/07_scraper-service.yaml
+++ b/aio/deploy/alternative/07_scraper-service.yaml
@@ -16,7 +16,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
   name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
@@ -24,4 +24,4 @@ spec:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -16,22 +16,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper
+      k8s-app: dashboard-metrics-scraper
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper
+        k8s-app: dashboard-metrics-scraper
     spec:
       containers:
-      - name: kubernetes-metrics-scraper
+      - name: dashboard-metrics-scraper
         image: kubernetesui/metrics-scraper:v1.0.0
         ports:
         - containerPort: 8000

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -111,11 +111,11 @@ rules:
     # Allow Dashboard to get metrics.
   - apiGroups: [""]
     resources: ["services"]
-    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper-head"]
     verbs: ["proxy"]
   - apiGroups: [""]
     resources: ["services/proxy"]
-    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper-head", "http:dashboard-metrics-scraper-head"]
     verbs: ["get"]
 
 ---
@@ -223,15 +223,15 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: dashboard-metrics-scraper
+    k8s-app: dashboard-metrics-scraper-head
+  name: dashboard-metrics-scraper-head
   namespace: kubernetes-dashboard-head
 spec:
   ports:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper-head
 
 ---
 
@@ -239,22 +239,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper-head
+  name: dashboard-metrics-scraper-head
   namespace: kubernetes-dashboard-head
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper
+      k8s-app: dashboard-metrics-scraper-head
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper
+        k8s-app: dashboard-metrics-scraper-head
     spec:
       containers:
-        - name: kubernetes-metrics-scraper
+        - name: dashboard-metrics-scraper-head
           image: kubernetesdashboarddev/dashboard-metrics-sidecar:latest
           ports:
             - containerPort: 8000

--- a/aio/deploy/head/05_dashboard-rbac.yaml
+++ b/aio/deploy/head/05_dashboard-rbac.yaml
@@ -33,11 +33,11 @@ rules:
     # Allow Dashboard to get metrics.
   - apiGroups: [""]
     resources: ["services"]
-    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper-head"]
     verbs: ["proxy"]
   - apiGroups: [""]
     resources: ["services/proxy"]
-    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper-head", "http:dashboard-metrics-scraper-head"]
     verbs: ["get"]
 
 ---

--- a/aio/deploy/head/07_scraper-service.yaml
+++ b/aio/deploy/head/07_scraper-service.yaml
@@ -16,12 +16,12 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper-head
+    k8s-app: dashboard-metrics-scraper-head
   name: dashboard-metrics-scraper-head
-  namespace: kubernetes-dashboard-head
+  namespace: dashboard-dashboard-head
 spec:
   ports:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper-head
+    k8s-app: dashboard-metrics-scraper-head

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -16,22 +16,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper-head
-  name: kubernetes-metrics-scraper-head
+    k8s-app: dashboard-metrics-scraper-head
+  name: dashboard-metrics-scraper-head
   namespace: kubernetes-dashboard-head
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper-head
+      k8s-app: dashboard-metrics-scraper-head
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper-head
+        k8s-app: dashboard-metrics-scraper-head
     spec:
       containers:
-      - name: kubernetes-metrics-scraper-head
+      - name: dashboard-metrics-scraper-head
         image: kubernetesdashboarddev/dashboard-metrics-sidecar:latest
         ports:
         - containerPort: 8000

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -231,7 +231,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
   name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
@@ -239,7 +239,7 @@ spec:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
 
 ---
 
@@ -247,22 +247,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper
+      k8s-app: dashboard-metrics-scraper
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper
+        k8s-app: dashboard-metrics-scraper
     spec:
       containers:
-        - name: kubernetes-metrics-scraper
+        - name: dashboard-metrics-scraper
           image: kubernetesui/metrics-scraper:v1.0.0
           ports:
             - containerPort: 8000

--- a/aio/deploy/recommended/07_scraper-service.yaml
+++ b/aio/deploy/recommended/07_scraper-service.yaml
@@ -16,12 +16,12 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper-head
-  name: dashboard-metrics-scraper-head
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
   ports:
     - port: 8000
       targetPort: 8000
   selector:
-    k8s-app: kubernetes-metrics-scraper-head
+    k8s-app: dashboard-metrics-scraper

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -16,22 +16,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    k8s-app: kubernetes-metrics-scraper
-  name: kubernetes-metrics-scraper
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-metrics-scraper
+      k8s-app: dashboard-metrics-scraper
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-metrics-scraper
+        k8s-app: dashboard-metrics-scraper
     spec:
       containers:
-        - name: kubernetes-metrics-scraper
+        - name: dashboard-metrics-scraper
           image: kubernetesui/metrics-scraper:v1.0.0
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Some names were inconsistent and might have caused metrics to fail.