### PR TITLE
add tmp-volume to metrics-scraper

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -266,8 +266,14 @@ spec:
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -43,8 +43,14 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -43,9 +43,9 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
-          volumeMounts:
-          - mountPath: /tmp
-            name: tmp-volume
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -266,8 +266,14 @@ spec:
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -43,9 +43,9 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
-          volumeMounts:
-          - mountPath: /tmp
-            name: tmp-volume
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -43,8 +43,14 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -274,8 +274,14 @@ spec:
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -43,8 +43,14 @@ spec:
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/aio/test-resources/kubernetes-dashboard-local.yaml
+++ b/aio/test-resources/kubernetes-dashboard-local.yaml
@@ -233,11 +233,17 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
       serviceAccountName: kubernetes-dashboard-local
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      volumes:
+      - emptyDir: {}
+        name: tmp-volume
 
 ---
 # ------------------- Metrics Scraper Service ------------------- #

--- a/aio/test-resources/kubernetes-dashboard-local.yaml
+++ b/aio/test-resources/kubernetes-dashboard-local.yaml
@@ -233,9 +233,9 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
-          volumeMounts:
-          - mountPath: /tmp
-            name: tmp-volume
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
       serviceAccountName: kubernetes-dashboard-local
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:


### PR DESCRIPTION
Add an emptyDir /tmp volume to the metrics-scraper so it doesn't have to run as root.  Matches setup with the dashboard itself.