### PR TITLE
Fix i18n/ko translation bug

### DIFF
--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -3375,15 +3375,9 @@
         <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>open_in_new<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
       </source>
         <target state="new">
+        더 배우기
         <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>open_in_new<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
-      </target> 더 배우기
-        
-        
-        
-        
-        
-        
-        
+      </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/template.html</context>
           <context context-type="linenumber">54</context>


### PR DESCRIPTION
This PR fixes a bug in i18n/ko/messages.ko.xlf. 
(bug: A translated content was misplaced and this bug keep generated empty lines.)

cc @shu-mutou 