### PR TITLE
Fix wrong job statuses in list view

### DIFF
--- a/src/app/frontend/common/components/resourcelist/job/component.ts
+++ b/src/app/frontend/common/components/resourcelist/job/component.ts
@@ -73,15 +73,19 @@ export class JobListComponent extends ResourceListWithStatuses<JobList, Job> {
   }
 
   isInErrorState(resource: Job): boolean {
-    return resource.podInfo.warnings.length > 0;
+    return resource.jobStatus.status === 'Failed';
   }
 
   isInPendingState(resource: Job): boolean {
-    return resource.podInfo.warnings.length === 0 && resource.podInfo.pending > 0;
+    return (
+      resource.podInfo.running === 0 &&
+      resource.jobStatus.status !== 'Complete' &&
+      resource.jobStatus.status !== 'Failed'
+    );
   }
 
   isInSuccessState(resource: Job): boolean {
-    return resource.podInfo.warnings.length === 0 && resource.podInfo.pending === 0;
+    return resource.podInfo.running > 0 || resource.jobStatus.status === 'Complete';
   }
 
   getDisplayColumns(): string[] {

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -33,6 +33,11 @@ export interface ObjectMeta {
   uid?: string;
 }
 
+export interface JobStatus {
+  status: string;
+  message: string;
+}
+
 export interface ResourceDetail {
   objectMeta: ObjectMeta;
   typeMeta: TypeMeta;
@@ -285,6 +290,7 @@ export interface Job extends Resource {
   containerImages: string[];
   initContainerImages: string[];
   parallelism: number;
+  jobStatus: JobStatus;
 }
 
 export interface Namespace extends Resource {


### PR DESCRIPTION
The way how the angular frontend calculates the job status is different from how the backend calculates it (https://github.com/kubernetes/dashboard/blob/master/src/app/backend/resource/job/common.go#L80-L88).
This PR fixes the calculation used by frontend and match it with the backend.
Specifically:
1. A job is failed only and if only the job state is `Failed`. This should not be determined by the job's pod states.
2. A job is in success state if the job state is `Complete` or there is at least one pod that is still running. As long as there is still pod(s) running in the job, the job shouldn't be considered failed or pending. The job will later on convert to failed state if the running pod keeps failing and backoff limit is reached.
3. A job is in pending state if the job state is not `Running` or `Failed`, and the number of pending pod is greater than 0.