### PR TITLE
Add zh code alias to make dashboard compatible with more browsers

### DIFF
--- a/docs/developer/internationalization.md
+++ b/docs/developer/internationalization.md
@@ -2,18 +2,18 @@
 
 Based on current browser locale the Dashboard can be displayed in one of the supported languages listed below. In case it does not work, make sure that your browser's locale is identified with correct language code. In more details, Dashboard determines requested language based on HTTP `Accept-Language` header from browser. We can check which language codes are requested by browser on `Network` tab in developer tool of browser.
 
-| Language            | Code    | Remarks    |
-|---------------------|---------|------------|
-| English (default)   | en      | -          |
-| French              | fr      | -          |
-| German              | de      | -          |
-| Japanese            | ja      | -          |
-| Korean              | ko      | -          |
-| Simplified Chinese  | zh      | -          |
-| Chinese (PRC)       | zh-cn   | Same as zh |
-| Chinese (Hong Kong) | zh-hk   | -          |
-| Chinese (Singapore) | zh-sg   | -          |
-| Chinese (Taiwan)    | zh-tw   | -          |
+| Language            | Code           | Remarks    |
+|---------------------|----------------|------------|
+| English (default)   | en             | -          |
+| French              | fr             | -          |
+| German              | de             | -          |
+| Japanese            | ja             | -          |
+| Korean              | ko             | -          |
+| Simplified Chinese  | zh             | -          |
+| Chinese (PRC)       | zh-cn or zh-CN | Same as zh |
+| Chinese (Hong Kong) | zh-hk or zh-HK | -          |
+| Chinese (Singapore) | zh-sg or zh-SG | -          |
+| Chinese (Taiwan)    | zh-tw or zh-TW | -          |
 
 ## Building localized dashboard
 

--- a/src/app/backend/handler/localehandler.go
+++ b/src/app/backend/handler/localehandler.go
@@ -34,6 +34,10 @@ var localeMap = map[string]string{
 	"zh-sg": "zh-Hans-SG",
 	"zh-tw": "zh-Hant",
 	"zh-hk": "zh-Hant-HK",
+	"zh-CN": "zh-Hans",
+	"zh-SG": "zh-Hans-SG",
+	"zh-TW": "zh-Hant",
+	"zh-HK": "zh-Hant-HK",
 }
 
 const defaultLocaleDir = "en"


### PR DESCRIPTION
In fact, many browsers don't set the `Accept-Language` to lowercase.
For instance, Chrome's `Accpt-Language` is `zh-CN` rather than `zh-cn` for simplified Chinese by default, as well as Firefox.

With this in mind, we'd better make dashboard compatible with this common language format.

This PR adds some zh code aliases to make dashboard compatible with more browsers.

<img width="485" alt="图片" src="https://user-images.githubusercontent.com/9354727/77222929-d91a5400-6b92-11ea-971b-0c3b96a043ba.png">

Ref: #4755