### PR TITLE
Refactor log viewer, remove follow logs option and fix autorefresh

### DIFF
--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -1163,7 +1163,7 @@
         <target>Logs von</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5dc4402dbf1d5f8f98da57b6061d5f9be05ca5c" datatype="html">
@@ -1179,7 +1179,7 @@
         <target>Init-Container</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -1187,7 +1187,7 @@
         <target>in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -1195,19 +1195,7 @@
         <target>Logs herunterladen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          Logs von <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> bis <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -1215,7 +1203,7 @@
         <target>Farben umkehren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -1223,7 +1211,7 @@
         <target>Textgröße reduzieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -1231,7 +1219,7 @@
         <target>Zeitstempel anzeigen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -1239,15 +1227,7 @@
         <target>Automatisch aktualisieren (alle <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>Logs folgen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -1255,7 +1235,19 @@
         <target>Zeige vorherige Logs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -1167,7 +1167,7 @@
         <target>Journaux de</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5dc4402dbf1d5f8f98da57b6061d5f9be05ca5c" datatype="html">
@@ -1183,7 +1183,7 @@
         <target>Conteneurs d'initilisation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -1191,7 +1191,7 @@
         <target>dans</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -1199,19 +1199,7 @@
         <target>Télécharger les journaux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          Logs de <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> à <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -1219,7 +1207,7 @@
         <target>Inverser les couleurs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -1227,7 +1215,7 @@
         <target>Réduire les caractères</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -1235,7 +1223,7 @@
         <target>Voir les horodatages</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -1243,15 +1231,7 @@
         <target state="new">Auto-refresh (every <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>Suivre les journaux</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -1259,7 +1239,19 @@
         <target>Voir les journaux précédents</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -4244,7 +4244,7 @@
         <target>ログ</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
@@ -4252,7 +4252,7 @@
         <target>初期化コンテナー</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -4260,7 +4260,7 @@
         <target>in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -4268,19 +4268,7 @@
         <target>ログのダウンロード</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> から <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC までのログ
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -4288,7 +4276,7 @@
         <target>色の反転</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -4296,7 +4284,7 @@
         <target>フォントサイズの縮小</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -4304,7 +4292,7 @@
         <target>タイムスタンプの表示</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -4312,15 +4300,7 @@
         <target>自動更新 (<x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> 秒毎)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>ログを追随</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -4328,7 +4308,19 @@
         <target>以前のログを表示</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -4570,7 +4570,7 @@
         <target>로그</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
@@ -4578,7 +4578,7 @@
         <target>초기화 컨테이너</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -4586,7 +4586,7 @@
         <target>안</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -4594,19 +4594,7 @@
         <target>로그 다운로드</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/>에서 <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC 까지 로그
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -4614,7 +4602,7 @@
         <target>색상 반전</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -4622,7 +4610,7 @@
         <target>글꼴 크기 축소</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -4630,7 +4618,7 @@
         <target>타임스탬프 보기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -4638,15 +4626,7 @@
         <target>(<x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> 초마다) 자동 새로고침.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>로그 따라가기</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -4654,7 +4634,19 @@
         <target>이전 로그 보기</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -3757,86 +3757,79 @@
         <source>Logs from</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60,67</context>
+          <context context-type="linenumber">59,65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f5dc4402dbf1d5f8f98da57b6061d5f9be05ca5c" datatype="html">
         <source>Containers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">72,78</context>
+          <context context-type="linenumber">72,77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
         <source>Init Containers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84,96</context>
+          <context context-type="linenumber">85,95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
         <source>in</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109,115</context>
+          <context context-type="linenumber">114,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
         <source>Download logs</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128,136</context>
+          <context context-type="linenumber">143,148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
         <source>Invert colors</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150,163</context>
+          <context context-type="linenumber">161,174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
         <source>Reduce font size</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183,188</context>
+          <context context-type="linenumber">190,201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
         <source>Show timestamps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201,209</context>
+          <context context-type="linenumber">215,220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
         <source>Auto-refresh (every <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150,154</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
         <source>Show previous logs</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
         <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> UTC </source>
+               format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> UTC </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154,95</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4346d3d4e2109584d33480fb8916a9b1cfcdf636" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -4557,7 +4557,7 @@
         <target>日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
@@ -4565,7 +4565,7 @@
         <target>初始化容器</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -4573,7 +4573,7 @@
         <target>in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -4581,19 +4581,7 @@
         <target>下载日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          日志来自 <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -4601,7 +4589,7 @@
         <target>反转颜色</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -4609,7 +4597,7 @@
         <target>减小字体大小</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -4617,7 +4605,7 @@
         <target>显示时间戳</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -4625,15 +4613,7 @@
         <target>自动刷新 (每 <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> 秒)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>追踪日志</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -4641,7 +4621,19 @@
         <target>显示以前的日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -4577,7 +4577,7 @@
         <target>日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
@@ -4585,7 +4585,7 @@
         <target>初始化容器</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -4593,7 +4593,7 @@
         <target>in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -4601,19 +4601,7 @@
         <target>下載日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          日志來自 <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -4621,7 +4609,7 @@
         <target>反轉顔色</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -4629,7 +4617,7 @@
         <target>減小字體大小</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -4637,7 +4625,7 @@
         <target>顯示時間戳</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -4645,15 +4633,7 @@
         <target state="new">Auto-refresh (every <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>Follow logs</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -4661,7 +4641,19 @@
         <target>顯示以前的日志</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -4549,7 +4549,7 @@
         <target>日誌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c7b6cfe5410900faa386dd25760731fc8f8d68d7" datatype="html">
@@ -4557,7 +4557,7 @@
         <target>初始化容器</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cb0f69bdd4dea41d7d45c74b6e07f98de8a2ab26" datatype="html">
@@ -4565,7 +4565,7 @@
         <target>in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bdf43b20b7101e83458a69a1e5e2008557feca1f" datatype="html">
@@ -4573,19 +4573,7 @@
         <target>下載日誌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4718e522f1a6e0d5ca2062f6c96ee1c584021326" datatype="html">
-        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
-                   format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
-        <target>
-          日誌來自 <x id="START_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD-DATE_1" ctype="x-kd-date" equiv-text="&lt;kd-date>"/><x id="CLOSE_TAG_KD-DATE" ctype="x-kd-date" equiv-text="&lt;/kd-date>"/> UTC
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="fb31e77d231aa06eb2e8494b50596519bbeeb386" datatype="html">
@@ -4593,7 +4581,7 @@
         <target>反轉顔色</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8902979878d0f294dfc6f5b95fd7788c3fa2dd49" datatype="html">
@@ -4601,7 +4589,7 @@
         <target>減小字體大小</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b5c4c520630525f705f7bddbeb2f0b0aec7a30d6" datatype="html">
@@ -4609,7 +4597,7 @@
         <target>顯示時間戳</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="72f275d9b31bf0e6dc122c1a9b58b4986800eb7a" datatype="html">
@@ -4617,15 +4605,7 @@
         <target state="new">Auto-refresh (every <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6e73f7b06ce74fa29c8866cf5a82bfbeaf2452ed" datatype="html">
-        <source>Follow logs</source>
-        <target>跟踪日誌</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">150</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3de87d94cff5d685043f035ac20e6d4521f8edf2" datatype="html">
@@ -4633,7 +4613,19 @@
         <target>顯示以前的日誌</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="948452dba1924a83bfe56a00c92ab7cb390c0889" datatype="html">
+        <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </source>
+        <target state="new"> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot;
+               format=&quot;short&quot;>"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date>"/> UTC </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
+          <context context-type="linenumber">157,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a21b5b669ab3f36e0f83e9a025c26662fd0616e8" datatype="html">

--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -24,6 +24,9 @@ $colors-dark: (
   chart-blue: #327df4,
   chart-green: #00c752,
   toolbar-button: #fff,
+  log-viewer-bg: #000,
+  log-viewer-text: #fff,
+  log-viewer-scrollbar: rgba(200, 200, 200, 0.66),
 );
 
 // sass-lint:disable function-name-format

--- a/src/app/frontend/_dark.scss
+++ b/src/app/frontend/_dark.scss
@@ -26,7 +26,7 @@ $colors-dark: (
   toolbar-button: #fff,
   log-viewer-bg: #000,
   log-viewer-text: #fff,
-  log-viewer-scrollbar: rgba(200, 200, 200, 0.66),
+  log-viewer-scrollbar: rgba(200, 200, 200, .66),
 );
 
 // sass-lint:disable function-name-format

--- a/src/app/frontend/_light.scss
+++ b/src/app/frontend/_light.scss
@@ -26,7 +26,7 @@ $colors-light: (
   toolbar-button: #000,
   log-viewer-bg: #000,
   log-viewer-text: #fff,
-  log-viewer-scrollbar: rgba(200, 200, 200, 0.66),
+  log-viewer-scrollbar: rgba(200, 200, 200, .66),
 );
 
 // sass-lint:disable function-name-format

--- a/src/app/frontend/_light.scss
+++ b/src/app/frontend/_light.scss
@@ -24,6 +24,9 @@ $colors-light: (
   chart-blue: #326de6,
   chart-green: #00c752,
   toolbar-button: #000,
+  log-viewer-bg: #000,
+  log-viewer-text: #fff,
+  log-viewer-scrollbar: rgba(200, 200, 200, 0.66),
 );
 
 // sass-lint:disable function-name-format

--- a/src/app/frontend/_theming.scss
+++ b/src/app/frontend/_theming.scss
@@ -326,4 +326,24 @@
   .mat-list {
     border: 1px solid $border;
   }
+
+  kd-logs {
+    .kd-card-content {
+      border-bottom: 1px solid lighten(map-get($colors, log-viewer-bg), 75%);
+      border-top: 1px solid lighten(map-get($colors, log-viewer-bg), 75%);
+    }
+
+    .kd-log-line-container {
+      background-color: map-get($colors, log-viewer-bg);
+      color: map-get($colors, log-viewer-text);
+
+      &::-webkit-scrollbar-thumb {
+        background-color: map-get($colors, log-viewer-scrollbar);
+      }
+
+      &.kd-logs-text-color-invert {
+        filter: invert(100%);
+      }
+    }
+  }
 }

--- a/src/app/frontend/common/components/card/component.ts
+++ b/src/app/frontend/common/components/card/component.ts
@@ -23,18 +23,18 @@ import {Animations} from '../../animations/animations';
 })
 export class CardComponent {
   @Input() initialized = true;
-  @Input() role: string;
+  @Input() role: 'inner' | 'table' | 'inner-content';
   @Input() withFooter = false;
   @Input() withTitle = true;
   @Input() expandable = true;
+  @Input() expanded = true;
+  @Input() graphMode = false;
+  private classes_: string[] = [];
+
   @Input()
   set titleClasses(val: string) {
     this.classes_ = val.split(/\s+/);
   }
-  @Input() expanded = true;
-  @Input() graphMode = false;
-
-  private classes_: string[] = [];
 
   expand(): void {
     if (this.expandable) {

--- a/src/app/frontend/common/components/card/style.scss
+++ b/src/app/frontend/common/components/card/style.scss
@@ -16,9 +16,37 @@
 @import '../../../mixins';
 
 :host {
+  div {
+    &.kd-inner-content {
+      display: flex;
+      flex-direction: column;
+      // Reserve 70px for the footer
+      min-height: 50 * $baseline-grid;
+      height: calc(100% - 70px);
+      max-height: calc(100% - 70px);
+
+      .kd-card-content {
+        > div {
+          height: 100%;
+        }
+      }
+    }
+  }
+
   .mat-card {
     min-width: 100 * $baseline-grid;
     padding: 0;
+
+    &.kd-inner-content {
+      width: 100%;
+      height: auto;
+
+      .mat-card-content {
+        flex-grow: 1;
+        overflow: auto;
+        padding: 0;
+      }
+    }
 
     &.kd-inner-table {
       box-shadow: none;

--- a/src/app/frontend/common/components/card/style.scss
+++ b/src/app/frontend/common/components/card/style.scss
@@ -21,9 +21,9 @@
       display: flex;
       flex-direction: column;
       // Reserve 70px for the footer
-      min-height: 50 * $baseline-grid;
       height: calc(100% - 70px);
       max-height: calc(100% - 70px);
+      min-height: 50 * $baseline-grid;
 
       .kd-card-content {
         > div {
@@ -38,8 +38,8 @@
     padding: 0;
 
     &.kd-inner-content {
-      width: 100%;
       height: auto;
+      width: 100%;
 
       .mat-card-content {
         flex-grow: 1;

--- a/src/app/frontend/common/components/card/template.html
+++ b/src/app/frontend/common/components/card/template.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<mat-card [ngClass]="{'kd-minimized-card': !expanded && !graphMode, 'kd-graph': graphMode, 'kd-inner-table': role === 'inner'}">
+<mat-card [ngClass]="{'kd-minimized-card': !expanded && !graphMode, 'kd-graph': graphMode, 'kd-inner-table': role === 'inner', 'kd-inner-content': role === 'inner-content'}">
   <mat-card-title *ngIf="withTitle"
                   [ngClass]="getTitleClasses()"
                   (click)="onCardHeaderClick(); $event.stopPropagation()"
@@ -47,7 +47,8 @@ limitations under the License.
     </button>
   </mat-card-title>
 
-  <div [@expandInOut]="!expanded">
+  <div [@expandInOut]="!expanded"
+       [ngClass]="{'kd-inner-content': role === 'inner-content'}">
     <mat-card-content class="kd-card-content"
                       [ngClass]="{'kd-card-content-table': role === 'table'}">
       <div *ngIf="initialized; else loading">

--- a/src/app/frontend/common/services/global/logs.ts
+++ b/src/app/frontend/common/services/global/logs.ts
@@ -19,10 +19,10 @@ import {Observable} from 'rxjs';
 @Injectable()
 export class LogService {
   previous_ = false;
-  inverted_ = true;
+  inverted_ = false;
   compact_ = false;
   showTimestamp_ = false;
-  following_ = true;
+  following_ = false;
   autoRefresh_ = false;
 
   constructor(private readonly http_: HttpClient) {}
@@ -35,15 +35,11 @@ export class LogService {
     this.following_ = status;
   }
 
-  toggleFollowing(): void {
-    this.following_ = !this.following_;
-  }
-
   getFollowing(): boolean {
     return this.following_;
   }
 
-  setAutoRefresh(): void {
+  toggleAutoRefresh(): void {
     this.autoRefresh_ = !this.autoRefresh_;
   }
 
@@ -51,7 +47,7 @@ export class LogService {
     return this.autoRefresh_;
   }
 
-  setPrevious(): void {
+  togglePrevious(): void {
     this.previous_ = !this.previous_;
   }
 
@@ -59,7 +55,7 @@ export class LogService {
     return this.previous_;
   }
 
-  setInverted(): void {
+  toggleInverted(): void {
     this.inverted_ = !this.inverted_;
   }
 
@@ -67,7 +63,7 @@ export class LogService {
     return this.inverted_;
   }
 
-  setCompact(): void {
+  toggleCompact(): void {
     this.compact_ = !this.compact_;
   }
 
@@ -75,7 +71,7 @@ export class LogService {
     return this.compact_;
   }
 
-  setShowTimestamp(): void {
+  toggleShowTimestamp(): void {
     this.showTimestamp_ = !this.showTimestamp_;
   }
 

--- a/src/app/frontend/index.scss
+++ b/src/app/frontend/index.scss
@@ -412,12 +412,12 @@ router-outlet::after {
 
 kd-logs {
   .mat-form-field {
-    width: auto;
     max-width: 22 * $baseline-grid;
+    width: auto;
 
     .mat-form-field-underline {
-      position: initial;
       margin-top: .25 * $baseline-grid;
+      position: initial;
     }
 
     .mat-form-field-wrapper {

--- a/src/app/frontend/index.scss
+++ b/src/app/frontend/index.scss
@@ -409,3 +409,36 @@ router-outlet::after {
     padding-top: 0;
   }
 }
+
+kd-logs {
+  .mat-form-field {
+    width: auto;
+    max-width: 22 * $baseline-grid;
+
+    .mat-form-field-underline {
+      position: initial;
+      margin-top: .25 * $baseline-grid;
+    }
+
+    .mat-form-field-wrapper {
+      padding-bottom: 0;
+    }
+
+    .mat-form-field-infix {
+      border-top: 0;
+      padding: 0;
+      width: auto;
+    }
+
+    .mat-select-trigger {
+      align-items: center;
+      display: flex;
+    }
+
+    .mat-select-value {
+      display: inline-flex;
+      max-width: 100%;
+      padding-right: $baseline-grid;
+    }
+  }
+}

--- a/src/app/frontend/logs/style.scss
+++ b/src/app/frontend/logs/style.scss
@@ -15,67 +15,8 @@
 @import '../variables';
 @import '../mixins';
 
-$logs-color-black: #000;
-$logs-color-white: #fff;
-
-$emphasis: #000;
-$content-background: #fff;
-
-$scrollbar-color-light: rgba(255, 255, 255, .5);
-
-.kd-logs-header-text {
-  line-height: $baseline-grid * 5.25;
-  white-space: nowrap;
-}
-
-.kd-logs-container {
-  box-sizing: border-box;
-  height: 100%;
-  padding-bottom: 35px;
-}
-
-.kd-logs-color-icon {
-  background-color: $logs-color-black;
-  color: $logs-color-white;
-}
-
-.kd-logs-text-color-invert {
-  background-color: $logs-color-black;
-  color: $logs-color-white;
-
-  ::-webkit-scrollbar-thumb {
-    background-color: $scrollbar-color-light;
-  }
-}
-
-.kd-logs-text-color {
-  background-color: $logs-color-white;
-  color: $logs-color-black;
-}
-
-.kd-logs-size-icon {
-  color: $logs-color-black;
-}
-
-.kd-logs-size-icon-compact {
-  color: $logs-color-black;
-  transform: scale(-1, 1);
-}
-
-.kd-log-view {
-  -webkit-font-smoothing: antialiased;
-  display: flex;
-  flex: 1;
-  font-family: $font-family-monospace;
-  padding: 0;
-  width: 100%;
-}
-
-.kd-log-line {
-  white-space: pre-wrap;
-}
-
 %kd-logs-element-base {
+  font-family: $font-family-monospace;
   padding: 0 (2 * $baseline-grid);
   word-wrap: break-word;
 }
@@ -92,99 +33,22 @@ $scrollbar-color-light: rgba(255, 255, 255, .5);
   font-size: $caption-font-size-base;
 }
 
-.kd-logs-toolbar-select {
-  display: inline-flex;
-  flex-grow: 1;
-  margin: 0;
-  position: relative;
-}
+.kd-log-line-container {
+  height: 100%;
+  overflow-y: auto;
 
-.kd-logs-style-buttons {
-  float: right;
-  white-space: nowrap;
-}
-
-.kd-cross-line-black {
-  stroke: $emphasis;
-  stroke-width: 2;
-}
-
-.kd-cross-line-white {
-  stroke: $content-background;
-  stroke-width: 4;
-}
-
-.kd-logs-info {
-  padding: 1.5 * $baseline-grid;
-}
-
-.kd-cross-style {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-.kd-list-pagination-buttons {
-  margin-right: $baseline-grid;
-}
-
-.mat-form-field {
-  align-items: center;
-  display: inline-flex;
-  margin-bottom: -25px;
-  margin-top: -16px;
-  padding: 0 5px;
-  vertical-align: middle;
-  width: auto;
-
-  &.kd-form-field {
-    flex: 1;
+  &::-webkit-scrollbar {
+    width: 5px;
   }
 }
 
-.kd-log-view-container {
-  -webkit-overflow-scrolling: touch;
-  background-color: inherit;
-  bottom: 50px;
-  box-sizing: border-box;
-  left: 0;
-  margin: 0;
-  overflow-x: hidden;
-  padding: 0;
-  position: absolute;
-  right: 0;
-  top: 57px;
+kd-card {
+  display: flex;
+  min-height: max(100%, 550px);
+  max-height: 100%;
 }
 
-.kd-virtual-repeat-sizer {
-  box-sizing: border-box;
-  display: block;
-  height: 1px;
-  margin: 0;
-  padding: 0;
-  width: 1px;
-}
-
-.kd-muted {
-  bottom: 0;
-  box-sizing: border-box;
-  color: $logs-color-black;
-  left: 0;
-  position: absolute;
-  width: 100%;
-}
-
-:host ::ng-deep mat-card {
-  height: 100%;
-}
-
-:host ::ng-deep .mat-form-field-infix {
-  width: inherit;
-}
-
-:host ::ng-deep .mat-select-value {
-  max-width: 100%;
-  width: inherit;
+.footer {
+  font-size: $body-font-size-base;
+  padding: 0 (2 * $baseline-grid);
 }

--- a/src/app/frontend/logs/style.scss
+++ b/src/app/frontend/logs/style.scss
@@ -44,8 +44,8 @@
 
 kd-card {
   display: flex;
-  min-height: max(100%, 550px);
   max-height: 100%;
+  min-height: max(100%, 550px);
 }
 
 .footer {

--- a/src/app/frontend/logs/template.html
+++ b/src/app/frontend/logs/template.html
@@ -14,110 +14,118 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="kd-logs-container">
-  <kd-card [expandable]="false">
-    <div title
-         [fxLayout]="'row'"
-         [fxFlex]="100">
-      <span class="kd-logs-header-text"
-            i18n>Logs from</span>
-      <mat-form-field>
-        <mat-select [(ngModel)]="container"
-                    class="kd-logs-toolbar-select"
-                    (selectionChange)="onContainerChange()">
-          <mat-optgroup label="Containers"
-                        i18n-label
-                        *ngIf="logSources?.containerNames?.length > 0">
-            <mat-option *ngFor="let item of logSources?.containerNames"
-                        [value]="item">
-              {{item}}
-            </mat-option>
-          </mat-optgroup>
-          <mat-optgroup label="Init Containers"
-                        i18n-label
-                        *ngIf="logSources?.initContainerNames?.length > 0">
-            <mat-option *ngFor="let item of logSources?.initContainerNames"
-                        [value]="item">
-              {{item}}
-            </mat-option>
-          </mat-optgroup>
-        </mat-select>
-      </mat-form-field>
-      <span class="kd-logs-header-text"
-            i18n>in</span>
-      <mat-form-field class="kd-form-field">
-        <mat-select [(ngModel)]="pod"
-                    class="kd-logs-toolbar-select"
-                    (selectionChange)="loadNewest()">
-          <mat-option *ngFor="let item of logSources?.podNames"
+<kd-card [expandable]="false"
+         role="inner-content">
+  <div title
+       fxLayout="row"
+       fxLayoutAlign="start center"
+       fxLayoutGap="8px"
+       fxFlex="100">
+    <span i18n>Logs from</span>
+    <mat-form-field>
+      <mat-select [(ngModel)]="container"
+                  (selectionChange)="onContainerChange()">
+        <mat-optgroup label="Containers"
+                      i18n-label
+                      *ngIf="logSources?.containerNames?.length > 0">
+          <mat-option *ngFor="let item of logSources?.containerNames"
                       [value]="item">
             {{item}}
           </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <div class="kd-logs-style-buttons">
-        <button mat-icon-button
-                i18n-matTooltip
-                matTooltip="Download logs"
-                (click)="downloadLog()">
-          <mat-icon>file_download</mat-icon>
-        </button>
-        <button mat-icon-button
-                [matMenuTriggerFor]="kdMenu">
-          <mat-icon>more_vert</mat-icon>
-        </button>
+        </mat-optgroup>
+        <mat-optgroup label="Init Containers"
+                      i18n-label
+                      *ngIf="logSources?.initContainerNames?.length > 0">
+          <mat-option *ngFor="let item of logSources?.initContainerNames"
+                      [value]="item">
+            {{item}}
+          </mat-option>
+        </mat-optgroup>
+      </mat-select>
+    </mat-form-field>
+
+    <span i18n>in</span>
+    <mat-form-field>
+      <mat-select [(ngModel)]="pod"
+                  (selectionChange)="loadNewest()">
+        <mat-option *ngFor="let item of logSources?.podNames"
+                    [value]="item">
+          {{item}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <div fxFlex></div>
+
+    <button fxFlexAlign="center end"
+            mat-icon-button
+            i18n-matTooltip
+            matTooltip="Download logs"
+            (click)="downloadLog()">
+      <mat-icon>file_download</mat-icon>
+    </button>
+    <button fxLayoutAlign="center end"
+            mat-icon-button
+            [matMenuTriggerFor]="kdMenu">
+      <mat-icon>more_vert</mat-icon>
+    </button>
+  </div>
+
+  <div content
+       #logViewContainer
+       class="kd-log-line-container"
+       (scroll)="onLogsScroll()"
+       [ngClass]="{'kd-logs-text-color-invert': logService?.getInverted(), 'kd-logs-text-color': !logService?.getInverted()}">
+    <div kdLoadingSpinner
+         [isLoading]="isLoading"></div>
+    <div fxFlex
+         fxLayout="column"
+         fxLayoutGap="2px">
+      <div *ngFor="let item of logsSet"
+           [ngClass]="{'kd-logs-element-compact': logService.getCompact(), 'kd-logs-element': !logService.getCompact()}">
+        <span>{{item}}</span>
       </div>
     </div>
+  </div>
 
-    <div content
-         class="kd-log-view"
-         [ngClass]="{'kd-logs-text-color-invert': logService?.getInverted(), 'kd-logs-text-color': !logService?.getInverted()}">
-      <div kdLoadingSpinner
-           [isLoading]="isLoading"></div>
-      <div class="kd-log-view-container"
-           #logViewContainer
-           (scroll)="onLogsScroll()">
-        <div class="kd-virtual-repeat-sizer"></div>
-        <div *ngFor="let item of logsSet"
-             class="kd-logs-element"
-             [ngClass]="{'kd-logs-element-compact': logService.getCompact(), 'kd-logs-element': !logService.getCompact()}">
-          <span class="kd-log-line"
-                [innerHTML]="item | kdSafeHtml"></span>
-        </div>
-      </div>
-
-      <div fxLayout="row"
-           class="kd-muted">
-        <span class="kd-logs-info"
-              *ngIf="logsSet?.length > 1"
-              i18n>
-          Logs from <kd-date [date]="podLogs?.info.fromDate"
-                   format="short"></kd-date> to <kd-date [date]="podLogs?.info.toDate"
-                   format="short"></kd-date> UTC
-        </span>
-        <span fxFlex></span>
-        <div class="kd-list-pagination-buttons">
-          <button mat-icon-button
-                  (click)="loadOldest()">
-            <mat-icon>first_page</mat-icon>
-          </button>
-          <button mat-icon-button
-                  (click)="loadOlder()">
-            <mat-icon>chevron_left</mat-icon>
-          </button>
-          <button mat-icon-button
-                  (click)="loadNewer()">
-            <mat-icon>chevron_right</mat-icon>
-          </button>
-          <button mat-icon-button
-                  (click)="loadNewest()">
-            <mat-icon>last_page</mat-icon>
-          </button>
-        </div>
-      </div>
+  <div footer
+       fxFlex
+       fxLayoutAlign="start center"
+       class="footer"
+       fxLayout="row">
+    <div *ngIf="logsSet?.length > 1"
+         i18n>
+      Logs from
+      <kd-date [date]="podLogs?.info.fromDate"
+               format="short">
+      </kd-date> to
+      <kd-date [date]="podLogs?.info.toDate"
+               format="short">
+      </kd-date> UTC
     </div>
-  </kd-card>
-</div>
+
+    <div fxFlex></div>
+
+    <div>
+      <button mat-icon-button
+              (click)="loadOldest()">
+        <mat-icon>first_page</mat-icon>
+      </button>
+      <button mat-icon-button
+              (click)="loadOlder()">
+        <mat-icon>chevron_left</mat-icon>
+      </button>
+      <button mat-icon-button
+              (click)="loadNewer()">
+        <mat-icon>chevron_right</mat-icon>
+      </button>
+      <button mat-icon-button
+              (click)="loadNewest()">
+        <mat-icon>last_page</mat-icon>
+      </button>
+    </div>
+  </div>
+</kd-card>
 
 <mat-menu #kdMenu="matMenu">
   <button mat-menu-item
@@ -139,11 +147,6 @@ limitations under the License.
           (click)="toggleLogAutoRefresh()">
     <mat-icon>{{logService.getAutoRefresh() ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>
     <span i18n>Auto-refresh (every {{refreshInterval}} s.)</span>
-  </button>
-  <button mat-menu-item
-          (click)="toggleLogFollow()">
-    <mat-icon>{{logService.getFollowing() ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>
-    <span i18n>Follow logs</span>
   </button>
   <button mat-menu-item
           (click)="onPreviousChange()">


### PR DESCRIPTION
Fixes #5854

- Complete refactoring of log viewer styling. Flex instead of absolute positioning.
- Auto-adjust height/width of log viewer to the window size up to the min. values. It was a bit buggy previously.
- Used theming framework to properly define colors inside the log viewer
- Removed the `Follow logs` option as it was not clear what it was actually doing. Instead, when autorefresh is applied and the user scrolls to the bottom of the log viewer it will automatically scroll to the latest part on refresh.
- Slightly changed timestamp formatting
- Fixed auto-refresh option and refactored component a bit

#### New timestamp
![Zrzut ekranu z 2021-03-11 11-34-35](https://user-images.githubusercontent.com/2285385/110774371-048fc600-825e-11eb-9d78-0f4e51cc156a.png)
#### Old timestamp
![Zrzut ekranu z 2021-03-11 11-34-50](https://user-images.githubusercontent.com/2285385/110774379-06598980-825e-11eb-9eb7-410183f2a2a5.png)
