### PR TITLE
Modified the PodRequestAndLimits function

### DIFF
--- a/src/app/backend/resource/node/detail.go
+++ b/src/app/backend/resource/node/detail.go
@@ -231,51 +231,60 @@ func getNodeAllocatedResources(node v1.Node, podList *v1.PodList) (NodeAllocated
 }
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
-// containers of the pod.
-func PodRequestsAndLimits(pod *v1.Pod) (reqs map[v1.ResourceName]resource.Quantity, limits map[v1.ResourceName]resource.Quantity, err error) {
-	reqs, limits = map[v1.ResourceName]resource.Quantity{}, map[v1.ResourceName]resource.Quantity{}
+// containers of the pod. If pod overhead is non-nil, the pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity.
+func PodRequestsAndLimits(pod *v1.Pod) (reqs, limits v1.ResourceList, err error) {
+	reqs, limits = v1.ResourceList{}, v1.ResourceList{}
 	for _, container := range pod.Spec.Containers {
-		for name, quantity := range container.Resources.Requests {
-			if value, ok := reqs[name]; !ok {
-				reqs[name] = quantity.DeepCopy()
-			} else {
-				value.Add(quantity)
-				reqs[name] = value
-			}
-		}
-		for name, quantity := range container.Resources.Limits {
-			if value, ok := limits[name]; !ok {
-				limits[name] = quantity.DeepCopy()
-			} else {
+		addResourceList(reqs, container.Resources.Requests)
+		addResourceList(limits, container.Resources.Limits)
+	}
+	// init containers define the minimum of any resource
+	for _, container := range pod.Spec.InitContainers {
+		maxResourceList(reqs, container.Resources.Requests)
+		maxResourceList(limits, container.Resources.Limits)
+	}
+
+	// Add overhead for running a pod to the sum of requests and to non-zero limits:
+	if pod.Spec.Overhead != nil {
+		addResourceList(reqs, pod.Spec.Overhead)
+
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
 				value.Add(quantity)
 				limits[name] = value
 			}
 		}
 	}
-	// init containers define the minimum of any resource
-	for _, container := range pod.Spec.InitContainers {
-		for name, quantity := range container.Resources.Requests {
-			value, ok := reqs[name]
-			if !ok {
-				reqs[name] = quantity.DeepCopy()
-				continue
-			}
-			if quantity.Cmp(value) > 0 {
-				reqs[name] = quantity.DeepCopy()
-			}
+	return
+}
+
+// addResourceList adds the resources in newList to list
+func addResourceList(list, new v1.ResourceList) {
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
 		}
-		for name, quantity := range container.Resources.Limits {
-			value, ok := limits[name]
-			if !ok {
-				limits[name] = quantity.DeepCopy()
-				continue
-			}
+	}
+}
+
+// maxResourceList sets list to the greater of list/newList for every resource
+// either list
+func maxResourceList(list, new v1.ResourceList) {
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+			continue
+		} else {
 			if quantity.Cmp(value) > 0 {
-				limits[name] = quantity.DeepCopy()
+				list[name] = quantity.DeepCopy()
 			}
 		}
 	}
-	return
 }
 
 // GetNodePods return pods list in given named node


### PR DESCRIPTION
Modified the PodRequestAndLimits function and Add overhead for running a pod to the sum of requests and to non-zero limits.
do as kubectl [PodRequestsAndLimits in kubectl](https://github.com/kubernetes/kubernetes/blob/3d17fd5c4f6b1ed22499c4db192e1ed6a867d579/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go)