### PR TITLE
Initialze overwatches restartCount map

### DIFF
--- a/src/app/backend/sync/overwatch.go
+++ b/src/app/backend/sync/overwatch.go
@@ -31,8 +31,9 @@ var Overwatch *overwatch
 // Initializes and starts Overwatch instance. It is private to make sure that only one instance is running.
 func init() {
 	Overwatch = &overwatch{
-		syncMap:   make(map[string]syncApi.Synchronizer),
-		policyMap: make(map[string]RestartPolicy),
+		syncMap:      make(map[string]syncApi.Synchronizer),
+		policyMap:    make(map[string]RestartPolicy),
+		restartCount: make(map[string]int),
 
 		registrationSignal: make(chan string),
 		restartSignal:      make(chan string),


### PR DESCRIPTION
The restartCount map is never initialized, thus writes to it cause a panic (on beta.4 but this wasn't fixed in the meantime):
```
2019/11/27 18:32:11 Starting overwatch
2019/11/27 18:32:11 Using kubeconfig file: /etc/kubernetes/kubeconfig/kubeconfig
2019/11/27 18:32:11 Using namespace: kubernetes-dashboard
2019/11/27 18:32:11 Skipping in-cluster config
2019/11/27 18:32:11 Using random key for csrf signing
2019/11/27 18:32:12 Successful initial request to the apiserver, version: v1.16.3
2019/11/27 18:32:12 Generating JWE encryption key
2019/11/27 18:32:12 New synchronizer has been registered: kubernetes-dashboard-key-holder-kubernetes-dashboard. Starting
2019/11/27 18:32:12 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kubernetes-dashboard
2019/11/27 18:32:12 Synchronizer kubernetes-dashboard-key-holder-kubernetes-dashboard exited with error: unexpected object: &Secret{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,ManagedFields:[],},Data:map[string][]byte{},Type:,StringData:map[string]string{},}
2019/11/27 18:32:14 Initializing secret synchronizer synchronously using secret kubernetes-dashboard-key-holder from namespace kubernetes-dashboard
2019/11/27 18:32:14 Initializing JWE encryption key from synchronized object
2019/11/27 18:32:14 Creating in-cluster Sidecar client
2019/11/27 18:32:14 Metric client health check failed: the server could not find the requested resource (get services dashboard-metrics-scraper). Retrying in 30 seconds.
E1127 18:32:14.090000       1 runtime.go:73] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
goroutine 32 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x13c5280, 0x1760ff0)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/runtime/runtime.go:69 +0x7b
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/runtime/runtime.go:51 +0x82
panic(0x13c5280, 0x1760ff0)
	/home/travis/.gimme/versions/go1.12.6.linux.amd64/src/runtime/panic.go:522 +0x1b5
github.com/kubernetes/dashboard/src/app/backend/sync.(*overwatch).monitorSynchronizerStatus.func1()
	/home/travis/build/kubernetes/dashboard/src/app/backend/sync/overwatch.go:125 +0x24c
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00047ce40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:152 +0x54
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00047ce40, 0x0, 0x0, 0x1, 0xc0001a8e40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc00047ce40, 0x0, 0xc0001a8e40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:88 +0x4d
created by github.com/kubernetes/dashboard/src/app/backend/sync.(*overwatch).monitorSynchronizerStatus
	/home/travis/build/kubernetes/dashboard/src/app/backend/sync/overwatch.go:117 +0x102
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 32 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/runtime/runtime.go:58 +0x105
panic(0x13c5280, 0x1760ff0)
	/home/travis/.gimme/versions/go1.12.6.linux.amd64/src/runtime/panic.go:522 +0x1b5
github.com/kubernetes/dashboard/src/app/backend/sync.(*overwatch).monitorSynchronizerStatus.func1()
	/home/travis/build/kubernetes/dashboard/src/app/backend/sync/overwatch.go:125 +0x24c
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00047ce40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:152 +0x54
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00047ce40, 0x0, 0x0, 0x1, 0xc0001a8e40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc00047ce40, 0x0, 0xc0001a8e40)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/wait/wait.go:88 +0x4d
created by github.com/kubernetes/dashboard/src/app/backend/sync.(*overwatch).monitorSynchronizerStatus
	/home/travis/build/kubernetes/dashboard/src/app/backend/sync/overwatch.go:117 +0x102
```

/kind bug
/assign @floreks 