### PR TITLE
styles: Turn off hover effects on disabled buttons

### DIFF
--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -276,7 +276,9 @@
   }
 
   .mat-icon-button:hover {
-    background-color: $border !important;
+    :not([disabled='true']) and :not(&[disabled='true']) {
+      background-color: $border !important;
+    }
   }
 
   .c3-tooltip {


### PR DESCRIPTION
Turns off the applied .mat-icon-button:hover on .mat-icon-button that are disabled.

This change should fix #5293 

This is my first PR to Kubernetes, if anything is missing, I will happily fix it :)