### PR TITLE
add test intro for i18n 

### DIFF
--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -75,7 +75,7 @@ The Dashboard project can be built for production by using the following task:
 npm run build
 ```
 
-The code is compiled, compressed and debug support removed. The dashboard binary can be found in the `dist` folder.
+The code is compiled, compressed, i18n support is enabled and debug support removed. The dashboard binary can be found in the `dist` folder.
 
 To build and immediately serve Dashboard from the `dist` folder, use the following task:
 

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -62,10 +62,13 @@ In the background, `npm start` makes a [concurrently](https://github.com/kimmobr
 
 Once the angular server starts, it takes some time to pre-compile all assets before serving them. By default, the angular development server watches for file changes and will update accordingly.
 
-Note that if you want to test your local language by i18n in the web ui, you should run dashboard with the command: `npm run start:prod`.
-And i18n support is only available in the production build, see the blow.
 
-## Building Dashboard for production
+As stated in the [Angular documentation](https://angular.io/guide/i18n#generate-app-versions-for-each-locale), i18n does not work in the development mode. 
+Follow [Building Dashboard for Production](#building-dashboard-for-production) section to test this feature.
+
+> Due to the deployment complexities of i18n and the need to minimize rebuild time, the development server only supports localizing a single locale at a time. Setting the "localize" option to true will cause an error when using ng serve if more than one locale is defined. Setting the option to a specific locale, such as "localize": ["fr"], can work if you want to develop against a specific locale (such as fr).
+
+## Building Dashboard for Production
 
 To build dashboard for production, you still need to install `bc`.
 

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -62,7 +62,8 @@ In the background, `npm start` makes a [concurrently](https://github.com/kimmobr
 
 Once the angular server starts, it takes some time to pre-compile all assets before serving them. By default, the angular development server watches for file changes and will update accordingly.
 
-If you want to test your local language in the web ui by i18n, you should run dashboard with the command: `npm run start:prod`.
+Note that if you want to test your local language by i18n in the web ui, you should run dashboard with the command: `npm run start:prod`.
+And i18n support is only available in the production build, see the blow.
 
 ## Building Dashboard for production
 

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -62,6 +62,8 @@ In the background, `npm start` makes a [concurrently](https://github.com/kimmobr
 
 Once the angular server starts, it takes some time to pre-compile all assets before serving them. By default, the angular development server watches for file changes and will update accordingly.
 
+If you want to test your local language in the web ui by i18n, you should run dashboard with the command: `npm run start:prod`.
+
 ## Building Dashboard for production
 
 To build dashboard for production, you still need to install `bc`.


### PR DESCRIPTION
When I test for my local language, I found that it didn't work. 
At last I found that we should use this command for my test: `npm start`.

we should use this `npm run start:prod` for my local test for i18n. but this is not mentioned in the document.

So I add some note. Please guy help to check if it is ok.
