### PR TITLE
Add apiserver-host-ca-file flag to dashboard

### DIFF
--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -84,6 +84,12 @@ func (self *holderBuilder) SetApiServerHost(apiServerHost string) *holderBuilder
 	return self
 }
 
+// SetApiServerHostCAFile 'api-server-host-ca-file' argument of Dashboard binary.
+func (self *holderBuilder) SetApiServerHostCAFile(apiServerHostCAFile string) *holderBuilder {
+	self.holder.apiServerHostCAFile = apiServerHostCAFile
+	return self
+}
+
 // SetMetricsProvider 'metrics-provider' argument of Dashboard binary.
 func (self *holderBuilder) SetMetricsProvider(metricsProvider string) *holderBuilder {
 	self.holder.metricsProvider = metricsProvider

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -37,6 +37,7 @@ type holder struct {
 	certFile             string
 	keyFile              string
 	apiServerHost        string
+	apiServerHostCAFile  string
 	metricsProvider      string
 	heapsterHost         string
 	sidecarHost          string
@@ -113,6 +114,11 @@ func (self *holder) GetKeyFile() string {
 // GetApiServerHost 'apiserver-host' argument of Dashboard binary.
 func (self *holder) GetApiServerHost() string {
 	return self.apiServerHost
+}
+
+// GetApiServerHostCAFile 'apiserver-host-ca-file' argument of Dashboard binary
+func (self *holder) GetApiServerHostCAFile() string {
+	return self.apiServerHostCAFile
 }
 
 // GetMetricsProvider 'metrics-provider' argument of Dashboard binary.

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -285,7 +285,7 @@ func (self *clientManager) initConfig(cfg *rest.Config) {
 // empty then in-cluster config will be used and if it is nil the error is returned.
 func (self *clientManager) buildConfigFromFlags(apiserverHost, apiserverHostCAFile, kubeConfigPath string) (
 	*rest.Config, error) {
-	if len(kubeConfigPath) > 0 || len(apiserverHost) > 0 || len(apiserverHostCAFile) > 0 {
+	if len(kubeConfigPath) > 0 || len(apiserverHost) > 0 {
 		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
 			&clientcmd.ConfigOverrides{

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -56,8 +56,9 @@ var (
 		"to connect to in the format of protocol://address:port, e.g., "+
 		"http://localhost:8080. If not specified, the assumption is that the binary runs inside a "+
 		"Kubernetes cluster and local discovery is attempted.")
-	argMetricsProvider = pflag.String("metrics-provider", "sidecar", "Select provider type for metrics. 'none' will not check metrics.")
-	argHeapsterHost    = pflag.String("heapster-host", "", "The address of the Heapster Apiserver "+
+	argApiserverHostCAFile = pflag.String("apiserver-host-ca-file", "", "File containing the x509 CA certificate needed for validating the apiserver certificate")
+	argMetricsProvider     = pflag.String("metrics-provider", "sidecar", "Select provider type for metrics. 'none' will not check metrics.")
+	argHeapsterHost        = pflag.String("heapster-host", "", "The address of the Heapster Apiserver "+
 		"to connect to in the format of protocol://address:port, e.g., "+
 		"http://localhost:8082. If not specified, the assumption is that the binary runs inside a "+
 		"Kubernetes cluster and service proxy will be used.")
@@ -237,6 +238,7 @@ func initArgHolder() {
 	builder.SetCertFile(*argCertFile)
 	builder.SetKeyFile(*argKeyFile)
 	builder.SetApiServerHost(*argApiserverHost)
+	builder.SetApiServerHostCAFile(*argApiserverHostCAFile)
 	builder.SetMetricsProvider(*argMetricsProvider)
 	builder.SetHeapsterHost(*argHeapsterHost)
 	builder.SetSidecarHost(*argSidecarHost)


### PR DESCRIPTION
This flag allows users to provide a CA certificate for the purpose
of validating connections to the API server. This is mostly helpful
when using an `apiserver-host` that is protected by TLS.

Related to https://github.com/kubernetes/dashboard/issues/4589