### PR TITLE
Replications Controllers → Replication Controllers

### DIFF
--- a/src/app/frontend/common/components/resourcelist/replicationcontroller/template.html
+++ b/src/app/frontend/common/components/resourcelist/replicationcontroller/template.html
@@ -18,7 +18,7 @@ limitations under the License.
          [hidden]="isHidden()">
   <div title
        fxLayout="row"
-       i18n>Replications Controllers</div>
+       i18n>Replication Controllers</div>
   <div description><span class="kd-muted-light"
           i18n>Items:&nbsp;</span>{{totalItems}}</div>
   <div actions>


### PR DESCRIPTION
'Replication"s" Controllers' appears only on this file.
All others, including the breadcrumb on the sidebar, are 'Replication Controllers'

And Google search results...
* No results found for "Replications Controllers" site:kubernetes.io
* About 2,340 results found for "Replication Controllers" site:kubernetes.io