### PR TITLE
golangci-lint need to run against whole go files

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -97,7 +97,7 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 # `npm ci` installs golangci, but this installation is needed
 # for running `npm run check` singlely, like
 # `aio/develop/run-npm-on-container.sh run check`.
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
 
 # Install delve for debuging go files.
 RUN go get github.com/go-delve/delve/cmd/dlv

--- a/aio/scripts/pre-commit-golangci-lint.sh
+++ b/aio/scripts/pre-commit-golangci-lint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `golangci-lint` can not check files on different directory.
+# It would reports "named files must all be in one directory" error.
+# So we need to check whole files in once without filepaths from `lint-staged`.
+# lint-staged passes all staged filepaths at once.
+# So this script will be called only once.
+golangci-lint run -c .golangci.yml --fix src/app/backend/...

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "git add"
     ],
     "src/**/*.go": [
-      "golangci-lint run -c .golangci.yml --fix",
+      "./aio/scripts/pre-commit-golangci-lint.sh",
       "git add"
     ],
     "src/**/*.html": [


### PR DESCRIPTION
`golangci-lint` can not check files on different directory.
It would reports "named files must all be in one directory" error.
So we need to check whole files in once without filepaths from `lint-staged`.

Also, bump golangci-lint from 1.17.1 to 1.22.2.

Closes: #3656 