### PR TITLE
Upgraded to a slightly newer kubernetesui/metrics-scraper

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -253,7 +253,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.4
+          image: kubernetesui/metrics-scraper:v1.0.5
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/aio/deploy/alternative/08_scraper-deployment.yaml
+++ b/aio/deploy/alternative/08_scraper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: dashboard-metrics-scraper
-        image: kubernetesui/metrics-scraper:v1.0.4
+        image: kubernetesui/metrics-scraper:v1.0.5
         ports:
         - containerPort: 8000
           protocol: TCP

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.8.0
+version: 2.8.1
 appVersion: 2.0.4
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -106,7 +106,7 @@ Parameter                                       | Description                   
 `pinnedCRDs`                                    | Pinned CRDs that will be displayed in dashboard's menu                                                                           | `[]`
 `metricsScraper.enabled`                        | Wether to enable dashboard-metrics-scraper                                                                                       | `false`
 `metricsScraper.image.repository`               | Repository for metrics-scraper image                                                                                             | `kubernetesui/metrics-scraper`
-`metricsScraper.image.tag`                      | Repository for metrics-scraper image tag                                                                                         | `v1.0.4`
+`metricsScraper.image.tag`                      | Repository for metrics-scraper image tag                                                                                         | `v1.0.5`
 `metricsScraper.containerSecurityContext`       | SecurityContext for the kubernetes dashboard metrics scraper container                                                           | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
 `metrics-server.enabled`                        | Wether to enable metrics-server                                                                                                  | `false`
 `rbac.create`                                   | Create & use RBAC resources                                                                                                      | `true`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -201,7 +201,7 @@ metricsScraper:
   enabled: false
   image:
     repository: kubernetesui/metrics-scraper
-    tag: v1.0.4
+    tag: v1.0.5
   resources: {}
   ## SecurityContext for the metrics scraper container
   containerSecurityContext:

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -271,7 +271,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.4
+          image: kubernetesui/metrics-scraper:v1.0.5
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/aio/deploy/recommended/08_scraper-deployment.yaml
+++ b/aio/deploy/recommended/08_scraper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.4
+          image: kubernetesui/metrics-scraper:v1.0.5
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
1.0.4 is more than a half year old now. 1.0.5 is marginally better, but is there a reason to not upgrade?

An important note: I'm **NOT** a hacktoberfest hunter, even though this PR is a one character changed only :-D I'm just a person who maintains several k8s clusters and has an alert set if docker containers running are too old.