### PR TITLE
Bump go-restful from v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.15
 
 require (
 	github.com/docker/distribution v2.7.1+incompatible
-	// emicklei/go-restful v2.14.0 or later breaks http response body if it has boolean value.
+	// emicklei/go-restful v3.3.0 or later breaks http response body if it has boolean value.
 	// See emicklei/go-restful#449
-	github.com/emicklei/go-restful v2.13.0+incompatible
+	github.com/emicklei/go-restful/v3 v3.2.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -94,9 +94,10 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.13.0+incompatible h1:XwckZriGdbXs1EoZ7Y1MdH6hWqZ4XnkFSiEibNi5BXg=
-github.com/emicklei/go-restful v2.13.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful/v3 v3.2.0 h1:bYqC4/ykCzQbUVO2c9h1J4XYTD1ApVxsZ1HWEFZY87s=
+github.com/emicklei/go-restful/v3 v3.2.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=

--- a/src/app/backend/auth/handler.go
+++ b/src/app/backend/auth/handler.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	authApi "github.com/kubernetes/dashboard/src/app/backend/auth/api"
 	"github.com/kubernetes/dashboard/src/app/backend/errors"

--- a/src/app/backend/auth/handler_test.go
+++ b/src/app/backend/auth/handler_test.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"testing"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {

--- a/src/app/backend/auth/manager_test.go
+++ b/src/app/backend/auth/manager_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 
 	authApi "github.com/kubernetes/dashboard/src/app/backend/auth/api"
 	"github.com/kubernetes/dashboard/src/app/backend/client"

--- a/src/app/backend/client/api/types.go
+++ b/src/app/backend/client/api/types.go
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	v1 "k8s.io/api/authorization/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	v1 "k8s.io/api/authorization/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/src/app/backend/client/manager_test.go
+++ b/src/app/backend/client/manager_test.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"testing"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/args"
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 	"k8s.io/client-go/rest"

--- a/src/app/backend/errors/handler.go
+++ b/src/app/backend/errors/handler.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"net/http"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/plugin"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	"golang.org/x/net/xsrftoken"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/remotecommand"

--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/args"
 	"github.com/kubernetes/dashboard/src/app/backend/auth"
 	authApi "github.com/kubernetes/dashboard/src/app/backend/auth/api"

--- a/src/app/backend/handler/download.go
+++ b/src/app/backend/handler/download.go
@@ -17,7 +17,7 @@ package handler
 import (
 	"io"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 )

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	"golang.org/x/net/xsrftoken"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 

--- a/src/app/backend/handler/parser/parser.go
+++ b/src/app/backend/handler/parser/parser.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 )

--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"sync"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"gopkg.in/igm/sockjs-go.v2/sockjs"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"

--- a/src/app/backend/integration/handler.go
+++ b/src/app/backend/integration/handler.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"net/http"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/integration/api"
 )
 

--- a/src/app/backend/integration/handler_test.go
+++ b/src/app/backend/integration/handler_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"testing"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {

--- a/src/app/backend/integration/metric/heapster/selector.go
+++ b/src/app/backend/integration/metric/heapster/selector.go
@@ -17,7 +17,7 @@ package heapster
 import (
 	"fmt"
 
-	"github.com/emicklei/go-restful/log"
+	"github.com/emicklei/go-restful/v3/log"
 	"github.com/kubernetes/dashboard/src/app/backend/api"
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	v1 "k8s.io/api/core/v1"

--- a/src/app/backend/integration/metric/sidecar/selector.go
+++ b/src/app/backend/integration/metric/sidecar/selector.go
@@ -17,7 +17,7 @@ package sidecar
 import (
 	"fmt"
 
-	"github.com/emicklei/go-restful/log"
+	"github.com/emicklei/go-restful/v3/log"
 	"github.com/kubernetes/dashboard/src/app/backend/api"
 	metricapi "github.com/kubernetes/dashboard/src/app/backend/integration/metric/api"
 	v1 "k8s.io/api/core/v1"

--- a/src/app/backend/plugin/config.go
+++ b/src/app/backend/plugin/config.go
@@ -17,7 +17,7 @@ package plugin
 import (
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/handler/parser"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 )

--- a/src/app/backend/plugin/config_test.go
+++ b/src/app/backend/plugin/config_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/plugin/apis/v1alpha1"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	authApi "github.com/kubernetes/dashboard/src/app/backend/auth/api"
 	clientapi "github.com/kubernetes/dashboard/src/app/backend/client/api"
 	"github.com/kubernetes/dashboard/src/app/backend/plugin/client/clientset/versioned"

--- a/src/app/backend/plugin/detail_test.go
+++ b/src/app/backend/plugin/detail_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kubernetes/dashboard/src/app/backend/plugin/apis/v1alpha1"
 	fakePluginClientset "github.com/kubernetes/dashboard/src/app/backend/plugin/client/clientset/versioned/fake"

--- a/src/app/backend/plugin/handler.go
+++ b/src/app/backend/plugin/handler.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/kubernetes/dashboard/src/app/backend/handler/parser"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	clientapi "github.com/kubernetes/dashboard/src/app/backend/client/api"
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 )

--- a/src/app/backend/plugin/handler_test.go
+++ b/src/app/backend/plugin/handler_test.go
@@ -17,7 +17,7 @@ package plugin
 import (
 	"testing"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {

--- a/src/app/backend/plugin/list_test.go
+++ b/src/app/backend/plugin/list_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 

--- a/src/app/backend/settings/handler.go
+++ b/src/app/backend/settings/handler.go
@@ -17,7 +17,7 @@ package settings
 import (
 	"net/http"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 
 	"github.com/kubernetes/dashboard/src/app/backend/args"
 	clientapi "github.com/kubernetes/dashboard/src/app/backend/client/api"

--- a/src/app/backend/settings/handler_test.go
+++ b/src/app/backend/settings/handler_test.go
@@ -17,7 +17,7 @@ package settings
 import (
 	"testing"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 )
 
 func TestIntegrationHandler_Install(t *testing.T) {

--- a/src/app/backend/systembanner/handler.go
+++ b/src/app/backend/systembanner/handler.go
@@ -17,7 +17,7 @@ package systembanner
 import (
 	"net/http"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/systembanner/api"
 )
 

--- a/src/app/backend/validation/validateloginstatus.go
+++ b/src/app/backend/validation/validateloginstatus.go
@@ -15,7 +15,7 @@
 package validation
 
 import (
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/args"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 )

--- a/src/app/backend/validation/validateloginstatus_test.go
+++ b/src/app/backend/validation/validateloginstatus_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	restful "github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful/v3"
 	"github.com/kubernetes/dashboard/src/app/backend/client"
 )
 


### PR DESCRIPTION
To make go-restful as go module compatible, bump it from v2 to v3.

But v3.3.0 or later have issue that breaks http response body,
if the response has boolean value.
So use v3.2.0 for now.
See emicklei/go-restful#449