### PR TITLE
Remove redundant settings in deploy configs

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -50,17 +50,6 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard-certs
-  namespace: kubernetes-dashboard
-type: Opaque
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard-csrf
   namespace: kubernetes-dashboard
 type: Opaque
@@ -101,7 +90,7 @@ rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]
@@ -156,7 +145,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -90,7 +90,7 @@ rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]

--- a/aio/deploy/alternative/03_dashboard-secret.yaml
+++ b/aio/deploy/alternative/03_dashboard-secret.yaml
@@ -17,17 +17,6 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard-certs
-  namespace: kubernetes-dashboard
-type: Opaque
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard-csrf
   namespace: kubernetes-dashboard
 type: Opaque

--- a/aio/deploy/alternative/05_dashboard-rbac.yaml
+++ b/aio/deploy/alternative/05_dashboard-rbac.yaml
@@ -23,7 +23,7 @@ rules:
     # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]
@@ -78,7 +78,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/aio/deploy/alternative/05_dashboard-rbac.yaml
+++ b/aio/deploy/alternative/05_dashboard-rbac.yaml
@@ -23,7 +23,7 @@ rules:
     # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -50,17 +50,6 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard-head
-  name: kubernetes-dashboard-certs
-  namespace: kubernetes-dashboard-head
-type: Opaque
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-csrf
   namespace: kubernetes-dashboard-head
 type: Opaque
@@ -156,7 +145,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-head
-  namespace: kubernetes-dashboard-head
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/aio/deploy/head/03_dashboard-secret.yaml
+++ b/aio/deploy/head/03_dashboard-secret.yaml
@@ -17,17 +17,6 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard-head
-  name: kubernetes-dashboard-certs
-  namespace: kubernetes-dashboard-head
-type: Opaque
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    k8s-app: kubernetes-dashboard-head
   name: kubernetes-dashboard-csrf
   namespace: kubernetes-dashboard-head
 type: Opaque

--- a/aio/deploy/head/05_dashboard-rbac.yaml
+++ b/aio/deploy/head/05_dashboard-rbac.yaml
@@ -23,7 +23,7 @@ rules:
     # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]

--- a/aio/deploy/head/05_dashboard-rbac.yaml
+++ b/aio/deploy/head/05_dashboard-rbac.yaml
@@ -23,7 +23,7 @@ rules:
     # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-csrf"]
     verbs: ["get", "update", "delete"]
     # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [""]
@@ -78,7 +78,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-head
-  namespace: kubernetes-dashboard-head
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -156,7 +156,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/aio/deploy/recommended/05_dashboard-rbac.yaml
+++ b/aio/deploy/recommended/05_dashboard-rbac.yaml
@@ -78,7 +78,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
* ClusterRoleBinding is cluster scoped, not bound to a namespace
* Secret kubernetes-dashboard-certs is not used when --auto-generate-certificates not set