### PR TITLE
Fix version for kubernetesui/metrics-scraper image

### DIFF
--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -271,7 +271,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.1
+          image: kubernetesui/metrics-scraper:v1.0.2
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
Will resolve #4750.

There is only one release left in dashboard-metrics-scraper. 

https://github.com/kubernetes-sigs/dashboard-metrics-scraper/releases