### PR TITLE
Show time tooltips for events FirstSeen and LastSeen

### DIFF
--- a/src/app/frontend/common/components/date/template.html
+++ b/src/app/frontend/common/components/date/template.html
@@ -14,11 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<span *ngIf="_relative"
-      class="kd-date"
+<span class="kd-date"
       [matTooltip]="date | date:format">
-  {{date | kdRelativeTime}}
-</span>
-<span *ngIf="!_relative">
-  {{date | date:format}}
+  {{_relative ? (date | kdRelativeTime) : (date | date)}}
 </span>

--- a/src/app/frontend/common/components/resourcelist/event/template.html
+++ b/src/app/frontend/common/components/resourcelist/event/template.html
@@ -70,7 +70,7 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>First Seen</mat-header-cell>
         <mat-cell *matCellDef="let event">
-          {{event.firstSeen | date}}
+          <kd-date [date]="event.firstSeen"></kd-date>
         </mat-cell>
       </ng-container>
 
@@ -78,7 +78,7 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Last Seen</mat-header-cell>
         <mat-cell *matCellDef="let event">
-          {{event.lastSeen | date}}
+          <kd-date [date]="event.lastSeen"></kd-date>
         </mat-cell>
       </ng-container>
 


### PR DESCRIPTION
Also refactored the `kd-date` component to also show tooltips for non-relative timestamp displays.