### PR TITLE
Update German translation.

### DIFF
--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -1200,7 +1200,7 @@
       </trans-unit>
       <trans-unit id="a4f6d660f2cc1c8c680a96e39c719b48c8ebe17a" datatype="html">
         <source>Network Policies</source>
-        <target>Netzwerkregeln</target>
+        <target>Network Policies</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/networkpolicy/template.html</context>
           <context context-type="linenumber">21</context>
@@ -1216,7 +1216,7 @@
       </trans-unit>
       <trans-unit id="51682f193e48c9ef0e687aea04f825af1721f0f0" datatype="html">
         <source>Role Bindings</source>
-        <target state="new">Role Bindings</target>
+        <target>Role Bindings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/rolebinding/template.html</context>
           <context context-type="linenumber">21</context>
@@ -1224,7 +1224,7 @@
       </trans-unit>
       <trans-unit id="2b689ed7a24edd60660708e03c2dc11cd540e950" datatype="html">
         <source>Subjects</source>
-        <target state="new">Subjects</target>
+        <target>Subjects</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/subject/template.html</context>
           <context context-type="linenumber">20</context>
@@ -1232,7 +1232,7 @@
       </trans-unit>
       <trans-unit id="fb8681ea25f262db7f8ede5306e82d081016d5c7" datatype="html">
         <source>API Group</source>
-        <target state="new">API Group</target>
+        <target>API Group</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/subject/template.html</context>
           <context context-type="linenumber">65</context>
@@ -1241,7 +1241,7 @@
       <trans-unit id="6d9edf35ea416301631125005b66c9440397176d" datatype="html">
         <source>Workloads
       </source>
-        <target state="new">Workloads
+        <target>Workloads
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1251,7 +1251,7 @@
       <trans-unit id="787093faa4cfa59c1499dca2cfc6e804f1838ab1" datatype="html">
         <source>Cron Jobs
       </source>
-        <target state="new">Cron Jobs
+        <target>Cron Jobs
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1261,7 +1261,7 @@
       <trans-unit id="d094e262a8d26c66b5eb9f7dbf501cd711c1306f" datatype="html">
         <source>Daemon Sets
       </source>
-        <target state="new">Daemon Sets
+        <target>Daemon Sets
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1271,7 +1271,7 @@
       <trans-unit id="a862522a568898e032031f6728be4eec8edeb61b" datatype="html">
         <source>Deployments
       </source>
-        <target state="new">Deployments
+        <target>Deployments
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1281,7 +1281,7 @@
       <trans-unit id="702b6f15c86ce19a17aa8ae644658c852d3c1c08" datatype="html">
         <source>Jobs
       </source>
-        <target state="new">Jobs
+        <target>Jobs
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1291,7 +1291,7 @@
       <trans-unit id="03ff2fadee6736ca0b92abdfe0f19db0d0b2c3f8" datatype="html">
         <source>Pods
       </source>
-        <target state="new">Pods
+        <target>Pods
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1301,7 +1301,7 @@
       <trans-unit id="6fed5420d42fcfbd09dfb4777c207274dd4f0c0a" datatype="html">
         <source>Replica Sets
       </source>
-        <target state="new">Replica Sets
+        <target>Replica Sets
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1311,7 +1311,7 @@
       <trans-unit id="5a60417d6a34e8c0655cb0678071c60ca8119aad" datatype="html">
         <source>Replication Controllers
       </source>
-        <target state="new">Replication Controllers
+        <target>Replication Controllers
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1321,7 +1321,7 @@
       <trans-unit id="1bc563edf644be0e1f682694e543cc8608575562" datatype="html">
         <source>Stateful Sets
       </source>
-        <target state="new">Stateful Sets
+        <target>Stateful Sets
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1331,7 +1331,7 @@
       <trans-unit id="22c030ecbaceb4c5cf969f5ca360d7e6c6384a6d" datatype="html">
         <source>Service
       </source>
-        <target state="new">Service
+        <target>Service
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1341,7 +1341,7 @@
       <trans-unit id="7b4d1721251562683d614269b06ebbe3af811a00" datatype="html">
         <source>Ingresses
       </source>
-        <target state="new">Ingresses
+        <target>Ingresses
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1351,7 +1351,7 @@
       <trans-unit id="5502d7f80d7951086a85d2da478f3f13763939d5" datatype="html">
         <source>Services
       </source>
-        <target state="new">Services
+        <target>Services
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1361,7 +1361,7 @@
       <trans-unit id="be3dcec436583ff66cce312fd2074779d8851f54" datatype="html">
         <source>Config and Storage
       </source>
-        <target state="new">Config and Storage
+        <target>Konfiguration und Datenspeicherung
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1371,7 +1371,7 @@
       <trans-unit id="990cffc29a7adb5ec1110b0176c8c12fff756eba" datatype="html">
         <source>Config Maps
       </source>
-        <target state="new">Config Maps
+        <target>Config Maps
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1381,7 +1381,7 @@
       <trans-unit id="74be5bc42681451056aacf13382e5b29c62bd903" datatype="html">
         <source>Persistent Volume Claims
       </source>
-        <target state="new">Persistent Volume Claims
+        <target>Persistent Volume Claims
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1391,7 +1391,7 @@
       <trans-unit id="755417c37ab5d459cd2443b3776aaaca7ec87f90" datatype="html">
         <source>Secrets
       </source>
-        <target state="new">Secrets
+        <target>Secrets
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1401,7 +1401,7 @@
       <trans-unit id="d49c812d67b965bd0a172844e265f55567c812ad" datatype="html">
         <source>Storage Classes
       </source>
-        <target state="new">Storage Classes
+        <target>Storage Classes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1411,7 +1411,7 @@
       <trans-unit id="67d3a6c50ed8a188e19ea8c541a56f0e35620e5c" datatype="html">
         <source>Cluster
       </source>
-        <target state="new">Cluster
+        <target>Cluster
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1421,7 +1421,7 @@
       <trans-unit id="2e7f50d0bef3580ae3c46acdcdd71e29e4fa3fed" datatype="html">
         <source>Cluster Role Bindings
       </source>
-        <target state="new">Cluster Role Bindings
+        <target>Cluster Role Bindings
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1431,7 +1431,7 @@
       <trans-unit id="1aff4cb93f64ca57fbf92fe405b2c1f2c4ec1b11" datatype="html">
         <source>Cluster Roles
       </source>
-        <target state="new">Cluster Roles
+        <target>Cluster Roles
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1441,7 +1441,7 @@
       <trans-unit id="3b91b541ed4a1e47b83fe91f4cae1eefa904f4d5" datatype="html">
         <source>Namespaces
       </source>
-        <target state="new">Namespaces
+        <target>Namespaces
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1451,7 +1451,7 @@
       <trans-unit id="bce7cd9302197070e1782d38622dbb351ad84b69" datatype="html">
         <source>Network Policies
       </source>
-        <target state="new">Network Policies
+        <target>Network Policies
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1461,7 +1461,7 @@
       <trans-unit id="9151fc3bbb78ca19bf93221148fb6f75c9adec73" datatype="html">
         <source>Nodes
       </source>
-        <target state="new">Nodes
+        <target>Nodes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1471,7 +1471,7 @@
       <trans-unit id="53fa14e4e66a4b88531ac5852644edf4c93430c5" datatype="html">
         <source>Persistent Volumes
       </source>
-        <target state="new">Persistent Volumes
+        <target>Persistent Volumes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1481,7 +1481,7 @@
       <trans-unit id="d4d25df076acf842b0705cc4ac54f4757a979a03" datatype="html">
         <source>Role Bindings
       </source>
-        <target state="new">Role Bindings
+        <target>Role Bindings
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1491,7 +1491,7 @@
       <trans-unit id="e9c8e24a53e2496d1bb734d0bd20d756bec5b200" datatype="html">
         <source>Roles
       </source>
-        <target state="new">Roles
+        <target>Roles
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1501,7 +1501,7 @@
       <trans-unit id="5deee9cd9fabadb49eb1e3fcae70ff560e41ba27" datatype="html">
         <source>Service Accounts
       </source>
-        <target state="new">Service Accounts
+        <target>Service Accounts
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1511,7 +1511,7 @@
       <trans-unit id="f2f9d18ebacb9e3bcb996d8176609e306864265e" datatype="html">
         <source>Custom Resource Definitions
       </source>
-        <target state="new">Custom Resource Definitions
+        <target>Custom Resource Definitions
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1521,7 +1521,7 @@
       <trans-unit id="9b39398e6c7a9dfb5cd43f405598934244f8bd17" datatype="html">
         <source>Plugins
         </source>
-        <target state="new">Plugins
+        <target>Plugins
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1531,7 +1531,7 @@
       <trans-unit id="03511cfe5e28ed3380ab198c13cf62ebde1e89e6" datatype="html">
         <source>Settings
       </source>
-        <target state="new">Settings
+        <target>Einstellungen
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1541,7 +1541,7 @@
       <trans-unit id="c2fa735eb6b1b2c10171c5acb818f6e0975a9406" datatype="html">
         <source>About
       </source>
-        <target state="new">About
+        <target>Über
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -1727,11 +1727,11 @@
         <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon>"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon>"/>
       <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> to learn more.
     </source>
-        <target state="new">
-      You can <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>deploy a containerized app<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>, select other namespace or
-      <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>take the Dashboard Tour
+        <target>
+      Sie können <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>eine containerisierte App deployen<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>, einen anderen Namespace auswählen oder
+      <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>die Dashboard-Tour starten
         <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon>"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon>"/>
-      <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> to learn more.
+      <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> um mehr zu erfahren.
     </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/zerostate/template.html</context>
@@ -2216,7 +2216,7 @@
       </trans-unit>
       <trans-unit id="5382098398f2c3d09d75fe21addc796d91077051" datatype="html">
         <source>Cluster Role Bindings</source>
-        <target state="new">Cluster Role Bindings</target>
+        <target>Cluster Role Bindings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/clusterrolebinding/template.html</context>
           <context context-type="linenumber">21</context>
@@ -3255,7 +3255,7 @@
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{getDisplayName(resource)}}"/>
   </source>
-        <target state="new"><x id="INTERPOLATION" equiv-text="{{getDisplayName(resource)}}"/>
+        <target><x id="INTERPOLATION" equiv-text="{{getDisplayName(resource)}}"/>
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/pinner/template.html</context>
@@ -3264,7 +3264,7 @@
       </trans-unit>
       <trans-unit id="82b29c3b4501afec72a7fb434e048547f9a067e4" datatype="html">
         <source>Role Reference</source>
-        <target state="new">Role Reference</target>
+        <target>Role-Referenzen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/resource/cluster/clusterrolebinding/detail/template.html</context>
           <context context-type="linenumber">28</context>
@@ -5318,7 +5318,7 @@
       </trans-unit>
       <trans-unit id="3925ecae114abc711d1b417b7bdc4f8d6ec0f585" datatype="html">
         <source>Max number of items that can be displayed on every list view.</source>
-        <target state="new">Max number of items that can be displayed on every list view.</target>
+        <target>Maximale Anzahl an Einträgen, die in jeder Listenansicht zeitgleich sichtbar sind.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/settings/global/template.html</context>
           <context context-type="linenumber">45</context>
@@ -5326,7 +5326,7 @@
       </trans-unit>
       <trans-unit id="f530d15919f9ecdc3c56f55eae1a78b905cc08fa" datatype="html">
         <source>Labels limit</source>
-        <target state="new">Labels limit</target>
+        <target>Labels-Limit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/settings/global/template.html</context>
           <context context-type="linenumber">62</context>
@@ -5334,7 +5334,7 @@
       </trans-unit>
       <trans-unit id="dd245a4e3a7100eb2fa1e91e62663f748016668b" datatype="html">
         <source>Max number of labels that are displayed by default on most views.</source>
-        <target state="new">Max number of labels that are displayed by default on most views.</target>
+        <target>Maximale Anzahl an Labels, die standardmäßig in den meisten Ansichten zu sehen sind.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/settings/global/template.html</context>
           <context context-type="linenumber">64</context>


### PR DESCRIPTION
Kubernetes-specific technical terms have not been translated.

A minor translation issue that was introduced in PR #5453, which was
spotted by @mkorbi after the PR was already merged has also been
corrected: "Network Policies" should *not* have been translated
as it's a Kubernetes-specific technical term.