### PR TITLE
Fix closing sidemenu issue

### DIFF
--- a/src/app/frontend/chrome/nav/style.scss
+++ b/src/app/frontend/chrome/nav/style.scss
@@ -19,20 +19,20 @@
   height: 100%;
   width: $nav-width + 8px;
 
+  &.visible {
+    transition: width .3s;
+  }
+
+  &.hidden {
+    transition: width .2s;
+    width: 0;
+  }
+
   .kd-nav {
     background-color: transparent;
     font-size: $body-font-size-base;
     overflow-y: auto;
     white-space: nowrap;
-
-    &.visible {
-      transition: width .3s;
-    }
-
-    &.hidden {
-      transition: width .2s;
-      width: 0;
-    }
 
     .kd-nav-items {
       padding: $content-padding 3px $content-padding $content-padding;


### PR DESCRIPTION
Hi

I have an issue with closing the side menu. When I close the side menu, the side menu content went away, but it's space stays.
I think the side menu component code is changed and now the hidden class is assigned to the wrong class.