### PR TITLE
Hardcoded ConfigMap name in helm chart

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 4.0.0
+version: 4.0.1
 appVersion: 2.1.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/configmap.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/configmap.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   labels:
 {{ include "kubernetes-dashboard.labels" . | indent 4 }}
-  name: {{ template "kubernetes-dashboard.fullname" . }}-settings
+  name: kubernetes-dashboard-settings
 data:
 {{- with .Values.settings }}
   _global: {{ toJson . | quote }}


### PR DESCRIPTION
Related issue #5753 

Hardcoded `ConfigMap` name to `kubernetes-dashboard-settings` to align with the backend code. Reference: https://github.com/kubernetes/dashboard/blob/master/src/app/backend/settings/api/types.go#L27