### PR TITLE
Update empty list message for CRD object list

### DIFF
--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -2126,6 +2126,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>Versionen</target>
@@ -2531,7 +2539,7 @@
         <target>Es wurden keine Ressourcen gefunden.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a44df39b2ce0f5d85e406c3aeec76ae898dbf9af" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -2130,6 +2130,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>Versions</target>
@@ -2535,7 +2543,7 @@
         <target>Aucune ressource trouvée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a44df39b2ce0f5d85e406c3aeec76ae898dbf9af" datatype="html">

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -1527,6 +1527,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>バージョン</target>
@@ -1756,7 +1764,7 @@
         <target>リソースがありません。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -1676,6 +1676,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>버전</target>
@@ -1869,7 +1877,7 @@
         <target>검색된 리소스가 없습니다.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -1616,6 +1616,13 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <context-group purpose="location">
@@ -1780,7 +1787,7 @@
         <source>No resources found.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -1676,6 +1676,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>版本</target>
@@ -1869,7 +1877,7 @@
         <target>找不到资源。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -1676,6 +1676,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>版本</target>
@@ -1861,7 +1869,7 @@
         <target>找不到資源。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -1676,6 +1676,14 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="a3e6ad731f3d27e2fd80064adf380f461ea0251b" datatype="html">
+        <source>No resources found in the selected namespace.</source>
+        <target state="new">No resources found in the selected namespace.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crdobject/template.html</context>
+          <context context-type="linenumber">90</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cfcee33b4f74fb641e9d6b00f72244d2b78c1480" datatype="html">
         <source>Versions</source>
         <target>版本</target>
@@ -1861,7 +1869,7 @@
         <target>找不到資源。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3a7e364a88ea4673199dfa98bc73e6dbe09dfac" datatype="html">

--- a/src/app/frontend/common/components/list/zerostate/component.ts
+++ b/src/app/frontend/common/components/list/zerostate/component.ts
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component} from '@angular/core';
+import {Component, ContentChild, Input, TemplateRef} from '@angular/core';
 
 @Component({
   selector: 'kd-list-zero-state',
   templateUrl: './template.html',
   styleUrls: ['./style.scss'],
 })
-export class ListZeroStateComponent {}
+export class ListZeroStateComponent {
+  @ContentChild('textTemplate', {read: TemplateRef}) textTemplate: TemplateRef<any>;
+}

--- a/src/app/frontend/common/components/list/zerostate/template.html
+++ b/src/app/frontend/common/components/list/zerostate/template.html
@@ -20,7 +20,10 @@ limitations under the License.
   <div fxFlexAlign="center"
        class="kd-zerostate-title"
        i18n>There is nothing to display here</div>
-  <div fxFlexAlign="center"
-       class="kd-zerostate-text"
-       i18n>No resources found.</div>
+  <ng-container *ngTemplateOutlet="textTemplate ? textTemplate : defaultTextTemplate"></ng-container>
+  <ng-template #defaultTextTemplate>
+    <div fxFlexAlign="center"
+         class="kd-zerostate-text"
+         i18n>No resources found.</div>
+  </ng-template>
 </div>

--- a/src/app/frontend/common/components/module.ts
+++ b/src/app/frontend/common/components/module.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {NgModule} from '@angular/core';
+import {MatTableModule} from '@angular/material/table';
 
 import {SharedModule} from '../../shared.module';
 import {DirectivesModule} from '../directives/module';
@@ -192,7 +193,7 @@ const components = [
 ];
 
 @NgModule({
-  imports: [SharedModule, DirectivesModule],
+  imports: [SharedModule, DirectivesModule, MatTableModule, MatTableModule],
   declarations: [...components],
   exports: [...components],
   entryComponents: [ChipDialog, RowDetailComponent, MenuComponent, NamespaceChangeDialog],

--- a/src/app/frontend/common/components/resourcelist/crdobject/component.ts
+++ b/src/app/frontend/common/components/resourcelist/crdobject/component.ts
@@ -32,6 +32,7 @@ import {ListGroupIdentifier, ListIdentifier} from '../groupids';
 })
 export class CRDObjectListComponent extends ResourceListBase<CRDObjectList, CRDObject> {
   @Input() endpoint: string;
+  @Input() namespaced = false;
 
   constructor(
     private readonly crdObject_: NamespacedResourceService<CRDObjectList>,
@@ -68,5 +69,9 @@ export class CRDObjectListComponent extends ResourceListBase<CRDObjectList, CRDO
 
   getDisplayColumns(): string[] {
     return ['name', 'namespace', 'created'];
+  }
+
+  areMultipleNamespacesSelected(): boolean {
+    return this.namespaceService_.areMultipleNamespacesSelected();
   }
 }

--- a/src/app/frontend/common/components/resourcelist/crdobject/template.html
+++ b/src/app/frontend/common/components/resourcelist/crdobject/template.html
@@ -83,6 +83,12 @@ limitations under the License.
 
   <div content
        [hidden]="!showZeroState()">
-    <kd-list-zero-state></kd-list-zero-state>
+    <kd-list-zero-state>
+      <ng-template #textTemplate
+                   *ngIf="!areMultipleNamespacesSelected() && namespaced">
+        <div fxFlexAlign="center"
+             i18n>No resources found in the selected namespace.</div>
+      </ng-template>
+    </kd-list-zero-state>
   </div>
 </kd-card>

--- a/src/app/frontend/crd/detail/component.ts
+++ b/src/app/frontend/crd/detail/component.ts
@@ -14,7 +14,7 @@
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {CRDDetail} from '@api/backendapi';
+import {CRD, CRDDetail} from '@api/backendapi';
 import {Subject, Subscription} from 'rxjs';
 import {switchMap, takeUntil, tap} from 'rxjs/operators';
 
@@ -56,5 +56,9 @@ export class CRDDetailComponent implements OnInit, OnDestroy {
     this.unsubscribe_.next();
     this.unsubscribe_.complete();
     this.actionbar_.onDetailsLeave.emit();
+  }
+
+  isNamespaced(): boolean {
+    return this.crd && this.crd.scope === 'Namespaced';
   }
 }

--- a/src/app/frontend/crd/detail/template.html
+++ b/src/app/frontend/crd/detail/template.html
@@ -90,7 +90,7 @@ limitations under the License.
   </div>
 </kd-card>
 
-<kd-crd-object-list></kd-crd-object-list>
+<kd-crd-object-list [namespaced]="isNamespaced()"></kd-crd-object-list>
 
 <kd-crd-versions-list *ngIf="crd?.versions"
                       [versions]="crd?.versions"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dashboard/issues/5090

If CRD is namespaced and a single namespace is selected below message will be displayed instead.
![Zrzut ekranu z 2020-05-07 16-20-37](https://user-images.githubusercontent.com/2285385/81305790-09ed1480-907f-11ea-8ca4-45177bf40d0f.png)
