### PR TITLE
Specified Linux as OS in nodeSelector, to make compatible with AKS cluster with Windows nodes

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -212,6 +212,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -270,6 +272,8 @@ spec:
           - mountPath: /tmp
             name: tmp-volume
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/alternative/06_dashboard-deployment.yaml
+++ b/aio/deploy/alternative/06_dashboard-deployment.yaml
@@ -56,6 +56,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -212,6 +212,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -270,6 +272,8 @@ spec:
           - mountPath: /tmp
             name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/head/06_dashboard-deployment.yaml
+++ b/aio/deploy/head/06_dashboard-deployment.yaml
@@ -64,6 +64,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -186,6 +186,8 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       containers:
         - name: kubernetes-dashboard
           image: kubernetesui/dashboard:v2.0.0-beta2
@@ -261,6 +263,8 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       containers:
         - name: dashboard-metrics-scraper
           image: kubernetesui/metrics-scraper:v1.0.1

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -186,8 +186,6 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
-      nodeSelector:
-        "beta.kubernetes.io/os": linux
       containers:
         - name: kubernetes-dashboard
           image: kubernetesui/dashboard:v2.0.0-beta2
@@ -222,6 +220,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -263,8 +263,6 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-      nodeSelector:
-        "beta.kubernetes.io/os": linux
       containers:
         - name: dashboard-metrics-scraper
           image: kubernetesui/metrics-scraper:v1.0.1
@@ -282,6 +280,8 @@ spec:
           - mountPath: /tmp
             name: tmp-volume
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended/06_dashboard-deployment.yaml
+++ b/aio/deploy/recommended/06_dashboard-deployment.yaml
@@ -64,6 +64,8 @@ spec:
         - name: tmp-volume
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -47,6 +47,8 @@ spec:
           - mountPath: /tmp
             name: tmp-volume
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/test-resources/kubernetes-dashboard-local.yaml
+++ b/aio/test-resources/kubernetes-dashboard-local.yaml
@@ -176,6 +176,8 @@ spec:
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard-local
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -237,6 +239,8 @@ spec:
         - mountPath: /tmp
           name: tmp-volume
       serviceAccountName: kubernetes-dashboard-local
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Updated dashboard to specify Linux as OS in nodeSelector, to make it compatible with AKS cluster that has Windows nodes.

```yaml
    spec:
      nodeSelector:
        "beta.kubernetes.io/os": linux
```