### PR TITLE
Available namespaces

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -183,6 +183,8 @@ spec:
           args:
             - --namespace=kubernetes-dashboard
             - --enable-insecure-login
+          # Uncomment the following line to manually specify the namespaces available (default, kubernetes-dashboard, etc.)
+          # - --available-namespaces=default,kubernetes-dashboard
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -182,6 +182,8 @@ spec:
               protocol: TCP
           args:
             - --namespace=kubernetes-dashboard-head
+          # Uncomment the following line to manually specify the namespaces available (default, kubernetes-dashboard, etc.)
+          # - --available-namespaces=default,kubernetes-dashboard-head
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - --namespace={{ .Release.Namespace }}
+ {{- if .Values.availableNamespaces-}}       
+          - --available-namespaces={{ join "," .Values.availableNamespaces }}
+{{- end -}}
 {{- if not .Values.protocolHttp }}
           - --auto-generate-certificates
 {{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -237,3 +237,9 @@ containerSecurityContext:
 
 networkPolicy:
   enabled: false
+
+
+## Define the list of available namespaces (set list, instead of cluster lookup)
+availableNamespaces:
+- default
+- kubernetes-dashboard

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -240,6 +240,6 @@ networkPolicy:
 
 
 ## Define the list of available namespaces (set list, instead of cluster lookup)
-availableNamespaces:
-- default
-- kubernetes-dashboard
+# availableNamespaces:
+# - default
+# - kubernetes-dashboard

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -195,6 +195,8 @@ spec:
           args:
             - --auto-generate-certificates
             - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify the namespaces available (default, kubernetes-dashboard, etc.)
+            # - --available-namespaces=default,kubernetes-dashboard
             # Uncomment the following line to manually specify Kubernetes API server Host
             # If not specified, Dashboard will attempt to auto discover the API server and connect
             # to it. Uncomment only if the default does not work.

--- a/aio/deploy/recommended/06_dashboard-deployment.yaml
+++ b/aio/deploy/recommended/06_dashboard-deployment.yaml
@@ -42,6 +42,8 @@ spec:
           args:
             - --auto-generate-certificates
             - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify the namespaces available (default, kubernetes-dashboard, etc.)
+            # - --available-namespaces=default,kubernetes-dashboard
             # Uncomment the following line to manually specify Kubernetes API server Host
             # If not specified, Dashboard will attempt to auto discover the API server and connect
             # to it. Uncomment only if the default does not work.

--- a/aio/gulp/conf.js
+++ b/aio/gulp/conf.js
@@ -154,11 +154,11 @@ export default {
     /**
      * Namespace kubernetes-dashboard should be scoped to
      */
-    namespace: gulpUtil.env.namespace !== undefined ? gulpUtil.env.namespace : '',
+    namespace: argv.namespace !== undefined ? argv.namespace : '',
     /**
      * Available namespaces for listing on the kubernetes dashboard UI
      */
-    availableNamespaces: gulpUtil.env['available-namespaces'] !== undefined ? gulpUtil.env['available-namespaces'] : '',
+    availableNamespaces: argv['available-namespaces'] !== undefined ? argv['available-namespaces'] : '',
     /**
      * Env variable with path to kubeconfig file.
      */

--- a/aio/gulp/conf.js
+++ b/aio/gulp/conf.js
@@ -152,6 +152,14 @@ export default {
      */
     apiServerHost: 'http://localhost:8080',
     /**
+     * Namespace kubernetes-dashboard should be scoped to
+     */
+    namespace: gulpUtil.env.namespace !== undefined ? gulpUtil.env.namespace : '',
+    /**
+     * Available namespaces for listing on the kubernetes dashboard UI
+     */
+    availableNamespaces: gulpUtil.env['available-namespaces'] !== undefined ? gulpUtil.env['available-namespaces'] : '',
+    /**
      * Env variable with path to kubeconfig file.
      */
     kubeconfig: argv.kubeconfig !== undefined ? argv.kubeconfig : '',

--- a/aio/gulp/conf.js
+++ b/aio/gulp/conf.js
@@ -154,7 +154,7 @@ export default {
     /**
      * Namespace kubernetes-dashboard should be scoped to
      */
-    namespace: argv.namespace !== undefined ? argv.namespace : '',
+    namespace: argv.namespace !== undefined ? argv.namespace : 'kube-system',
     /**
      * Available namespaces for listing on the kubernetes dashboard UI
      */

--- a/aio/gulp/serve.js
+++ b/aio/gulp/serve.js
@@ -39,7 +39,9 @@ function getBackendArgs() {
     `--tls-key-file=${conf.backend.tlsKey}`,
     `--auto-generate-certificates=${conf.backend.autoGenerateCerts}`,
     `--enable-insecure-login=${conf.backend.enableInsecureLogin}`,
-    `--enable-skip-login=${conf.backend.enableSkipButton}`
+    `--enable-skip-login=${conf.backend.enableSkipButton}`,
+    `--available-namespaces=${conf.backend.availableNamespaces}`,
+    `--namespace=${conf.backend.namespace}`
   ];
 
   if (conf.backend.systemBanner.length > 0) {

--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -162,6 +162,12 @@ func (self *holderBuilder) SetNamespace(namespace string) *holderBuilder {
 	return self
 }
 
+// SetNamespace 'available-namespaces' argument of Dashboard binary.
+func (self *holderBuilder) SetAvailableNamespaces(availableNamespaces []string) *holderBuilder {
+	self.holder.availableNamespaces = availableNamespaces
+	return self
+}
+
 // SetLocaleConfig 'locale-config' argument of Dashboard binary.
 func (self *holderBuilder) SetLocaleConfig(localeConfig string) *holderBuilder {
 	self.holder.localeConfig = localeConfig

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -45,6 +45,7 @@ type holder struct {
 	systemBannerSeverity string
 	apiLogLevel          string
 	namespace            string
+	availableNamespaces  []string
 
 	authenticationMode []string
 
@@ -178,6 +179,11 @@ func (self *holder) GetEnableSkipLogin() bool {
 // GetNamespace 'namespace' argument of Dashboard binary.
 func (self *holder) GetNamespace() string {
 	return self.namespace
+}
+
+// GetNamespace 'available-namespaces' argument of Dashboard binary.
+func (self *holder) GetAvailableNamespaces() []string {
+	return self.availableNamespaces
 }
 
 // GetLocaleConfig 'locale-config' argument of Dashboard binary.

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -78,6 +78,7 @@ var (
 	argAPILogLevel               = pflag.String("api-log-level", "INFO", "Level of API request logging. Should be one of 'INFO|NONE|DEBUG'.")
 	argDisableSettingsAuthorizer = pflag.Bool("disable-settings-authorizer", false, "When enabled, Dashboard settings page will not require user to be logged in and authorized to access settings page. (default false)")
 	argNamespace                 = pflag.String("namespace", getEnv("POD_NAMESPACE", "kube-system"), "When non-default namespace is used, create encryption key in the specified namespace.")
+	argAvailableNamespaces       = pflag.StringSlice("available-namespaces", nil, "Specify a subset of namespaces which should be made available/shown within the interface. Comma separated. Other namespaces are hidden.")
 	localeConfig                 = pflag.String("locale-config", "./locale_conf.json", "File containing the configuration of locales")
 )
 
@@ -253,6 +254,7 @@ func initArgHolder() {
 	builder.SetDisableSettingsAuthorizer(*argDisableSettingsAuthorizer)
 	builder.SetEnableSkipLogin(*argEnableSkip)
 	builder.SetNamespace(*argNamespace)
+	builder.SetAvailableNamespaces(*argAvailableNamespaces)
 	builder.SetLocaleConfig(*localeConfig)
 }
 

--- a/src/app/backend/resource/namespace/list.go
+++ b/src/app/backend/resource/namespace/list.go
@@ -69,10 +69,11 @@ func GetNamespaceList(client kubernetes.Interface, dsQuery *dataselect.DataSelec
 	availableNamespaces := args.Holder.GetAvailableNamespaces()
 
 	if len(availableNamespaces) > 0 {
-		log.Println("Setting list of namespaces from ags")
+		log.Println("Setting list of namespaces from args")
 		namespaces = new(v1.NamespaceList)
 
 		for _, nsName := range availableNamespaces {
+			// Validate the namespace
 			ns, err := client.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 			nces, criticalError := errors.HandleError(err)
 			if criticalError != nil {


### PR DESCRIPTION
Add the ability to specify the namespaces to display in the dashboard. This allows for a clean list of user-centric namespaces, without the clutter of system-like namespaces.

This doesn't prevent you from navigating to the namespace of choice, if you know that it exists. It's a simple UI tweak to show the namespaces that you want your users to easily find. 