### PR TITLE
Improve Namespace-awareness for CRDs

### DIFF
--- a/src/app/backend/resource/customresourcedefinition/objects.go
+++ b/src/app/backend/resource/customresourcedefinition/objects.go
@@ -103,12 +103,10 @@ func GetCustomResourceObjectList(client apiextensionsclientset.Interface, config
 		return nil, criticalError
 	}
 
-	request := restClient.Get().Resource(customResourceDefinition.Spec.Names.Plural)
-	if customResourceDefinition.Spec.Scope == apiextensions.NamespaceScoped {
-		request = request.Namespace(namespace.ToRequestParam())
-	}
-
-	raw, err := request.Do().Raw()
+	raw, err := restClient.Get().
+		NamespaceIfScoped(namespace.ToRequestParam(), customResourceDefinition.Spec.Scope == apiextensions.NamespaceScoped).
+		Resource(customResourceDefinition.Spec.Names.Plural).
+		Do().Raw()
 	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
 	if criticalError != nil {
 		return nil, criticalError
@@ -151,12 +149,10 @@ func GetCustomResourceObjectDetail(client apiextensionsclientset.Interface, name
 		return nil, criticalError
 	}
 
-	request := restClient.Get().Resource(customResourceDefinition.Spec.Names.Plural).Name(name)
-	if customResourceDefinition.Spec.Scope == apiextensions.NamespaceScoped {
-		request = request.Namespace(namespace.ToRequestParam())
-	}
-
-	raw, err := request.Do().Raw()
+	raw, err := restClient.Get().
+		NamespaceIfScoped(namespace.ToRequestParam(), customResourceDefinition.Spec.Scope == apiextensions.NamespaceScoped).
+		Resource(customResourceDefinition.Spec.Names.Plural).
+		Name(name).Do().Raw()
 	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
 	if criticalError != nil {
 		return nil, criticalError

--- a/src/app/frontend/crd/routing.ts
+++ b/src/app/frontend/crd/routing.ts
@@ -32,10 +32,16 @@ const CRD_DETAIL_ROUTE: Route = {
   data: {breadcrumb: '{{ crdName }}', parent: CRD_LIST_ROUTE},
 };
 
-const CRD_OBJECT_DETAIL_ROUTE: Route = {
+const CRD_NAMESPACED_OBJECT_DETAIL_ROUTE: Route = {
   path: ':crdName/:namespace/:objectName',
   component: CRDObjectDetailComponent,
   data: {breadcrumb: '{{ objectName }}', routeParamsCount: 2, parent: CRD_DETAIL_ROUTE},
+};
+
+const CRD_CLUSTER_OBJECT_DETAIL_ROUTE: Route = {
+  path: ':crdName/:objectName',
+  component: CRDObjectDetailComponent,
+  data: {breadcrumb: '{{ objectName }}', parent: CRD_DETAIL_ROUTE},
 };
 
 @NgModule({
@@ -43,7 +49,8 @@ const CRD_OBJECT_DETAIL_ROUTE: Route = {
     RouterModule.forChild([
       CRD_LIST_ROUTE,
       CRD_DETAIL_ROUTE,
-      CRD_OBJECT_DETAIL_ROUTE,
+      CRD_NAMESPACED_OBJECT_DETAIL_ROUTE,
+      CRD_CLUSTER_OBJECT_DETAIL_ROUTE,
       DEFAULT_ACTIONBAR,
     ]),
   ],

--- a/src/app/frontend/crd/routing.ts
+++ b/src/app/frontend/crd/routing.ts
@@ -41,7 +41,7 @@ const CRD_NAMESPACED_OBJECT_DETAIL_ROUTE: Route = {
 const CRD_CLUSTER_OBJECT_DETAIL_ROUTE: Route = {
   path: ':crdName/:objectName',
   component: CRDObjectDetailComponent,
-  data: {breadcrumb: '{{ objectName }}', parent: CRD_DETAIL_ROUTE},
+  data: {breadcrumb: '{{ objectName }}', routeParamsCount: 1, parent: CRD_DETAIL_ROUTE},
 };
 
 @NgModule({


### PR DESCRIPTION
- On the backend, only filter CRDs by namespace if namespace-scoped.
- On the frontend, adds a new page for cluster-scoped CRD objects.