### PR TITLE
Update creating-sample-user.md -- token is encoded with base64

### DIFF
--- a/docs/user/access-control/creating-sample-user.md
+++ b/docs/user/access-control/creating-sample-user.md
@@ -47,7 +47,7 @@ EOF
 Now we need to find token we can use to log in. Execute following command:
 
 ```bash
-kubectl -n kubernetes-dashboard get secret $(kubectl -n kubernetes-dashboard get sa/admin-user -o jsonpath="{.secrets[0].name}") -o jsonpath="{.data.token}{'\n'}"
+kubectl -n kubernetes-dashboard get secret $(kubectl -n kubernetes-dashboard get sa/admin-user -o jsonpath="{.secrets[0].name}") -o jsonpath="{.data.token}{'\n'}" | base64 --decode
 ```
 
 It should print something like:


### PR DESCRIPTION
Highlight that returned data is base64 encoded, and it should be decoded to get valid bearer token