### PR TITLE
Code block highlighting on README.md at root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters.
 
 To deploy Dashboard, execute following command:
 
-```sh
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.1.0/aio/deploy/recommended.yaml
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.1.0/aio/deploy/recommended.yaml
 ```
 
-Alternatively, you can install Dashboard using Helm as described at https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard.
+Alternatively, you can install Dashboard using Helm as described at [`https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard`](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard).
 
 ### Access
 
 To access Dashboard from your local workstation you must create a secure channel to your Kubernetes cluster. Run the following command:
 
-```sh
-$ kubectl proxy
+```shell
+kubectl proxy
 ```
 Now access Dashboard at:
 
@@ -42,15 +42,15 @@ To find out how to create sample user and log in follow [Creating sample user](d
 
 **NOTE:**
 * Kubeconfig Authentication method does not support external identity providers or certificate-based authentication.
-* [metrics-server](https://github.com/kubernetes-sigs/metrics-server) has to be running in the cluster for the metrics and graphs to be available. Read more about it in [Integrations](docs/user/integrations.md) guide.
+* [Metrics-Server](https://github.com/kubernetes-sigs/metrics-server) has to be running in the cluster for the metrics and graphs to be available. Read more about it in [Integrations](docs/user/integrations.md) guide.
 
 ## Documentation
 
 Dashboard documentation can be found on [docs](docs/README.md) directory which contains:
 
-* [Common](docs/common/README.md): Entry-level overview
-* [User Guide](docs/user/README.md): [Installation](docs/user/installation.md), [Accessing Dashboard](docs/user/accessing-dashboard/README.md) and more for users
-* [Developer Guide](docs/developer/README.md): [Getting Started](docs/developer/getting-started.md), [Dependency Management](docs/developer/dependency-management.md) and more for anyone interested in contributing
+* [Common](docs/common/README.md): Entry-level overview.
+* [User Guide](docs/user/README.md): [Installation](docs/user/installation.md), [Accessing Dashboard](docs/user/accessing-dashboard/README.md) and more for users.
+* [Developer Guide](docs/developer/README.md): [Getting Started](docs/developer/getting-started.md), [Dependency Management](docs/developer/dependency-management.md) and more for anyone interested in contributing.
 
 ## Community, discussion, contribution, and support
 
@@ -66,7 +66,7 @@ You can reach the maintainers of this project at:
 
 ### Contribution
 
-Learn how to start contribution on the [Contributing Guidline](CONTRIBUTING.md)
+Learn how to start contribution on the [Contributing Guidline](CONTRIBUTING.md).
 
 ### Code of conduct
 


### PR DESCRIPTION
Fix 'Highlighting code blocks in docs '(#5805)

* Separate commands from output on README.md at root.

* Add the Code blocks in the Markdown spec to make README.md at root easy to read.

Signed-off-by: ydFu <ader.ydfu@gmail.com>