### PR TITLE
Fix terminal bug when using multiple replicas in helm

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.8.2
+version: 2.8.3
 appVersion: 2.0.4
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/service.yaml
@@ -51,3 +51,4 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -119,6 +119,8 @@ service:
     enabled: true
     key: "kubernetes.io/cluster-service"
 
+  sessionAffinity: ClientIP
+
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.
   ##


### PR DESCRIPTION
Set sessionAffinity to ClientIP on the Helm service when using multiple replicas. This keeps the session intact for clients, preventing the terminal from hanging.

Fixes this: #2272