### PR TITLE
add `force-skip-login` flag to automatically skip login

### DIFF
--- a/docs/common/dashboard-arguments.md
+++ b/docs/common/dashboard-arguments.md
@@ -26,6 +26,7 @@ Dashboard container accepts multiple arguments that can be used to customize it 
 | authentication-mode | token   | Enables authentication options that will be reflected on the login screen in the same order as provided. Multiple options can be used at once. Supported values: token, basic. Note that basic option should only be used if apiserver has '--authorization-mode=ABAC' and '--basic-auth-file' flags set. |
 | enable-insecure-login | false | When enabled, Dashboard login view will also be shown when Dashboard is not served over HTTPS. |
 | enable-skip-login | false | When enabled, the skip button on the login page will be shown. |
+| force-skip-login | false | When enabled, the login page will be not shown and immediately set to skip. |
 | disable-settings-authorizer | false | When enabled, Dashboard settings page will not require user to be logged in and authorized to access settings page. |
 | locale-config | ./locale_conf.json |File containing the configuration of locales.
 | system-banner | -             | When non-empty displays message to Dashboard users. Accepts simple HTML tags. |

--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -156,6 +156,12 @@ func (self *holderBuilder) SetEnableSkipLogin(enableSkipLogin bool) *holderBuild
 	return self
 }
 
+// SetForceSkipLogin 'force-skip-login' argument of Dashboard binary.
+func (self *holderBuilder) SetForceSkipLogin(forceSkipLogin bool) *holderBuilder {
+	self.holder.forceSkipLogin = forceSkipLogin
+	return self
+}
+
 // SetNamespace 'namespace' argument of Dashboard binary.
 func (self *holderBuilder) SetNamespace(namespace string) *holderBuilder {
 	self.holder.namespace = namespace

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -53,6 +53,7 @@ type holder struct {
 	disableSettingsAuthorizer bool
 
 	enableSkipLogin bool
+	forceSkipLogin  bool
 
 	localeConfig string
 }
@@ -173,6 +174,11 @@ func (self *holder) GetDisableSettingsAuthorizer() bool {
 // GetEnableSkipLogin 'enable-skip-login' argument of Dashboard binary.
 func (self *holder) GetEnableSkipLogin() bool {
 	return self.enableSkipLogin
+}
+
+// GetForceSkipLogin 'force-skip-login' argument of Dashboard binary.
+func (self *holder) GetForceSkipLogin() bool {
+	return self.forceSkipLogin
 }
 
 // GetNamespace 'namespace' argument of Dashboard binary.

--- a/src/app/backend/auth/api/types.go
+++ b/src/app/backend/auth/api/types.go
@@ -89,6 +89,8 @@ type AuthManager interface {
 	AuthenticationModes() []AuthenticationMode
 	// AuthenticationSkippable tells if the Skip button should be enabled or not
 	AuthenticationSkippable() bool
+	// AuthenticationForceSkip tells if dashboard to skip login immediately
+	AuthenticationForceSkip() bool
 }
 
 // TokenManager is responsible for generating and decrypting tokens used for authorization. Authorization is handled
@@ -149,8 +151,11 @@ type LoginModesResponse struct {
 	Modes []AuthenticationMode `json:"modes"`
 }
 
-// LoginSkippableResponse contains a flag that tells the UI not to display the Skip button.
-// Note that this only hides the button, it doesn't disable unauthenticated access.
+// LoginSkippableResponse contains flags about whether login can/should be skipped.
 type LoginSkippableResponse struct {
+	// Skippable is a flag that tells the UI not to display the Skip button.
+	// Note that this only hides the button, it doesn't disable unauthenticated access.
 	Skippable bool `json:"skippable"`
+	// ForceSkip is a flag that tells the UI to automatically skip Login.
+	ForceSkip bool `json:"forceSkip"`
 }

--- a/src/app/backend/auth/handler.go
+++ b/src/app/backend/auth/handler.go
@@ -104,7 +104,7 @@ func (self *AuthHandler) handleLoginModes(request *restful.Request, response *re
 }
 
 func (self *AuthHandler) handleLoginSkippable(request *restful.Request, response *restful.Response) {
-	response.WriteHeaderAndEntity(http.StatusOK, authApi.LoginSkippableResponse{Skippable: self.manager.AuthenticationSkippable()})
+	response.WriteHeaderAndEntity(http.StatusOK, authApi.LoginSkippableResponse{Skippable: self.manager.AuthenticationSkippable(), ForceSkip: self.manager.AuthenticationForceSkip()})
 }
 
 // NewAuthHandler created AuthHandler instance.

--- a/src/app/backend/auth/manager.go
+++ b/src/app/backend/auth/manager.go
@@ -28,6 +28,7 @@ type authManager struct {
 	clientManager           clientapi.ClientManager
 	authenticationModes     authApi.AuthenticationModes
 	authenticationSkippable bool
+	authenticationForceSkip bool
 }
 
 // Login implements auth manager. See AuthManager interface for more information.
@@ -69,6 +70,10 @@ func (self authManager) AuthenticationSkippable() bool {
 	return self.authenticationSkippable
 }
 
+func (self authManager) AuthenticationForceSkip() bool {
+	return self.authenticationForceSkip
+}
+
 // Returns authenticator based on provided LoginSpec.
 func (self authManager) getAuthenticator(spec *authApi.LoginSpec) (authApi.Authenticator, error) {
 	if len(self.authenticationModes) == 0 {
@@ -95,11 +100,12 @@ func (self authManager) healthCheck(authInfo api.AuthInfo) error {
 
 // NewAuthManager creates auth manager.
 func NewAuthManager(clientManager clientapi.ClientManager, tokenManager authApi.TokenManager,
-	authenticationModes authApi.AuthenticationModes, authenticationSkippable bool) authApi.AuthManager {
+	authenticationModes authApi.AuthenticationModes, authenticationSkippable bool, authenticationForceSkip bool) authApi.AuthManager {
 	return &authManager{
 		tokenManager:            tokenManager,
 		clientManager:           clientManager,
 		authenticationModes:     authenticationModes,
 		authenticationSkippable: authenticationSkippable,
+		authenticationForceSkip: authenticationForceSkip,
 	}
 }

--- a/src/app/backend/auth/manager_test.go
+++ b/src/app/backend/auth/manager_test.go
@@ -156,7 +156,7 @@ func TestAuthManager_Login(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		authManager := NewAuthManager(c.cManager, c.tManager, authApi.AuthenticationModes{authApi.Token: true}, true)
+		authManager := NewAuthManager(c.cManager, c.tManager, authApi.AuthenticationModes{authApi.Token: true}, true, false)
 		response, err := authManager.Login(c.spec)
 
 		if !areErrorsEqual(err, c.expectedErr) {
@@ -183,7 +183,7 @@ func TestAuthManager_AuthenticationModes(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		authManager := NewAuthManager(cManager, tManager, c.modes, true)
+		authManager := NewAuthManager(cManager, tManager, c.modes, true, false)
 		got := authManager.AuthenticationModes()
 
 		if !reflect.DeepEqual(got, c.expected) {
@@ -198,8 +198,22 @@ func TestAuthManager_AuthenticationSkippable(t *testing.T) {
 	cModes := authApi.AuthenticationModes{}
 
 	for _, flag := range []bool{true, false} {
-		authManager := NewAuthManager(cManager, tManager, cModes, flag)
+		authManager := NewAuthManager(cManager, tManager, cModes, flag, false)
 		got := authManager.AuthenticationSkippable()
+		if got != flag {
+			t.Errorf("Expected %v, but got %v.", flag, got)
+		}
+	}
+}
+
+func TestAuthManager_AuthenticationForceSkip(t *testing.T) {
+	cManager := &fakeClientManager{}
+	tManager := &fakeTokenManager{}
+	cModes := authApi.AuthenticationModes{}
+
+	for _, flag := range []bool{true, false} {
+		authManager := NewAuthManager(cManager, tManager, cModes, false, flag)
+		got := authManager.AuthenticationForceSkip()
 		if got != flag {
 			t.Errorf("Expected %v, but got %v.", flag, got)
 		}

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -398,11 +398,11 @@ func (self *clientManager) isLoginEnabled(req *restful.Request) bool {
 // Secure mode means that every request to Dashboard has to be authenticated and privileges
 // of Dashboard SA can not be used.
 func (self *clientManager) isSecureModeEnabled(req *restful.Request) bool {
-	if self.isLoginEnabled(req) && !args.Holder.GetEnableSkipLogin() {
+	if self.isLoginEnabled(req) && !args.Holder.GetEnableSkipLogin() && !args.Holder.GetForceSkipLogin() {
 		return true
 	}
 
-	return self.isLoginEnabled(req) && args.Holder.GetEnableSkipLogin() && self.containsAuthInfo(req)
+	return self.isLoginEnabled(req) && (args.Holder.GetEnableSkipLogin() || args.Holder.GetForceSkipLogin()) && self.containsAuthInfo(req)
 }
 
 func (self *clientManager) secureClient(req *restful.Request) (kubernetes.Interface, error) {

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -73,6 +73,7 @@ var (
 	argAutoGenerateCertificates  = pflag.Bool("auto-generate-certificates", false, "When set to true, Dashboard will automatically generate certificates used to serve HTTPS. (default false)")
 	argEnableInsecureLogin       = pflag.Bool("enable-insecure-login", false, "When enabled, Dashboard login view will also be shown when Dashboard is not served over HTTPS. (default false)")
 	argEnableSkip                = pflag.Bool("enable-skip-login", false, "When enabled, the skip button on the login page will be shown. (default false)")
+	argForceSkip                 = pflag.Bool("force-skip-login", false, "When enabled, the login page will be not shown and immediately set to skip. (default false)")
 	argSystemBanner              = pflag.String("system-banner", "", "When non-empty displays message to Dashboard users. Accepts simple HTML tags.")
 	argSystemBannerSeverity      = pflag.String("system-banner-severity", "INFO", "Severity of system banner. Should be one of 'INFO|WARNING|ERROR'.")
 	argAPILogLevel               = pflag.String("api-log-level", "INFO", "Level of API request logging. Should be one of 'INFO|NONE|DEBUG'.")
@@ -224,8 +225,9 @@ func initAuthManager(clientManager clientapi.ClientManager) authApi.AuthManager 
 
 	// UI logic dictates this should be the inverse of the cli option
 	authenticationSkippable := args.Holder.GetEnableSkipLogin()
+	authenticationForceSkip := args.Holder.GetForceSkipLogin()
 
-	return auth.NewAuthManager(clientManager, tokenManager, authModes, authenticationSkippable)
+	return auth.NewAuthManager(clientManager, tokenManager, authModes, authenticationSkippable, authenticationForceSkip)
 }
 
 func initArgHolder() {
@@ -252,6 +254,7 @@ func initArgHolder() {
 	builder.SetEnableInsecureLogin(*argEnableInsecureLogin)
 	builder.SetDisableSettingsAuthorizer(*argDisableSettingsAuthorizer)
 	builder.SetEnableSkipLogin(*argEnableSkip)
+	builder.SetForceSkipLogin(*argForceSkip)
 	builder.SetNamespace(*argNamespace)
 	builder.SetLocaleConfig(*localeConfig)
 }

--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -44,7 +44,7 @@ func getTokenManager() authApi.TokenManager {
 
 func TestCreateHTTPAPIHandler(t *testing.T) {
 	cManager := client.NewClientManager("", "http://localhost:8080")
-	authManager := auth.NewAuthManager(cManager, getTokenManager(), authApi.AuthenticationModes{}, true)
+	authManager := auth.NewAuthManager(cManager, getTokenManager(), authApi.AuthenticationModes{}, true, false)
 	sManager := settings.NewSettingsManager()
 	sbManager := systembanner.NewSystemBannerManager("Hello world!", "INFO")
 	_, err := CreateHTTPAPIHandler(nil, cManager, authManager, sManager, sbManager)

--- a/src/app/frontend/login/component.spec.ts
+++ b/src/app/frontend/login/component.spec.ts
@@ -150,6 +150,7 @@ describe('LoginComponent', () => {
     it('does not render skip button if login is not skippable', () => {
       const mockLoginSkippableResponse: LoginSkippableResponse = {
         skippable: false,
+        forceSkip: false,
       };
       fixture.detectChanges();
       const req = httpTestingController.expectOne('api/v1/login/skippable');
@@ -236,6 +237,7 @@ describe('LoginComponent', () => {
   const initializeForSkip = (): void => {
     const mockLoginSkippableResponse: LoginSkippableResponse = {
       skippable: true,
+      forceSkip: false,
     };
     fixture.detectChanges();
     const req = httpTestingController.expectOne('api/v1/login/skippable');

--- a/src/app/frontend/login/component.ts
+++ b/src/app/frontend/login/component.ts
@@ -46,6 +46,7 @@ export class LoginComponent implements OnInit {
 
   private enabledAuthenticationModes_: AuthenticationMode[] = [];
   private isLoginSkippable_ = false;
+  private enableForceSkipLogin_ = false;
   private kubeconfig_: string;
   private token_: string;
   private username_: string;
@@ -73,6 +74,7 @@ export class LoginComponent implements OnInit {
       .get<LoginSkippableResponse>('api/v1/login/skippable')
       .subscribe((loginSkippableResponse: LoginSkippableResponse) => {
         this.isLoginSkippable_ = loginSkippableResponse.skippable;
+        this.enableForceSkipLogin_ = loginSkippableResponse.forceSkip;
       });
 
     this.route_.paramMap.pipe(map(() => window.history.state)).subscribe((state: StateError) => {
@@ -80,6 +82,10 @@ export class LoginComponent implements OnInit {
         this.errors = [state.error];
       }
     });
+
+    if (this.enableForceSkipLogin_) {
+      this.skip();
+    }
   }
 
   getEnabledAuthenticationModes(): AuthenticationMode[] {

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -1082,6 +1082,7 @@ export interface EnabledAuthenticationModes {
 
 export interface LoginSkippableResponse {
   skippable: boolean;
+  forceSkip: boolean;
 }
 
 export interface SystemBanner {


### PR DESCRIPTION
We use oauth2-proxy to authorize into kubernetes dashboard at ingress and always skip login, I'm sure there're more groups using the dashboard in this favor. I propose a flag to automatically skip login.