### PR TITLE
Use bionic in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
 # Travis continuous integration system configuration file.
-# Read more at: http://docs.travis-ci.com/user/customizing-the-build/
+# Read more follows:
+# * https://docs.travis-ci.com/user/customizing-the-build/
+# * https://docs.travis-ci.com/user/reference/bionic/
+# * https://docs.travis-ci.com/user/installing-dependencies/
+# * https://config.travis-ci.com/ref/job/addons/apt
 
 sudo: required
-dist: xenial
+dist: bionic
 language: node_js
 node_js: 11.6.0
+
+apt:
+  packages:
+  - google-chrome
+  sources:
+  - google-chrome-stable
+  update: true
 
 git:
   depth: 500
@@ -24,13 +35,14 @@ before_install:
   - export PATH=$PATH:$GOPATH/bin
   - eval "$(gimme 1.12.6)"
 
+# `npm ci` will run between `before_install` and `before_script`.
+
 before_script:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce libgconf2-4
-  - sudo service docker restart
+  - echo "Recheck versions before job."
+  - go version
   - docker --version
+  - google-chrome-stable --version
+  - firefox --version
 
 jobs:
   include:


### PR DESCRIPTION
Ubuntu bionic image is available now.

To switch to bionic, change travis.yml according to follows.
* https://docs.travis-ci.com/user/reference/bionic/
* https://docs.travis-ci.com/user/installing-dependencies/
* https://config.travis-ci.com/ref/job/addons/apt