### PR TITLE
Use perl instead of sed to fix build error in macos.

### DIFF
--- a/aio/scripts/build.sh
+++ b/aio/scripts/build.sh
@@ -45,7 +45,7 @@ function build::frontend {
     filename=("$(find "${localeDir}" -name 'main.*.js' -exec basename {} \;)")
 
     mv "${localeDir}/${filename}" "${localeDir}/${language}.${filename}"
-    sed -i "s/${filename}/${language}.${filename}/" "${localeDir}/index.html"
+    perl -i -pe"s/${filename}/${language}.${filename}/" "${localeDir}/index.html"
   done
 }
 


### PR DESCRIPTION
Hi

In my previous PR for adding change language option, @floreks added some lines to `aio/scripts/build.sh` to prevent caching after changing language using `sed` command which makes build failed in macOS, because in macOS `sed` command is a little bit different from Linux.
I changed `sed` with `perl` which does the same thing and the dashboard builds successfully in macOS and I think it works in Linux, too.