### PR TITLE
Update Helm chart's TL;DR for Helm v3.

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 4.0.2
+version: 4.0.3
 appVersion: 2.2.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -9,7 +9,7 @@ It allows users to manage applications running in the cluster and troubleshoot t
 # Add kubernetes-dashboard repository
 helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 # Deploy a Helm Release named "my-release" using the kubernetes-dashboard chart
-helm install kubernetes-dashboard/kubernetes-dashboard --name my-release
+helm install my-release kubernetes-dashboard/kubernetes-dashboard
 ```
 
 ## Introduction


### PR DESCRIPTION
The TL;DR still contained Helm's v2 command structure, while the rest of the README is using v3.