### PR TITLE
BugFix: raw API calls for ingress should use NetworkingV1beta1 client

### DIFF
--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -171,17 +171,18 @@ type ClientType string
 
 // List of client types supported by the UI.
 const (
-	ClientTypeDefault             = "restclient"
-	ClientTypeExtensionClient     = "extensionclient"
-	ClientTypeAppsClient          = "appsclient"
-	ClientTypeBatchClient         = "batchclient"
-	ClientTypeBetaBatchClient     = "betabatchclient"
-	ClientTypeAutoscalingClient   = "autoscalingclient"
-	ClientTypeStorageClient       = "storageclient"
-	ClientTypeRbacClient          = "rbacclient"
-	ClientTypeAPIExtensionsClient = "apiextensionsclient"
-	ClientTypeNetworkingClient    = "networkingclient"
-	ClientTypePluginsClient       = "plugin"
+	ClientTypeDefault              = "restclient"
+	ClientTypeExtensionClient      = "extensionclient"
+	ClientTypeAppsClient           = "appsclient"
+	ClientTypeBatchClient          = "batchclient"
+	ClientTypeBetaBatchClient      = "betabatchclient"
+	ClientTypeAutoscalingClient    = "autoscalingclient"
+	ClientTypeStorageClient        = "storageclient"
+	ClientTypeRbacClient           = "rbacclient"
+	ClientTypeAPIExtensionsClient  = "apiextensionsclient"
+	ClientTypeNetworkingClient     = "networkingclient"
+	ClientTypeBetaNetworkingClient = "betanetworkingclient"
+	ClientTypePluginsClient        = "plugin"
 )
 
 // APIMapping is the mapping from resource kind to ClientType and Namespaced.
@@ -204,7 +205,7 @@ var KindToAPIMapping = map[string]APIMapping{
 	ResourceKindDeployment:               {"deployments", ClientTypeAppsClient, true},
 	ResourceKindEvent:                    {"events", ClientTypeDefault, true},
 	ResourceKindHorizontalPodAutoscaler:  {"horizontalpodautoscalers", ClientTypeAutoscalingClient, true},
-	ResourceKindIngress:                  {"ingresses", ClientTypeNetworkingClient, true},
+	ResourceKindIngress:                  {"ingresses", ClientTypeBetaNetworkingClient, true},
 	ResourceKindJob:                      {"jobs", ClientTypeBatchClient, true},
 	ResourceKindCronJob:                  {"cronjobs", ClientTypeBetaBatchClient, true},
 	ResourceKindLimitRange:               {"limitrange", ClientTypeDefault, true},

--- a/src/app/backend/auth/manager_test.go
+++ b/src/app/backend/auth/manager_test.go
@@ -87,7 +87,7 @@ func (self *fakeClientManager) HasAccess(authInfo api.AuthInfo) error {
 }
 
 func (self *fakeClientManager) VerberClient(req *restful.Request, config *rest.Config) (clientapi.ResourceVerber, error) {
-	return client.NewResourceVerber(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), nil
+	return client.NewResourceVerber(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), nil
 }
 
 func (self *fakeClientManager) CanI(req *restful.Request, ssar *v1.SelfSubjectAccessReview) bool {

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -276,6 +276,7 @@ func (self *clientManager) VerberClient(req *restful.Request, config *rest.Confi
 		k8sClient.StorageV1().RESTClient(),
 		k8sClient.RbacV1().RESTClient(),
 		k8sClient.NetworkingV1().RESTClient(),
+		k8sClient.NetworkingV1beta1().RESTClient(),
 		apiextensionsRestClient,
 		pluginsclient.DashboardV1alpha1().RESTClient(),
 		config), nil

--- a/src/app/backend/client/verber.go
+++ b/src/app/backend/client/verber.go
@@ -33,18 +33,19 @@ import (
 // resourceVerber is a struct responsible for doing common verb operations on resources, like
 // DELETE, PUT, UPDATE.
 type resourceVerber struct {
-	client              RESTClient
-	extensionsClient    RESTClient
-	appsClient          RESTClient
-	batchClient         RESTClient
-	betaBatchClient     RESTClient
-	autoscalingClient   RESTClient
-	storageClient       RESTClient
-	rbacClient          RESTClient
-	networkingClient    RESTClient
-	apiExtensionsClient RESTClient
-	pluginsClient       RESTClient
-	config              *restclient.Config
+	client               RESTClient
+	extensionsClient     RESTClient
+	appsClient           RESTClient
+	batchClient          RESTClient
+	betaBatchClient      RESTClient
+	autoscalingClient    RESTClient
+	storageClient        RESTClient
+	rbacClient           RESTClient
+	networkingClient     RESTClient
+	betaNetworkingClient RESTClient
+	apiExtensionsClient  RESTClient
+	pluginsClient        RESTClient
+	config               *restclient.Config
 }
 
 type crdInfo struct {
@@ -72,6 +73,8 @@ func (verber *resourceVerber) getRESTClientByType(clientType api.ClientType) RES
 		return verber.rbacClient
 	case api.ClientTypeNetworkingClient:
 		return verber.networkingClient
+	case api.ClientTypeBetaNetworkingClient:
+		return verber.betaNetworkingClient
 	case api.ClientTypeAPIExtensionsClient:
 		return verber.apiExtensionsClient
 	case api.ClientTypePluginsClient:
@@ -167,9 +170,9 @@ type RESTClient interface {
 }
 
 // NewResourceVerber creates a new resource verber that uses the given client for performing operations.
-func NewResourceVerber(client, extensionsClient, appsClient, batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, apiExtensionsClient, pluginsClient RESTClient, config *restclient.Config) clientapi.ResourceVerber {
+func NewResourceVerber(client, extensionsClient, appsClient, batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, betaNetworkingClient, apiExtensionsClient, pluginsClient RESTClient, config *restclient.Config) clientapi.ResourceVerber {
 	return &resourceVerber{client, extensionsClient, appsClient,
-		batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, apiExtensionsClient, pluginsClient, config}
+		batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, betaNetworkingClient, apiExtensionsClient, pluginsClient, config}
 }
 
 // Delete deletes the resource of the given kind in the given namespace with the given name.


### PR DESCRIPTION
This is the bugfix for an issue I caused myself. Ops (but it has never been released :)

When I wrote the PR to move Ingress calls to use extensions/networkingv1beta ( https://github.com/kubernetes/dashboard/pull/5742 ) I forgot to make the raw links to use it.

In other words, on k8s <= 1.18 one could not see the raw yaml of an ingress.

This PR fix that