### PR TITLE
Ingress v1 2021

### DIFF
--- a/src/app/backend/api/types.go
+++ b/src/app/backend/api/types.go
@@ -171,18 +171,17 @@ type ClientType string
 
 // List of client types supported by the UI.
 const (
-	ClientTypeDefault              = "restclient"
-	ClientTypeExtensionClient      = "extensionclient"
-	ClientTypeAppsClient           = "appsclient"
-	ClientTypeBatchClient          = "batchclient"
-	ClientTypeBetaBatchClient      = "betabatchclient"
-	ClientTypeAutoscalingClient    = "autoscalingclient"
-	ClientTypeStorageClient        = "storageclient"
-	ClientTypeRbacClient           = "rbacclient"
-	ClientTypeAPIExtensionsClient  = "apiextensionsclient"
-	ClientTypeNetworkingClient     = "networkingclient"
-	ClientTypeBetaNetworkingClient = "betanetworkingclient"
-	ClientTypePluginsClient        = "plugin"
+	ClientTypeDefault             = "restclient"
+	ClientTypeExtensionClient     = "extensionclient"
+	ClientTypeAppsClient          = "appsclient"
+	ClientTypeBatchClient         = "batchclient"
+	ClientTypeBetaBatchClient     = "betabatchclient"
+	ClientTypeAutoscalingClient   = "autoscalingclient"
+	ClientTypeStorageClient       = "storageclient"
+	ClientTypeRbacClient          = "rbacclient"
+	ClientTypeAPIExtensionsClient = "apiextensionsclient"
+	ClientTypeNetworkingClient    = "networkingclient"
+	ClientTypePluginsClient       = "plugin"
 )
 
 // APIMapping is the mapping from resource kind to ClientType and Namespaced.
@@ -205,7 +204,7 @@ var KindToAPIMapping = map[string]APIMapping{
 	ResourceKindDeployment:               {"deployments", ClientTypeAppsClient, true},
 	ResourceKindEvent:                    {"events", ClientTypeDefault, true},
 	ResourceKindHorizontalPodAutoscaler:  {"horizontalpodautoscalers", ClientTypeAutoscalingClient, true},
-	ResourceKindIngress:                  {"ingresses", ClientTypeBetaNetworkingClient, true},
+	ResourceKindIngress:                  {"ingresses", ClientTypeNetworkingClient, true},
 	ResourceKindJob:                      {"jobs", ClientTypeBatchClient, true},
 	ResourceKindCronJob:                  {"cronjobs", ClientTypeBetaBatchClient, true},
 	ResourceKindLimitRange:               {"limitrange", ClientTypeDefault, true},

--- a/src/app/backend/auth/manager_test.go
+++ b/src/app/backend/auth/manager_test.go
@@ -87,7 +87,7 @@ func (self *fakeClientManager) HasAccess(authInfo api.AuthInfo) error {
 }
 
 func (self *fakeClientManager) VerberClient(req *restful.Request, config *rest.Config) (clientapi.ResourceVerber, error) {
-	return client.NewResourceVerber(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), nil
+	return client.NewResourceVerber(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), nil
 }
 
 func (self *fakeClientManager) CanI(req *restful.Request, ssar *v1.SelfSubjectAccessReview) bool {

--- a/src/app/backend/client/manager.go
+++ b/src/app/backend/client/manager.go
@@ -276,7 +276,6 @@ func (self *clientManager) VerberClient(req *restful.Request, config *rest.Confi
 		k8sClient.StorageV1().RESTClient(),
 		k8sClient.RbacV1().RESTClient(),
 		k8sClient.NetworkingV1().RESTClient(),
-		k8sClient.NetworkingV1beta1().RESTClient(),
 		apiextensionsRestClient,
 		pluginsclient.DashboardV1alpha1().RESTClient(),
 		config), nil

--- a/src/app/backend/client/verber.go
+++ b/src/app/backend/client/verber.go
@@ -33,19 +33,18 @@ import (
 // resourceVerber is a struct responsible for doing common verb operations on resources, like
 // DELETE, PUT, UPDATE.
 type resourceVerber struct {
-	client               RESTClient
-	extensionsClient     RESTClient
-	appsClient           RESTClient
-	batchClient          RESTClient
-	betaBatchClient      RESTClient
-	autoscalingClient    RESTClient
-	storageClient        RESTClient
-	rbacClient           RESTClient
-	networkingClient     RESTClient
-	betaNetworkingClient RESTClient
-	apiExtensionsClient  RESTClient
-	pluginsClient        RESTClient
-	config               *restclient.Config
+	client              RESTClient
+	extensionsClient    RESTClient
+	appsClient          RESTClient
+	batchClient         RESTClient
+	betaBatchClient     RESTClient
+	autoscalingClient   RESTClient
+	storageClient       RESTClient
+	rbacClient          RESTClient
+	networkingClient    RESTClient
+	apiExtensionsClient RESTClient
+	pluginsClient       RESTClient
+	config              *restclient.Config
 }
 
 type crdInfo struct {
@@ -73,8 +72,6 @@ func (verber *resourceVerber) getRESTClientByType(clientType api.ClientType) RES
 		return verber.rbacClient
 	case api.ClientTypeNetworkingClient:
 		return verber.networkingClient
-	case api.ClientTypeBetaNetworkingClient:
-		return verber.betaNetworkingClient
 	case api.ClientTypeAPIExtensionsClient:
 		return verber.apiExtensionsClient
 	case api.ClientTypePluginsClient:
@@ -170,9 +167,9 @@ type RESTClient interface {
 }
 
 // NewResourceVerber creates a new resource verber that uses the given client for performing operations.
-func NewResourceVerber(client, extensionsClient, appsClient, batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, betaNetworkingClient, apiExtensionsClient, pluginsClient RESTClient, config *restclient.Config) clientapi.ResourceVerber {
+func NewResourceVerber(client, extensionsClient, appsClient, batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, apiExtensionsClient, pluginsClient RESTClient, config *restclient.Config) clientapi.ResourceVerber {
 	return &resourceVerber{client, extensionsClient, appsClient,
-		batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, betaNetworkingClient, apiExtensionsClient, pluginsClient, config}
+		batchClient, betaBatchClient, autoscalingClient, storageClient, rbacClient, networkingClient, apiExtensionsClient, pluginsClient, config}
 }
 
 // Delete deletes the resource of the given kind in the given namespace with the given name.

--- a/src/app/backend/resource/ingress/common.go
+++ b/src/app/backend/resource/ingress/common.go
@@ -16,12 +16,12 @@ package ingress
 
 import (
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 )
 
 // The code below allows to perform complex data section on []extensions.Ingress
 
-type IngressCell v1beta1.Ingress
+type IngressCell v1.Ingress
 
 func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.ComparableValue {
 	switch name {
@@ -37,7 +37,7 @@ func (self IngressCell) GetProperty(name dataselect.PropertyName) dataselect.Com
 	}
 }
 
-func toCells(std []v1beta1.Ingress) []dataselect.DataCell {
+func toCells(std []v1.Ingress) []dataselect.DataCell {
 	cells := make([]dataselect.DataCell, len(std))
 	for i := range std {
 		cells[i] = IngressCell(std[i])
@@ -45,10 +45,10 @@ func toCells(std []v1beta1.Ingress) []dataselect.DataCell {
 	return cells
 }
 
-func fromCells(cells []dataselect.DataCell) []v1beta1.Ingress {
-	std := make([]v1beta1.Ingress, len(cells))
+func fromCells(cells []dataselect.DataCell) []v1.Ingress {
+	std := make([]v1.Ingress, len(cells))
 	for i := range std {
-		std[i] = v1beta1.Ingress(cells[i].(IngressCell))
+		std[i] = v1.Ingress(cells[i].(IngressCell))
 	}
 	return std
 }

--- a/src/app/backend/resource/ingress/detail.go
+++ b/src/app/backend/resource/ingress/detail.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"log"
 
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
 )
@@ -30,10 +30,10 @@ type IngressDetail struct {
 	Ingress `json:",inline"`
 
 	// Spec is the desired state of the Ingress.
-	Spec v1beta1.IngressSpec `json:"spec"`
+	Spec v1.IngressSpec `json:"spec"`
 
 	// Status is the current state of the Ingress.
-	Status v1beta1.IngressStatus `json:"status"`
+	Status v1.IngressStatus `json:"status"`
 
 	// List of non-critical errors, that occurred during resource retrieval.
 	Errors []error `json:"errors"`
@@ -43,7 +43,7 @@ type IngressDetail struct {
 func GetIngressDetail(client client.Interface, namespace, name string) (*IngressDetail, error) {
 	log.Printf("Getting details of %s ingress in %s namespace", name, namespace)
 
-	rawIngress, err := client.NetworkingV1beta1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
+	rawIngress, err := client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
 
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func GetIngressDetail(client client.Interface, namespace, name string) (*Ingress
 	return getIngressDetail(rawIngress), nil
 }
 
-func getIngressDetail(i *v1beta1.Ingress) *IngressDetail {
+func getIngressDetail(i *v1.Ingress) *IngressDetail {
 	return &IngressDetail{
 		Ingress: toIngress(i),
 		Spec:    i.Spec,

--- a/src/app/backend/resource/ingress/list.go
+++ b/src/app/backend/resource/ingress/list.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes/dashboard/src/app/backend/errors"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
 	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	client "k8s.io/client-go/kubernetes"
 )
 
@@ -49,7 +49,7 @@ type IngressList struct {
 // GetIngressList returns all ingresses in the given namespace.
 func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	dsQuery *dataselect.DataSelectQuery) (*IngressList, error) {
-	ingressList, err := client.NetworkingV1beta1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
+	ingressList, err := client.NetworkingV1().Ingresses(namespace.ToRequestParam()).List(context.TODO(), api.ListEverything)
 
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
@@ -59,7 +59,7 @@ func GetIngressList(client client.Interface, namespace *common.NamespaceQuery,
 	return toIngressList(ingressList.Items, nonCriticalErrors, dsQuery), nil
 }
 
-func getEndpoints(ingress *v1beta1.Ingress) []common.Endpoint {
+func getEndpoints(ingress *v1.Ingress) []common.Endpoint {
 	endpoints := make([]common.Endpoint, 0)
 	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
 		for _, status := range ingress.Status.LoadBalancer.Ingress {
@@ -75,7 +75,7 @@ func getEndpoints(ingress *v1beta1.Ingress) []common.Endpoint {
 	return endpoints
 }
 
-func getHosts(ingress *v1beta1.Ingress) []string {
+func getHosts(ingress *v1.Ingress) []string {
 	hosts := make([]string, 0)
 	set := make(map[string]struct{})
 
@@ -90,7 +90,7 @@ func getHosts(ingress *v1beta1.Ingress) []string {
 	return hosts
 }
 
-func toIngress(ingress *v1beta1.Ingress) Ingress {
+func toIngress(ingress *v1.Ingress) Ingress {
 	return Ingress{
 		ObjectMeta: api.NewObjectMeta(ingress.ObjectMeta),
 		TypeMeta:   api.NewTypeMeta(api.ResourceKindIngress),
@@ -99,7 +99,7 @@ func toIngress(ingress *v1beta1.Ingress) Ingress {
 	}
 }
 
-func toIngressList(ingresses []v1beta1.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
+func toIngressList(ingresses []v1.Ingress, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *IngressList {
 	newIngressList := &IngressList{
 		ListMeta: api.ListMeta{TotalItems: len(ingresses)},
 		Items:    make([]Ingress, 0),


### PR DESCRIPTION
The networking.k8s.io/v1 API is stable since k8s v1.19 and should not be available in 1.22 (source: https://github.com/kubernetes/kubernetes/issues/43214 ) , it's now time for our dashboard to move on!

Thsi PR is the same as https://github.com/kubernetes/dashboard/pull/5741 , except it's the right time to merge it now!

It also reverts https://github.com/kubernetes/dashboard/pull/5774, as planned!