### PR TITLE
add bc dependence

### DIFF
--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -62,6 +62,8 @@ Once the angular server starts, it takes some time to pre-compile all assets bef
 
 ## Building Dashboard for production
 
+To build dashboard for production, you still need to install `bc`.
+
 The Dashboard project can be built for production by using the following task:
 
 ```


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Without `bc`, build would fail:
```
...
Copying locales file to backend dist dirs

Copying Dockerfile to backend dist dirs
./aio/scripts/build.sh: line 126: bc: command not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! kubernetes-dashboard@2.0.0-beta4 build: ./aio/scripts/build.sh
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the kubernetes-dashboard@2.0.0-beta4 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR! /root/.npm/_logs/2020-01-20T09_59_52_893Z-debug.log
```