### PR TITLE
Code block highlighting on docs/plugins.

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -8,7 +8,8 @@
 ### Installation
 
 To enable plugin support in the dashboard you must register a custom [CRD](../../aio/test-resources/plugin-crd.yml) in your cluster.
-```
+
+```shell
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/test-resources/plugin-crd.yml
 ```
 
@@ -18,7 +19,8 @@ In order to take advantage of AOT compilation, sharing the code across plugins a
 You can clone this repository and checkout to [`plugin/base`](https://github.com/kubernetes/dashboard/tree/plugin/base) branch. The build process is specified under [`builders`](https://github.com/kubernetes/dashboard/tree/plugin/base/builders) directory.
 
 On this branch, you can compile the plugin with following command
-```
+
+```shell
 ng build plugin && ng build --project custom-plugin --prod --modulePath="k8s-plugin#PluginModule" --pluginName="k8s-plugin" --outputPath="./dist/bundle"
 ng build --project custom-plugin --prod --modulePath="./plugin1/plugin1.module#Plugin1Module" --pluginName="plugin1" --sharedLibs="k8s-plugin" --outputPath="./dist/bundle"
 ```
@@ -29,7 +31,7 @@ The key thing here is that we specify the `custom-plugin` project in the `angula
 
 Once the custom CRD is registered we can now create [instances](../../aio/test-resources/plugin-test.yml) of the CRD which will hold the spec for plugin.
 
-```
+```shell
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/test-resources/plugin-test.yml
 ```
 
@@ -39,9 +41,12 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/a
 
 We can now create config-maps to hold the compiled plugin source code.
 
-```
+```shell
 kubectl create configmap k8s-plugin-src --from-file="./dist/bundle/k8s-plugin.js"
 kubectl create configmap plugin1-src --from-file="./dist/bundle/plugin1.js"
 ```
 
 After following all the above steps, your new plugin should be available in the dashboard.
+
+----
+_Copyright 2021 [The Kubernetes Dashboard Authors](https://github.com/kubernetes/dashboard/graphs/contributors)_


### PR DESCRIPTION
Fix 'Highlighting code blocks in docs '(#5805)

* Add the Code blocks in the Markdown spec to make docs/plugins at root easy to read.

* Add Copyright 2021 [The Kubernetes Dashboard Authors]

Signed-off-by: ydFu <ader.ydfu@gmail.com>