### PR TITLE
feat(aio/Dockerfile): Add nonroot user to final image

### DIFF
--- a/aio/Dockerfile
+++ b/aio/Dockerfile
@@ -15,13 +15,22 @@
 # Main Dockerfile of the project. It creates an image that serves the application. This image should
 # be built from the dist directory.
 
+FROM ubuntu:20.04 as builder
+
+# Create a nonroot user for final image
+RUN useradd -u 10001 nonroot 
+
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
-FROM scratch
+FROM scratch as final
 
 # Add all files from current working directory to the root of the image, i.e., copy dist directory
 # layout to the root directory.
 ADD . /
+
+# Copy nonroot user
+COPY --from=builder /etc/passwd /etc/passwd
+USER nonroot
 
 # The port that the application listens on.
 EXPOSE 9090 8443


### PR DESCRIPTION
Vulnerability scans against the dashboard image show that it was created with a nonroot user. Even if the user is changed in the deployment yaml this will still fail the scan.

I have made a similar change for metrics scraper - https://github.com/kubernetes-sigs/dashboard-metrics-scraper/pull/32