### PR TITLE
Bump node.js to 12.x LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 sudo: required
 dist: bionic
 language: node_js
-node_js: 11.6.0
+node_js: 12.16.0
 
 apt:
   packages:

--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -24,8 +24,8 @@ FROM golang:1.12
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,
 # so there's no need to run it again.
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
-  && apt-get install -y --no-install-recommends \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+	&& apt-get install -y --no-install-recommends \
 	nodejs \
 	patch \
 	chromium \

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -11,7 +11,7 @@ Make sure the following software is installed and added to the $PATH variable:
 * Docker 1.13.1+ ([installation manual](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/))
 * Golang 1.12.0+ ([installation manual](https://golang.org/dl/))
     * Dashboard uses `go mod` for go dependency management, so enable it with running `export GO111MODULE=on`.
-* Node.js 11+ and npm 6+ ([installation with nvm](https://github.com/creationix/nvm#usage))
+* Node.js 12+ and npm 6+ ([installation with nvm](https://github.com/creationix/nvm#usage))
 * Gulp.js 4+ ([installation manual](https://github.com/gulpjs/gulp/blob/master/docs/getting-started/1-quick-start.md))
 
 Clone the repository into `$GOPATH/src/github.com/kubernetes/dashboard` and install the dependencies:


### PR DESCRIPTION
Now dashboard supports nodejs 11.6, but it had been end-of-life already.
So bump nodejs to 12.x LTS.