### PR TITLE
Fix cookie handling in Firefox when using HTTP

### DIFF
--- a/aio/gulp/conf.js
+++ b/aio/gulp/conf.js
@@ -69,10 +69,40 @@ const version = {
  */
 const imageNameBase = 'dashboard';
 
+function envToArgv() {
+  let envArgs = process.env.DASHBOARD_ARGS;
+  let result = {};
+
+  const args = minimist(process.argv.splice(2));
+  delete args._;
+  Object.keys(args).forEach(key => result[key] = args[key]);
+
+  if(!envArgs) {
+    return result;
+  }
+
+  envArgs = envArgs.split(';');
+  if(envArgs.length === 0) {
+    return result;
+  }
+
+  envArgs.forEach(arg => {
+    const parts = arg.split('=');
+    if(parts.length === 2) {
+      result[parts[0]] = parts[1];
+      return;
+    }
+
+    result[parts[0]] = true;
+  })
+
+  return result;
+}
+
 /**
  * Arguments
  */
-const argv = minimist(process.argv.slice(2));
+const argv = envToArgv();
 
 /**
  * Exported configuration object with common constants used in build pipeline.
@@ -184,6 +214,13 @@ export default {
     enableSkipButton: argv.enableSkipButton !== undefined ?
         argv.enableSkipButton :
         false,
+
+    /**
+     * Allows to enable login view when serving on http.
+     */
+    enableInsecureLogin: argv.enableInsecureLogin !== undefined ?
+      argv.enableInsecureLogin :
+      false,
   },
 
   /**

--- a/aio/gulp/serve.js
+++ b/aio/gulp/serve.js
@@ -38,6 +38,8 @@ function getBackendArgs() {
     `--tls-cert-file=${conf.backend.tlsCert}`,
     `--tls-key-file=${conf.backend.tlsKey}`,
     `--auto-generate-certificates=${conf.backend.autoGenerateCerts}`,
+    `--enable-insecure-login=${conf.backend.enableInsecureLogin}`,
+    `--enable-skip-login=${conf.backend.enableSkipButton}`
   ];
 
   if (conf.backend.systemBanner.length > 0) {
@@ -56,10 +58,6 @@ function getBackendArgs() {
     args.push(`--kubeconfig=${conf.backend.kubeconfig}`);
   } else {
     args.push(`--apiserver-host=${conf.backend.apiServerHost}`);
-  }
-
-  if (conf.backend.enableSkipButton) {
-    args.push(`--enable-skip-login=${conf.backend.enableSkipButton}`);
   }
 
   return args;

--- a/src/app/frontend/login/component.spec.ts
+++ b/src/app/frontend/login/component.spec.ts
@@ -65,12 +65,8 @@ class MockAuthService {
 
   skipLoginPage(): void {}
 
-  get allowedProtocol(): string {
-    return 'https';
-  }
-
-  get domainWhitelist(): string[] {
-    return ['localhost', '127.0.0.1'];
+  isLoginEnabled(): boolean {
+    return true;
   }
 }
 

--- a/src/app/frontend/login/component.ts
+++ b/src/app/frontend/login/component.ts
@@ -117,9 +117,7 @@ export class LoginComponent implements OnInit {
   }
 
   isLoginEnabled(): boolean {
-    return this.authService_.domainWhitelist.indexOf(location.hostname) > -1
-      ? true
-      : location.protocol === this.authService_.allowedProtocol;
+    return this.authService_.isLoginEnabled();
   }
 
   onChange(event: Event & KdFile): void {


### PR DESCRIPTION
Fixes #5126

I have also fixed argument handling when running dev build. The old way of passing arguments to npm did not work. New way:
```
DASHBOARD_ARGS="enableInsecureLogin;enableSkipLogin=true npm run start"
```

Parameters are split using a semicolon and for non-boolean values use equals operator to pass a value. For boolean values it is optional.