### PR TITLE
i18n: fix zh-hans translation of "Scale"

### DIFF
--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -235,7 +235,7 @@
     Scale
   </source>
         <target>
-    规模
+    缩放
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/scaleresource/template.html</context>
@@ -712,7 +712,7 @@
       </trans-unit>
       <trans-unit id="a062b45312698e8669cb644bff887f93778d334f" datatype="html">
         <source>Scale</source>
-        <target>规模</target>
+        <target>缩放</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/column/menu/template.html</context>
           <context context-type="linenumber">35</context>


### PR DESCRIPTION
"规模" is the noun form of "Scale". Need to use verb "缩放" instead.