### PR TITLE
Set GOPROXY environment variable in development container

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -98,6 +98,9 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 # Enable go mod. Note(shu-mutou): do not set this before `go get`
 ENV GO111MODULE=on
 
+# Set GOPROXY to ensure download modules
+ENV GOPROXY=https://proxy.golang.org
+
 # Volume for source code
 VOLUME ["/go/src/github.com/kubernetes/dashboard"]
 


### PR DESCRIPTION
Because downloading go modules fails sometimes, set GOPROXY to stabilize download modules.