### PR TITLE
Show relative time for events

### DIFF
--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -1983,7 +1983,7 @@
         <target>Zuletzt gesehen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -1987,7 +1987,7 @@
         <target>Dernière vue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -1788,7 +1788,7 @@
         <target>直近</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -1929,7 +1929,7 @@
         <target>마지막에 표시된</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -1853,7 +1853,7 @@
         <source>Last Seen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -1929,7 +1929,7 @@
         <target>最后一次</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -1929,7 +1929,7 @@
         <target>最後一次</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -1929,7 +1929,7 @@
         <target>最後一次</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/event/template.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7f910609b2f8e23ae9694be7103f52e258827fd5" datatype="html">

--- a/src/app/frontend/common/components/resourcelist/event/template.html
+++ b/src/app/frontend/common/components/resourcelist/event/template.html
@@ -71,7 +71,8 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>First Seen</mat-header-cell>
         <mat-cell *matCellDef="let event">
-          <kd-date [date]="event.firstSeen"></kd-date>
+          <kd-date [date]="event.firstSeen"
+                   [relative]="true"></kd-date>
         </mat-cell>
       </ng-container>
 
@@ -79,7 +80,8 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Last Seen</mat-header-cell>
         <mat-cell *matCellDef="let event">
-          <kd-date [date]="event.lastSeen"></kd-date>
+          <kd-date [date]="event.lastSeen"
+                   [relative]="true"></kd-date>
         </mat-cell>
       </ng-container>
 


### PR DESCRIPTION
Updated events to show relative time. Related to #5603.

![Zrzut ekranu z 2020-10-08 11-03-43](https://user-images.githubusercontent.com/2285385/95437948-f3145c00-0955-11eb-845e-1bd1e03a2349.png)
