### PR TITLE
Add condition to job status return in backend

### DIFF
--- a/src/app/backend/resource/job/list.go
+++ b/src/app/backend/resource/job/list.go
@@ -59,7 +59,7 @@ type JobStatus struct {
 	Status JobStatusType `json:"status"`
 	// A human-readable description of the status of related job.
 	Message string `json:"message"`
-	// The last transition time of the conditions of job status
+	// Conditions describe the state of a job after it finishes.
 	Conditions []common.Condition `json:"conditions"`
 }
 

--- a/src/app/backend/resource/job/list.go
+++ b/src/app/backend/resource/job/list.go
@@ -59,6 +59,8 @@ type JobStatus struct {
 	Status JobStatusType `json:"status"`
 	// A human-readable description of the status of related job.
 	Message string `json:"message"`
+	// The last transition time of the conditions of job status
+	Conditions []common.Condition `json:"conditions"`
 }
 
 // Job is a presentation layer view of Kubernetes Job resource. This means it is Job plus additional
@@ -173,7 +175,7 @@ func toJob(job *batch.Job, podInfo *common.PodInfo) Job {
 }
 
 func getJobStatus(job *batch.Job) JobStatus {
-	jobStatus := JobStatus{Status: JobStatusRunning}
+	jobStatus := JobStatus{Status: JobStatusRunning, Conditions: getJobConditions(job)}
 	for _, condition := range job.Status.Conditions {
 		if condition.Type == batch.JobComplete && condition.Status == v1.ConditionTrue {
 			jobStatus.Status = JobStatusComplete
@@ -185,4 +187,19 @@ func getJobStatus(job *batch.Job) JobStatus {
 		}
 	}
 	return jobStatus
+}
+
+func getJobConditions(job *batch.Job) []common.Condition {
+	var conditions []common.Condition
+	for _, condition := range job.Status.Conditions {
+		conditions = append(conditions, common.Condition{
+			Type:               string(condition.Type),
+			Status:             condition.Status,
+			LastProbeTime:      condition.LastProbeTime,
+			LastTransitionTime: condition.LastTransitionTime,
+			Reason:             condition.Reason,
+			Message:            condition.Message,
+		})
+	}
+	return conditions
 }

--- a/src/app/backend/resource/job/list_test.go
+++ b/src/app/backend/resource/job/list_test.go
@@ -208,6 +208,10 @@ func TestGetJobListFromChannels(t *testing.T) {
 					},
 					JobStatus: JobStatus{
 						Status: JobStatusFailed,
+						Conditions: []common.Condition{{
+							Type:   string(batch.JobFailed),
+							Status: v1.ConditionTrue,
+						}},
 					},
 				}},
 				Errors: []error{},

--- a/src/app/frontend/resource/workloads/job/detail/template.html
+++ b/src/app/frontend/resource/workloads/job/detail/template.html
@@ -71,7 +71,7 @@ limitations under the License.
   </div>
 </kd-card>
 
-<kd-condition-list [conditions]="job?.jobStatus.conditions"
+<kd-condition-list [conditions]="job?.jobStatus?.conditions"
                    [initialized]="isInitialized"></kd-condition-list>
 
 <kd-pod-status-card [podInfo]="job?.podInfo"

--- a/src/app/frontend/resource/workloads/job/detail/template.html
+++ b/src/app/frontend/resource/workloads/job/detail/template.html
@@ -71,6 +71,9 @@ limitations under the License.
   </div>
 </kd-card>
 
+<kd-condition-list [conditions]="job?.jobStatus.conditions"
+                   [initialized]="isInitialized"></kd-condition-list>
+
 <kd-pod-status-card [podInfo]="job?.podInfo"
                     [initialized]="isInitialized"></kd-pod-status-card>
 

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -33,6 +33,12 @@ export interface ObjectMeta {
   uid?: string;
 }
 
+export interface JobStatus {
+  status: string;
+  message: string;
+  conditions: Condition[];
+}
+
 export interface ResourceDetail {
   objectMeta: ObjectMeta;
   typeMeta: TypeMeta;
@@ -480,6 +486,7 @@ export interface JobDetail extends ResourceDetail {
   eventList: EventList;
   parallelism: number;
   completions: number;
+  jobStatus: JobStatus;
 }
 
 export interface CronJobDetail extends ResourceDetail {


### PR DESCRIPTION
Add job condition return in job status in backend.
This can be used in the future by the frontend to render more information about the job such as the job stop time (which is currently not available in frontend).
The PR requires no addition query in the backend, so performance-wise it should stay pretty much the same.

A demo of the revised job detail page:
![image](https://user-images.githubusercontent.com/1560135/83807807-a526d900-a681-11ea-8db4-b4863c50ec1c.png)
