### PR TITLE
Add healthz endpoint

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -175,6 +175,9 @@ func main() {
 	http.Handle("/config", handler.AppHandler(handler.ConfigHandler))
 	http.Handle("/api/sockjs/", handler.CreateAttachHandler("/api/sockjs"))
 	http.Handle("/metrics", prometheus.Handler())
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
 
 	// Listen for http or https
 	if servingCerts != nil {


### PR DESCRIPTION
If you use dashboard in insecure mode and reverse-proxy to secure it – you need to have some endpoint in the dashboard, which can be exposed without any authentication to be used in readiness and liveness probes.