### PR TITLE
Hide area under zero in graph

### DIFF
--- a/src/app/frontend/common/components/graph/component.ts
+++ b/src/app/frontend/common/components/graph/component.ts
@@ -34,7 +34,7 @@ export class GraphComponent implements OnInit, OnChanges {
   customColors = {};
   yAxisLabel = '';
   yAxisTickFormatting = (value: number) => `${value} ${this.yAxisSuffix_}`;
-  yScaleMax = '';
+  yScaleMax = 0;
 
   private suffixMap_: Map<number, string> = new Map<number, string>();
   private yAxisSuffix_ = '';
@@ -94,15 +94,6 @@ export class GraphComponent implements OnInit, OnChanges {
 
     this.yAxisSuffix_ = highestSuffix;
 
-    // Find out max value
-    this.metric.dataPoints.forEach(value => {
-      if (maxValue < value.y) {
-        maxValue = value.y;
-      }
-    });
-    // Set yScaleMax not to show area under zero
-    this.yScaleMax = maxValue ? '' : '1';
-
     this.metric.dataPoints.forEach((_, idx) => {
       points.push({
         x: this.metric.dataPoints[idx].x,
@@ -110,10 +101,14 @@ export class GraphComponent implements OnInit, OnChanges {
       } as DataPoint);
     });
 
-    return [
+    const result = [
       {
         name: this.id,
         series: points.reduce(this._average.bind(this), []).map(point => {
+          if (maxValue < point.y) {
+            maxValue = point.y;
+          }
+
           return {
             value: point.y,
             name: timeFormat('%H:%M')(new Date(1000 * point.x)),
@@ -121,6 +116,20 @@ export class GraphComponent implements OnInit, OnChanges {
         }),
       },
     ];
+
+    // This way if max value is very small i.e. 0.0001 graph will be scaled to the more significant
+    // value.
+    switch (this.graphType) {
+      case GraphType.CPU:
+        this.yScaleMax = maxValue + 0.01;
+        break;
+      case GraphType.Memory:
+        this.yScaleMax = maxValue + 10;
+        break;
+      default:
+    }
+
+    return result;
   }
 
   // Calculate the average usage based on minute intervals. If there are more data points within

--- a/src/app/frontend/common/components/graph/component.ts
+++ b/src/app/frontend/common/components/graph/component.ts
@@ -34,6 +34,7 @@ export class GraphComponent implements OnInit, OnChanges {
   customColors = {};
   yAxisLabel = '';
   yAxisTickFormatting = (value: number) => `${value} ${this.yAxisSuffix_}`;
+  yScaleMax = '';
 
   private suffixMap_: Map<number, string> = new Map<number, string>();
   private yAxisSuffix_ = '';
@@ -62,6 +63,7 @@ export class GraphComponent implements OnInit, OnChanges {
     let series: FormattedValue[];
     let highestSuffixPower = 0;
     let highestSuffix = '';
+    let maxValue = 0;
 
     switch (this.graphType) {
       case GraphType.Memory:
@@ -91,6 +93,15 @@ export class GraphComponent implements OnInit, OnChanges {
     });
 
     this.yAxisSuffix_ = highestSuffix;
+
+    // Find out max value
+    this.metric.dataPoints.forEach(value => {
+      if (maxValue < value.y) {
+        maxValue = value.y;
+      }
+    });
+    // Set yScaleMax not to show area under zero
+    this.yScaleMax = maxValue ? '' : '1';
 
     this.metric.dataPoints.forEach((_, idx) => {
       points.push({

--- a/src/app/frontend/common/components/graph/template.html
+++ b/src/app/frontend/common/components/graph/template.html
@@ -20,6 +20,7 @@ limitations under the License.
                        [showYAxisLabel]="true"
                        [yAxisLabel]="yAxisLabel"
                        [yAxisTickFormatting]="yAxisTickFormatting"
+                       [yScaleMax]="yScaleMax"
                        [results]="series"
                        [showGridLines]="true"
                        [curve]="curve"


### PR DESCRIPTION
Set `yScaleMax` not to show area under zero, if the maximum metrics data is zero.

Closes #4995 