### PR TITLE
Helm Chart CD: create PR instead of trying to push to protected branch

### DIFF
--- a/.github/workflows/cd-helm-workflow.yml
+++ b/.github/workflows/cd-helm-workflow.yml
@@ -44,8 +44,23 @@ jobs:
         env:
           TERM: xterm-256color
 
-      - name: Publish
+      - name: Create Pull Request branch
+        run: |
+          git checkout -b gh-pages-pull-request
+
+      # Note that will fail if branch already exists.
+      - name: Push Git Branch
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
+          branch: gh-pages-pull-request
+
+      # Note that will silently fail if PR already exists.
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: gh-pages-pull-request
+          destination_branch: gh-pages
+          pr_title: "Helm Chart: Update Helm repository"
+          pr_body: "Automatically created from Helm CD workflow."


### PR DESCRIPTION
This is a workaround from the fact that Github Actions can't push to protected branches for security reasons.

https://github.community/t/allowing-github-actions-bot-to-push-to-protected-branch/16536/2

What it does:
- Run the release script
- Create a gh-pages-pull-request branch (only one can exist at a time)
- Create a PR using this branch (current version of the action will SILENTLY fail (i.e all green) if it can't create the PR, for example if such a PR already exists.

Examples from my fork:
- CD: https://github.com/wiremind/dashboard/actions/runs/147574658
- Creates https://github.com/wiremind/dashboard/pull/6

Note that it is not battle-tested and can be improved/simplified in the future.

Note that on my fork, source branch is automatically deleted, we should see if it is the case here.