### PR TITLE
Fix e2e test

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Kernel for cypress file watcher
-        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sysctl -p
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -156,6 +156,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Kernel for cypress file watcher
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sysctl -p
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Increase fs.inotify.max_user_watches for cypress file watcher.

E2E test does not result error, but tons of `Error: ENOSPC: System limit for number of file watchers reached` occur.
Ref: https://github.com/cypress-io/cypress/issues/4283#issuecomment-522001274