### PR TITLE
Update triage/support label references to kind/support

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,7 +1,7 @@
 ---
 name: Support Request
 about: Support request or question relating to Kubernetes Dashboard project
-labels: triage/support
+labels: kind/support
 
 ---
 

--- a/docs/user/labels.md
+++ b/docs/user/labels.md
@@ -11,6 +11,7 @@ Labels used to determine issue kind.
 * `kind/documentation` - documentation, that need to be improved or updated.
 * `kind/failing-test` - blocker of CI jobs, that should be fixed as soon as posible.
 * `kind/feature` - new features, that could be added to the application.
+* `kind/support` - issue that is a support question.
 
 ## Priority
 
@@ -62,7 +63,6 @@ Other labels used for issues and pull requests.
 * `triage/duplicate` - duplicates, that should be closed and linked with original issues.
 * `triage/needs-information` - issue needs more information in order to work on it.
 * `triage/not-reproducible` - issue can not be reproduced as described.
-* `triage/support` - issue that is a support question.
 * `triage/unresolved` - issue that can not or will not be resolved.
 
 ----


### PR DESCRIPTION
The label triage/support has been reclassified as kind/support. The
kind/* family of labels makes more logical sense, as they describe the
"kind" of thing an issue or PR is.

For more information, see the announcement email:
https://groups.google.com/g/kubernetes-dev/c/YcaJpsjjLKw/m/i15cLLx5CAAJ


/assign @jeefy 