### PR TITLE
Dashboard fix pod status

### DIFF
--- a/src/app/backend/resource/common/resourcestatus.go
+++ b/src/app/backend/resource/common/resourcestatus.go
@@ -27,4 +27,10 @@ type ResourceStatus struct {
 
 	// Number of resources that are in succeeded state.
 	Succeeded int `json:"succeeded"`
+
+	// Number of resources that are in unknown state.
+	Unknown int `json:"unknown"`
+
+	// Number of resources that are in terminating state.
+	Terminating int `json:"terminating"`
 }

--- a/src/app/backend/resource/pod/common.go
+++ b/src/app/backend/resource/pod/common.go
@@ -46,7 +46,7 @@ func getPodStatus(pod v1.Pod, warnings []common.Event) PodStatus {
 	}
 }
 
-// getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed, Unknow, Terminating)
+// getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed, Unknown, Terminating)
 func getPodStatusPhase(pod v1.Pod, warnings []common.Event) v1.PodPhase {
 	// For terminated pods that failed
 	if pod.Status.Phase == v1.PodFailed {

--- a/src/app/backend/resource/pod/common.go
+++ b/src/app/backend/resource/pod/common.go
@@ -46,7 +46,7 @@ func getPodStatus(pod v1.Pod, warnings []common.Event) PodStatus {
 	}
 }
 
-// getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed)
+// getPodStatusPhase returns one of four pod status phases (Pending, Running, Succeeded, Failed, Unknow, Terminating)
 func getPodStatusPhase(pod v1.Pod, warnings []common.Event) v1.PodPhase {
 	// For terminated pods that failed
 	if pod.Status.Phase == v1.PodFailed {
@@ -77,6 +77,12 @@ func getPodStatusPhase(pod v1.Pod, warnings []common.Event) v1.PodPhase {
 	// failed and show and error to the user.
 	if len(warnings) > 0 {
 		return v1.PodFailed
+	}
+
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
+		return v1.PodUnknown
+	} else if pod.DeletionTimestamp != nil {
+		return "Terminating"
 	}
 
 	// pending
@@ -160,6 +166,10 @@ func getStatus(list *v1.PodList, events []v1.Event) common.ResourceStatus {
 			info.Running++
 		case v1.PodPending:
 			info.Pending++
+    case v1.PodUnknown:
+      info.Unknown++
+    case "Terminating":
+      info.Terminating++
 		}
 	}
 

--- a/src/app/backend/resource/pod/common.go
+++ b/src/app/backend/resource/pod/common.go
@@ -166,10 +166,10 @@ func getStatus(list *v1.PodList, events []v1.Event) common.ResourceStatus {
 			info.Running++
 		case v1.PodPending:
 			info.Pending++
-    case v1.PodUnknown:
-      info.Unknown++
-    case "Terminating":
-      info.Terminating++
+		case v1.PodUnknown:
+			info.Unknown++
+		case "Terminating":
+			info.Terminating++
 		}
 	}
 


### PR DESCRIPTION
refer to issue #4740 

I found that  dashboard can not handle the pod terminating status,
BTW, when the pod phase is Running and the DeletionTimestamp is not nil, dashboard will show the pod is Running, but it's Terminating if I use kubectl describe pod

cc @maciaszczykm @floreks @shu-mutou 
Please don't merge it now. I think it should be discussed. Maybe the front-end should be changed either.

Above it's some reference about pod status:
[How to use the kubernetes go-client to get the same Pod status info that kubectl gives](https://stackoverflow.com/questions/57297817/how-to-use-the-kubernetes-go-client-to-get-the-same-pod-status-info-that-kubectl)
[kubernetes/kubernetes printpod](https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go#L558)