### PR TITLE
comment curl

### DIFF
--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -70,6 +70,7 @@ The Dashboard project can be built for production by using the following task:
 ```
 npm run build
 ```
+Notice that it would check whether `golangci-lint` in your path, if not, it would use `curl` to install it. Make sure you have installed `curl`.
 
 The code is compiled, compressed and debug support removed. The dashboard binary can be found in the `dist` folder.
 

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -6,6 +6,7 @@ This document describes how to setup your development environment.
 
 Make sure the following software is installed and added to the $PATH variable:
 
+* Curl 7+
 * Git 2.13.2+
 * Docker 1.13.1+ ([installation manual](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/))
 * Golang 1.12.0+ ([installation manual](https://golang.org/dl/))
@@ -70,7 +71,6 @@ The Dashboard project can be built for production by using the following task:
 ```
 npm run build
 ```
-Notice that it would check whether `golangci-lint` in your path, if not, it would use `curl` to install it. Make sure you have installed `curl`.
 
 The code is compiled, compressed and debug support removed. The dashboard binary can be found in the `dist` folder.
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

If there is no `golangci-cli` or `curl`, build would fail:
```
npm WARN lifecycle kubernetes-dashboard@2.0.0-beta4~postinstall: cannot run in wd kubernetes-dashboard@2.0.0-beta4 node aio/scripts/version.js && command -v golangci-lint >/dev/
null 2>&1 || { curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1; } && go mod download (wd=/app)
```