### PR TITLE
Smart default

### DIFF
--- a/src/app/backend/handler/confighandler.go
+++ b/src/app/backend/handler/confighandler.go
@@ -67,6 +67,7 @@ func getAppConfigJSON() string {
 	return string(jsonConfig)
 }
 
+// ConfigHandler handles config calls
 func ConfigHandler(w http.ResponseWriter, r *http.Request) (int, error) {
 	configTemplate, err := template.New(ConfigTemplateName).Parse(ConfigTemplate)
 	w.Header().Set("Content-Type", "application/json")

--- a/src/app/backend/handler/confighandler.go
+++ b/src/app/backend/handler/confighandler.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"text/template"
 	"time"
+
+	"github.com/kubernetes/dashboard/src/app/backend/args"
 )
 
 // AppHandler is an application handler.
@@ -28,7 +30,8 @@ type AppHandler func(http.ResponseWriter, *http.Request) (int, error)
 // AppConfig is a global configuration of application.
 type AppConfig struct {
 	// ServerTime is current server time.
-	ServerTime int64 `json:"serverTime"`
+	ServerTime       int64  `json:"serverTime"`
+	DefaultNamespace string `json:"defaultNamespace"`
 }
 
 const (
@@ -49,8 +52,14 @@ func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func getAppConfigJSON() string {
 	log.Println("Getting application global configuration")
 
+	defaultNamespace := args.Holder.GetNamespace()
+	if defaultNamespace == "kube-system" || defaultNamespace == "kube-dashboard" {
+		defaultNamespace = "default"
+	}
+
 	config := &AppConfig{
-		ServerTime: time.Now().UTC().UnixNano() / 1e6,
+		ServerTime:       time.Now().UTC().UnixNano() / 1e6,
+		DefaultNamespace: defaultNamespace,
 	}
 
 	jsonConfig, _ := json.Marshal(config)

--- a/src/app/backend/handler/confighandler_test.go
+++ b/src/app/backend/handler/confighandler_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubernetes/dashboard/src/app/backend/args"
+)
+
+func TestGetAppConfigJSON(t *testing.T) {
+	type test struct {
+		namespace string
+		want      string
+	}
+	tests := []test{
+		{
+			namespace: "default",
+			want:      `"defaultNamespace":"default"`,
+		},
+		{
+			namespace: "my-namespace",
+			want:      `"defaultNamespace":"my-namespace"`,
+		},
+	}
+
+	for _, tc := range tests {
+		builder := args.GetHolderBuilder()
+		builder.SetNamespace(tc.namespace)
+		got := getAppConfigJSON()
+		if !strings.Contains(got, tc.want) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}
+
+func TestConfigHandler(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	statusCode, _ := ConfigHandler(w, r)
+	if statusCode != http.StatusOK {
+		t.Errorf("Unexpected status code %d", statusCode)
+	}
+}

--- a/src/app/frontend/common/components/namespace/component.ts
+++ b/src/app/frontend/common/components/namespace/component.ts
@@ -20,7 +20,6 @@ import {NamespaceList} from '@api/backendapi';
 import {Subject} from 'rxjs';
 import {distinctUntilChanged, filter, startWith, switchMap, takeUntil} from 'rxjs/operators';
 
-import {CONFIG} from '../../../index.config';
 import {NAMESPACE_STATE_PARAM} from '../../params/params';
 import {HistoryService} from '../../services/global/history';
 import {NamespaceService} from '../../services/global/namespace';
@@ -248,7 +247,7 @@ export class NamespaceSelectorComponent implements OnInit, OnDestroy {
 
   setDefaultQueryParams_() {
     this.router_.navigate([this._activatedRoute.snapshot.url], {
-      queryParams: {[NAMESPACE_STATE_PARAM]: CONFIG.defaultNamespace},
+      queryParams: {[NAMESPACE_STATE_PARAM]: this.namespaceService_.getDefaultNamespace()},
       queryParamsHandling: 'merge',
     });
   }

--- a/src/app/frontend/common/services/global/config.ts
+++ b/src/app/frontend/common/services/global/config.ts
@@ -18,6 +18,7 @@ import {AppConfig} from '@api/backendapi';
 import {VersionInfo} from '@api/frontendapi';
 import {Observable} from 'rxjs';
 import {version} from '../../../environments/version';
+import {CONFIG} from '../../../index.config';
 
 @Injectable()
 export class ConfigService {
@@ -37,6 +38,13 @@ export class ConfigService {
 
   getAppConfig(): Observable<AppConfig> {
     return this.http.get<AppConfig>(this.configPath_);
+  }
+
+  getNamespace(): string {
+    if (this.config_.namespace) {
+      return this.config_.namespace;
+    }
+    return CONFIG.defaultNamespace;
   }
 
   getServerTime(): Date {

--- a/src/app/frontend/common/services/global/namespace.ts
+++ b/src/app/frontend/common/services/global/namespace.ts
@@ -13,10 +13,16 @@
 // limitations under the License.
 
 import {EventEmitter, Injectable} from '@angular/core';
-import {CONFIG} from '../../../index.config';
+import {ConfigService} from './config';
 
 @Injectable()
 export class NamespaceService {
+  private defaultNamespace: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.defaultNamespace = config.getNamespace();
+  }
+
   onNamespaceChangeEvent = new EventEmitter<string>();
 
   /**
@@ -37,7 +43,7 @@ export class NamespaceService {
   }
 
   current(): string {
-    return this.currentNamespace_ || CONFIG.defaultNamespace;
+    return this.currentNamespace_ || this.defaultNamespace;
   }
 
   getAllNamespacesKey(): string {

--- a/src/app/frontend/common/services/global/namespace.ts
+++ b/src/app/frontend/common/services/global/namespace.ts
@@ -51,7 +51,7 @@ export class NamespaceService {
   }
 
   getDefaultNamespace(): string {
-    return CONFIG.defaultNamespace;
+    return this.defaultNamespace;
   }
 
   isNamespaceValid(namespace: string): boolean {

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -719,6 +719,7 @@ export interface LocalSettings {
 
 export interface AppConfig {
   serverTime: number;
+  namespace: string;
 }
 
 export interface StringMap {


### PR DESCRIPTION
Leverage the target namespace that hosts the dashboard deployment, to determine if the "default" namespace should be used as the first namespace to select.

Use cases:

k8s Dashboard deployed in NS `kube-system` -> default namespace is `default`
k8s Dashboard deployed in NS `kubernetes-dashboard` -> default namespace is `default`
k8s Dashboard deployed in NS `my-namespace` -> default namespace is `my-namespace`