### PR TITLE
Use allocatable resources rather than total capacity.

### DIFF
--- a/src/app/backend/resource/node/detail.go
+++ b/src/app/backend/resource/node/detail.go
@@ -198,13 +198,13 @@ func getNodeAllocatedResources(node v1.Node, podList *v1.PodList) (NodeAllocated
 		limits[v1.ResourceCPU], reqs[v1.ResourceMemory], limits[v1.ResourceMemory]
 
 	var cpuRequestsFraction, cpuLimitsFraction float64 = 0, 0
-	if capacity := float64(node.Status.Capacity.Cpu().MilliValue()); capacity > 0 {
+	if capacity := float64(node.Status.Allocatable.Cpu().MilliValue()); capacity > 0 {
 		cpuRequestsFraction = float64(cpuRequests.MilliValue()) / capacity * 100
 		cpuLimitsFraction = float64(cpuLimits.MilliValue()) / capacity * 100
 	}
 
 	var memoryRequestsFraction, memoryLimitsFraction float64 = 0, 0
-	if capacity := float64(node.Status.Capacity.Memory().MilliValue()); capacity > 0 {
+	if capacity := float64(node.Status.Allocatable.Memory().MilliValue()); capacity > 0 {
 		memoryRequestsFraction = float64(memoryRequests.MilliValue()) / capacity * 100
 		memoryLimitsFraction = float64(memoryLimits.MilliValue()) / capacity * 100
 	}
@@ -220,12 +220,12 @@ func getNodeAllocatedResources(node v1.Node, podList *v1.PodList) (NodeAllocated
 		CPURequestsFraction:    cpuRequestsFraction,
 		CPULimits:              cpuLimits.MilliValue(),
 		CPULimitsFraction:      cpuLimitsFraction,
-		CPUCapacity:            node.Status.Capacity.Cpu().MilliValue(),
+		CPUCapacity:            node.Status.Allocatable.Cpu().MilliValue(),
 		MemoryRequests:         memoryRequests.Value(),
 		MemoryRequestsFraction: memoryRequestsFraction,
 		MemoryLimits:           memoryLimits.Value(),
 		MemoryLimitsFraction:   memoryLimitsFraction,
-		MemoryCapacity:         node.Status.Capacity.Memory().Value(),
+		MemoryCapacity:         node.Status.Allocatable.Memory().Value(),
 		AllocatedPods:          len(podList.Items),
 		PodCapacity:            podCapacity,
 		PodFraction:            podFraction,


### PR DESCRIPTION
Fixes #5796.

The Cluster and Node Memory metrics are not intuitive. The statistics shown are relative to node.Status.Capacity instead of node.Status.Allocatable which can be highly misleading for certain cloud providers/node VM sizes (due to provider specific resource reservations described here). In my circumstance using Azure Kubernetes Service with Standard_B2s results in a reported utilization of ~55% when it is actually ~98% according to kubectl describe node. This difference makes it very difficult to understand why a cluster would report insufficient memory when scheduling pods. Memory consumption relative to the cluster or node's total Allocatable Memory is a much more useful metric for most users who are generally only concerned with the resources available for consumption by pods/workloads. This is supported by kubectl's default reporting of node memory (i.e. relative to the allocatable memory).