### PR TITLE
Fix version for kubernetesui/metrics-scraper image

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -253,7 +253,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.1
+          image: kubernetesui/metrics-scraper:v1.0.2
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: dashboard-metrics-scraper
-        image: kubernetesui/metrics-scraper:v1.0.1
+        image: kubernetesui/metrics-scraper:v1.0.2
         ports:
         - containerPort: 8000
           protocol: TCP

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.1
+          image: kubernetesui/metrics-scraper:v1.0.2
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
Fix further (#4768) image version strings of `kubernetesui/metrics-scraper:1.0.1` to `kubernetesui/metrics-scraper:1.0.2`

See https://github.com/kubernetes/dashboard/pull/4768#issuecomment-574067332

Initial issue reported #4750.