### PR TITLE
The Ingress Detail pane now has an extra table which shows all the rules

### DIFF
--- a/src/app/frontend/common/components/ingressrulelist/component.ts
+++ b/src/app/frontend/common/components/ingressrulelist/component.ts
@@ -1,0 +1,80 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, Input} from '@angular/core';
+import {MatTableDataSource} from '@angular/material/table';
+import {IngressSpecRule, IngressSpecRuleHttpPath} from '@api/backendapi';
+import {KdStateService} from '../../services/global/state';
+import {GlobalServicesModule} from '../../services/global/module';
+
+interface IngressRuleFlat {
+  host?: string;
+  path: IngressSpecRuleHttpPath;
+}
+
+@Component({
+  selector: 'kd-ingressruleflat-card-list',
+  templateUrl: './template.html',
+})
+export class IngressRuleFlatListComponent {
+  @Input() initialized: boolean;
+  @Input() ingressSpecRules?: IngressSpecRule[];
+  @Input() namespace: string;
+
+  private readonly kdState_: KdStateService = GlobalServicesModule.injector.get(KdStateService);
+
+  getIngressRulesFlatColumns(): string[] {
+    return ['Host', 'Path', 'Path Type', 'Service Name', 'Service Port'];
+  }
+
+  trackByIngressRuleFlat(index: number, item: any): any {
+    return item.host ? index : index;
+  }
+
+  ingressSpecRuleToIngressRuleFlat(ingressSpecRules: IngressSpecRule[]): IngressRuleFlat[] {
+    const output: IngressRuleFlat[] = [];
+
+    ingressSpecRules.forEach(ingressSpecRule => {
+      let host: string = null;
+      if (ingressSpecRule.host !== undefined) {
+        host = ingressSpecRule.host;
+      }
+
+      ingressSpecRule.http.paths.forEach(path => {
+        const ingressRuleFlat: IngressRuleFlat = {
+          path: path,
+        };
+        if (host !== null) {
+          ingressRuleFlat.host = host;
+        }
+        output.push(ingressRuleFlat);
+      });
+    });
+    return output;
+  }
+
+  getDataSource(): MatTableDataSource<IngressRuleFlat> {
+    const tableData = new MatTableDataSource<IngressRuleFlat>();
+    const the_input =
+      this.ingressSpecRules === undefined || this.ingressSpecRules === null ? [] : this.ingressSpecRules;
+
+    tableData.data = this.ingressSpecRuleToIngressRuleFlat(the_input);
+
+    return tableData;
+  }
+
+  getDetailsHref(name: string, kind: string): string {
+    return this.kdState_.href(kind, name, this.namespace);
+  }
+}

--- a/src/app/frontend/common/components/ingressrulelist/component.ts
+++ b/src/app/frontend/common/components/ingressrulelist/component.ts
@@ -39,25 +39,17 @@ export class IngressRuleFlatListComponent {
   }
 
   ingressSpecRuleToIngressRuleFlat(ingressSpecRules: IngressSpecRule[]): IngressRuleFlat[] {
-    const output: IngressRuleFlat[] = [];
-
-    ingressSpecRules.forEach(ingressSpecRule => {
-      let host: string = null;
-      if (ingressSpecRule.host !== undefined) {
-        host = ingressSpecRule.host;
-      }
-
-      ingressSpecRule.http.paths.forEach(path => {
-        const ingressRuleFlat: IngressRuleFlat = {
-          path: path,
-        };
-        if (host !== null) {
-          ingressRuleFlat.host = host;
-        }
-        output.push(ingressRuleFlat);
-      });
-    });
-    return output;
+    return [].concat(
+      ...ingressSpecRules.map(rule =>
+        rule.http.paths.map(
+          specPath =>
+            ({
+              host: rule.host || '',
+              path: specPath,
+            } as IngressRuleFlat)
+        )
+      )
+    );
   }
 
   getDataSource(): MatTableDataSource<IngressRuleFlat> {

--- a/src/app/frontend/common/components/ingressrulelist/component.ts
+++ b/src/app/frontend/common/components/ingressrulelist/component.ts
@@ -29,17 +29,13 @@ interface IngressRuleFlat {
 })
 export class IngressRuleFlatListComponent {
   @Input() initialized: boolean;
-  @Input() ingressSpecRules?: IngressSpecRule[];
+  @Input() ingressSpecRules: IngressSpecRule[] = [];
   @Input() namespace: string;
 
   private readonly kdState_: KdStateService = GlobalServicesModule.injector.get(KdStateService);
 
   getIngressRulesFlatColumns(): string[] {
     return ['Host', 'Path', 'Path Type', 'Service Name', 'Service Port'];
-  }
-
-  trackByIngressRuleFlat(index: number, item: any): any {
-    return item.host ? index : index;
   }
 
   ingressSpecRuleToIngressRuleFlat(ingressSpecRules: IngressSpecRule[]): IngressRuleFlat[] {
@@ -66,10 +62,7 @@ export class IngressRuleFlatListComponent {
 
   getDataSource(): MatTableDataSource<IngressRuleFlat> {
     const tableData = new MatTableDataSource<IngressRuleFlat>();
-    const the_input =
-      this.ingressSpecRules === undefined || this.ingressSpecRules === null ? [] : this.ingressSpecRules;
-
-    tableData.data = this.ingressSpecRuleToIngressRuleFlat(the_input);
+    tableData.data = this.ingressSpecRuleToIngressRuleFlat(this.ingressSpecRules || []);
 
     return tableData;
   }

--- a/src/app/frontend/common/components/ingressrulelist/template.html
+++ b/src/app/frontend/common/components/ingressrulelist/template.html
@@ -44,14 +44,14 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Path</mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.path.path">{{ingressRuleFlat.path.path}}</ng-container>
+          {{!!ingressRuleFlat?.path?.path ? ingressRuleFlat?.path?.path : '-'}}
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[2]">
         <mat-header-cell *matHeaderCellDef
                          i18n>Path Type</mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.path.pathType">{{ingressRuleFlat.path.pathType}}</ng-container>
+          {{!!ingressRuleFlat?.path?.pathType ? ingressRuleFlat?.path?.pathType : '-'}}
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[3]">

--- a/src/app/frontend/common/components/ingressrulelist/template.html
+++ b/src/app/frontend/common/components/ingressrulelist/template.html
@@ -1,0 +1,92 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-card [initialized]="initialized"
+         role="table">
+  <div title
+       i18n>Rules</div>
+
+  <div description>
+    <div class="kd-inline-property"
+         *ngIf="ingressSpecRules?.length">
+      <span class="kd-muted-light"
+            i18n>Items:&nbsp;</span>
+      <span>{{ingressSpecRules.length}}</span>
+    </div>
+  </div>
+
+  <div content
+       [hidden]="ingressSpecRules?.length === 0">
+    <mat-table [dataSource]="getDataSource()"
+               class="kd-table-no-footer">
+      <ng-container [matColumnDef]="getIngressRulesFlatColumns()[0]">
+        <mat-header-cell *matHeaderCellDef
+                         i18n>Host</mat-header-cell>
+        <mat-cell *matCellDef="let ingressRuleFlat">
+          <ng-container *ngIf="ingressRuleFlat.host">{{ingressRuleFlat.host}}</ng-container>
+          <ng-container *ngIf="!ingressRuleFlat.host">*</ng-container>
+        </mat-cell>
+      </ng-container>
+      <ng-container [matColumnDef]="getIngressRulesFlatColumns()[1]">
+        <mat-header-cell *matHeaderCellDef
+                         i18n>Path</mat-header-cell>
+        <mat-cell *matCellDef="let ingressRuleFlat">
+          <ng-container *ngIf="ingressRuleFlat.path.path">{{ingressRuleFlat.path.path}}</ng-container>
+        </mat-cell>
+      </ng-container>
+      <ng-container [matColumnDef]="getIngressRulesFlatColumns()[2]">
+        <mat-header-cell *matHeaderCellDef
+                         i18n>Path Type</mat-header-cell>
+        <mat-cell *matCellDef="let ingressRuleFlat">
+          <ng-container *ngIf="ingressRuleFlat.path.pathType">{{ingressRuleFlat.path.pathType}}</ng-container>
+        </mat-cell>
+      </ng-container>
+      <ng-container [matColumnDef]="getIngressRulesFlatColumns()[3]">
+        <mat-header-cell *matHeaderCellDef
+                         i18n>Service Name</mat-header-cell>
+        <mat-cell *matCellDef="let ingressRuleFlat">
+          <ng-container *ngIf="ingressRuleFlat.path.backend.serviceName">
+            <a [routerLink]="getDetailsHref(ingressRuleFlat.path.backend.serviceName, 'service')"
+               queryParamsHandling="preserve">
+              {{ingressRuleFlat.path.backend.serviceName}}
+            </a>
+          </ng-container>
+          <ng-container *ngIf="ingressRuleFlat.path.backend.resource">
+            <a [routerLink]="getDetailsHref(ingressRuleFlat.path.backend.resource.name, ingressRuleFlat.path.backend.resource.kind)"
+               queryParamsHandling="preserve">
+              {{ingressRuleFlat.path.backend.resource.apiGroup}}/{{ingressRuleFlat.path.backend.resource.name}}
+            </a>
+          </ng-container>
+        </mat-cell>
+      </ng-container>
+      <ng-container [matColumnDef]="getIngressRulesFlatColumns()[4]">
+        <mat-header-cell *matHeaderCellDef
+                         i18n>Service Port</mat-header-cell>
+        <mat-cell *matCellDef="let ingressRuleFlat">
+          <ng-container *ngIf="ingressRuleFlat.path.backend.servicePort">{{ingressRuleFlat.path.backend.servicePort}}</ng-container>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="getIngressRulesFlatColumns()"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: getIngressRulesFlatColumns();"></mat-row>
+    </mat-table>
+  </div>
+
+  <div content
+       [hidden]="ingressSpecRules?.length != 0">
+    <kd-list-zero-state></kd-list-zero-state>
+  </div>
+</kd-card>

--- a/src/app/frontend/common/components/ingressrulelist/template.html
+++ b/src/app/frontend/common/components/ingressrulelist/template.html
@@ -36,8 +36,7 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Host</mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.host">{{ingressRuleFlat.host}}</ng-container>
-          <ng-container *ngIf="!ingressRuleFlat.host">*</ng-container>
+          {{!!ingressRuleFlat.host ? ingressRuleFlat.host : '-'}}
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[1]">

--- a/src/app/frontend/common/components/module.ts
+++ b/src/app/frontend/common/components/module.ts
@@ -75,6 +75,7 @@ import {DeploymentListComponent} from './resourcelist/deployment/component';
 import {EventListComponent} from './resourcelist/event/component';
 import {HorizontalPodAutoscalerListComponent} from './resourcelist/horizontalpodautoscaler/component';
 import {IngressListComponent} from './resourcelist/ingress/component';
+import {IngressRuleFlatListComponent} from './ingressrulelist/component';
 import {JobListComponent} from './resourcelist/job/component';
 import {NamespaceListComponent} from './resourcelist/namespace/component';
 import {NodeListComponent} from './resourcelist/node/component';
@@ -141,6 +142,7 @@ const components = [
   HiddenPropertyComponent,
   HorizontalPodAutoscalerListComponent,
   IngressListComponent,
+  IngressRuleFlatListComponent,
   InternalEndpointComponent,
   JobListComponent,
   LoadingSpinner,

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -51,6 +51,40 @@ class MiniTestComponent {
     },
     typeMeta: {kind: 'Ingress'},
     errors: [],
+    endpoints: [],
+    spec: {
+      rules: [
+        {
+          http: {
+            paths: [
+              {
+                path: '/testpath',
+                pathType: 'Prefix',
+                backend: {
+                  serviceName: 'test',
+                  servicePort: 80,
+                },
+              },
+            ],
+          },
+        },
+        {
+          host: 'foo.bar.com',
+          http: {
+            paths: [
+              {
+                path: '/bar',
+                pathType: 'Prefix',
+                backend: {
+                  serviceName: 'service1',
+                  servicePort: 'a_port_name',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
   };
 }
 
@@ -71,6 +105,41 @@ class MaxiTestComponent {
     },
     typeMeta: {kind: 'Ingress'},
     errors: [],
+    endpoints: [],
+    spec: {
+      rules: [
+        {
+          host: 'foox.bar.com',
+          http: {
+            paths: [
+              {
+                path: '/',
+                pathType: 'Prefix',
+                backend: {
+                  serviceName: 'service1',
+                  servicePort: 80,
+                },
+              },
+            ],
+          },
+        },
+        {
+          host: 'barx.foo.com',
+          http: {
+            paths: [
+              {
+                path: '/',
+                pathType: 'Prefix',
+                backend: {
+                  serviceName: 'service2',
+                  servicePort: 80,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
   };
 }
 

--- a/src/app/frontend/resource/discovery/ingress/detail/template.html
+++ b/src/app/frontend/resource/discovery/ingress/detail/template.html
@@ -16,3 +16,8 @@ limitations under the License.
 
 <kd-object-meta [initialized]="isInitialized"
                 [objectMeta]="ingress?.objectMeta"></kd-object-meta>
+
+<kd-ingressruleflat-card-list [ingressSpecRules]="ingress?.spec.rules"
+                              [namespace]="ingress?.objectMeta.namespace"
+                              [initialized]="isInitialized">
+</kd-ingressruleflat-card-list>

--- a/src/app/frontend/typings/backendapi.ts
+++ b/src/app/frontend/typings/backendapi.ts
@@ -505,7 +505,56 @@ export interface SecretDetail extends ResourceDetail {
 
 export type ServiceAccountDetail = ResourceDetail;
 
-export type IngressDetail = ResourceDetail;
+export interface IngressDetail extends ResourceDetail {
+  endpoints: Endpoint[];
+  spec: IngressSpec;
+}
+
+export interface IngressSpec {
+  defaultBackend?: IngressDefaultBackend;
+  rules?: IngressSpecRule[];
+}
+
+export interface IngressDefaultBackend {
+  service: IngressService;
+}
+
+export interface IngressService {
+  name: string;
+  port: IngressServicePort;
+}
+
+export interface IngressServicePort {
+  number?: number;
+  name?: string;
+}
+
+export interface IngressSpecRule {
+  host?: string;
+  http: IngressSpecRuleHttp;
+}
+
+export interface IngressSpecRuleHttp {
+  paths: IngressSpecRuleHttpPath[];
+}
+
+export interface IngressSpecRuleHttpPath {
+  path: string;
+  pathType: string;
+  backend: IngressSpecRuleHttpPathBackend;
+}
+
+export interface IngressSpecRuleHttpPathBackend {
+  serviceName?: string;
+  servicePort?: string | number;
+  resource?: IngressSpecRuleHttpPathBackendResource;
+}
+
+export interface IngressSpecRuleHttpPathBackendResource {
+  apiGroup: string;
+  kind: string;
+  name: string;
+}
 
 export interface NetworkPolicyDetail extends ResourceDetail {
   podSelector: LabelSelector;


### PR DESCRIPTION
I've always felt the ingress panel has less information than necessary. So I added an extra table for rules.

It can be tested using the following container: `marcosdiez/dashboard:v2.1.0h`

Although the PR is not ready yet to be merged, I do accept comments on my implementation.

Things I am not really sure:

* should the new `template.html` and `components.ts` be located inside ` src/app/frontend/resource/discovery/ingress/rulelist/` or `src/app/frontend/common/components/resourcelist` ? Since rules are not a  resource,, but a part of `ingress`, I am not sure

* what exactly should I do with `ingresses` that don't point to `services` ? For starters, I've never seen it in real life, but the specs do say it's possible.

* please notice that I "flatten" the original structure so that every row has a hostname (hence my `IngressRuleFlat` interface)

This is how it looks like:

![image](https://user-images.githubusercontent.com/297498/102725791-1c5b4c00-42f8-11eb-806a-321411b7e63d.png)


