### PR TITLE
GetCustomResourceDefinitionDetail function can't queries more than 10

### DIFF
--- a/src/app/backend/handler/apihandler.go
+++ b/src/app/backend/handler/apihandler.go
@@ -2441,9 +2441,9 @@ func (apiHandler *APIHandler) handleGetCustomResourceDefinitionDetail(request *r
 		errors.HandleInternalError(response, err)
 		return
 	}
-
+	dataSelect := parser.ParseDataSelectPathParameter(request)
 	name := request.PathParameter("crd")
-	result, err := customresourcedefinition.GetCustomResourceDefinitionDetail(apiextensionsclient, config, name)
+	result, err := customresourcedefinition.GetCustomResourceDefinitionDetail(apiextensionsclient, config, dataSelect, name)
 	if err != nil {
 		errors.HandleInternalError(response, err)
 		return

--- a/src/app/backend/resource/customresourcedefinition/common.go
+++ b/src/app/backend/resource/customresourcedefinition/common.go
@@ -88,7 +88,7 @@ func GetCustomResourceDefinitionList(client apiextensionsclientset.Interface, ds
 	return nil, errors.NewNotFound(fmt.Sprintf("unsupported extensions api version: %s", version))
 }
 
-func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, name string) (*types.CustomResourceDefinitionDetail, error) {
+func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, dsQuery *dataselect.DataSelectQuery, name string) (*types.CustomResourceDefinitionDetail, error) {
 	version, err := GetExtensionsAPIVersion(client)
 	if err != nil {
 		return nil, err
@@ -96,9 +96,9 @@ func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, 
 
 	switch version {
 	case v1:
-		return crdv1.GetCustomResourceDefinitionDetail(client, config, name)
+		return crdv1.GetCustomResourceDefinitionDetail(client, config, dsQuery, name)
 	case v1beta1:
-		return crdv1beta1.GetCustomResourceDefinitionDetail(client, config, name)
+		return crdv1beta1.GetCustomResourceDefinitionDetail(client, config, dsQuery, name)
 	}
 
 	return nil, errors.NewNotFound(fmt.Sprintf("unsupported extensions api versions: %s", version))

--- a/src/app/backend/resource/customresourcedefinition/v1/detail.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/detail.go
@@ -29,14 +29,14 @@ import (
 )
 
 // GetCustomResourceDefinitionDetail returns detailed information about a custom resource definition.
-func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, name string) (*types.CustomResourceDefinitionDetail, error) {
+func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, dsQuery *dataselect.DataSelectQuery, name string) (*types.CustomResourceDefinitionDetail, error) {
 	customResourceDefinition, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
 		return nil, criticalError
 	}
 
-	objects, err := GetCustomResourceObjectList(client, config, &common.NamespaceQuery{}, dataselect.DefaultDataSelect, name)
+	objects, err := GetCustomResourceObjectList(client, config, &common.NamespaceQuery{}, dsQuery, name)
 	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
 	if criticalError != nil {
 		return nil, criticalError

--- a/src/app/backend/resource/customresourcedefinition/v1beta1/detail.go
+++ b/src/app/backend/resource/customresourcedefinition/v1beta1/detail.go
@@ -29,14 +29,14 @@ import (
 )
 
 // GetCustomResourceDefinitionDetail returns detailed information about a custom resource definition.
-func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, name string) (*types.CustomResourceDefinitionDetail, error) {
+func GetCustomResourceDefinitionDetail(client apiextensionsclientset.Interface, config *rest.Config, dsQuery *dataselect.DataSelectQuery, name string) (*types.CustomResourceDefinitionDetail, error) {
 	customResourceDefinition, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
 		return nil, criticalError
 	}
 
-	objects, err := GetCustomResourceObjectList(client, config, &common.NamespaceQuery{}, dataselect.DefaultDataSelect, name)
+	objects, err := GetCustomResourceObjectList(client, config, &common.NamespaceQuery{}, dsQuery, name)
 	nonCriticalErrors, criticalError = errors.AppendError(err, nonCriticalErrors)
 	if criticalError != nil {
 		return nil, criticalError


### PR DESCRIPTION
When the GetCustomResourceDefinitionDetail function queries more than 10, will not be queried.