### PR TITLE
Update Korean translation

### DIFF
--- a/i18n/ko/OWNERS
+++ b/i18n/ko/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+  - gochist
   - seokho-son
 
 labels:

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -1798,7 +1798,7 @@
       </trans-unit>
       <trans-unit id="18cd38a8b51485adf1e5a7e33f3fbbf8d6c92c00" datatype="html">
         <source>Min Replicas</source>
-        <target state="new">Min Replicas</target>
+        <target state="new">최소 레플리카</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/horizontalpodautoscaler/template.html</context>
           <context context-type="linenumber">58</context>
@@ -1806,7 +1806,7 @@
       </trans-unit>
       <trans-unit id="db972eb77504c0dfc832ecb36168c5b64ab6d30b" datatype="html">
         <source>Max Replicas</source>
-        <target state="new">Max Replicas</target>
+        <target state="new">최대 레플리카</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/horizontalpodautoscaler/template.html</context>
           <context context-type="linenumber">64</context>
@@ -1814,7 +1814,7 @@
       </trans-unit>
       <trans-unit id="7529307ff5a8475ecd0755abb1b8a91ae24c1d52" datatype="html">
         <source>Reference</source>
-        <target state="new">Reference</target>
+        <target state="new">참조</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/horizontalpodautoscaler/template.html</context>
           <context context-type="linenumber">70</context>


### PR DESCRIPTION
Update Korean translation file for #4625
(related issue #4259)

Please note that I referenced the Korean translation guide() by Korean localization team in Sig-docs.
I didn't translate the term "Horizontal Pod Autoscalers" according to the Korean translation guide.
 
Also I hope to add @gochist as an approver of contents in i18n/ko.
@gochist is an Korean localization expert and active contributor of K8s/website as well as K8s/dashboard.
 
/cc @shu-mutou

