### PR TITLE
Add approvers for 'de' translations.

### DIFF
--- a/i18n/de/OWNERS
+++ b/i18n/de/OWNERS
@@ -1,4 +1,7 @@
-approvers: []
+approvers:
+- headcr4sh
+- kgroschoff
+- mkorbi
 
 labels:
 - language/de


### PR DESCRIPTION
This PR adds approvers for German translations.

@shu-mutou suggested to add the three whilst working on PR #4905 

- ✔️@headcr4sh I am interested in reviewing German translations of the dashboard.
- ✔️ @mkorbi  I already talked to him on Slack and he would be willing to take on this role.
- ✔️ @kgroschoff ~~I have not (yet) added you to the list because I wanted to ask first if that's ok for you.~~ left a comment further below an wrote that she'd like to help out as well