### PR TITLE
[bugfix] Change golang tag

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -19,7 +19,7 @@
 
 # golang is based on debian:jessie
 # Specify version to clarify which version we use.
-FROM golang:1.12
+FROM golang:1.10
 
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,

--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -19,14 +19,13 @@
 
 # golang is based on debian:jessie
 # Specify version to clarify which version we use.
-FROM golang:1.10
+FROM golang:1.12
 
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,
 # so there's no need to run it again.
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
   && apt-get install -y --no-install-recommends \
-	openjdk-8-jre \
 	nodejs \
 	patch \
 	chromium \


### PR DESCRIPTION
`golang:1.12` is inherited `buildpack-deps:stretch-scm`, There is no `openjdk-8` in its corresponding `debian` version. 
so apt-get can't install `openjdk-8-jre`.
![golang:1.12](https://holegots-picgo.oss-cn-beijing.aliyuncs.com/img/20190723133758.png)
I use apt install `openjdk-8-jre` successfully in `golang:1.10`.
![golang:1.10](https://holegots-picgo.oss-cn-beijing.aliyuncs.com/img/20190723133957.png)
Then build image sucessfully in `golang:1.10`.
![image](https://user-images.githubusercontent.com/22197568/61685871-92006880-ad50-11e9-8a0b-1ea8d53bc089.png)

Fixes #4097 