### PR TITLE
Helm Chart: setup Continuous Deployment + Create settings Configmap

### DIFF
--- a/.github/workflows/cd-helm-workflow.yml
+++ b/.github/workflows/cd-helm-workflow.yml
@@ -1,0 +1,51 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Continuous Deployment - Helm
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aio/deploy/helm-chart/**'
+    - 'aio/scripts/helm-release-chart.sh'
+    - '.github/workflows/cd-helm-workflow.yml'
+
+jobs:
+  release:
+    name: Helm Chart Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Environment
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Package
+        shell: bash
+        run: aio/scripts/helm-release-chart.sh
+        env:
+          TERM: xterm-256color
+
+      - name: Publish
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/configmap.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/configmap.yaml
@@ -13,18 +13,8 @@
 # limitations under the License.
 
 apiVersion: v1
-name: kubernetes-dashboard
-version: 2.1.1
-appVersion: 2.0.3
-description: General-purpose web UI for Kubernetes clusters
-keywords:
-- kubernetes
-- dashboard
-home: https://github.com/kubernetes/dashboard
-sources:
-- https://github.com/kubernetes/dashboard
-maintainers:
-- name: desaintmartin
-  email: cdesaintmartin@wiremind.fr
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
-kubeVersion: ">=1.10.0-0"
+kind: ConfigMap
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-settings

--- a/aio/scripts/helm-release-chart.sh
+++ b/aio/scripts/helm-release-chart.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script takes an argument: the tag name ("v1.2.3") to release from.
+
+# Exit on error.
+set -e
+
+# Import config.
+ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
+. "${ROOT_DIR}/aio/scripts/conf.sh"
+
+# Declare variables.
+HELM_CHART_DIR="$AIO_DIR/deploy/helm-chart/kubernetes-dashboard"
+
+function release-helm-chart {
+  if [ -n "$(git status --porcelain)" ]; then
+    saye "\nGit working tree not clean, aborting."
+    exit 1
+  fi
+  say "\nGenerating Helm Chart package for new version."
+  say "Please note that your gh-pages branch, if it locally exists, should be up-to-date."
+  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  helm dependency build "$HELM_CHART_DIR"
+  helm package "$HELM_CHART_DIR"
+  rm -rf "$HELM_CHART_DIR/charts/"
+  say "\nSwitching git branch to gh-pages so that we can commit package along the previous versions."
+  git checkout gh-pages
+  say "\nGenerating new Helm index, containing all existing versions in gh-pages (previous ones + new one)."
+  helm repo index .
+  say "\nCommit new package and index."
+  git add -A "./kubernetes-dashboard-*.tgz" ./index.yaml && git commit -m "Update Helm repository from CI."
+  say "\nIf you are happy with the changes, please manually push to the gh-pages branch. No force should be needed."
+  say "Assuming upstream is your remote, please run: git push upstream gh-pages."
+}
+
+# Execute script.
+release-helm-chart


### PR DESCRIPTION
- Restored previously deleted helm-release-chart.sh without modification
- Made a change in the Chart within the same PR in order to test CD.
- You can find results on my fork:
  - https://github.com/wiremind/dashboard
  - CD job: https://github.com/wiremind/dashboard/actions/runs/147292803
  - Resulted automatic commit pushed on gh-pages: https://github.com/wiremind/dashboard/tree/gh-pages
  - Published index: https://wiremind.github.io/dashboard/index.yaml
- Note that it uses the built-in GITHUB_TOKEN, no need to set a manual secret (see https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token).


Note that if anything goes wrong, it will raise, as in this CD job: https://github.com/wiremind/dashboard/actions/runs/147296059 where I just rebased my changes (thus triggering CD but 2.0.4 already exists on gh-pages)