### PR TITLE
helm: use helm api v2 version

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.lock
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.helm.sh/stable/
   version: 2.11.1
 digest: sha256:2204066c4b4bc9daba461f92f4cccff2cdf97e72c473d6e49ab6d17ee9560033
-generated: "2020-11-17T02:26:27.039499349Z"
+generated: "2020-12-18T15:56:13.388323+01:00"

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 3.1.0
+version: 4.0.0
 appVersion: 2.1.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
+apiVersion: v2
 name: kubernetes-dashboard
-version: 3.0.2
+version: 3.1.0
 appVersion: 2.1.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:
@@ -28,3 +28,8 @@ maintainers:
   email: cdesaintmartin@wiremind.fr
 icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
 kubeVersion: ">=1.14.0-0"
+dependencies:
+- name: metrics-server
+  version: 2.11.1
+  repository: https://charts.helm.sh/stable/
+  condition: metrics-server.enabled

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -61,6 +61,13 @@ Version 2.0.0 of this chart is the first version hosted in the kubernetes/dashbo
 
 In order to upgrade, please update your configuration to remove `clusterAdminRole` parameter and adapt `enableSkipLogin`, `enableInsecureLogin`, `podAnnotations` and `securityContext` parameters, and uninstall/reinstall the chart.
 
+### Version 4.0.0
+
+Version 4.0.0 of this chart only support Helm 3 and remove the support from Helm 2.
+If you still use Helm 2 you will need first to migrate the deployment to Helm 3 and then you can upgrade your chart.
+
+To do that you can follow the [guide](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
+
 ## Access control
 
 It is critical for the Kubernetes cluster to correctly setup access control of Kubernetes Dashboard.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: metrics-server
-    version: 2.11.1
-    repository: https://charts.helm.sh/stable/
-    condition: metrics-server.enabled


### PR DESCRIPTION
Helm2 is deprecated and should not be used anymore, we should use helm3 from now on.
this PR update the chart.yaml to use the v2 apiversion

