### PR TITLE
Change base image to distroless/static

### DIFF
--- a/aio/Dockerfile
+++ b/aio/Dockerfile
@@ -17,7 +17,7 @@
 
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
-FROM scratch
+FROM gcr.io/distroless/static
 
 # Add all files from current working directory to the root of the image, i.e., copy dist directory
 # layout to the root directory.


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces the base image with distroless/static. This is a continuation of the PR #4288 

Context around this change can be found on its [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md) and on upstream issue: kubernetes/kubernetes#70249

**Which issue(s) this PR fixes**:
Fixes #4287