### PR TITLE
Improve contras ratio for dark theme

### DIFF
--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -91,12 +91,14 @@ $kd-dark-theme-warn: mat-palette($kd-dark-palette-warn);
 
 $kd-dark-theme: mat-dark-theme($kd-dark-theme-primary, $kd-dark-theme-accent, $kd-dark-theme-warn);
 
+// sass-lint:disable function-name-format
 $background: map-get($kd-dark-theme, background);
 $background: map_merge($background, (background: #1d1d1d));
 $background: map_merge($background, (app-bar: #1d1d1d));
 $background: map_merge($background, (card: #2d2d2d));
 $background: map_merge($background, (dialog: #2d2d2d));
 $kd-dark-theme: map_merge($kd-dark-theme, (background: $background));
+// sass-lint:enable function-name-format
 
 .kd-dark-theme {
   @include angular-material-theme($kd-dark-theme);

--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -18,12 +18,12 @@
 $kd-dark-palette-primary: (
   50: #fff, // Primary toolbar buttons.
   100: #fff,
-  200: #326de6,
+  200: #327df4,
   300: #9575cd,
   400: #7e57c2,
-  500: #326de6,
+  500: #327df4,
   600: #5e35b1,
-  700: #326de6,
+  700: #327df4,
   800: #4527a0,
   900: #311b92,
   A100: #b388ff,
@@ -51,7 +51,7 @@ $kd-dark-palette-primary: (
 $kd-dark-palette-warn: (
   50: #00c752, // Chart green.
   100: #008000,
-  200: #326de6, // Chart blue.
+  200: #327df4, // Chart blue.
   300: #0d47a1,
   400: #ff0,
   500: #ffad20,
@@ -90,6 +90,13 @@ $kd-dark-theme-accent: mat-palette($kd-dark-palette-accent);
 $kd-dark-theme-warn: mat-palette($kd-dark-palette-warn);
 
 $kd-dark-theme: mat-dark-theme($kd-dark-theme-primary, $kd-dark-theme-accent, $kd-dark-theme-warn);
+
+$background: map-get($kd-dark-theme, background);
+$background: map_merge($background, (background: #1d1d1d));
+$background: map_merge($background, (app-bar: #1d1d1d));
+$background: map_merge($background, (card: #2d2d2d));
+$background: map_merge($background, (dialog: #2d2d2d));
+$kd-dark-theme: map_merge($kd-dark-theme, (background: $background));
 
 .kd-dark-theme {
   @include angular-material-theme($kd-dark-theme);

--- a/src/app/frontend/_light.scss
+++ b/src/app/frontend/_light.scss
@@ -97,6 +97,8 @@ $kd-light-theme: mat-light-theme($kd-light-theme-primary, $kd-light-theme-accent
   @include kd-theme($kd-light-theme);
 
   .kd-primary-toolbar {
+    // sass-lint:disable no-color-literals
     background-color: #fafafa;
+    // sass-lint:enable no-color-literals
   }
 }

--- a/src/app/frontend/_light.scss
+++ b/src/app/frontend/_light.scss
@@ -95,4 +95,8 @@ $kd-light-theme: mat-light-theme($kd-light-theme-primary, $kd-light-theme-accent
 .kd-light-theme {
   @include angular-material-theme($kd-light-theme);
   @include kd-theme($kd-light-theme);
+
+  .kd-primary-toolbar {
+    background-color: #fafafa;
+  }
 }

--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -183,10 +183,6 @@
     background: $border;
   }
 
-  .kd-primary-toolbar {
-    background-color: lighten($background, 5%);
-  }
-
   .kd-search {
     background-color: darken($background, 5%);
 


### PR DESCRIPTION
Fixes #4188

I have improved current contrast ratios between app/card background and primary color.

#### Previous 
`2.1` - card background -> primary
`2.8` -  app background -> primary

![Zrzut ekranu z 2019-11-21 12-54-26](https://user-images.githubusercontent.com/2285385/69336849-bff2ac80-0c5f-11ea-9404-66688d448ccd.png)


#### Current
`3.5` - card background -> primary
`4.3` - app background -> primary

![Zrzut ekranu z 2019-11-21 12-54-32](https://user-images.githubusercontent.com/2285385/69336856-c2ed9d00-0c5f-11ea-92f0-8288f7102aee.png)

Still it's not suggested ratio of `4.5`, but it's hard to achieve that without making it look worse. We can work on that later on if needed.