### PR TITLE
Update Korean translation

### DIFF
--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -5144,7 +5144,7 @@
       </trans-unit>
       <trans-unit id="a4f3393592e5ebfd34408e85c3bd576d88839191" datatype="html">
         <source>Disable access denied notification</source>
-        <target state="new">Disable access denied notification</target>
+        <target state="new">접근 거부 알림 해제</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/settings/global/template.html</context>
           <context context-type="linenumber">100</context>
@@ -5152,7 +5152,7 @@
       </trans-unit>
       <trans-unit id="b6484080715a11bad65395e51d42e6ae4aa3c856" datatype="html">
         <source>Hides all access denied warnings in the notification panel.</source>
-        <target state="new">Hides all access denied warnings in the notification panel.</target>
+        <target state="new">알림 패널에서 접근 거부 경고 모두 숨김.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/settings/global/template.html</context>
           <context context-type="linenumber">102</context>


### PR DESCRIPTION
This PR updates Korean translation (i18n/ko/messages.ko.xlf) for the following changes.
- Fix CRD details switch #5016
- Add option to disable access denied notifications #5004

(Related root issue: #4259)