### PR TITLE
Migrate documentation for installation

### DIFF
--- a/docs/user/certificate-management.md
+++ b/docs/user/certificate-management.md
@@ -1,6 +1,49 @@
 # Certificate management
 
-___It will be moved soon, for now you can [visit Wiki](https://github.com/kubernetes/dashboard/wiki/Certificate-management).___
+This document describes shortly how to get certificates, that can be used to enable HTTPS in Dashboard. There are two steps required to do it:
+
+1. Generate certificates.
+    1. [Public trusted CA](#public-trusted-certificate-authority).
+    2. [Self-signed certificate](#self-signed-certificate).
+2. Pass them to Dashboard.
+    1. In case you are following [Recommended Setup](./installation.md#recommended-setup) to deploy Dashboard just generate certificates and follow it.
+    2. In any other case you need to alter Dashboard's YAML deploy file and pass --tls-key-file and --tls-cert-file flags to Dashboard. More information about how to mount them into the pods can be found [here](https://kubernetes.io/docs/concepts/storage/volumes/).
+
+## Public trusted Certificate Authority
+
+There are many public and free certificate providers to choose from. One of the best trusted certificate providers is [Let's encrypt](https://letsencrypt.org/). Everything you need to know about how to generate certificates signed by their trusted CA can be found [here](https://letsencrypt.org/getting-started/).
+
+## Self-signed certificate
+
+In case you want to generate certificates on your own you need library like [OpenSSL](https://www.openssl.org/) that will help you do that.
+
+### Generate private key and certificate signing request
+
+A private key and certificate signing request are required to create an SSL certificate. These can be generated with a few simple commands. When the openssl req command asks for a “challenge password”, just press return, leaving the password empty. This password is used by Certificate Authorities to authenticate the certificate owner when they want to revoke their certificate. Since this is a self-signed certificate, there’s no way to revoke it via CRL (Certificate Revocation List).
+
+```
+openssl genrsa -des3 -passout pass:x -out dashboard.pass.key 2048
+...
+openssl rsa -passin pass:x -in dashboard.pass.key -out dashboard.key
+# Writing RSA key
+rm dashboard.pass.key
+openssl req -new -key dashboard.key -out dashboard.csr
+...
+Country Name (2 letter code) [AU]: US
+...
+A challenge password []:
+...
+```
+
+### Generate SSL certificate
+
+The self-signed SSL certificate is generated from the `dashboard.key` private key and `dashboard.csr` files.
+
+```
+openssl x509 -req -sha256 -days 365 -in dashboard.csr -signkey dashboard.key -out dashboard.crt
+```
+
+The `dashboard.crt` file is your certificate suitable for use with Dashboard along with the `dashboard.key` private key.
 
 ----
 _Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,6 +1,64 @@
 # Installation
 
-___It will be moved soon, for now you can [visit Wiki](https://github.com/kubernetes/dashboard/wiki/Installation).___
+## Official release
+
+**IMPORTANT:** Before upgrading from older version of Dashboard to 1.7+ make sure to delete Cluster Role Binding for `kubernetes-dashboard` Service Account, otherwise Dashboard will have full admin access to the cluster.
+
+### Quick setup
+
+The fastest way of deploying Dashboard has been described in our [README](../../README.md). It is destined for people that are new to Kubernetes and want to quickly start using Dashboard. Other possible setups for more experienced users, that want to know more about our deployment procedure can be found below.
+
+### Recommended setup
+
+To access Dashboard directly (without `kubectl proxy`) valid certificates should be used to establish a secure HTTPS connection. They can be generated using public trusted Certificate Authorities like [Let's Encrypt](https://letsencrypt.org/). Use them to replace the auto-generated certificates from Dashboard.
+
+By default self-signed certificates are generated and stored in-memory. In case you would like to use your custom certificates follow the below steps, otherwise skip directly to the Dashboard deploy part.
+
+Custom certificates have to be stored in a secret named `kubernetes-dashboard-certs` in the same namespace as Kubernetes Dashboard. Assuming that you have `dashboard.crt` and `dashboard.key` files stored under `$HOME/certs` directory, you should create secret with contents of these files:
+
+```
+kubectl create secret generic kubernetes-dashboard-certs --from-file=$HOME/certs -n kubernetes-dashboard
+```
+
+Afterwards, you are ready to deploy Dashboard using the following command:
+
+```
+kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta3/aio/deploy/recommended.yaml
+```
+
+### Alternative setup
+
+This setup is not fully secure. Certificates are not used and Dashboard is exposed only over HTTP. In this setup access control can be ensured only by using [Authorization Header](./access-control/README.md#authorization-header) feature.
+
+To deploy Dashboard execute following command:
+
+```
+kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta3/aio/deploy/alternative.yaml
+```
+
+## Development release
+
+Besides official releases, there are also development releases, that are pushed after every successful master build. It is not advised to use them on production environment as they are less stable than the official ones. Following sections describe installation and discovery of development releases.
+
+### Installation
+
+In most of the use cases you need to execute the following command to deploy latest development release:
+
+```
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta3/aio/deploy/head.yaml
+```
+
+### Update
+
+Once installed, the deployment is not automatically updated. In order to update it you need to delete the deployment's pods and wait for it to be recreated. After recreation, it should use the latest image.
+
+Delete all Dashboard pods (assuming that Dashboard is deployed in kubernetes-dashboard namespace):
+
+```
+kubectl -n kubernetes-dashboard delete $(kubectl -n kubernetes-dashboard get pod -o name | grep dashboard)
+pod "dashboard-metrics-scraper-fb986f88d-gnfnk" deleted
+pod "kubernetes-dashboard-7d8b9cc8d-npljm" deleted
+```
 
 ----
 _Copyright 2019 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_


### PR DESCRIPTION
Migrate Wiki pages for Installation and Certificate Management into `docs`.

Related to #4008