### PR TITLE
fix display pvc storage when it is appending

### DIFF
--- a/src/app/backend/resource/persistentvolumeclaim/list.go
+++ b/src/app/backend/resource/persistentvolumeclaim/list.go
@@ -80,7 +80,7 @@ func toPersistentVolumeClaim(pvc v1.PersistentVolumeClaim) PersistentVolumeClaim
 		TypeMeta:     api.NewTypeMeta(api.ResourceKindPersistentVolumeClaim),
 		Status:       string(pvc.Status.Phase),
 		Volume:       pvc.Spec.VolumeName,
-		Capacity:     pvc.Status.Capacity,
+		Capacity:     pvc.Spec.Resources.Requests,
 		AccessModes:  pvc.Spec.AccessModes,
 		StorageClass: pvc.Spec.StorageClassName,
 	}


### PR DESCRIPTION
I think the status of pvc and the property of pvc are different,
status is for running time,
property is some attribute that the pvc should have wether it is running or not.

![image](https://user-images.githubusercontent.com/433500/102562342-d5abfd00-4111-11eb-9df0-271ea5f80aa8.png)
![image](https://user-images.githubusercontent.com/433500/102562353-dba1de00-4111-11eb-9ab1-b8a667c4b871.png)
