### PR TITLE
Added quick edit icon to Secrets page with dialog to decode and update a data value

### DIFF
--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -270,6 +278,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="32c4fb786d3f614318c26ef8adc8f195d581545d" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -274,6 +282,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="32c4fb786d3f614318c26ef8adc8f195d581545d" datatype="html">

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -268,6 +276,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -30,6 +30,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -40,6 +44,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -235,6 +243,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/zh-Hans-SG/messages.zh-Hans-SG.xlf
+++ b/i18n/zh-Hans-SG/messages.zh-Hans-SG.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/i18n/zh/messages.zh.xlf
+++ b/i18n/zh/messages.zh.xlf
@@ -33,6 +33,10 @@
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/editresource/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="d7b35c384aecd25a516200d6921836374613dfe7" datatype="html">
         <source>Cancel</source>
@@ -44,6 +48,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/deleteresource/template.html</context>
           <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">35</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/createnamespace/template.html</context>
@@ -280,6 +288,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/triggerresource/template.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="53d97005806d2b556fbb5c1ddb5b89846cf37f31" datatype="html">
+        <source>Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></source>
+        <target state="new">Quick Edit:  <x id="INTERPOLATION" equiv-text="{{data.resourceKey}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/dialogs/quickedit/template.html</context>
+          <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fdd9581a3e200dad80fb751572e7f416424f8844" datatype="html">

--- a/src/app/frontend/common/components/hiddenproperty/component.ts
+++ b/src/app/frontend/common/components/hiddenproperty/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input} from '@angular/core';
+import {Component, Input, Output, EventEmitter} from '@angular/core';
 
 @Component({
   selector: 'kd-hidden-property',
@@ -20,5 +20,12 @@ import {Component, Input} from '@angular/core';
   styleUrls: ['./style.scss'],
 })
 export class HiddenPropertyComponent {
+  @Output() edit: EventEmitter<any> = new EventEmitter();
   @Input() hidden = true;
+
+  onEdit(event: MouseEvent): void {
+    // Prevent secret display from being toggled.
+    event.stopPropagation();
+    this.edit.emit(null);
+  }
 }

--- a/src/app/frontend/common/components/hiddenproperty/template.html
+++ b/src/app/frontend/common/components/hiddenproperty/template.html
@@ -25,6 +25,7 @@ limitations under the License.
       <ng-container *ngIf="hidden">visibility</ng-container>
       <ng-container *ngIf="!hidden">visibility_off</ng-container>
     </mat-icon>
+    <mat-icon class="kd-hidden-property-icon" (click)="onEdit($event)">edit</mat-icon>
   </div>
   <div value>
 

--- a/src/app/frontend/common/dialogs/module.ts
+++ b/src/app/frontend/common/dialogs/module.ts
@@ -23,6 +23,7 @@ import {LogsDownloadDialog} from './download/dialog';
 import {EditResourceDialog} from './editresource/dialog';
 import {ScaleResourceDialog} from './scaleresource/dialog';
 import {TriggerResourceDialog} from './triggerresource/dialog';
+import {QuickEditDialog} from './quickedit/dialog';
 
 @NgModule({
   imports: [SharedModule, ComponentsModule],
@@ -33,6 +34,7 @@ import {TriggerResourceDialog} from './triggerresource/dialog';
     LogsDownloadDialog,
     ScaleResourceDialog,
     TriggerResourceDialog,
+    QuickEditDialog,
   ],
   exports: [
     AlertDialog,
@@ -41,6 +43,7 @@ import {TriggerResourceDialog} from './triggerresource/dialog';
     LogsDownloadDialog,
     ScaleResourceDialog,
     TriggerResourceDialog,
+    QuickEditDialog,
   ],
   entryComponents: [
     AlertDialog,
@@ -49,6 +52,7 @@ import {TriggerResourceDialog} from './triggerresource/dialog';
     LogsDownloadDialog,
     ScaleResourceDialog,
     TriggerResourceDialog,
+    QuickEditDialog,
   ],
 })
 export class DialogsModule {}

--- a/src/app/frontend/common/dialogs/quickedit/dialog.ts
+++ b/src/app/frontend/common/dialogs/quickedit/dialog.ts
@@ -1,0 +1,76 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HttpClient} from '@angular/common/http';
+import {Component, Inject, OnInit} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+
+import {RawResource} from '../../resources/rawresource';
+import {ObjectMeta, TypeMeta, SecretDetail, ConfigMapDetail} from '@api/backendapi';
+
+export class QuickEditMeta {
+  resourceKey: string;
+  objectMeta: ObjectMeta;
+  typeMeta: TypeMeta;
+
+  constructor(resourceKey: string, objectMeta: ObjectMeta, typeMeta: TypeMeta) {
+    this.resourceKey = resourceKey;
+    this.objectMeta = objectMeta;
+    this.typeMeta = typeMeta;
+  }
+}
+
+@Component({
+  selector: 'kd-quick-edit-dialog',
+  templateUrl: 'template.html',
+})
+export class QuickEditDialog implements OnInit {
+  text = '';
+
+  private resourceDetail_: SecretDetail | ConfigMapDetail;
+
+  constructor(
+    public dialogRef: MatDialogRef<QuickEditDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: QuickEditMeta,
+    private readonly http_: HttpClient,
+  ) {}
+
+  ngOnInit(): void {
+    const url = RawResource.getUrl(this.data.typeMeta, this.data.objectMeta);
+    this.http_
+      .get(url)
+      .toPromise()
+      .then(response => {
+        this.resourceDetail_ = response as SecretDetail | ConfigMapDetail;
+        this.text = atob(this.resourceDetail_.data[this.data.resourceKey]);
+      });
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  getJSON(): string {
+    if (!this.resourceDetail_) {
+      return '';
+    }
+
+    this.resourceDetail_.data[this.data.resourceKey] = btoa(this.text);
+    return this.toRawJSON(this.resourceDetail_);
+  }
+
+  private toRawJSON(object: {}): string {
+    return JSON.stringify(object, null, '\t');
+  }
+}

--- a/src/app/frontend/common/dialogs/quickedit/template.html
+++ b/src/app/frontend/common/dialogs/quickedit/template.html
@@ -1,0 +1,36 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<h2 mat-dialog-title
+    i18n>Quick Edit:  {{data.resourceKey}}</h2>
+<mat-dialog-content class="kd-dialog-text">
+  <kd-text-input [(text)]="text"
+                 [prettify]="false"></kd-text-input>
+  <div class="kd-equivalent-block kd-muted kd-bg-card-dark"
+       fxLayoutAlign=" center">
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button
+          color="primary"
+          id="confirm-edit"
+          [mat-dialog-close]="getJSON()"
+          i18n>Update</button>
+  <button mat-button
+          color="primary"
+          [mat-dialog-close]="false"
+          i18n>Cancel</button>
+</mat-dialog-actions>

--- a/src/app/frontend/common/services/global/verber.ts
+++ b/src/app/frontend/common/services/global/verber.ts
@@ -22,6 +22,7 @@ import {DeleteResourceDialog} from '../../dialogs/deleteresource/dialog';
 import {EditResourceDialog} from '../../dialogs/editresource/dialog';
 import {ScaleResourceDialog} from '../../dialogs/scaleresource/dialog';
 import {TriggerResourceDialog} from '../../dialogs/triggerresource/dialog';
+import {QuickEditDialog, QuickEditMeta} from '../../dialogs/quickedit/dialog';
 import {RawResource} from '../../resources/rawresource';
 
 import {ResourceMeta} from './actionbar';
@@ -54,6 +55,21 @@ export class VerberService {
     const dialogConfig = this.getDialogConfig_(displayName, typeMeta, objectMeta);
     this.dialog_
       .open(EditResourceDialog, dialogConfig)
+      .afterClosed()
+      .subscribe(result => {
+        if (result) {
+          const url = RawResource.getUrl(typeMeta, objectMeta);
+          this.http_
+            .put(url, JSON.parse(result), {headers: this.getHttpHeaders_(), responseType: 'text'})
+            .subscribe(() => this.onEdit.emit(true), this.handleErrorResponse_.bind(this));
+        }
+      });
+  }
+
+  showQuickEditDialog(resourceKey: string, typeMeta: TypeMeta, objectMeta: ObjectMeta): void {
+    const dialogConfig = this.getQuickEditDialogConfig_(resourceKey, typeMeta, objectMeta);
+    this.dialog_
+      .open(QuickEditDialog, dialogConfig)
       .afterClosed()
       .subscribe(result => {
         if (result) {
@@ -99,6 +115,14 @@ export class VerberService {
             .subscribe(() => this.onTrigger.emit(true), this.handleErrorResponse_.bind(this));
         }
       });
+  }
+
+  getQuickEditDialogConfig_(
+    resourceKey: string,
+    typeMeta: TypeMeta,
+    objectMeta: ObjectMeta,
+  ): MatDialogConfig<QuickEditMeta> {
+    return {width: '900px', data: {resourceKey, typeMeta, objectMeta}};
   }
 
   getDialogConfig_(

--- a/src/app/frontend/resource/config/secret/detail/component.ts
+++ b/src/app/frontend/resource/config/secret/detail/component.ts
@@ -21,6 +21,7 @@ import {ActionbarService, ResourceMeta} from '../../../../common/services/global
 import {NotificationsService} from '../../../../common/services/global/notifications';
 import {EndpointManager, Resource} from '../../../../common/services/resource/endpoint';
 import {NamespacedResourceService} from '../../../../common/services/resource/resource';
+import {VerberService} from '../../../../common/services/global/verber';
 
 @Component({
   selector: 'kd-secret-detail',
@@ -37,6 +38,7 @@ export class SecretDetailComponent implements OnInit, OnDestroy {
     private readonly actionbar_: ActionbarService,
     private readonly activatedRoute_: ActivatedRoute,
     private readonly notifications_: NotificationsService,
+    private readonly verber_: VerberService,
   ) {}
 
   ngOnInit(): void {
@@ -64,5 +66,9 @@ export class SecretDetailComponent implements OnInit, OnDestroy {
 
   decode(s: string): string {
     return atob(s);
+  }
+
+  edit(key: string): void {
+    this.verber_.showQuickEditDialog(key, this.secret.typeMeta, this.secret.objectMeta);
   }
 }

--- a/src/app/frontend/resource/config/secret/detail/template.html
+++ b/src/app/frontend/resource/config/secret/detail/template.html
@@ -21,7 +21,7 @@ limitations under the License.
   <div title
        i18n>Data</div>
   <div content>
-    <kd-hidden-property *ngFor="let key of getDataKeys()">
+    <kd-hidden-property *ngFor="let key of getDataKeys()" (edit)="edit(key)">
       <div key>{{key}}</div>
       <div whenVisible
            class="kd-code-block">{{decode(secret?.data[key])}}</div>


### PR DESCRIPTION
I added a quick edit next to the eye icon of the Secret page, that allows you to open a modal for one entry in the secret and save. This is direct text unencoded, and should provide a good user experience.

![image](https://user-images.githubusercontent.com/1800213/77833740-379c8080-7105-11ea-9cb3-59397f81e2aa.png)

![image](https://user-images.githubusercontent.com/1800213/77833762-4b47e700-7105-11ea-8395-93d8fc28d975.png)
