### PR TITLE
Deprecate API version in sample plugin-crd

### DIFF
--- a/aio/test-resources/plugin-crd.yml
+++ b/aio/test-resources/plugin-crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: plugins.dashboard.k8s.io


### PR DESCRIPTION
This is a temporary fix to at least enable developers to work and test it out.
#4598 