### PR TITLE
Bump golangci-lint to v1.30.0 for development container

### DIFF
--- a/aio/develop/Dockerfile
+++ b/aio/develop/Dockerfile
@@ -84,7 +84,7 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 # `npm ci` installs golangci, but this installation is needed
 # for running `npm run check` singlely, like
 # `aio/develop/run-npm-on-container.sh run check`.
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
 
 # Install delve for debuging go files.
 RUN go get github.com/go-delve/delve/cmd/dlv
@@ -94,6 +94,9 @@ ENV GO111MODULE=on
 
 # Set GOPROXY to ensure download modules
 ENV GOPROXY=https://proxy.golang.org
+
+# Set NODE_OPTIONS to increase NodeJS heap size
+ENV NODE_OPTIONS=--max-old-space-size=8192
 
 # Volume for source code
 VOLUME ["/go/src/github.com/kubernetes/dashboard"]


### PR DESCRIPTION
Also add env `NODE_OPTIONS=--max-old-space-size=8192`.