### PR TITLE
Migrate DOCKER_CLI_EXPERIMENTAL and GOPROXY env from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ cache:
 
 before_install:
   - export NG_CLI_ANALYTICS=ci
+  - export DOCKER_CLI_EXPERIMENTAL=enabled
   - export GO111MODULE=on
+  - export GOPROXY=https://proxy.golang.org
   - export PATH=$PATH:$GOPATH/bin
   - eval "$(gimme 1.12.6)"
 


### PR DESCRIPTION
To clarify, log and test automatically changes for environment variables in travis, migrate these definitions from repository settings in travis UI to `.travis.yml` under repository.