### PR TITLE
Apply Security hardening

### DIFF
--- a/aio/Dockerfile
+++ b/aio/Dockerfile
@@ -17,7 +17,7 @@
 
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
-FROM gcr.io/distroless/static
+FROM scratch
 
 # Add all files from current working directory to the root of the image, i.e., copy dist directory
 # layout to the root directory.

--- a/aio/Dockerfile
+++ b/aio/Dockerfile
@@ -17,7 +17,7 @@
 
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
-FROM scratch
+FROM gcr.io/distroless/static
 
 # Add all files from current working directory to the root of the image, i.e., copy dist directory
 # layout to the root directory.

--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -257,6 +257,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: dashboard-metrics-scraper

--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -208,6 +208,11 @@ spec:
               port: 9090
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: tmp-volume
           emptyDir: {}
@@ -269,6 +274,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/alternative/06_dashboard-deployment.yaml
+++ b/aio/deploy/alternative/06_dashboard-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: kubernetes-dashboard

--- a/aio/deploy/alternative/06_dashboard-deployment.yaml
+++ b/aio/deploy/alternative/06_dashboard-deployment.yaml
@@ -52,6 +52,11 @@ spec:
               port: 9090
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: tmp-volume
           emptyDir: {}

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
       - name: dashboard-metrics-scraper

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -46,6 +46,11 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -208,6 +208,11 @@ spec:
               port: 9090
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: tmp-volume
           emptyDir: {}
@@ -269,6 +274,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard-head
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -257,6 +257,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper-head
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: dashboard-metrics-scraper-head

--- a/aio/deploy/head/06_dashboard-deployment.yaml
+++ b/aio/deploy/head/06_dashboard-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard-head
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: kubernetes-dashboard-head

--- a/aio/deploy/head/06_dashboard-deployment.yaml
+++ b/aio/deploy/head/06_dashboard-deployment.yaml
@@ -57,6 +57,11 @@ spec:
               port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: kubernetes-dashboard-certs
           secret:

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -43,6 +43,11 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper-head
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
       - name: dashboard-metrics-scraper-head

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -213,6 +213,11 @@ spec:
               port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: kubernetes-dashboard-certs
           secret:
@@ -277,6 +282,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -265,6 +265,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: dashboard-metrics-scraper

--- a/aio/deploy/recommended/06_dashboard-deployment.yaml
+++ b/aio/deploy/recommended/06_dashboard-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: kubernetes-dashboard

--- a/aio/deploy/recommended/06_dashboard-deployment.yaml
+++ b/aio/deploy/recommended/06_dashboard-deployment.yaml
@@ -57,6 +57,11 @@ spec:
               port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: kubernetes-dashboard-certs
           secret:

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -46,6 +46,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         k8s-app: dashboard-metrics-scraper
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       containers:
         - name: dashboard-metrics-scraper


### PR DESCRIPTION
**What this PR does / why we need it**:
Hardens the dashboard add-on by implementing some security best practices, such as:
- Run as non-root & disallow privilege escalation
- ReadOnlyRootFilesystem
- Replaces deprecated seccomp
- Reduces dependencies in the base image (https://github.com/kubernetes/kubernetes/issues/40248 https://github.com/kubernetes/kubernetes/issues/70249)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4287

/assign @tallclair
/sig auth
