### PR TITLE
Support 'Scale' subresource for CRDs

### DIFF
--- a/i18n/messages.fr.xlf
+++ b/i18n/messages.fr.xlf
@@ -1879,7 +1879,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="90ae2a4959c979abc049f4652f59b85e993e16cd" datatype="html">
@@ -2470,12 +2470,20 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="d9ac1caf6715c8011155c0a027d544dbeca63062" datatype="html">
+        <source>Subresources</source>
+        <target state="new">Subresources</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1ec17de9560711cd81108ccf93eb5b1df4eb6d4c" datatype="html">
         <source>Accepted Names</source>
         <target state="new">Accepted Names</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa1312fe00bfe38662df238fa059bcd75866ecd7" datatype="html">
@@ -2483,7 +2491,7 @@
         <target state="new">Plural</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="712232bebfc8836a394c358ce9679452fabb945f" datatype="html">
@@ -2491,7 +2499,7 @@
         <target state="new">Singular</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a2fcb3c1d8240f8f966564ee3500235d7427245" datatype="html">
@@ -2499,7 +2507,7 @@
         <target state="new">List Kind</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d27e60f49dba9b7994331db545a4c14e1e2683ad" datatype="html">
@@ -2507,7 +2515,7 @@
         <target state="new">Short Names</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
@@ -2515,7 +2523,7 @@
         <target state="new">Categories</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="004b222ff9ef9dd4771b777950ca1d0e4cd4348a" datatype="html">

--- a/i18n/messages.ja.xlf
+++ b/i18n/messages.ja.xlf
@@ -1291,7 +1291,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7357d53d819cc1f5dd329a4fff4c582461ee1317" datatype="html">
@@ -2869,12 +2869,20 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="d9ac1caf6715c8011155c0a027d544dbeca63062" datatype="html">
+        <source>Subresources</source>
+        <target state="new">Subresources</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1ec17de9560711cd81108ccf93eb5b1df4eb6d4c" datatype="html">
         <source>Accepted Names</source>
         <target>容認された名前</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa1312fe00bfe38662df238fa059bcd75866ecd7" datatype="html">
@@ -2882,7 +2890,7 @@
         <target>複数</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="712232bebfc8836a394c358ce9679452fabb945f" datatype="html">
@@ -2890,7 +2898,7 @@
         <target>単数</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a2fcb3c1d8240f8f966564ee3500235d7427245" datatype="html">
@@ -2898,7 +2906,7 @@
         <target>種類一覧</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d27e60f49dba9b7994331db545a4c14e1e2683ad" datatype="html">
@@ -2906,7 +2914,7 @@
         <target>省略名</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
@@ -2914,7 +2922,7 @@
         <target>カテゴリー</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7db62a1ccd31f1bb55e3532b0f58984a492296a8" datatype="html">

--- a/i18n/messages.ko.xlf
+++ b/i18n/messages.ko.xlf
@@ -1475,7 +1475,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81054386839df6c7c45d298e0044956413589ef4" datatype="html">
@@ -2912,12 +2912,20 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="d9ac1caf6715c8011155c0a027d544dbeca63062" datatype="html">
+        <source>Subresources</source>
+        <target state="new">Subresources</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1ec17de9560711cd81108ccf93eb5b1df4eb6d4c" datatype="html">
         <source>Accepted Names</source>
         <target state="new">Accepted Names</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa1312fe00bfe38662df238fa059bcd75866ecd7" datatype="html">
@@ -2925,7 +2933,7 @@
         <target state="new">복수</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="712232bebfc8836a394c358ce9679452fabb945f" datatype="html">
@@ -2933,7 +2941,7 @@
         <target state="new">단수</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a2fcb3c1d8240f8f966564ee3500235d7427245" datatype="html">
@@ -2941,7 +2949,7 @@
         <target state="new">종류 리스트</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d27e60f49dba9b7994331db545a4c14e1e2683ad" datatype="html">
@@ -2949,7 +2957,7 @@
         <target state="new">단축 이름</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
@@ -2957,7 +2965,7 @@
         <target state="new">카테고리</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5ad4eecbd0fe09c34678fefce317a052af39dc96" datatype="html">
@@ -3253,6 +3261,7 @@
         <target state="new">
         <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>open_in_new<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
       </target> 더 배우기
+        
         
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/template.html</context>

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -1374,7 +1374,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81054386839df6c7c45d298e0044956413589ef4" datatype="html">
@@ -2619,46 +2619,53 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="d9ac1caf6715c8011155c0a027d544dbeca63062" datatype="html">
+        <source>Subresources</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1ec17de9560711cd81108ccf93eb5b1df4eb6d4c" datatype="html">
         <source>Accepted Names</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa1312fe00bfe38662df238fa059bcd75866ecd7" datatype="html">
         <source>Plural</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="712232bebfc8836a394c358ce9679452fabb945f" datatype="html">
         <source>Singular</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a2fcb3c1d8240f8f966564ee3500235d7427245" datatype="html">
         <source>List Kind</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d27e60f49dba9b7994331db545a4c14e1e2683ad" datatype="html">
         <source>Short Names</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
         <source>Categories</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5ad4eecbd0fe09c34678fefce317a052af39dc96" datatype="html">

--- a/i18n/messages.zh.xlf
+++ b/i18n/messages.zh.xlf
@@ -1483,7 +1483,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="81054386839df6c7c45d298e0044956413589ef4" datatype="html">
@@ -2930,12 +2930,20 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="d9ac1caf6715c8011155c0a027d544dbeca63062" datatype="html">
+        <source>Subresources</source>
+        <target state="new">Subresources</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1ec17de9560711cd81108ccf93eb5b1df4eb6d4c" datatype="html">
         <source>Accepted Names</source>
         <target state="new">Accepted Names</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fa1312fe00bfe38662df238fa059bcd75866ecd7" datatype="html">
@@ -2943,7 +2951,7 @@
         <target state="new">Plural</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="712232bebfc8836a394c358ce9679452fabb945f" datatype="html">
@@ -2951,7 +2959,7 @@
         <target state="new">Singular</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5a2fcb3c1d8240f8f966564ee3500235d7427245" datatype="html">
@@ -2959,7 +2967,7 @@
         <target state="new">List Kind</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d27e60f49dba9b7994331db545a4c14e1e2683ad" datatype="html">
@@ -2967,7 +2975,7 @@
         <target state="new">Short Names</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="04201f9d27abd7d6f58a4328ab98063ce1072006" datatype="html">
@@ -2975,7 +2983,7 @@
         <target state="new">Categories</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/crd/detail/template.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7db62a1ccd31f1bb55e3532b0f58984a492296a8" datatype="html">

--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -102,7 +102,8 @@ func NewObjectMeta(k8SObjectMeta metaV1.ObjectMeta) ObjectMeta {
 // NewTypeMeta creates new type mete for the resource kind.
 func NewTypeMeta(kind ResourceKind) TypeMeta {
 	return TypeMeta{
-		Kind: kind,
+		Kind:     kind,
+		Scalable: kind.Scalable(),
 	}
 }
 
@@ -138,6 +139,23 @@ const (
 	ResourceKindClusterRole              = "clusterrole"
 	ResourceKindEndpoint                 = "endpoint"
 )
+
+func (k ResourceKind) Scalable() bool {
+	scalable := []ResourceKind{
+		ResourceKindDeployment,
+		ResourceKindReplicaSet,
+		ResourceKindReplicationController,
+		ResourceKindStatefulSet,
+	}
+
+	for _, kind := range scalable {
+		if k == kind {
+			return true
+		}
+	}
+
+	return false
+}
 
 // ClientType represents type of client that is used to perform generic operations on resources.
 // Different resources belong to different client, i.e. Deployments belongs to extension client

--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -77,7 +77,7 @@ type TypeMeta struct {
 	Kind ResourceKind `json:"kind,omitempty"`
 
 	// Scalable represents whether or not an object is scalable.
-	Scalable bool `json:"scalable"`
+	Scalable bool `json:"scalable,omitempty"`
 }
 
 // ListMeta describes list of objects, i.e. holds information about pagination options set for the list.

--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -75,6 +75,9 @@ type TypeMeta struct {
 	// In smalllettercase.
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
 	Kind ResourceKind `json:"kind,omitempty"`
+
+	// Scalable represents whether or not an object is scalable.
+	Scalable bool `json:"scalable"`
 }
 
 // ListMeta describes list of objects, i.e. holds information about pagination options set for the list.

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -269,7 +269,15 @@ func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clie
 			To(apiHandler.handleScaleResource).
 			Writes(scaling.ReplicaCounts{}))
 	apiV1Ws.Route(
+		apiV1Ws.PUT("/scale/{kind}/{name}/").
+			To(apiHandler.handleScaleResource).
+			Writes(scaling.ReplicaCounts{}))
+	apiV1Ws.Route(
 		apiV1Ws.GET("/scale/{kind}/{namespace}/{name}").
+			To(apiHandler.handleGetReplicaCount).
+			Writes(scaling.ReplicaCounts{}))
+	apiV1Ws.Route(
+		apiV1Ws.GET("/scale/{kind}/{name}").
 			To(apiHandler.handleGetReplicaCount).
 			Writes(scaling.ReplicaCounts{}))
 
@@ -550,7 +558,7 @@ func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clie
 	apiV1Ws.Route(
 		apiV1Ws.GET("/crd/{namespace}/{crd}/{object}").
 			To(apiHandler.handleGetCustomResourceObjectDetail).
-			Writes(customresourcedefinition.CustomResourceObject{}))
+			Writes(customresourcedefinition.CustomResourceObjectDetail{}))
 
 	apiV1Ws.Route(
 		apiV1Ws.GET("/crd/{namespace}/{crd}/{object}/event").

--- a/src/app/backend/resource/customresourcedefinition/detail.go
+++ b/src/app/backend/resource/customresourcedefinition/detail.go
@@ -27,9 +27,10 @@ import (
 type CustomResourceDefinitionDetail struct {
 	CustomResourceDefinition `json:",inline"`
 
-	Versions   []CustomResourceDefinitionVersion `json:"versions,omitempty"`
-	Conditions []common.Condition                `json:"conditions"`
-	Objects    CustomResourceObjectList          `json:"objects"`
+	Versions     []CustomResourceDefinitionVersion `json:"versions,omitempty"`
+	Conditions   []common.Condition                `json:"conditions"`
+	Objects      CustomResourceObjectList          `json:"objects"`
+	Subresources []string                          `json:"subresources"`
 
 	// List of non-critical errors, that occurred during resource retrieval.
 	Errors []error `json:"errors"`
@@ -61,11 +62,22 @@ func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, 
 }
 
 func toCustomResourceDefinitionDetail(crd *apiextensions.CustomResourceDefinition, objects CustomResourceObjectList, nonCriticalErrors []error) *CustomResourceDefinitionDetail {
+	subresources := []string{}
+	if crd.Spec.Subresources != nil {
+		if crd.Spec.Subresources.Scale != nil {
+			subresources = append(subresources, "Scale")
+		}
+		if crd.Spec.Subresources.Status != nil {
+			subresources = append(subresources, "Status")
+		}
+	}
+
 	return &CustomResourceDefinitionDetail{
 		CustomResourceDefinition: toCustomResourceDefinition(crd),
 		Versions:                 getCRDVersions(crd),
 		Conditions:               getCRDConditions(crd),
 		Objects:                  objects,
+		Subresources:             subresources,
 		Errors:                   nonCriticalErrors,
 	}
 }

--- a/src/app/backend/resource/deployment/detail_test.go
+++ b/src/app/backend/resource/deployment/detail_test.go
@@ -111,7 +111,10 @@ func TestGetDeploymentDetail(t *testing.T) {
 						Namespace: "ns-1",
 						Labels:    map[string]string{"foo": "bar"},
 					},
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindDeployment},
+					TypeMeta: api.TypeMeta{
+						Kind:     api.ResourceKindDeployment,
+						Scalable: true,
+					},
 					Pods: common.PodInfo{
 						Desired:  &desired,
 						Current:  4,

--- a/src/app/backend/resource/deployment/list_test.go
+++ b/src/app/backend/resource/deployment/list_test.go
@@ -114,7 +114,10 @@ func TestGetDeploymentListFromChannels(t *testing.T) {
 						Labels:            map[string]string{"key": "value"},
 						CreationTimestamp: metaV1.Unix(111, 222),
 					},
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindDeployment},
+					TypeMeta: api.TypeMeta{
+						Kind:     api.ResourceKindDeployment,
+						Scalable: true,
+					},
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  getReplicasPointer(21),

--- a/src/app/backend/resource/replicaset/common_test.go
+++ b/src/app/backend/resource/replicaset/common_test.go
@@ -35,7 +35,7 @@ func TestToReplicaSet(t *testing.T) {
 			&common.PodInfo{Running: 1, Warnings: []common.Event{}},
 			ReplicaSet{
 				ObjectMeta: api.ObjectMeta{Name: "replica-set"},
-				TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+				TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 				Pods:       common.PodInfo{Running: 1, Warnings: []common.Event{}},
 			},
 		},

--- a/src/app/backend/resource/replicaset/detail_test.go
+++ b/src/app/backend/resource/replicaset/detail_test.go
@@ -54,7 +54,7 @@ func TestGetReplicaSetDetail(t *testing.T) {
 				ReplicaSet: ReplicaSet{
 					ObjectMeta: api.ObjectMeta{Name: "rs-1", Namespace: "ns-1",
 						Labels: map[string]string{"app": "test"}},
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 					Pods: common.PodInfo{
 						Warnings: []common.Event{},
 						Desired:  &replicas,
@@ -118,7 +118,7 @@ func TestToReplicaSetDetail(t *testing.T) {
 			horizontalpodautoscaler.HorizontalPodAutoscalerList{},
 			ReplicaSetDetail{
 				ReplicaSet: ReplicaSet{
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 				},
 				Errors: []error{},
 			},
@@ -136,7 +136,7 @@ func TestToReplicaSetDetail(t *testing.T) {
 			ReplicaSetDetail{
 				ReplicaSet: ReplicaSet{
 					ObjectMeta: api.ObjectMeta{Name: "replica-set"},
-					TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+					TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 				},
 				HorizontalPodAutoscalerList: horizontalpodautoscaler.HorizontalPodAutoscalerList{
 					HorizontalPodAutoscalers: []horizontalpodautoscaler.HorizontalPodAutoscaler{{

--- a/src/app/backend/resource/replicaset/list_test.go
+++ b/src/app/backend/resource/replicaset/list_test.go
@@ -144,7 +144,7 @@ func TestGetReplicaSetListFromChannels(t *testing.T) {
 						Labels:            map[string]string{"key": "value"},
 						CreationTimestamp: metaV1.Unix(111, 222),
 					},
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+					TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  &replicas,
@@ -234,7 +234,7 @@ func TestToReplicaSetList(t *testing.T) {
 				ReplicaSets: []ReplicaSet{
 					{
 						ObjectMeta: api.ObjectMeta{Name: "replica-set", Namespace: "ns-1"},
-						TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+						TypeMeta:   api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 						Pods: common.PodInfo{
 							Warnings: []common.Event{},
 							Desired:  &replicas,
@@ -285,7 +285,7 @@ func TestGetReplicaSetList(t *testing.T) {
 							Name:   "rs-1",
 							Labels: map[string]string{},
 						},
-						TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet},
+						TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicaSet, Scalable: true},
 						Pods: common.PodInfo{
 							Desired:  &replicas,
 							Warnings: make([]common.Event, 0),

--- a/src/app/backend/resource/replicationcontroller/list_test.go
+++ b/src/app/backend/resource/replicationcontroller/list_test.go
@@ -177,7 +177,10 @@ func TestToReplicationControllerList(t *testing.T) {
 							Namespace: "namespace-1",
 							UID:       "uid-1",
 						},
-						TypeMeta:        api.TypeMeta{Kind: api.ResourceKindReplicationController},
+						TypeMeta: api.TypeMeta{
+							Kind:     api.ResourceKindReplicationController,
+							Scalable: true,
+						},
 						ContainerImages: []string{"my-container-image-1"},
 						Pods: common.PodInfo{
 							Desired:   &replicas,
@@ -193,7 +196,10 @@ func TestToReplicationControllerList(t *testing.T) {
 							Namespace: "namespace-2",
 							UID:       "uid-2",
 						},
-						TypeMeta:        api.TypeMeta{Kind: api.ResourceKindReplicationController},
+						TypeMeta: api.TypeMeta{
+							Kind:     api.ResourceKindReplicationController,
+							Scalable: true,
+						},
 						ContainerImages: []string{"my-container-image-2"},
 						Pods: common.PodInfo{
 							Desired:  &replicas,
@@ -245,7 +251,10 @@ func TestGetReplicationControllerList(t *testing.T) {
 							Name:   "rc-1",
 							Labels: map[string]string{},
 						},
-						TypeMeta: api.TypeMeta{Kind: api.ResourceKindReplicationController},
+						TypeMeta: api.TypeMeta{
+							Kind:     api.ResourceKindReplicationController,
+							Scalable: true,
+						},
 						Pods: common.PodInfo{
 							Desired:  &replicas,
 							Warnings: make([]common.Event, 0),

--- a/src/app/backend/resource/statefulset/list_test.go
+++ b/src/app/backend/resource/statefulset/list_test.go
@@ -148,7 +148,10 @@ func TestGetStatefulSetListFromChannels(t *testing.T) {
 						Labels:            map[string]string{"key": "value"},
 						CreationTimestamp: metaV1.Unix(111, 222),
 					},
-					TypeMeta: api.TypeMeta{Kind: api.ResourceKindStatefulSet},
+					TypeMeta: api.TypeMeta{
+						Kind:     api.ResourceKindStatefulSet,
+						Scalable: true,
+					},
 					Pods: common.PodInfo{
 						Current:  7,
 						Desired:  getReplicasPointer(21),

--- a/src/app/frontend/common/components/actionbars/scaledefault/component.ts
+++ b/src/app/frontend/common/components/actionbars/scaledefault/component.ts
@@ -51,7 +51,6 @@ export class ScaleDefaultActionbar implements OnInit, OnDestroy {
   }
 
   scalable(): boolean {
-    // @todo set scalable property for all scalable resources from the backend
-    return this.resourceMeta.typeMeta.scalable !== undefined || this.resourceMeta.typeMeta.scalable;
+    return this.resourceMeta.typeMeta.scalable;
   }
 }

--- a/src/app/frontend/common/components/actionbars/scaledefault/component.ts
+++ b/src/app/frontend/common/components/actionbars/scaledefault/component.ts
@@ -51,9 +51,7 @@ export class ScaleDefaultActionbar implements OnInit, OnDestroy {
   }
 
   scalable(): boolean {
-    if (this.resourceMeta.typeMeta.scalable !== undefined) {
-      return this.resourceMeta.typeMeta.scalable;
-    }
-    return true;
+    // @todo set scalable property for all scalable resources from the backend
+    return this.resourceMeta.typeMeta.scalable !== undefined || this.resourceMeta.typeMeta.scalable;
   }
 }

--- a/src/app/frontend/common/components/actionbars/scaledefault/component.ts
+++ b/src/app/frontend/common/components/actionbars/scaledefault/component.ts
@@ -49,4 +49,11 @@ export class ScaleDefaultActionbar implements OnInit, OnDestroy {
     this._unsubscribe.next();
     this._unsubscribe.complete();
   }
+
+  scalable(): boolean {
+    if (this.resourceMeta.typeMeta.scalable !== undefined) {
+      return this.resourceMeta.typeMeta.scalable;
+    }
+    return true;
+  }
 }

--- a/src/app/frontend/common/components/actionbars/scaledefault/template.html
+++ b/src/app/frontend/common/components/actionbars/scaledefault/template.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <div fxLayout="row"
      *ngIf="isVisible">
-  <kd-actionbar-detail-scale *ngIf="isInitialized && resourceMeta?.typeMeta.scalable"
+  <kd-actionbar-detail-scale *ngIf="isInitialized && scalable()"
                              [objectMeta]="resourceMeta?.objectMeta"
                              [typeMeta]="resourceMeta?.typeMeta"
                              [displayName]="resourceMeta?.displayName"></kd-actionbar-detail-scale>

--- a/src/app/frontend/common/components/actionbars/scaledefault/template.html
+++ b/src/app/frontend/common/components/actionbars/scaledefault/template.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <div fxLayout="row"
      *ngIf="isVisible">
-  <kd-actionbar-detail-scale *ngIf="isInitialized"
+  <kd-actionbar-detail-scale *ngIf="isInitialized && resourceMeta?.typeMeta.scalable"
                              [objectMeta]="resourceMeta?.objectMeta"
                              [typeMeta]="resourceMeta?.typeMeta"
                              [displayName]="resourceMeta?.displayName"></kd-actionbar-detail-scale>

--- a/src/app/frontend/common/components/list/column/menu/component.ts
+++ b/src/app/frontend/common/components/list/column/menu/component.ts
@@ -97,7 +97,7 @@ export class MenuComponent implements ActionColumn {
   }
 
   isScaleEnabled(): boolean {
-    return scalableResources.includes(this.typeMeta.kind);
+    return this.typeMeta.scalable || scalableResources.includes(this.typeMeta.kind);
   }
 
   onScale(): void {

--- a/src/app/frontend/common/components/list/column/menu/component.ts
+++ b/src/app/frontend/common/components/list/column/menu/component.ts
@@ -31,13 +31,6 @@ const loggableResources: string[] = [
   Resource.statefulSet,
 ];
 
-const scalableResources: string[] = [
-  Resource.deployment,
-  Resource.replicaSet,
-  Resource.replicationController,
-  Resource.statefulSet,
-];
-
 const pinnableResources: string[] = [Resource.crdFull];
 
 const executableResources: string[] = [Resource.pod];
@@ -97,7 +90,7 @@ export class MenuComponent implements ActionColumn {
   }
 
   isScaleEnabled(): boolean {
-    return this.typeMeta.scalable || scalableResources.includes(this.typeMeta.kind);
+    return this.typeMeta.scalable;
   }
 
   onScale(): void {

--- a/src/app/frontend/common/components/resourcelist/crdobject/template.html
+++ b/src/app/frontend/common/components/resourcelist/crdobject/template.html
@@ -65,9 +65,9 @@ limitations under the License.
       <ng-container *ngFor="let col of getActionColumns()"
                     [matColumnDef]="col.name">
         <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let crd">
+        <mat-cell *matCellDef="let object">
           <kd-dynamic-cell [component]="col.component"
-                           [resource]="crd"></kd-dynamic-cell>
+                           [resource]="object"></kd-dynamic-cell>
         </mat-cell>
       </ng-container>
 

--- a/src/app/frontend/common/dialogs/scaleresource/dialog.ts
+++ b/src/app/frontend/common/dialogs/scaleresource/dialog.ts
@@ -34,7 +34,11 @@ export class ScaleResourceDialog implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const url = `api/v1/scale/${this.data.typeMeta.kind}/${this.data.objectMeta.namespace}/${this.data.objectMeta.name}/`;
+    const url =
+      `api/v1/scale/${this.data.typeMeta.kind}` +
+      (this.data.objectMeta.namespace ? `/${this.data.objectMeta.namespace}` : '') +
+      `/${this.data.objectMeta.name}/`;
+
     this.http_
       .get<ReplicaCounts>(url)
       .toPromise()

--- a/src/app/frontend/common/services/global/verber.ts
+++ b/src/app/frontend/common/services/global/verber.ts
@@ -72,7 +72,11 @@ export class VerberService {
       .afterClosed()
       .subscribe(result => {
         if (Number.isInteger(result)) {
-          const url = `api/v1/scale/${typeMeta.kind}/${objectMeta.namespace}/${objectMeta.name}/`;
+          const url =
+            `api/v1/scale/${typeMeta.kind}` +
+            (objectMeta.namespace ? `/${objectMeta.namespace}` : '') +
+            `/${objectMeta.name}/`;
+
           this.http_
             .put(url, result, {
               params: {

--- a/src/app/frontend/crd/detail/template.html
+++ b/src/app/frontend/crd/detail/template.html
@@ -38,6 +38,11 @@ limitations under the License.
            i18n>Group</div>
       <div value>{{crd?.group}}</div>
     </kd-property>
+    <kd-property *ngIf="crd.subresources.length > 0">
+      <div key
+           i18n>Subresources</div>
+      <div value>{{crd.subresources.join(", ")}}</div>
+    </kd-property>
   </div>
 </kd-card>
 

--- a/src/app/frontend/crd/routing.ts
+++ b/src/app/frontend/crd/routing.ts
@@ -17,31 +17,64 @@ import {Route, RouterModule} from '@angular/router';
 
 import {CRDDetailComponent} from './detail/component';
 import {CRDListComponent} from './list/component';
-import {PIN_DEFAULT_ACTIONBAR} from '../common/components/actionbars/routing';
+import {DEFAULT_ACTIONBAR, PIN_DEFAULT_ACTIONBAR} from '../common/components/actionbars/routing';
 import {CRDObjectDetailComponent} from './crdobject/component';
+import {SCALE_DEFAULT_ACTIONBAR} from '../common/components/actionbars/routing';
 
 const CRD_LIST_ROUTE: Route = {
   path: '',
-  component: CRDListComponent,
-  data: {breadcrumb: 'Custom Resource Definitions'},
+  children: [
+    {
+      path: '',
+      component: CRDListComponent,
+      data: {breadcrumb: 'Custom Resource Definitions'},
+    },
+    DEFAULT_ACTIONBAR,
+  ],
 };
 
 const CRD_DETAIL_ROUTE: Route = {
-  path: ':crdName',
-  component: CRDDetailComponent,
-  data: {breadcrumb: '{{ crdName }}', parent: CRD_LIST_ROUTE},
+  path: '',
+  children: [
+    {
+      path: ':crdName',
+      component: CRDDetailComponent,
+      data: {breadcrumb: '{{ crdName }}', parent: CRD_LIST_ROUTE.children[0]},
+    },
+    PIN_DEFAULT_ACTIONBAR,
+  ],
 };
 
 const CRD_NAMESPACED_OBJECT_DETAIL_ROUTE: Route = {
   path: ':crdName/:namespace/:objectName',
-  component: CRDObjectDetailComponent,
-  data: {breadcrumb: '{{ objectName }}', routeParamsCount: 2, parent: CRD_DETAIL_ROUTE},
+  children: [
+    {
+      path: '',
+      component: CRDObjectDetailComponent,
+      data: {
+        breadcrumb: '{{ objectName }}',
+        routeParamsCount: 2,
+        parent: CRD_DETAIL_ROUTE.children[0],
+      },
+    },
+    SCALE_DEFAULT_ACTIONBAR,
+  ],
 };
 
 const CRD_CLUSTER_OBJECT_DETAIL_ROUTE: Route = {
   path: ':crdName/:objectName',
-  component: CRDObjectDetailComponent,
-  data: {breadcrumb: '{{ objectName }}', routeParamsCount: 1, parent: CRD_DETAIL_ROUTE},
+  children: [
+    {
+      path: '',
+      component: CRDObjectDetailComponent,
+      data: {
+        breadcrumb: '{{ objectName }}',
+        routeParamsCount: 1,
+        parent: CRD_DETAIL_ROUTE.children[0],
+      },
+    },
+    SCALE_DEFAULT_ACTIONBAR,
+  ],
 };
 
 @NgModule({
@@ -51,7 +84,6 @@ const CRD_CLUSTER_OBJECT_DETAIL_ROUTE: Route = {
       CRD_DETAIL_ROUTE,
       CRD_NAMESPACED_OBJECT_DETAIL_ROUTE,
       CRD_CLUSTER_OBJECT_DETAIL_ROUTE,
-      PIN_DEFAULT_ACTIONBAR,
     ]),
   ],
 })

--- a/src/app/frontend/typings/backendapi.d.ts
+++ b/src/app/frontend/typings/backendapi.d.ts
@@ -17,7 +17,7 @@ import {KdError} from '@api/frontendapi';
 
 export interface TypeMeta {
   kind: string;
-  scalable: boolean;
+  scalable?: boolean;
 }
 
 export interface ListMeta {

--- a/src/app/frontend/typings/backendapi.d.ts
+++ b/src/app/frontend/typings/backendapi.d.ts
@@ -17,6 +17,7 @@ import {KdError} from '@api/frontendapi';
 
 export interface TypeMeta {
   kind: string;
+  scalable: boolean;
 }
 
 export interface ListMeta {
@@ -459,6 +460,7 @@ export interface CRDDetail extends ResourceDetail {
   versions: CRDVersion[];
   objects: CRDObjectList;
   conditions: Condition[];
+  subresources: string[];
 }
 
 export interface CRDObjectDetail extends ResourceDetail {}


### PR DESCRIPTION
Backend implementation via `k8s.io/client-go/scale` currently unable to work with cluster-scoped resources. Tracking issue: https://github.com/kubernetes/kubernetes/issues/81380

Closes #4167 