### PR TITLE
Helm Chart: Add options for extraVolumes and extraVolumeMounts

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.5.1
+version: 2.6.0
 appVersion: 2.0.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.5.0
+version: 2.5.1
 appVersion: 2.0.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -79,6 +79,8 @@ Parameter                                       | Description                   
 `labels`                                        | Labels for deployment                                                                                                            | `{}`
 `extraArgs`                                     | Additional container arguments                                                                                                   | `[]`
 `extraEnv`                                      | Additional container environment variables                                                                                       | `[]`
+`extraVolumes`                                  | Additional volumes                                                                                                               | `[]`
+`extraVolumeMounts`                             | Additional container volumeMounts                                                                                                | `[]`
 `podAnnotations`                                | Annotations to be added to pods                                                                                                  | `seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'}`
 `podLabels`                                     | Labels to be added to pods                                                                                                       | `{}`
 `nodeSelector`                                  | node labels for pod assignment                                                                                                   | `{}`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
           # Create on-disk volume to store exec logs
         - mountPath: /tmp
           name: tmp-volume
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         livenessProbe:
           httpGet:
 {{- if .Values.protocolHttp }}
@@ -156,6 +159,9 @@ spec:
           secretName: {{ template "kubernetes-dashboard.fullname" . }}-certs
       - name: tmp-volume
         emptyDir: {}
+{{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+{{- end }}
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -43,6 +43,21 @@ extraEnv: []
 # - name: SOME_VAR
 #   value: 'some value'
 
+## Additional volumes to be added to kubernetes dashboard pods
+##
+extraVolumes: []
+# - name: dashboard-kubeconfig
+#   secret:
+#     defaultMode: 420
+#     secretName: dashboard-kubeconfig
+
+## Additional volumeMounts to be added to kubernetes dashboard pods
+##
+extraVolumeMounts: []
+# - mountPath: /kubeconfig
+#   name: dashboard-kubeconfig
+#   readOnly: true
+
 # Annotations to be added to kubernetes dashboard pods
 podAnnotations:
   seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'


### PR DESCRIPTION
This is to add options for specifying helm values for `extraVolumes` and `extraVolumeMounts`.

I've recently needed to provide a custom `kubeconfig` file to the dashboard, to make it work with `kube-oidc-proxy` (https://github.com/jetstack/kube-oidc-proxy). Without being able to specify `extraVolumes` and `extraVolumeMounts`, you're unable to actually provide a custom `kubeconfig` file using the official helm chart, even though the dashboard binary supports the option.