### PR TITLE
Adding override for ingress paths

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.0.3
+version: 2.1.0
 appVersion: 2.0.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -93,7 +93,7 @@ Parameter                                       | Description                   
 `ingress.labels`                                | Add custom labels                                                                                                                | `[]`
 `ingress.enabled`                               | Enable ingress controller resource                                                                                               | `false`
 `ingress.paths`                                 | Paths to match against incoming requests. Both `/` and `/*` are required to work on gce ingress.                                 | `[/]`
-`ingress.paths_custom`                          | Override for the ingress paths                                                                                                   | `[]`
+`ingress.customPaths`                           | Override the default ingress paths                                                                                               | `[]`
 `ingress.hosts`                                 | Dashboard Hostnames                                                                                                              | `nil`
 `ingress.tls`                                   | Ingress TLS configuration                                                                                                        | `[]`
 `metricsScraper.enabled`                        | Wether to enable dashboard-metrics-scraper                                                                                       | `false`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -93,6 +93,7 @@ Parameter                                       | Description                   
 `ingress.labels`                                | Add custom labels                                                                                                                | `[]`
 `ingress.enabled`                               | Enable ingress controller resource                                                                                               | `false`
 `ingress.paths`                                 | Paths to match against incoming requests. Both `/` and `/*` are required to work on gce ingress.                                 | `[/]`
+`ingress.paths_custom`                          | Override for the ingress paths                                                                                                   | `[]`
 `ingress.hosts`                                 | Dashboard Hostnames                                                                                                              | `nil`
 `ingress.tls`                                   | Ingress TLS configuration                                                                                                        | `[]`
 `metricsScraper.enabled`                        | Wether to enable dashboard-metrics-scraper                                                                                       | `false`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/charts/metrics-server
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/charts/metrics-server
@@ -1,0 +1,1 @@
+/home/jtyr/Documents/projects/helm/charts/stable/metrics-server

--- a/aio/deploy/helm-chart/kubernetes-dashboard/charts/metrics-server
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/charts/metrics-server
@@ -1,1 +1,0 @@
-/home/jtyr/Documents/projects/helm/charts/stable/metrics-server

--- a/aio/deploy/helm-chart/kubernetes-dashboard/ci/ingress-customPaths-values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/ci/ingress-customPaths-values.yaml
@@ -1,0 +1,11 @@
+ingress:
+  enabled: true
+
+  customPaths:
+    - backend:
+        serviceName: ssl-redirect
+        servicePort: use-annotation
+    - backend:
+        serviceName: >-
+          {{ include "kubernetes-dashboard.fullname" . }}
+        servicePort: 443

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -43,21 +43,29 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+  {{- if len ($.Values.ingress.paths_custom) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.paths_custom | indent 10) $ }}
+  {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+  {{- end -}}
   {{- end -}}
   {{- end -}}
   {{- else }}
     - http:
         paths:
+  {{- if len ($.Values.ingress.paths_custom) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.paths_custom | indent 10) $ }}
+  {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+  {{- end -}}
   {{- end -}}
   {{- end -}}
   {{- if .Values.ingress.tls }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -43,8 +43,8 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-  {{- if len ($.Values.ingress.paths_custom) }}
-  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.paths_custom | indent 10) $ }}
+  {{- if len ($.Values.ingress.customPaths) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.customPaths | indent 10) $ }}
   {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
@@ -57,8 +57,8 @@ spec:
   {{- else }}
     - http:
         paths:
-  {{- if len ($.Values.ingress.paths_custom) }}
-  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.paths_custom | indent 10) $ }}
+  {{- if len ($.Values.ingress.customPaths) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.customPaths | indent 10) $ }}
   {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -119,6 +119,18 @@ ingress:
     - /
   #  - /*
 
+  ## CustomKubernetes Dashboard Ingress paths
+  ##
+  paths_custom: []
+  #  - backend:
+  #      serviceName: ssl-redirect
+  #      servicePort: use-annotation
+  #  - backend:
+  #      serviceName: >-
+  #        {{ include "kubernetes-dashboard.fullname" . }}
+  #      # Don't use string here, use only integer value!
+  #      servicePort: 443
+
   ## Kubernetes Dashboard Ingress hostnames
   ## Must be provided if Ingress is enabled
   ##

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -119,9 +119,9 @@ ingress:
     - /
   #  - /*
 
-  ## CustomKubernetes Dashboard Ingress paths
+  ## Custom Kubernetes Dashboard Ingress paths. Will override default paths.
   ##
-  paths_custom: []
+  customPaths: []
   #  - backend:
   #      serviceName: ssl-redirect
   #      servicePort: use-annotation


### PR DESCRIPTION
This PR is adding the possibility to override the default Ingress paths in the Helm chart with a new block of paths defined as YAML data structure. This allows to configure the Ingress resource to work with the AWS ALB Ingress Controller to automatically [redirect HTTP traffic to HTTPS](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/) on the load balancer.