### PR TITLE
Add value for cluster service label

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.3.1
+version: 2.4.0
 appVersion: 2.0.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.0.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -91,6 +91,7 @@ Parameter                                       | Description                   
 `service.externalPort`                          | Dashboard external port                                                                                                          | `443`
 `service.loadBalancerSourceRanges`              | list of IP CIDRs allowed access to load balancer (if supported)                                                                  | `nil`
 `service.loadBalancerIP`                        | A user-specified IP address for load balancer to use as External IP (if supported)                                               | `nil`
+`service.clusterServiceLabel`                   | The cluster-service label                                                                                                        | `kubernetes.io/cluster-service: true`
 `ingress.annotations`                           | Specify ingress class                                                                                                            | `kubernetes.io/ingress.class: nginx`
 `ingress.labels`                                | Add custom labels                                                                                                                | `[]`
 `ingress.enabled`                               | Enable ingress controller resource                                                                                               | `false`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -91,7 +91,8 @@ Parameter                                       | Description                   
 `service.externalPort`                          | Dashboard external port                                                                                                          | `443`
 `service.loadBalancerSourceRanges`              | list of IP CIDRs allowed access to load balancer (if supported)                                                                  | `nil`
 `service.loadBalancerIP`                        | A user-specified IP address for load balancer to use as External IP (if supported)                                               | `nil`
-`service.clusterServiceLabel`                   | The cluster-service label                                                                                                        | `kubernetes.io/cluster-service: true`
+`service.clusterServiceLabel.enabled            | Enable the cluster-service label                                                                                                 | `true`
+`service.clusterServiceLabel.key                | The cluster-service label key                                                                                                    | `kubernetes.io/cluster-service`
 `ingress.annotations`                           | Specify ingress class                                                                                                            | `kubernetes.io/ingress.class: nginx`
 `ingress.labels`                                | Add custom labels                                                                                                                | `[]`
 `ingress.enabled`                               | Enable ingress controller resource                                                                                               | `false`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
 {{ include "kubernetes-dashboard.labels" . | indent 4 }}
     app.kubernetes.io/component: kubernetes-dashboard
-{{ .Values.service.clusterServiceLabel | indent 4 }}
+{{ .Values.service.clusterServiceLabel.key | indent 4}}: {{ .Values.service.clusterServiceLabel.enabled | quote }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
 {{ include "kubernetes-dashboard.labels" . | indent 4 }}
     app.kubernetes.io/component: kubernetes-dashboard
-    kubernetes.io/cluster-service: "true"
+{{ .Values.service.clusterServiceLabel | indent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -98,8 +98,11 @@ service:
   ## set a specific load balancer Ip if you're using one
   # loadBalancerIP:
 
-  ## enable or disable the kubernetes.io/cluster-service label
-  clusterServiceLabel: "kubernetes.io/cluster-service: true"
+  ## Enable or disable the kubernetes.io/cluster-service label. Should be disabled for GKE clusters >=1.15.
+  ## Otherwise, the addon manager will presume ownership of the service and try to delete it.
+  clusterServiceLabel:
+    enabled: true
+    key: "kubernetes.io/cluster-service"
 
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -98,6 +98,9 @@ service:
   ## set a specific load balancer Ip if you're using one
   # loadBalancerIP:
 
+  ## enable or disable the kubernetes.io/cluster-service label
+  clusterServiceLabel: "kubernetes.io/cluster-service: true"
+
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.
   ##


### PR DESCRIPTION
This is a PR to make the Service object's cluster-service label configurable. This is because having this label hardcoded (as it is today) breaks GKE clusters >=1.15. The GKE addon manager will discover this label and try to delete the Service.