### PR TITLE
Add firefox and enable to run test on development container

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -43,6 +43,7 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
 	xvfb \
 	libgtk-3-0 \
 	libgconf-2-4 \
+	bzip2 \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& apt-get clean
 
@@ -52,6 +53,12 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
 #                 So re-install specified version of git from source code.
 RUN GIT_VERSION=2.22.0 && apt-get remove -y git && cd /tmp && rm -fr git* && wget https://github.com/git/git/archive/v${GIT_VERSION}.zip -O git.zip && unzip git.zip && mv git-${GIT_VERSION} git && cd git && make prefix=/usr all && make prefix=/usr install
 ENV GIT_EDITOR=nano
+
+# Install firefox from Mozilla binaries
+RUN mkdir -p /usr/local/lib/firefox
+RUN wget "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O /tmp/firefox.tar.bz2
+RUN tar -xjf /tmp/firefox.tar.bz2 -C /usr/local/lib
+RUN ln -s /usr/local/lib/firefox/firefox /usr/local/bin/firefox
 
 # Install dependencies. This will take a while.
 RUN npm install -g npm@latest gulp@4.0.2 @angular/cli@8.0.3 ngx-i18nsupport

--- a/aio/karma.conf.js
+++ b/aio/karma.conf.js
@@ -75,8 +75,8 @@ module.exports = function(config) {
     singleRun: false
   };
 
-  // Use custom browser configuration when running on Travis CI.
-  if (!!process.env.TRAVIS) {
+  // Use custom browser configuration when running on Travis CI or container.
+  if (!!process.env.TRAVIS || !!process.env.K8S_DASHBOARD_CONTAINER) {
     configuration.browsers = ['ChromeHeadless', 'FirefoxHeadless'];
     configuration.customLaunchers = {
       ChromeHeadless: {
@@ -91,22 +91,6 @@ module.exports = function(config) {
       FirefoxHeadless: {
         base: 'Firefox',
         flags: ['-headless'],
-      },
-    };
-  }
-
-  // Use custom browser configuration when running on container.
-  if (!!process.env.K8S_DASHBOARD_CONTAINER) {
-    configuration.browsers = ['ChromeHeadless'];
-    configuration.customLaunchers = {
-      ChromeHeadless: {
-        base: 'Chrome',
-        flags: [
-          '--disable-gpu',
-          '--headless',
-          '--no-sandbox',
-          '--remote-debugging-port=9222',
-        ],
       },
     };
   }


### PR DESCRIPTION
We should check not only chrome but also firefox on local development environment.
So install firefox and enable to run test using firefox on container.