### PR TITLE
modify the comment in pod/common.go

### DIFF
--- a/src/app/backend/resource/pod/common.go
+++ b/src/app/backend/resource/pod/common.go
@@ -46,7 +46,7 @@ func getPodStatus(pod v1.Pod, warnings []common.Event) PodStatus {
 	}
 }
 
-// getPodStatus returns one of three pod statuses (pending, success, failed)
+// getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed)
 func getPodStatusPhase(pod v1.Pod, warnings []common.Event) v1.PodPhase {
 	// For terminated pods that failed
 	if pod.Status.Phase == v1.PodFailed {
@@ -79,7 +79,7 @@ func getPodStatusPhase(pod v1.Pod, warnings []common.Event) v1.PodPhase {
 		return v1.PodFailed
 	}
 
-	// Unknown?
+	// pending
 	return v1.PodPending
 }
 


### PR DESCRIPTION
The solution to fix issue #4318 : the comment is wrong, and it should be "getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed)" @floreks The pr #4322 is still has some wrong(the method name),  and I will close it after.  @maciaszczykm Please has a look, if it have other something wrong, please let me know, and i will fix it, thank you all~