### PR TITLE
Add sign out button for Oauth / token

### DIFF
--- a/TEMP.md
+++ b/TEMP.md
@@ -1,0 +1,8 @@
+the plan:
+- add sign out button for oauth
+- call sign out url on click (auth service?)
+- configurable sign out url?
+- only call sign out url if config set?
+
+ref: https://github.com/kubernetes/dashboard/issues/2353
+https://github.com/kubernetes/dashboard/issues/2464

--- a/aio/gulp/conf.js
+++ b/aio/gulp/conf.js
@@ -221,6 +221,10 @@ export default {
       argv.enableInsecureLogin :
       false,
     /**
+     * Optional signout url to be called when signing out (if signed in with token)
+     */
+    signoutUrl: argv.signoutUrl,
+    /**
      * Defines token time to live.
      */
     tokenTTL: argv.tokenTTL !== undefined ?

--- a/aio/gulp/serve.js
+++ b/aio/gulp/serve.js
@@ -39,7 +39,8 @@ function getBackendArgs() {
     `--tls-key-file=${conf.backend.tlsKey}`,
     `--auto-generate-certificates=${conf.backend.autoGenerateCerts}`,
     `--enable-insecure-login=${conf.backend.enableInsecureLogin}`,
-    `--enable-skip-login=${conf.backend.enableSkipButton}`
+    `--enable-skip-login=${conf.backend.enableSkipButton}`,
+    `--signout-url=${conf.backend.signoutUrl}`
   ];
 
   if (conf.backend.systemBanner.length > 0) {

--- a/docs/common/dashboard-arguments.md
+++ b/docs/common/dashboard-arguments.md
@@ -26,6 +26,7 @@ Dashboard container accepts multiple arguments that can be used to customize it 
 | authentication-mode | token   | Enables authentication options that will be reflected on the login screen in the same order as provided. Multiple options can be used at once. Supported values: token, basic. Note that basic option should only be used if apiserver has '--authorization-mode=ABAC' and '--basic-auth-file' flags set. |
 | enable-insecure-login | false | When enabled, Dashboard login view will also be shown when Dashboard is not served over HTTPS. |
 | enable-skip-login | false | When enabled, the skip button on the login page will be shown. |
+| signout-url   | -             | If set, this url is invoked when signing out (if you're signed in with header) |
 | disable-settings-authorizer | false | When enabled, Dashboard settings page will not require user to be logged in and authorized to access settings page. |
 | locale-config | ./locale_conf.json |File containing the configuration of locales.
 | system-banner | -             | When non-empty displays message to Dashboard users. Accepts simple HTML tags. |

--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -3251,14 +3251,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -3210,9 +3210,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>Mit Auth-Header angemeldet</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -3223,7 +3227,7 @@
         <target>Mit Token angemeldet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -3231,7 +3235,7 @@
         <target>Standard Service Account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -3240,7 +3244,7 @@
         <target>Anmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -3249,7 +3253,19 @@
         <target>Abmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -3210,13 +3210,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -3227,7 +3223,7 @@
         <target>Mit Token angemeldet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -3235,7 +3231,7 @@
         <target>Standard Service Account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -3244,7 +3240,7 @@
         <target>Anmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -3253,7 +3249,7 @@
         <target>Abmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3265,7 +3261,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -3214,13 +3214,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -3231,7 +3227,7 @@
         <target>Connecté avec un token</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -3239,7 +3235,7 @@
         <target>Compte de service par défaut</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -3248,7 +3244,7 @@
         <target>Connexion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -3257,7 +3253,7 @@
         <target>Déconnexion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3269,7 +3265,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -3214,9 +3214,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>Connecté avec une entête auth</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -3227,7 +3231,7 @@
         <target>Connecté avec un token</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -3235,7 +3239,7 @@
         <target>Compte de service par défaut</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -3244,7 +3248,7 @@
         <target>Connexion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -3253,7 +3257,19 @@
         <target>Déconnexion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -3255,14 +3255,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -2958,14 +2958,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -2917,13 +2917,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2934,7 +2930,7 @@
         <target>トークンでログイン</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2942,7 +2938,7 @@
         <target>デフォルトのサービスアカウント</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2951,7 +2947,7 @@
         <target>サインイン</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2960,7 +2956,7 @@
         <target>サインアウト</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -2972,7 +2968,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -2917,9 +2917,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>認証ヘッダーでログイン</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2930,7 +2934,7 @@
         <target>トークンでログイン</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2938,7 +2942,7 @@
         <target>デフォルトのサービスアカウント</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2947,7 +2951,7 @@
         <target>サインイン</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2956,7 +2960,19 @@
         <target>サインアウト</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -2995,14 +2995,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -2952,9 +2952,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>인증 헤더로 로그인됨</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2965,7 +2969,7 @@
         <target>토큰으로 로그인됨</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2973,7 +2977,7 @@
         <target>기본 서비스 어카운트</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2983,7 +2987,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2993,7 +2997,19 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -2952,13 +2952,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2969,7 +2965,7 @@
         <target>토큰으로 로그인됨</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2977,7 +2973,7 @@
         <target>기본 서비스 어카운트</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2987,7 +2983,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2997,7 +2993,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3009,7 +3005,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -2771,11 +2771,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -2735,8 +2735,10 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2746,14 +2748,14 @@
         <source>Logged in with token</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
         <source>Default service account</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2761,7 +2763,7 @@
   </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2769,7 +2771,16 @@
   </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -2735,10 +2735,8 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2748,14 +2746,14 @@
         <source>Logged in with token</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
         <source>Default service account</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2763,7 +2761,7 @@
   </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2771,7 +2769,7 @@
   </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -2780,7 +2778,7 @@
   </source>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2952,9 +2952,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>使用 auth header 登录</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2965,7 +2969,7 @@
         <target>使用 token 登录</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2973,7 +2977,7 @@
         <target>默认 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2983,7 +2987,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2993,7 +2997,19 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2952,13 +2952,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2969,7 +2965,7 @@
         <target>使用 token 登录</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2977,7 +2973,7 @@
         <target>默认 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2987,7 +2983,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2997,7 +2993,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3009,7 +3005,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2995,14 +2995,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -2956,9 +2956,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>使用 auth header 登錄</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2969,7 +2973,7 @@
         <target>使用 token 登錄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2977,7 +2981,7 @@
         <target>默認 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2987,7 +2991,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2997,7 +3001,19 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -2956,13 +2956,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2973,7 +2969,7 @@
         <target>使用 token 登錄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2981,7 +2977,7 @@
         <target>默認 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2991,7 +2987,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -3001,7 +2997,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3013,7 +3009,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -2999,14 +2999,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -2952,13 +2952,9 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
-        <source>
-          Logged in with auth header
-        </source>
-        <target state="new">
-          Logged in with auth header
-        </target>
+      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
+        <source>Logged in with auth header</source>
+        <target state="new">Logged in with auth header</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2969,7 +2965,7 @@
         <target>使用 token 登入</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2977,7 +2973,7 @@
         <target>默認 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2987,7 +2983,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2997,7 +2993,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
@@ -3009,7 +3005,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -2995,14 +2995,6 @@
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
-        <source>
-    Sign out
-  </source>
-        <target state="new">
-    Sign out
-  </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">49</context>

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -2952,9 +2952,13 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7003098da97db80a0761fe9fdadb2f0349eb462c" datatype="html">
-        <source>Logged in with auth header</source>
-        <target>使用 auth header 登入</target>
+      <trans-unit id="17e954c8f8ad84606c1f7fc92c195088e5998cbb" datatype="html">
+        <source>
+          Logged in with auth header
+        </source>
+        <target state="new">
+          Logged in with auth header
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">23</context>
@@ -2965,7 +2969,7 @@
         <target>使用 token 登入</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f88774e30855665c168f36b58fdac3fdffbbe24f" datatype="html">
@@ -2973,7 +2977,7 @@
         <target>默認 service account</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f798949a4cdc74591fbf665c178513e4219c0898" datatype="html">
@@ -2983,7 +2987,7 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6426cc90184df1cdb238f45fce5220df8438ed62" datatype="html">
@@ -2993,7 +2997,19 @@
   </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="c3ac815ec8c13020ec9ccb53a50a4f8b4c0b5929" datatype="html">
+        <source>
+    Sign out
+  </source>
+        <target state="new">
+    Sign out
+  </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../src/app/frontend/chrome/userpanel/template.html</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="84d40318243f782005db3040f6bd3b9ec388b5d8" datatype="html">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "start-oauth": "concurrently \"npm run start:backend --signout-url:oauth2/sign_out --kubernetes-dashboard:sidecar_host=$npm_package_config_sidecar_host\" \"npm run start:frontend --kubernetes-dashboard:bind_address=$npm_package_config_bind_address --signout-url:oauth2/sign_out --kubernetes-dashboard:port=$npm_package_config_port\"",
     "start": "concurrently \"npm run start:backend --kubernetes-dashboard:sidecar_host=$npm_package_config_sidecar_host\" \"npm run start:frontend --kubernetes-dashboard:bind_address=$npm_package_config_bind_address --kubernetes-dashboard:port=$npm_package_config_port\"",
     "start:https": "concurrently \"npm run start:backend:https --kubernetes-dashboard:sidecar_host=$npm_package_config_sidecar_host\" \"npm run start:frontend:https --kubernetes-dashboard:bind_address=$npm_package_config_bind_address --kubernetes-dashboard:port=$npm_package_config_port\"",
     "start:frontend": "npm run postversion && ng serve --aot --progress=false --proxy-config aio/proxy.conf.json --host=$npm_package_config_bind_address --port $npm_package_config_port",

--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -156,6 +156,12 @@ func (self *holderBuilder) SetEnableSkipLogin(enableSkipLogin bool) *holderBuild
 	return self
 }
 
+// SetSignOutUrl 'signout-url' argument of Dashboard binary.
+func (self *holderBuilder) SetSignOutUrl(signOutUrl string) *holderBuilder {
+	self.holder.signOutUrl = signOutUrl
+	return self
+}
+
 // SetNamespace 'namespace' argument of Dashboard binary.
 func (self *holderBuilder) SetNamespace(namespace string) *holderBuilder {
 	self.holder.namespace = namespace

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -53,6 +53,7 @@ type holder struct {
 	disableSettingsAuthorizer bool
 
 	enableSkipLogin bool
+	signOutUrl      string
 
 	localeConfig string
 }

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -73,6 +73,7 @@ var (
 	argAutoGenerateCertificates  = pflag.Bool("auto-generate-certificates", false, "When set to true, Dashboard will automatically generate certificates used to serve HTTPS. (default false)")
 	argEnableInsecureLogin       = pflag.Bool("enable-insecure-login", false, "When enabled, Dashboard login view will also be shown when Dashboard is not served over HTTPS. (default false)")
 	argEnableSkip                = pflag.Bool("enable-skip-login", false, "When enabled, the skip button on the login page will be shown. (default false)")
+	argSignOutUrl                = pflag.String("signout-url", "", "When set, this url will be invoked when signing out of dashboard if signed in with token")
 	argSystemBanner              = pflag.String("system-banner", "", "When non-empty displays message to Dashboard users. Accepts simple HTML tags.")
 	argSystemBannerSeverity      = pflag.String("system-banner-severity", "INFO", "Severity of system banner. Should be one of 'INFO|WARNING|ERROR'.")
 	argAPILogLevel               = pflag.String("api-log-level", "INFO", "Level of API request logging. Should be one of 'INFO|NONE|DEBUG'.")
@@ -252,6 +253,7 @@ func initArgHolder() {
 	builder.SetEnableInsecureLogin(*argEnableInsecureLogin)
 	builder.SetDisableSettingsAuthorizer(*argDisableSettingsAuthorizer)
 	builder.SetEnableSkipLogin(*argEnableSkip)
+	builder.SetSignOutUrl(*argSignOutUrl)
 	builder.SetNamespace(*argNamespace)
 	builder.SetLocaleConfig(*localeConfig)
 }

--- a/src/app/backend/validation/validateloginstatus.go
+++ b/src/app/backend/validation/validateloginstatus.go
@@ -32,7 +32,6 @@ type LoginStatus struct {
 	HTTPSMode bool `json:"httpsMode"`
 	// True if impersonation is enabled
 	ImpersonationPresent bool `json:"impersonationPresent"`
-
 	// The impersonated user
 	ImpersonatedUser string `json:"impersonatedUser"`
 }

--- a/src/app/frontend/chrome/userpanel/component.ts
+++ b/src/app/frontend/chrome/userpanel/component.ts
@@ -15,6 +15,7 @@
 import {Component, OnInit} from '@angular/core';
 import {LoginStatus} from '@api/backendapi';
 import {AuthService} from '../../common/services/global/authentication';
+import {Observable} from 'rxjs';
 
 @Component({
   selector: 'kd-user-panel',
@@ -41,7 +42,7 @@ export class UserPanelComponent implements OnInit {
     return this.loginStatus && !this.authService_.isLoginPageEnabled() && !this.loginStatus.headerPresent;
   }
 
-  isLoggedIn(): boolean {
+  isLoggedInClassic(): boolean {
     return this.loginStatus && !this.loginStatus.headerPresent && this.loginStatus.tokenPresent;
   }
 
@@ -49,7 +50,15 @@ export class UserPanelComponent implements OnInit {
     return this.loginStatus ? this.loginStatus.httpsMode : false;
   }
 
-  logout(): void {
+  logoutClassic(): void {
     this.authService_.logout();
+  }
+
+  isLoggedInHeader() {
+    return this.loginStatus && this.loginStatus.headerPresent && !this.loginStatus.impersonationPresent;
+  }
+
+  logoutHeader(): Observable<void> {
+    return this.authService_.logoutWithHeader();
   }
 }

--- a/src/app/frontend/chrome/userpanel/template.html
+++ b/src/app/frontend/chrome/userpanel/template.html
@@ -46,8 +46,7 @@ limitations under the License.
   <button mat-menu-item
           *ngIf="isLoggedInHeader()"
           (click)="logoutHeader()"
-          i18n>
-    Sign out
+          i18n>Sign out
   </button>
 
 </mat-menu>

--- a/src/app/frontend/chrome/userpanel/template.html
+++ b/src/app/frontend/chrome/userpanel/template.html
@@ -20,9 +20,7 @@ limitations under the License.
     <ng-container *ngIf="isLoginStatusInitialized">
       <ng-container [ngSwitch]="true">
         <ng-container *ngSwitchCase="loginStatus.headerPresent && !loginStatus.impersonationPresent"
-                      i18n>
-          Logged in with auth header
-        </ng-container>
+                      i18n>Logged in with auth header</ng-container>
         <ng-container *ngSwitchCase="loginStatus.tokenPresent"
                       i18n>Logged in with token</ng-container>
         <ng-container *ngSwitchCase="loginStatus.headerPresent && loginStatus.impersonationPresent">{{loginStatus.impersonatedUser}}</ng-container>

--- a/src/app/frontend/chrome/userpanel/template.html
+++ b/src/app/frontend/chrome/userpanel/template.html
@@ -20,7 +20,9 @@ limitations under the License.
     <ng-container *ngIf="isLoginStatusInitialized">
       <ng-container [ngSwitch]="true">
         <ng-container *ngSwitchCase="loginStatus.headerPresent && !loginStatus.impersonationPresent"
-                      i18n>Logged in with auth header</ng-container>
+                      i18n>
+          Logged in with auth header
+        </ng-container>
         <ng-container *ngSwitchCase="loginStatus.tokenPresent"
                       i18n>Logged in with token</ng-container>
         <ng-container *ngSwitchCase="loginStatus.headerPresent && loginStatus.impersonationPresent">{{loginStatus.impersonatedUser}}</ng-container>
@@ -30,17 +32,26 @@ limitations under the License.
 
     </ng-container>
   </div>
-  <mat-divider *ngIf="!loginStatus?.headerPresent"></mat-divider>
+  <mat-divider *ngIf="!isLoggedInHeader()"></mat-divider>
   <button mat-menu-item
           *ngIf="isAuthSkipped()"
-          (click)="logout()"
+          (click)="logoutClassic()"
           i18n>Sign in
   </button>
+
   <button mat-menu-item
-          *ngIf="isLoggedIn()"
-          (click)="logout()"
+          *ngIf="isLoggedInClassic()"
+          (click)="logoutClassic()"
           i18n>Sign out
   </button>
+
+  <button mat-menu-item
+          *ngIf="isLoggedInHeader()"
+          (click)="logoutHeader()"
+          i18n>
+    Sign out
+  </button>
+
 </mat-menu>
 
 <button mat-icon-button

--- a/src/app/frontend/common/services/global/authentication.ts
+++ b/src/app/frontend/common/services/global/authentication.ts
@@ -109,6 +109,11 @@ export class AuthService {
     this.router_.navigate(['login']);
   }
 
+  logoutWithHeader(): Observable<void> {
+    this.removeAuthCookies();
+    return this.callLogoutUrl();
+  }
+
   /**
    * Sends a token refresh request to the backend. In case user is not logged in
    * with token nothing will happen.
@@ -178,5 +183,13 @@ export class AuthService {
    */
   isLoginEnabled(): boolean {
     return this.isCurrentDomainSecure_() || this.isCurrentProtocolSecure_();
+  }
+
+  private callLogoutUrl(): Observable<void> {
+    const temp = 'oauth2/sign_out';
+
+    // TODO: get sign out url oauth from settings
+
+    return this.http_.get<void>(temp);
   }
 }

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -673,9 +673,11 @@ export interface LoginSpec {
 }
 
 export interface LoginStatus {
+  impersonationPresent: boolean;
   tokenPresent: boolean;
   headerPresent: boolean;
   httpsMode: boolean;
+  signOutUrl?: string;
 }
 
 export interface AppDeploymentContentSpec {


### PR DESCRIPTION
-- work in progress --

Problem:
There is no way to sign out from UI when signed in with Authorization header.
In our case we setup oauth proxy under url `/oauth2`, to sign out we need to manually enter url `/oauth2/sign_out`.

Suggested solution:
- Make sign out button visible when signed in with Authorization header.
- Add (optional) parameter `--signout-url` which will be called when signing out

ref issues:
https://github.com/kubernetes/dashboard/issues/2353
https://github.com/kubernetes/dashboard/issues/2464