### PR TITLE
feat(helm-chart): adding toggle for read-only role logging

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 4.0.2
+version: 4.1.0
 appVersion: 2.2.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -123,6 +123,7 @@ Parameter                                       | Description                   
 `rbac.create`                                   | Create & use RBAC resources                                                                                                      | `true`
 `rbac.clusterRoleMetrics`                       | If set, an additional cluster role / role binding will be created to access metrics.                                             | `true`
 `rbac.clusterReadOnlyRole`                      | If set, an additional cluster role / role binding will be created with read only permissions to all resources listed inside.     | `false`
+`rbac.clusterReadOnlyRolePermissions.logging`   | Whether or not to allow the Kubernetes Dashboard read-only role to view Pod logs.                                                | `true`
 `serviceAccount.create`                         | Whether a new service account name that the agent will use should be created.                                                    | `true`
 `serviceAccount.name`                           | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template.      |
 `livenessProbe.initialDelaySeconds`             | Number of seconds to wait before sending first probe                                                                             | `30`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -45,7 +45,9 @@ rules:
       - events
       - limitranges
       - namespaces/status
+      {{- if .Values.rbac.clusterReadOnlyRolePermissions.logging }}
       - pods/log
+      {{- end }}
       - pods/status
       - replicationcontrollers/status
       - resourcequotas

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -246,6 +246,12 @@ rbac:
   # Independent from rbac.create parameter.
   clusterReadOnlyRole: false
 
+  # Individual permissions for the `clusterReadOnlyRole`.
+  # Only available if `rbac.clusterReadOnlyRole` is set to `true`.
+  clusterReadOnlyRolePermissions:
+    # Whether or not to allow the Kubernetes Dashboard read-only role to view Pod logs.
+    logging: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
# Description

Fairly simple addition. This adds the ability to enable / disable the read-only role's ability to view `Pod` logs in the dashboard. This came up in my company as we wanted to disable only this part of the dashboard. Figured I'd submit it here for a potential merge.