### PR TITLE
[Trival] beta.kubernetes.io/os is already deprecated since v1.14, are targeted for removal in v1.18

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -207,7 +207,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -274,7 +274,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/alternative/06_dashboard-deployment.yaml
+++ b/aio/deploy/alternative/06_dashboard-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -219,7 +219,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -286,7 +286,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard-head
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/head/06_dashboard-deployment.yaml
+++ b/aio/deploy/head/06_dashboard-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard-head
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/head/08_scraper-deployment.yaml
+++ b/aio/deploy/head/08_scraper-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           name: tmp-volume
       serviceAccountName: kubernetes-dashboard-head
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -225,7 +225,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -292,7 +292,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended/06_dashboard-deployment.yaml
+++ b/aio/deploy/recommended/06_dashboard-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/aio/test-resources/kubernetes-dashboard-local.yaml
+++ b/aio/test-resources/kubernetes-dashboard-local.yaml
@@ -177,7 +177,7 @@ spec:
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard-local
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -240,7 +240,7 @@ spec:
           name: tmp-volume
       serviceAccountName: kubernetes-dashboard-local
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master


### PR DESCRIPTION
/kind cleanup

Ref: kubernetes/kubernetes#89477