### PR TITLE
Fix a typo at messages.zh-Hant.xlf.

### DIFF
--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -107,7 +107,7 @@
   Download logs file
 </source>
         <target>
-  下載日志文件
+  下載日誌文件
 </target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/dialogs/download/template.html</context>
@@ -316,7 +316,7 @@
       </trans-unit>
       <trans-unit id="80a528a1e6015b28276e4ff83d1558722c354585" datatype="html">
         <source>View logs</source>
-        <target>顯示日志</target>
+        <target>顯示日誌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/actionbar/detailactions/logs/template.html</context>
           <context context-type="linenumber">21</context>
@@ -708,7 +708,7 @@
       </trans-unit>
       <trans-unit id="eb3d5aefff38a814b76da74371cbf02c0789a1ef" datatype="html">
         <source>Logs</source>
-        <target>日志</target>
+        <target>日誌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../src/app/frontend/common/components/list/column/menu/template.html</context>
           <context context-type="linenumber">22</context>


### PR DESCRIPTION
* The transform of 'logs' should be unified at messages.zh-Hant.xlf.(日志 → 日誌)