### PR TITLE
Fix alternative deployment auth header usage

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -194,6 +194,7 @@ spec:
               protocol: TCP
           args:
             - --namespace=kubernetes-dashboard
+            - --enable-insecure-login
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.

--- a/aio/deploy/alternative/06_dashboard-deployment.yaml
+++ b/aio/deploy/alternative/06_dashboard-deployment.yaml
@@ -40,6 +40,7 @@ spec:
               protocol: TCP
           args:
             - --namespace=kubernetes-dashboard
+            - --enable-insecure-login=true
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.


### PR DESCRIPTION
To allow usage of authorization header when Dashboard is exposed via HTTP, we have to add this flag.

Fixes #4312