### PR TITLE
Fix build script

### DIFF
--- a/aio/scripts/build.sh
+++ b/aio/scripts/build.sh
@@ -106,7 +106,7 @@ function parse::args {
 }
 
 # Execute script.
-START=$(date +%s.%N)
+START=$(date +%s)
 
 parse::args "$@"
 clean
@@ -129,6 +129,6 @@ copy::frontend
 copy::supported-locales
 copy::dockerfile
 
-END=$(date +%s.%N)
+END=$(date +%s)
 TOOK=$(echo "${END} - ${START}" | bc)
 say "\nBuild finished successfully after ${TOOK}s"


### PR DESCRIPTION
In MacOS, `date` command does not have `%N` option.
We do not need elapsed time in nanosecond.

Related: #4128

