### PR TITLE
Enlarge the "Edit a resource" modal

### DIFF
--- a/src/app/frontend/common/components/textinput/component.ts
+++ b/src/app/frontend/common/components/textinput/component.ts
@@ -47,6 +47,7 @@ export class TextInputComponent implements OnInit {
   // All possible options can be found at:
   // https://github.com/ajaxorg/ace/wiki/Configuring-Ace
   options = {
+    showPrintMargin: false,
     highlightActiveLine: false,
     tabSize: 2,
     wrap: true,

--- a/src/app/frontend/common/services/global/verber.ts
+++ b/src/app/frontend/common/services/global/verber.ts
@@ -108,7 +108,7 @@ export class VerberService {
     typeMeta: TypeMeta,
     objectMeta: ObjectMeta,
   ): MatDialogConfig<ResourceMeta> {
-    return {width: '630px', data: {displayName, typeMeta, objectMeta}};
+    return {width: '900px', data: {displayName, typeMeta, objectMeta}};
   }
 
   handleErrorResponse_(err: HttpErrorResponse): void {


### PR DESCRIPTION
Fixes #4225 

Also removes the ACE Editor margin mark which becomes visible when enlarging the editor zone