### PR TITLE
Add labels key to i18n/ja/OWNERS

### DIFF
--- a/i18n/ja/OWNERS
+++ b/i18n/ja/OWNERS
@@ -2,3 +2,6 @@ approvers:
   - shu-mutou
   - atoato88
 
+labels:
+- language/ja
+


### PR DESCRIPTION
This PR adds `labels` item to `i18n/ja/OWNERS` for automatic `language/ja` labeling.