### PR TITLE
update zh translation

### DIFF
--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -1782,7 +1782,7 @@
       </trans-unit>
       <trans-unit id="c3e2c59f79e1c277706a4106e7ada43e5387a9d0" datatype="html">
         <source>Namespaced</source>
-        <target>Namespaced</target>
+        <target>有命名空间的</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/crd/template.html</context>
           <context context-type="linenumber">73</context>
@@ -2022,7 +2022,7 @@
       </trans-unit>
       <trans-unit id="6e2329529b1953198c7dfa0edb260554310bc636" datatype="html">
         <source>Nodes</source>
-        <target>Nodes</target>
+        <target>节点</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/node/template.html</context>
           <context context-type="linenumber">24</context>
@@ -2462,7 +2462,7 @@
       </trans-unit>
       <trans-unit id="3bb5706d8e2b719394b49d48ef5bf5398bfdc33f" datatype="html">
         <source>Storage Classes</source>
-        <target>Storage Classes</target>
+        <target>存储类</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/storageclass/template.html</context>
           <context context-type="linenumber">21</context>
@@ -2601,7 +2601,7 @@
       <trans-unit id="6d9edf35ea416301631125005b66c9440397176d" datatype="html">
         <source>Workloads
       </source>
-        <target>Workload
+        <target>工作负载
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2741,7 +2741,7 @@
       <trans-unit id="74be5bc42681451056aacf13382e5b29c62bd903" datatype="html">
         <source>Persistent Volume Claims
       </source>
-        <target>Persistent Volume Claims
+        <target>持久卷申领
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2761,7 +2761,7 @@
       <trans-unit id="d49c812d67b965bd0a172844e265f55567c812ad" datatype="html">
         <source>Storage Classes
       </source>
-        <target>Storage Classes
+        <target>存储类
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2781,7 +2781,7 @@
       <trans-unit id="2e7f50d0bef3580ae3c46acdcdd71e29e4fa3fed" datatype="html">
         <source>Cluster Role Bindings
       </source>
-        <target>Cluster Role Bindings
+        <target>集群角色绑定
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2791,7 +2791,7 @@
       <trans-unit id="1aff4cb93f64ca57fbf92fe405b2c1f2c4ec1b11" datatype="html">
         <source>Cluster Roles
       </source>
-        <target>Cluster Roles
+        <target>集群角色
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2821,7 +2821,7 @@
       <trans-unit id="9151fc3bbb78ca19bf93221148fb6f75c9adec73" datatype="html">
         <source>Nodes
       </source>
-        <target>Nodes
+        <target>工作节点
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2831,7 +2831,7 @@
       <trans-unit id="53fa14e4e66a4b88531ac5852644edf4c93430c5" datatype="html">
         <source>Persistent Volumes
       </source>
-        <target>Persistent Volumes
+        <target>持久卷
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2841,7 +2841,7 @@
       <trans-unit id="d4d25df076acf842b0705cc4ac54f4757a979a03" datatype="html">
         <source>Role Bindings
       </source>
-        <target>Role Bindings
+        <target>角色绑定
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2851,7 +2851,7 @@
       <trans-unit id="e9c8e24a53e2496d1bb734d0bd20d756bec5b200" datatype="html">
         <source>Roles
       </source>
-        <target>Roles
+        <target>角色
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2861,7 +2861,7 @@
       <trans-unit id="5deee9cd9fabadb49eb1e3fcae70ff560e41ba27" datatype="html">
         <source>Service Accounts
       </source>
-        <target>Service Accounts
+        <target>服务账号
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -3032,7 +3032,7 @@
       </trans-unit>
       <trans-unit id="4346d3d4e2109584d33480fb8916a9b1cfcdf636" datatype="html">
         <source>Workloads</source>
-        <target>Workloads</target>
+        <target>工作负载</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/overview/template.html</context>
           <context context-type="linenumber">19</context>
@@ -3220,8 +3220,8 @@
     </source>
         <target>
       Kubernetes Dashboard 是由 Dashboard
-      <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>社区<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> 作为一个
-      <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>开源项目<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>实现的。
+      <x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/>社区<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> 开发的
+      <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a>"/>开源项目<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>。
     </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/about/template.html</context>
@@ -3820,7 +3820,7 @@
       </trans-unit>
       <trans-unit id="f87cc4e8fdd870d5f0fe071889d30939f9d0cd37" datatype="html">
         <source>Image Pull Secret</source>
-        <target>镜像拉取得 Secret</target>
+        <target>拉取镜像的 Secret</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/template.html</context>
           <context context-type="linenumber">213</context>
@@ -4333,7 +4333,7 @@
           Label key name must be alphanumeric separated by '-', '_' or '.', optionally prefixed by a DNS subdomain and '/'.
         </source>
         <target>
-            标签密钥名称必须是由 “ - ”，“_” 或 “.” 分隔的字母数字，可选以DNS子域和“/”为前缀。
+            标签密钥名称必须是由 “ - ”，“_” 或 “.” 分隔的字母数字，可选以 DNS 子域和“/”为前缀。
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/deploylabel/template.html</context>
@@ -4345,7 +4345,7 @@
           Prefix should not exceed 253 characters.
         </source>
         <target>
-          前缀不应超过253个字符。
+          前缀不应超过 253 个字符。
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/deploylabel/template.html</context>
@@ -4357,7 +4357,7 @@
           Label Key name should not exceed 63 characters.
         </source>
         <target>
-          Label Key 名称不应超过63个字符
+          Label Key 名称不应超过 63 个字符
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/deploylabel/template.html</context>
@@ -4389,7 +4389,7 @@
           Label Value must not exceed 253 characters.
         </source>
         <target>
-            标签值不得超过253个字符。
+            标签值不得超过 253 个字符。
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/deploylabel/template.html</context>
@@ -5050,7 +5050,7 @@
       </trans-unit>
       <trans-unit id="318e1e7193512514e192cab4e4b6b722548b017b" datatype="html">
         <source>Init images</source>
-        <target>初始 images</target>
+        <target>初始镜像</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/resource/workloads/replicationcontroller/detail/template.html</context>
           <context context-type="linenumber">48</context>
@@ -5094,7 +5094,7 @@
       </trans-unit>
       <trans-unit id="9f07294f08e99e9cad8c3814756b402d7f16460a" datatype="html">
         <source>Revision history limit: </source>
-        <target>调整 history 范围: </target>
+        <target>修改历史记录限制: </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/resource/workloads/deployment/detail/template.html</context>
           <context context-type="linenumber">42</context>
@@ -5118,7 +5118,7 @@
       </trans-unit>
       <trans-unit id="a196b130fac39c26bd90978276d5fcd5add00dd9" datatype="html">
         <source>Revision history limit</source>
-        <target>调整历史记录限制</target>
+        <target>修改历史记录限制</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/resource/workloads/deployment/detail/template.html</context>
           <context context-type="linenumber">64</context>

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2518,7 +2518,7 @@
       </trans-unit>
       <trans-unit id="fcc3e654108a95539975cf06678f999f5c429a2e" datatype="html">
         <source>Internal Endpoints</source>
-        <target>内部 Endpoints</target>
+        <target>内部端点</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/service/template.html</context>
           <context context-type="linenumber">84</context>
@@ -2526,7 +2526,7 @@
       </trans-unit>
       <trans-unit id="cfe8c5b521a487c8f2f9d2d4232032bfe2e609ec" datatype="html">
         <source>External Endpoints</source>
-        <target>外部 Endpoints</target>
+        <target>外部端点</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/service/template.html</context>
           <context context-type="linenumber">92</context>

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2022,7 +2022,7 @@
       </trans-unit>
       <trans-unit id="6e2329529b1953198c7dfa0edb260554310bc636" datatype="html">
         <source>Nodes</source>
-        <target>节点</target>
+        <target>Nodes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/node/template.html</context>
           <context context-type="linenumber">24</context>
@@ -2462,7 +2462,7 @@
       </trans-unit>
       <trans-unit id="3bb5706d8e2b719394b49d48ef5bf5398bfdc33f" datatype="html">
         <source>Storage Classes</source>
-        <target>存储类</target>
+        <target>Storage Classes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/storageclass/template.html</context>
           <context context-type="linenumber">21</context>
@@ -2518,7 +2518,7 @@
       </trans-unit>
       <trans-unit id="fcc3e654108a95539975cf06678f999f5c429a2e" datatype="html">
         <source>Internal Endpoints</source>
-        <target>内部端点</target>
+        <target>内部 Endpoints</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/service/template.html</context>
           <context context-type="linenumber">84</context>
@@ -2526,7 +2526,7 @@
       </trans-unit>
       <trans-unit id="cfe8c5b521a487c8f2f9d2d4232032bfe2e609ec" datatype="html">
         <source>External Endpoints</source>
-        <target>外部端点</target>
+        <target>外部 Endpoints</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/resourcelist/service/template.html</context>
           <context context-type="linenumber">92</context>
@@ -2741,7 +2741,7 @@
       <trans-unit id="74be5bc42681451056aacf13382e5b29c62bd903" datatype="html">
         <source>Persistent Volume Claims
       </source>
-        <target>持久卷申领
+        <target>Persistent Volume Claims
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2761,7 +2761,7 @@
       <trans-unit id="d49c812d67b965bd0a172844e265f55567c812ad" datatype="html">
         <source>Storage Classes
       </source>
-        <target>存储类
+        <target>Storage Classes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2781,7 +2781,7 @@
       <trans-unit id="2e7f50d0bef3580ae3c46acdcdd71e29e4fa3fed" datatype="html">
         <source>Cluster Role Bindings
       </source>
-        <target>集群角色绑定
+        <target>Cluster Role Bindings
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2791,7 +2791,7 @@
       <trans-unit id="1aff4cb93f64ca57fbf92fe405b2c1f2c4ec1b11" datatype="html">
         <source>Cluster Roles
       </source>
-        <target>集群角色
+        <target>Cluster Roles
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2821,7 +2821,7 @@
       <trans-unit id="9151fc3bbb78ca19bf93221148fb6f75c9adec73" datatype="html">
         <source>Nodes
       </source>
-        <target>工作节点
+        <target>Nodes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2831,7 +2831,7 @@
       <trans-unit id="53fa14e4e66a4b88531ac5852644edf4c93430c5" datatype="html">
         <source>Persistent Volumes
       </source>
-        <target>持久卷
+        <target>Persistent Volumes
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2841,7 +2841,7 @@
       <trans-unit id="d4d25df076acf842b0705cc4ac54f4757a979a03" datatype="html">
         <source>Role Bindings
       </source>
-        <target>角色绑定
+        <target>Role Bindings
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2851,7 +2851,7 @@
       <trans-unit id="e9c8e24a53e2496d1bb734d0bd20d756bec5b200" datatype="html">
         <source>Roles
       </source>
-        <target>角色
+        <target>Roles
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>
@@ -2861,7 +2861,7 @@
       <trans-unit id="5deee9cd9fabadb49eb1e3fcae70ff560e41ba27" datatype="html">
         <source>Service Accounts
       </source>
-        <target>服务账号
+        <target>Service Accounts
       </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/nav/template.html</context>

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -3828,7 +3828,7 @@
       </trans-unit>
       <trans-unit id="141fd856fac50370a82a6082ef9e55f22014f32f" datatype="html">
         <source>The specified image could require a pull secret credential if it is private. You may choose an existing secret or create a new one.</source>
-        <target>如果指定的 Image 是私有的，则可能需要 pull secret credential。 您可以选择现有 secret 或创建新 secret。</target>
+        <target>如果指定的镜像是私有的，则可能需要拉取 secret 凭据。 您可以选择现有 secret 或创建新 secret。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/template.html</context>
           <context context-type="linenumber">226</context>
@@ -3924,7 +3924,7 @@
       </trans-unit>
       <trans-unit id="7f64de7337ceb8f09ec7db1778676b02f07a73df" datatype="html">
         <source>By default, your containers run the selected image's default entrypoint command. You can use the command options to override the default.</source>
-        <target>默认情况下，容器运行所选镜像的默认 entrypoint command。 您可以使用命令选项覆盖默认值。</target>
+        <target>默认情况下，容器运行所选镜像的默认 entrypoint 命令。 您可以使用命令选项覆盖默认值。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/create/from/form/template.html</context>
           <context context-type="linenumber">303</context>


### PR DESCRIPTION
1. fix some words
2.translation some word we haven't
3.we did't translate some words because we think we should't do it and those words show keep. but I find that those has already translated in the kubernetes doc,  here is some url for kubernetes zh doc:

* https://kubernetes.io/zh/docs/concepts/storage/storage-capacity/
* https://kubernetes.io/zh/docs/reference/access-authn-authz/rbac/
* https://kubernetes.io/zh/docs/concepts/

You can find more here :  https://kubernetes.io/zh/docs

before this pr, the old UI is like this:
![image](https://user-images.githubusercontent.com/433500/99047066-9b10eb00-25ce-11eb-8e2b-4a760f67cb9a.png)

now with this pr it is like this:
![image](https://user-images.githubusercontent.com/433500/99047375-1a062380-25cf-11eb-8e3a-30c23a313fb6.png)
