### PR TITLE
backend: ingress will now use the networking/v1beta1 API instead of extensions/v1beta1

### DIFF
--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -204,7 +204,7 @@ var KindToAPIMapping = map[string]APIMapping{
 	ResourceKindDeployment:               {"deployments", ClientTypeAppsClient, true},
 	ResourceKindEvent:                    {"events", ClientTypeDefault, true},
 	ResourceKindHorizontalPodAutoscaler:  {"horizontalpodautoscalers", ClientTypeAutoscalingClient, true},
-	ResourceKindIngress:                  {"ingresses", ClientTypeExtensionClient, true},
+	ResourceKindIngress:                  {"ingresses", ClientTypeNetworkingClient, true},
 	ResourceKindJob:                      {"jobs", ClientTypeBatchClient, true},
 	ResourceKindCronJob:                  {"cronjobs", ClientTypeBetaBatchClient, true},
 	ResourceKindLimitRange:               {"limitrange", ClientTypeDefault, true},

--- a/src/app/backend/resource/ingress/common.go
+++ b/src/app/backend/resource/ingress/common.go
@@ -16,12 +16,12 @@ package ingress
 
 import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	v1 "k8s.io/api/networking/v1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 )
 
 // The code below allows to perform complex data section on []extensions.Ingress
 
-type IngressCell v1.Ingress
+type IngressCell v1beta1.Ingress
 
 func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.ComparableValue {
 	switch name {
@@ -37,7 +37,7 @@ func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.Com
 	}
 }
 
-func toCells(std []v1.Ingress) []dataselect.DataCell {
+func toCells(std []v1beta1.Ingress) []dataselect.DataCell {
 	cells := make([]dataselect.DataCell, len(std))
 	for i := range std {
 		cells[i] = IngressCell(std[i])
@@ -45,10 +45,10 @@ func toCells(std []v1.Ingress) []dataselect.DataCell {
 	return cells
 }
 
-func fromCells(cells []dataselect.DataCell) []v1.Ingress {
-	std := make([]v1.Ingress, len(cells))
+func fromCells(cells []dataselect.DataCell) []v1beta1.Ingress {
+	std := make([]v1beta1.Ingress, len(cells))
 	for i := range std {
-		std[i] = v1.Ingress(cells[i].(IngressCell))
+		std[i] = v1beta1.Ingress(cells[i].(IngressCell))
 	}
 	return std
 }

--- a/src/app/backend/resource/ingress/common.go
+++ b/src/app/backend/resource/ingress/common.go
@@ -16,12 +16,12 @@ package ingress
 
 import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	extensions "k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 )
 
 // The code below allows to perform complex data section on []extensions.Ingress
 
-type IngressCell extensions.Ingress
+type IngressCell v1.Ingress
 
 func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.ComparableValue {
 	switch name {
@@ -37,7 +37,7 @@ func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.Com
 	}
 }
 
-func toCells(std []extensions.Ingress) []dataselect.DataCell {
+func toCells(std []v1.Ingress) []dataselect.DataCell {
 	cells := make([]dataselect.DataCell, len(std))
 	for i := range std {
 		cells[i] = IngressCell(std[i])
@@ -45,10 +45,10 @@ func toCells(std []extensions.Ingress) []dataselect.DataCell {
 	return cells
 }
 
-func fromCells(cells []dataselect.DataCell) []extensions.Ingress {
-	std := make([]extensions.Ingress, len(cells))
+func fromCells(cells []dataselect.DataCell) []v1.Ingress {
+	std := make([]v1.Ingress, len(cells))
 	for i := range std {
-		std[i] = extensions.Ingress(cells[i].(IngressCell))
+		std[i] = v1.Ingress(cells[i].(IngressCell))
 	}
 	return std
 }

--- a/src/app/backend/resource/ingress/detail.go
+++ b/src/app/backend/resource/ingress/detail.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"log"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
 )
@@ -30,10 +30,10 @@ type IngressDetail struct {
 	Ingress `json:",inline"`
 
 	// Spec is the desired state of the Ingress.
-	Spec extensions.IngressSpec `json:"spec"`
+	Spec v1.IngressSpec `json:"spec"`
 
 	// Status is the current state of the Ingress.
-	Status extensions.IngressStatus `json:"status"`
+	Status v1.IngressStatus `json:"status"`
 
 	// List of non-critical errors, that occurred during resource retrieval.
 	Errors []error `json:"errors"`
@@ -43,7 +43,7 @@ type IngressDetail struct {
 func GetIngressDetail(client client.Interface, namespace, name string) (*IngressDetail, error) {
 	log.Printf("Getting details of %s ingress in %s namespace", name, namespace)
 
-	rawIngress, err := client.ExtensionsV1beta1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
+	rawIngress, err := client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func GetIngressDetail(client client.Interface, namespace, name string) (*Ingress
 	return getIngressDetail(rawIngress), nil
 }
 
-func getIngressDetail(i *extensions.Ingress) *IngressDetail {
+func getIngressDetail(i *v1.Ingress) *IngressDetail {
 	return &IngressDetail{
 		Ingress: toIngress(i),
 		Spec:    i.Spec,

--- a/src/app/backend/resource/ingress/detail.go
+++ b/src/app/backend/resource/ingress/detail.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"log"
 
-	v1 "k8s.io/api/networking/v1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
 )
@@ -30,10 +30,10 @@ type IngressDetail struct {
 	Ingress `json:",inline"`
 
 	// Spec is the desired state of the Ingress.
-	Spec v1.IngressSpec `json:"spec"`
+	Spec v1beta1.IngressSpec `json:"spec"`
 
 	// Status is the current state of the Ingress.
-	Status v1.IngressStatus `json:"status"`
+	Status v1beta1.IngressStatus `json:"status"`
 
 	// List of non-critical errors, that occurred during resource retrieval.
 	Errors []error `json:"errors"`
@@ -43,7 +43,7 @@ type IngressDetail struct {
 func GetIngressDetail(client client.Interface, namespace, name string) (*IngressDetail, error) {
 	log.Printf("Getting details of %s ingress in %s namespace", name, namespace)
 
-	rawIngress, err := client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
+	rawIngress, err := client.NetworkingV1beta1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func GetIngressDetail(client client.Interface, namespace, name string) (*Ingress
 	return getIngressDetail(rawIngress), nil
 }
 
-func getIngressDetail(i *v1.Ingress) *IngressDetail {
+func getIngressDetail(i *v1beta1.Ingress) *IngressDetail {
 	return &IngressDetail{
 		Ingress: toIngress(i),
 		Spec:    i.Spec,

--- a/src/app/backend/resource/ingress/list.go
+++ b/src/app/backend/resource/ingress/list.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	extensions "k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	client "k8s.io/client-go/kubernetes"
 )
 
@@ -48,7 +48,7 @@ type IngressList struct {
 // GetIngressList returns all ingresses in the given namespace.
 func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	dsQuery *dataselect.DataSelectQuery) (*IngressList, error) {
-	ingressList, err := client.ExtensionsV1beta1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
+	ingressList, err := client.NetworkingV1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
 
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
@@ -58,7 +58,7 @@ func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	return toIngressList(ingressList.Items, nonCriticalErrors, dsQuery), nil
 }
 
-func getEndpoints(ingress *extensions.Ingress) []common.Endpoint {
+func getEndpoints(ingress *v1.Ingress) []common.Endpoint {
 	endpoints := make([]common.Endpoint, 0)
 	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
 		for _, status := range ingress.Status.LoadBalancer.Ingress {
@@ -74,7 +74,7 @@ func getEndpoints(ingress *extensions.Ingress) []common.Endpoint {
 	return endpoints
 }
 
-func toIngress(ingress *extensions.Ingress) Ingress {
+func toIngress(ingress *v1.Ingress) Ingress {
 	return Ingress{
 		ObjectMeta: api.NewObjectMeta(ingress.ObjectMeta),
 		TypeMeta:   api.NewTypeMeta(api.ResourceKindIngress),
@@ -82,7 +82,7 @@ func toIngress(ingress *extensions.Ingress) Ingress {
 	}
 }
 
-func toIngressList(ingresses []extensions.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
+func toIngressList(ingresses []v1.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
 	newIngressList := &IngressList{
 		ListMeta: api.ListMeta{TotalItems: len(ingresses)},
 		Items:    make([]Ingress, 0),

--- a/src/app/backend/resource/ingress/list.go
+++ b/src/app/backend/resource/ingress/list.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	v1 "k8s.io/api/networking/v1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 	client "k8s.io/client-go/kubernetes"
 )
 
@@ -48,7 +48,7 @@ type IngressList struct {
 // GetIngressList returns all ingresses in the given namespace.
 func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	dsQuery *dataselect.DataSelectQuery) (*IngressList, error) {
-	ingressList, err := client.NetworkingV1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
+	ingressList, err := client.NetworkingV1beta1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
 
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
@@ -58,7 +58,7 @@ func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	return toIngressList(ingressList.Items, nonCriticalErrors, dsQuery), nil
 }
 
-func getEndpoints(ingress *v1.Ingress) []common.Endpoint {
+func getEndpoints(ingress *v1beta1.Ingress) []common.Endpoint {
 	endpoints := make([]common.Endpoint, 0)
 	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
 		for _, status := range ingress.Status.LoadBalancer.Ingress {
@@ -74,7 +74,7 @@ func getEndpoints(ingress *v1.Ingress) []common.Endpoint {
 	return endpoints
 }
 
-func toIngress(ingress *v1.Ingress) Ingress {
+func toIngress(ingress *v1beta1.Ingress) Ingress {
 	return Ingress{
 		ObjectMeta: api.NewObjectMeta(ingress.ObjectMeta),
 		TypeMeta:   api.NewTypeMeta(api.ResourceKindIngress),
@@ -82,7 +82,7 @@ func toIngress(ingress *v1.Ingress) Ingress {
 	}
 }
 
-func toIngressList(ingresses []v1.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
+func toIngressList(ingresses []v1beta1.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
 	newIngressList := &IngressList{
 		ListMeta: api.ListMeta{TotalItems: len(ingresses)},
 		Items:    make([]Ingress, 0),


### PR DESCRIPTION
Just like https://github.com/kubernetes/dashboard/pull/5741, except that this one works in k8s 1.14+ instead 1.18+ :)

closes #5558 