### PR TITLE
Fix prod build for macOS

### DIFF
--- a/aio/gulp/backend.js
+++ b/aio/gulp/backend.js
@@ -101,7 +101,6 @@ function backendProd(outputBinaryPathsAndArchs) {
             // Disable cgo package. Required to run on scratch docker image.
             CGO_ENABLED: '0',
             GOARCH: arch,
-            GOOS: 'linux',
           });
     };
   };


### PR DESCRIPTION
`GOOS` is set automatically, no need to block it only for `linux`.