### PR TITLE
Fix create resource input component: set inputData string to empty

### DIFF
--- a/src/app/frontend/create/from/input/component.ts
+++ b/src/app/frontend/create/from/input/component.ts
@@ -24,7 +24,7 @@ import {NamespaceService} from '../../../common/services/global/namespace';
   styleUrls: ['./style.scss'],
 })
 export class CreateFromInputComponent {
-  inputData: string;
+  inputData = '';
 
   constructor(
     private readonly namespace_: NamespaceService,


### PR DESCRIPTION
Fixes #4273 

undefined string's initial value caused errors, as described in the issue above.
