### PR TITLE
Add "language/xx" to "labels" in all i18n OWNERS

### DIFF
--- a/i18n/fr/OWNERS
+++ b/i18n/fr/OWNERS
@@ -1,3 +1,5 @@
 approvers:
   - feloy
 
+labels:
+- language/fr

--- a/i18n/ja/OWNERS
+++ b/i18n/ja/OWNERS
@@ -4,4 +4,3 @@ approvers:
 
 labels:
 - language/ja
-

--- a/i18n/ko/OWNERS
+++ b/i18n/ko/OWNERS
@@ -1,3 +1,5 @@
 approvers:
   - seokho-son
 
+labels:
+- language/ko

--- a/i18n/zh/OWNERS
+++ b/i18n/zh/OWNERS
@@ -1,0 +1,2 @@
+labels:
+- language/zh


### PR DESCRIPTION
This PR adds "language/xx" to "labels" key in all `i18n/xx/OWNERS` files.
By this change, if any files in `i18n/xx/` has changed, "language/xx" label is added in automatically.
