### PR TITLE
update documentation for building on darwin

### DIFF
--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -80,6 +80,12 @@ Open a browser and access the UI under `localhost:9090`. The following processes
 
 `Dashboard backend (9090) ---> Kubernetes API server (8080)`
 
+To build the docker image on darwin OS you will need to set environment variable for go to build as linux:
+
+```
+export GOOS=linux
+```
+
 In order to package everything into a ready-to-run Docker image, use the following task:
 
 ```


### PR DESCRIPTION
otherwise you can't build docker when working in a darwin environment, you get incompatible architectures from go build.