### PR TITLE
Update helm stable repo

### DIFF
--- a/.github/workflows/ci-helm-workflow.yml
+++ b/.github/workflows/ci-helm-workflow.yml
@@ -41,7 +41,7 @@ jobs:
           config: aio/deploy/helm-chart/.helm-chart-testing.yaml
 
       - name: Validate schema
-        uses: desaintmartin/helm-kubeval-action@v1.0.1
+        uses: desaintmartin/helm-kubeval-action@v1.0.2
         with:
           path: aio/deploy/helm-chart
 

--- a/.github/workflows/ci-helm-workflow.yml
+++ b/.github/workflows/ci-helm-workflow.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-rc.2
+        uses: helm/chart-testing-action@v2.0.1
         with:
           command: lint
           config: aio/deploy/helm-chart/.helm-chart-testing.yaml
@@ -46,12 +46,12 @@ jobs:
           path: aio/deploy/helm-chart
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.1.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-rc.2
+        uses: helm/chart-testing-action@v2.0.1
         with:
           command: install
           config: aio/deploy/helm-chart/.helm-chart-testing.yaml

--- a/aio/deploy/helm-chart/.helm-chart-testing.yaml
+++ b/aio/deploy/helm-chart/.helm-chart-testing.yaml
@@ -1,5 +1,5 @@
 chart-dirs:
   - aio/deploy/helm-chart
 chart-repos:
-  - stable=https://charts.helm.sh/stable
+  - stable=https://charts.helm.sh/stable/
 debug: true

--- a/aio/deploy/helm-chart/.helm-chart-testing.yaml
+++ b/aio/deploy/helm-chart/.helm-chart-testing.yaml
@@ -1,5 +1,5 @@
 chart-dirs:
   - aio/deploy/helm-chart
 chart-repos:
-  - stable=https://kubernetes-charts.storage.googleapis.com/
+  - stable=https://charts.helm.sh/stable
 debug: true

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.8.2
+version: 2.8.3
 appVersion: 2.0.4
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: metrics-server
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 2.11.1
 digest: sha256:22392d72416a0330f0c537fcc6cd306da7d25ddf511726bdf8a227d6a6ca8be1
 generated: "2020-04-23T20:58:52.074628+02:00"

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: metrics-server
-  repository: https://charts.helm.sh/stable
+  repository: https://charts.helm.sh/stable/
   version: 2.11.1
 digest: sha256:22392d72416a0330f0c537fcc6cd306da7d25ddf511726bdf8a227d6a6ca8be1
 generated: "2020-04-23T20:58:52.074628+02:00"

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: metrics-server
   repository: https://charts.helm.sh/stable/
   version: 2.11.1
-digest: sha256:22392d72416a0330f0c537fcc6cd306da7d25ddf511726bdf8a227d6a6ca8be1
-generated: "2020-04-23T20:58:52.074628+02:00"
+digest: sha256:2204066c4b4bc9daba461f92f4cccff2cdf97e72c473d6e49ab6d17ee9560033
+generated: "2020-11-17T02:26:27.039499349Z"

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: metrics-server
     version: 2.11.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: metrics-server.enabled

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: metrics-server
     version: 2.11.1
-    repository: https://charts.helm.sh/stable
+    repository: https://charts.helm.sh/stable/
     condition: metrics-server.enabled

--- a/aio/scripts/helm-release-chart.sh
+++ b/aio/scripts/helm-release-chart.sh
@@ -32,7 +32,7 @@ function release-helm-chart {
   fi
   say "\nGenerating Helm Chart package for new version."
   say "Please note that your gh-pages branch, if it locally exists, should be up-to-date."
-  helm repo add stable https://charts.helm.sh/stable
+  helm repo add stable https://charts.helm.sh/stable/
   cd "$HELM_CHART_DIR"
   helm dependency build .
   helm package .

--- a/aio/scripts/helm-release-chart.sh
+++ b/aio/scripts/helm-release-chart.sh
@@ -32,7 +32,7 @@ function release-helm-chart {
   fi
   say "\nGenerating Helm Chart package for new version."
   say "Please note that your gh-pages branch, if it locally exists, should be up-to-date."
-  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  helm repo add stable https://charts.helm.sh/stable
   cd "$HELM_CHART_DIR"
   helm dependency build .
   helm package .


### PR DESCRIPTION
As https://helm.sh/blog/new-location-stable-incubator-charts/ the helm stable repo has been changed to https://charts.helm.sh/stable
In addition, if using helm v3.4.0+ the old stable repo installation is failed.
So this updates the stable repo to avoid such error.