### PR TITLE
Improve chart metric calculation to better support wider time windows

### DIFF
--- a/aio/jest.config.js
+++ b/aio/jest.config.js
@@ -14,6 +14,7 @@
 
 const config = {
   rootDir: '../src/app/frontend',
+  coverageDirectory: '../../../coverage',
   preset: "jest-preset-angular/presets/defaults",
   setupFilesAfterEnv: ["<rootDir>/test.base.ts"],
   globals: {

--- a/aio/scripts/pre-commit-i18n.sh
+++ b/aio/scripts/pre-commit-i18n.sh
@@ -25,18 +25,25 @@ MD5_OLD=$(md5sum "${I18N_DIR}/messages.xlf" | cut -c -32)
 MD5_NEW=$(md5sum "${I18N_DIR}/messages.new.xlf" | cut -c -32)
 
 if [ $MD5_OLD != $MD5_NEW ] ; then
+  mv "${I18N_DIR}/messages.xlf" "${I18N_DIR}/messages.old.xlf"
+  mv "${I18N_DIR}/messages.new.xlf" "${I18N_DIR}/messages.xlf"
   "${AIO_DIR}/scripts/xliffmerge.sh"
 
   languages=($(find "${I18N_DIR}"/* -type d -exec basename {} \;))
+  updated=false
   for language in "${languages[@]}"; do
     if ! _=$(git diff --exit-code "${I18N_DIR}/${language}/messages.${language}.xlf"); then
       say "Translation files were updated. Commit them too."
-      mv "${I18N_DIR}/messages.new.xlf" "${I18N_DIR}/messages.xlf"
-      git add i18n
+      updated=true
       break
     fi
   done
+
+  if [ ${updated} == false ]; then
+    mv "${I18N_DIR}/messages.old.xlf" "${I18N_DIR}/messages.xlf"
+  fi
 fi
 
 # Remove extracted file for check
 rm -rf "${I18N_DIR}/messages.new.xlf"
+rm -rf "${I18N_DIR}/messages.old.xlf"

--- a/i18n/de/messages.de.xlf
+++ b/i18n/de/messages.de.xlf
@@ -3164,6 +3164,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>Custom Resource Definitions</target>

--- a/i18n/fr/messages.fr.xlf
+++ b/i18n/fr/messages.fr.xlf
@@ -3168,6 +3168,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>Définitions de ressources personnalisées</target>

--- a/i18n/ja/messages.ja.xlf
+++ b/i18n/ja/messages.ja.xlf
@@ -1768,6 +1768,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>カスタムリソース定義</target>

--- a/i18n/ko/messages.ko.xlf
+++ b/i18n/ko/messages.ko.xlf
@@ -2092,6 +2092,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>사용자 리소스 정의</target>

--- a/i18n/messages.xlf
+++ b/i18n/messages.xlf
@@ -128,13 +128,6 @@
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4580988005648117665" datatype="html">
-        <source>Search</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/chrome/search/template.html</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8047723565849701689" datatype="html">
         <source>Logged in with auth header</source>
         <context-group purpose="location">
@@ -168,6 +161,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/chrome/userpanel/template.html</context>
           <context context-type="linenumber">42,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4580988005648117665" datatype="html">
+        <source>Search</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/chrome/search/template.html</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="686980668228952182" datatype="html">
@@ -1296,43 +1296,11 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="374277779600579508" datatype="html">
-        <source>Resource Limits</source>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6945090506337625182" datatype="html">
-        <source>Resource name</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/resource/cluster/persistentvolume/detail/template.html</context>
-          <context context-type="linenumber">95</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2132886845235480834" datatype="html">
-        <source>Resource type</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
-          <context context-type="linenumber">42</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5607669932062416162" datatype="html">
-        <source>Default</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4575431999029130927" datatype="html">
-        <source>Default request</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4645345687322304891" datatype="html">
@@ -1400,6 +1368,45 @@
           <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="374277779600579508" datatype="html">
+        <source>Resource Limits</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6945090506337625182" datatype="html">
+        <source>Resource name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/resource/cluster/persistentvolume/detail/template.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2132886845235480834" datatype="html">
+        <source>Resource type</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5607669932062416162" datatype="html">
+        <source>Default</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4575431999029130927" datatype="html">
+        <source>Default request</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/limits/template.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8390750136998580263" datatype="html">
         <source>Namespace conflict</source>
         <context-group purpose="location">
@@ -1433,6 +1440,87 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/components/namespace/changedialog/template.html</context>
           <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7785878041239516628" datatype="html">
+        <source>Pods status</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/resource/workloads/deployment/detail/template.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3569677708978335155" datatype="html">
+        <source>Desired: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5103064776441485656" datatype="html">
+        <source>Running: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="858785118348238543" datatype="html">
+        <source>Succeeded: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6239075439253810960" datatype="html">
+        <source>Pending: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1828068287723658160" datatype="html">
+        <source>Failed: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4730472395791216695" datatype="html">
+        <source>Desired</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">88</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2956098160626271284" datatype="html">
+        <source>Running</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2807689216255894412" datatype="html">
+        <source>Succeeded</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4416413576346763682" datatype="html">
+        <source>Pending</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7256395947475975935" datatype="html">
+        <source>Failed</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="218403386307979629" datatype="html">
@@ -1700,87 +1788,6 @@
           <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7785878041239516628" datatype="html">
-        <source>Pods status</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/resource/workloads/deployment/detail/template.html</context>
-          <context context-type="linenumber">119</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3569677708978335155" datatype="html">
-        <source>Desired: </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5103064776441485656" datatype="html">
-        <source>Running: </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="858785118348238543" datatype="html">
-        <source>Succeeded: </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">33</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6239075439253810960" datatype="html">
-        <source>Pending: </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1828068287723658160" datatype="html">
-        <source>Failed: </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4730472395791216695" datatype="html">
-        <source>Desired</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2956098160626271284" datatype="html">
-        <source>Running</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2807689216255894412" datatype="html">
-        <source>Succeeded</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">69</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4416413576346763682" datatype="html">
-        <source>Pending</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7256395947475975935" datatype="html">
-        <source>Failed</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/podstatus/template.html</context>
-          <context context-type="linenumber">82</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="2446117790692479672" datatype="html">
         <source>Resources</source>
         <context-group purpose="location">
@@ -1823,17 +1830,64 @@
           <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8825668517883103754" datatype="html">
-        <source>Cluster Roles</source>
+      <trans-unit id="1161753671258784736" datatype="html">
+        <source>Endpoints</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/clusterrole/template.html</context>
-          <context context-type="linenumber">21</context>
+          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/resource/discovery/ingress/detail/template.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6595420178679632820" datatype="html">
+        <source>Ports (Name, Port, Protocol)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3663367271392398931" datatype="html">
+        <source>unset</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
+          <context context-type="linenumber">51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3971614543116674506" datatype="html">
+        <source>Node</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/pod/template.html</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6423210280939340786" datatype="html">
+        <source>Ready</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/node/template.html</context>
+          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3463375855672784957" datatype="html">
         <source>Cluster Role Bindings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/clusterrolebinding/template.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8825668517883103754" datatype="html">
+        <source>Cluster Roles</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/clusterrole/template.html</context>
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
@@ -1969,6 +2023,17 @@
           <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8137040815577930934" datatype="html">
+        <source>Deployments</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/deployment/template.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
+          <context context-type="linenumber">80</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5729418620241283277" datatype="html">
         <source>Events</source>
         <context-group purpose="location">
@@ -2009,17 +2074,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/event/template.html</context>
           <context context-type="linenumber">94</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8137040815577930934" datatype="html">
-        <source>Deployments</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/deployment/template.html</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
-          <context context-type="linenumber">80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6157826473930539567" datatype="html">
@@ -2094,152 +2148,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
           <context context-type="linenumber">100</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1161753671258784736" datatype="html">
-        <source>Endpoints</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/resource/discovery/ingress/detail/template.html</context>
-          <context context-type="linenumber">48</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6595420178679632820" datatype="html">
-        <source>Ports (Name, Port, Protocol)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3663367271392398931" datatype="html">
-        <source>unset</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3971614543116674506" datatype="html">
-        <source>Node</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
-          <context context-type="linenumber">59</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/pod/template.html</context>
-          <context context-type="linenumber">115</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6423210280939340786" datatype="html">
-        <source>Ready</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/endpoint/cardlist/template.html</context>
-          <context context-type="linenumber">69</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/node/template.html</context>
-          <context context-type="linenumber">80</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7585826646011739428" datatype="html">
-        <source>Edit</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">49</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7022070615528435141" datatype="html">
-        <source>Delete</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">57</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/dialogs/deleteresource/template.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4804785061014590286" datatype="html">
-        <source>Logs</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3796390051357100906" datatype="html">
-        <source>Exec</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7343642247493540451" datatype="html">
-        <source>Trigger</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">31</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1371553127733924023" datatype="html">
-        <source>Scale</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">35</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7425524211157837406" datatype="html">
-        <source>Unpin</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">41</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4475093671158329161" datatype="html">
-        <source>Pin</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">43</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1236604279860679031" datatype="html">
-        <source>Restart</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
-          <context context-type="linenumber">53</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8829497237648100098" datatype="html">
-        <source>Filter</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/filter/template.html</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5382206657406454291" datatype="html">
-        <source>Filter objects by name</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/filter/template.html</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6991803345598959405" datatype="html">
-        <source>There is nothing to display here</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">22</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/zerostate/template.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8830410678905901214" datatype="html">
-        <source>No resources found.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/list/zerostate/template.html</context>
-          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7060498773332878646" datatype="html">
@@ -2376,6 +2284,105 @@
           <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7585826646011739428" datatype="html">
+        <source>Edit</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7022070615528435141" datatype="html">
+        <source>Delete</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/dialogs/deleteresource/template.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4804785061014590286" datatype="html">
+        <source>Logs</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3796390051357100906" datatype="html">
+        <source>Exec</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7343642247493540451" datatype="html">
+        <source>Trigger</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1371553127733924023" datatype="html">
+        <source>Scale</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7425524211157837406" datatype="html">
+        <source>Unpin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4475093671158329161" datatype="html">
+        <source>Pin</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1236604279860679031" datatype="html">
+        <source>Restart</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/column/menu/template.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8829497237648100098" datatype="html">
+        <source>Filter</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/filter/template.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5382206657406454291" datatype="html">
+        <source>Filter objects by name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/filter/template.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6991803345598959405" datatype="html">
+        <source>There is nothing to display here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/zerostate/template.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/zerostate/template.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8830410678905901214" datatype="html">
+        <source>No resources found.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/list/zerostate/template.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8046568214089535613" datatype="html">
         <source>Persistent Volume Claims</source>
         <context-group purpose="location">
@@ -2461,24 +2468,6 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="5014304060513019917" datatype="html">
-        <source>Workload Status</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8503490437651973860" datatype="html">
-        <source>Stateful Sets</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/statefulset/template.html</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
-          <context context-type="linenumber">181</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7143579180750436311" datatype="html">
         <source>Services</source>
         <context-group purpose="location">
@@ -2511,13 +2500,6 @@
           <context context-type="linenumber">112</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="788903633413068121" datatype="html">
-        <source>Service Accounts</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/serviceaccount/template.html</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="960921869392057255" datatype="html">
         <source>Storage Classes</source>
         <context-group purpose="location">
@@ -2541,6 +2523,31 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/storageclass/template.html</context>
           <context context-type="linenumber">64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="788903633413068121" datatype="html">
+        <source>Service Accounts</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/serviceaccount/template.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8503490437651973860" datatype="html">
+        <source>Stateful Sets</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/resourcelist/statefulset/template.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
+          <context context-type="linenumber">181</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5014304060513019917" datatype="html">
+        <source>Workload Status</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/workloadstatus/template.html</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7343483184381401407" datatype="html">
@@ -2931,6 +2938,27 @@
           <context context-type="linenumber">21,25</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9034287169969953424" datatype="html">
+        <source>Trigger a <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="31200575933930123" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> will be triggered.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8425620343514116260" datatype="html">
+        <source> Trigger </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
+          <context context-type="linenumber">26,27</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="6929072613146586031" datatype="html">
         <source>Scale a resource</source>
         <context-group purpose="location">
@@ -2964,27 +2992,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/common/dialogs/scaleresource/template.html</context>
           <context context-type="linenumber">64,65</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="9034287169969953424" datatype="html">
-        <source>Trigger a <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/></source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
-          <context context-type="linenumber">18</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="31200575933930123" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> will be triggered.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8425620343514116260" datatype="html">
-        <source> Trigger </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/common/dialogs/triggerresource/template.html</context>
-          <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7920227693577024356" datatype="html">
@@ -3056,6 +3063,48 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/search/template.html</context>
           <context context-type="linenumber">68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1911298252045423500" datatype="html">
+        <source>Create from input</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1000282742611934867" datatype="html">
+        <source>Create from file</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8451232601628619325" datatype="html">
+        <source>Create from form</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1726363342938046830" datatype="html">
+        <source>About</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4814940703935231049" datatype="html">
+        <source>General-purpose web UI for Kubernetes clusters</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3319732415078214507" datatype="html">
+        <source> Kubernetes Dashboard is made possible by the Dashboard <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#16\uFFFD&quot;"/>community<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#16\uFFFD|\uFFFD/#17\uFFFD]&quot;"/> as an <x id="START_LINK_1" equiv-text="&quot;\uFFFD#17\uFFFD&quot;"/>open source project<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#16\uFFFD|\uFFFD/#17\uFFFD]&quot;"/>. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
+          <context context-type="linenumber">38,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1021548113296205274" datatype="html">
@@ -3133,48 +3182,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/logs/template.html</context>
           <context context-type="linenumber">98,105</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1911298252045423500" datatype="html">
-        <source>Create from input</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1000282742611934867" datatype="html">
-        <source>Create from file</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8451232601628619325" datatype="html">
-        <source>Create from form</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/create/template.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1726363342938046830" datatype="html">
-        <source>About</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
-          <context context-type="linenumber">19</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4814940703935231049" datatype="html">
-        <source>General-purpose web UI for Kubernetes clusters</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
-          <context context-type="linenumber">30</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3319732415078214507" datatype="html">
-        <source> Kubernetes Dashboard is made possible by the Dashboard <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#16\uFFFD&quot;"/>community<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#16\uFFFD|\uFFFD/#17\uFFFD]&quot;"/> as an <x id="START_LINK_1" equiv-text="&quot;\uFFFD#17\uFFFD&quot;"/>open source project<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#16\uFFFD|\uFFFD/#17\uFFFD]&quot;"/>. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/about/template.html</context>
-          <context context-type="linenumber">38,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3207734347890377749" datatype="html">
@@ -3471,38 +3478,6 @@
           <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2634769168106360285" datatype="html">
-        <source>Add Namespace</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8000125105974293495" datatype="html">
-        <source>Provide a namespace name that should be added to the namespace fallback list</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
-          <context context-type="linenumber">23</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4646834153496382565" datatype="html">
-        <source>Add </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
-          <context context-type="linenumber">47,48</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1476552057166072952" datatype="html">
-        <source>Close </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
-          <context context-type="linenumber">52,53</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/editdialog/template.html</context>
-          <context context-type="linenumber">50,51</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1244504753529533521" datatype="html">
         <source>Edit Namespace List</source>
         <context-group purpose="location">
@@ -3524,11 +3499,43 @@
           <context context-type="linenumber">45,46</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1476552057166072952" datatype="html">
+        <source>Close </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
+          <context context-type="linenumber">52,53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/editdialog/template.html</context>
+          <context context-type="linenumber">50,51</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5793766132158032827" datatype="html">
         <source>No namespaces selected</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/settings/global/namespace/editdialog/template.html</context>
           <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2634769168106360285" datatype="html">
+        <source>Add Namespace</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8000125105974293495" datatype="html">
+        <source>Provide a namespace name that should be added to the namespace fallback list</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4646834153496382565" datatype="html">
+        <source>Add </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/settings/global/namespace/adddialog/template.html</context>
+          <context context-type="linenumber">47,48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2417328504220076358" datatype="html">
@@ -4125,6 +4132,17 @@
           <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1138967786822653104" datatype="html">
+        <source>Role Reference</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/resource/cluster/clusterrolebinding/detail/template.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/resource/cluster/rolebinding/detail/template.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="3482104516399089245" datatype="html">
         <source>Active Jobs</source>
         <context-group purpose="location">
@@ -4183,17 +4201,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/frontend/resource/workloads/cronjob/detail/template.html</context>
           <context context-type="linenumber">82</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1138967786822653104" datatype="html">
-        <source>Role Reference</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/resource/cluster/clusterrolebinding/detail/template.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/frontend/resource/cluster/rolebinding/detail/template.html</context>
-          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2397234605876541174" datatype="html">

--- a/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -2085,6 +2085,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>自定义资源的定义</target>

--- a/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -2092,6 +2092,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>自定義資源的定義</target>

--- a/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -2092,6 +2092,14 @@
           <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1788882133182474939" datatype="html">
+        <source> Waiting for more data to display chart... </source>
+        <target state="new"> Waiting for more data to display chart... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/frontend/common/components/graph/template.html</context>
+          <context context-type="linenumber">23,24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1730144297199101193" datatype="html">
         <source>Custom Resource Definitions</source>
         <target>自定義資源的定義</target>

--- a/src/app/frontend/common/components/graph/component.ts
+++ b/src/app/frontend/common/components/graph/component.ts
@@ -30,7 +30,7 @@ enum TimeScale {
   Days,
 }
 
-@Component({selector: 'kd-graph', templateUrl: './template.html'})
+@Component({selector: 'kd-graph', templateUrl: './template.html', styleUrls: ['./style.scss']})
 export class GraphComponent implements OnInit, OnChanges {
   @Input() metric: Metric;
   @Input() id: string;
@@ -41,6 +41,8 @@ export class GraphComponent implements OnInit, OnChanges {
   customColors = {};
   yAxisLabel = '';
   yScaleMax = 0;
+  shouldShowGraph = false;
+
   private suffixMap_: Map<number, string> = new Map<number, string>();
   private yAxisSuffix_ = '';
   private visible_ = false;
@@ -116,6 +118,7 @@ export class GraphComponent implements OnInit, OnChanges {
     this._findTimeScale(points);
 
     points = points.reduce(this._average.bind(this), []);
+    this.shouldShowGraph = points.length >= this.minMetricsCount_;
     points = this._averageWithReduce(points, this.maxMetricsCount_);
 
     const result = [

--- a/src/app/frontend/common/components/graph/component.ts
+++ b/src/app/frontend/common/components/graph/component.ts
@@ -24,6 +24,12 @@ export enum GraphType {
   Memory = 'memory',
 }
 
+enum TimeScale {
+  Minutes,
+  Hours,
+  Days,
+}
+
 @Component({selector: 'kd-graph', templateUrl: './template.html'})
 export class GraphComponent implements OnInit, OnChanges {
   @Input() metric: Metric;
@@ -34,27 +40,30 @@ export class GraphComponent implements OnInit, OnChanges {
   curve = d3.curveMonotoneX;
   customColors = {};
   yAxisLabel = '';
-  yAxisTickFormatting = (value: number) => `${value} ${this.yAxisSuffix_}`;
   yScaleMax = 0;
-
   private suffixMap_: Map<number, string> = new Map<number, string>();
   private yAxisSuffix_ = '';
   private visible_ = false;
+  private minMetricsCount_ = 5;
+  private maxMetricsCount_ = 15;
+  private timeScale_ = TimeScale.Minutes;
+
+  yAxisTickFormatting = (value: number) => `${value} ${this.yAxisSuffix_}`;
 
   ngOnInit(): void {
     if (!this.graphType) {
       throw new Error('Graph type has to be provided.');
     }
 
-    this.series = this.generateSeries_();
-    this.customColors = this.getColor_();
+    this.series = this._generateSeries();
+    this.customColors = this._getColor();
     this.yAxisLabel = this.graphType === GraphType.CPU ? 'CPU (cores)' : 'Memory (bytes)';
   }
 
   ngOnChanges(_: SimpleChanges): void {
     if (this.visible_) {
       this.suffixMap_.clear();
-      this.series = this.generateSeries_();
+      this.series = this._generateSeries();
     }
   }
 
@@ -66,8 +75,8 @@ export class GraphComponent implements OnInit, OnChanges {
     return `${value} ${this.suffixMap_.has(value) ? this.suffixMap_.get(value) : ''}`;
   }
 
-  private generateSeries_(): Array<{name: string; series: Array<{value: number; name: string}>}> {
-    const points: DataPoint[] = [];
+  private _generateSeries(): Array<{name: string; series: Array<{value: number; name: string}>}> {
+    let points: DataPoint[] = [];
     let series: FormattedValue[];
     let highestSuffixPower = 0;
     let highestSuffix = '';
@@ -84,16 +93,13 @@ export class GraphComponent implements OnInit, OnChanges {
         throw new Error(`Unsupported graph type ${this.graphType}.`);
     }
 
-    // Find out the highest suffix
-    series.forEach(value => {
+    // Find out the highest suffix and normalize all values to a single suffix
+    series.map(value => {
       if (highestSuffixPower < value.suffixPower) {
         highestSuffixPower = value.suffixPower;
         highestSuffix = value.suffix;
       }
-    });
 
-    // Normalize all values to a single suffix
-    series.map(value => {
       value.normalize(highestSuffix);
       return value;
     });
@@ -107,16 +113,21 @@ export class GraphComponent implements OnInit, OnChanges {
       } as DataPoint);
     });
 
+    this._findTimeScale(points);
+
+    points = points.reduce(this._average.bind(this), []);
+    points = this._averageWithReduce(points, this.maxMetricsCount_);
+
     const result = [
       {
         name: this.id,
-        series: points.reduce(this._average.bind(this), []).map(point => {
+        series: points.map(point => {
           if (maxValue < point.y) {
             maxValue = point.y;
           }
 
           return {
-            value: point.y,
+            value: Number(point.y.toPrecision(3)),
             name: d3.timeFormat('%H:%M')(new Date(1000 * point.x)),
           };
         }),
@@ -138,32 +149,32 @@ export class GraphComponent implements OnInit, OnChanges {
     return result;
   }
 
-  // Calculate the average usage based on minute intervals. If there are more data points within
-  // a single minute, they will be accumulated and an average will be taken.
+  // Calculate the average usage based on detected time unit intervals. If there are more data points than
+  // max allowed metrics, they will be accumulated and an average will be taken.
   private _average(acc: DataPoint[], point: DataPoint, idx: number, points: DataPoint[]): DataPoint[] {
     if (idx > 0) {
-      const currMinute = this._getMinute(point.x);
-      const lastMinute = this._getMinute(points[idx - 1].x);
+      const currTimeUnit = this._getTimeScale(point.x);
+      const lastTimeUnit = this._getTimeScale(points[idx - 1].x);
 
-      // Minute changed or we are at the end of an array
-      if (currMinute !== lastMinute || idx === points.length - 1) {
+      // Time unit changed or we are at the end of an array
+      if (currTimeUnit !== lastTimeUnit || idx === points.length - 1) {
         let i = idx - 2;
-        // Initialize with last minute
+        // Initialize with last time unit
         const minutes = [points[idx - 1].y];
 
-        // Track back all remaining points for the last minute
-        while (i >= 0 && lastMinute === this._getMinute(points[i].x)) {
+        // Track back all remaining points for the last time unit
+        while (i >= 0 && lastTimeUnit === this._getTimeScale(points[i].x)) {
           minutes.push(points[i].y);
           i--;
         }
 
-        // Calculate an average of this minute values
+        // Calculate an average of this time unit values
         const average = minutes.reduce((a, b) => a + b, 0) / minutes.length;
 
         // Accumulate the result
         return acc.concat({
           x: points[idx - 1].x,
-          y: Number(average.toPrecision(3)),
+          y: average,
         });
       }
     }
@@ -171,11 +182,92 @@ export class GraphComponent implements OnInit, OnChanges {
     return acc;
   }
 
+  // Average with reduce scales the number of provided points to the given limit.
+  private _averageWithReduce(points: DataPoint[], limit: number): DataPoint[] {
+    const result: DataPoint[] = [];
+    const divider = Math.floor(points.length / limit);
+    let reminder = points.length % limit;
+
+    if (divider === 0 || (divider === 1 && reminder === 0)) {
+      return points;
+    }
+
+    for (let i = 0; i < points.length; i += divider) {
+      let sum = 0;
+      let count = 0;
+
+      for (let j = 0; j < divider && i + j < points.length; j++) {
+        sum += points[i + j].y;
+        count++;
+      }
+
+      if (reminder > 0) {
+        sum += points[i + divider].y;
+        i++;
+        count++;
+        reminder--;
+      }
+
+      result.push({
+        x: points[i].x,
+        y: sum / count,
+      } as DataPoint);
+    }
+
+    return result;
+  }
+
+  private _getTimeScale(date: number): number {
+    switch (this.timeScale_) {
+      case TimeScale.Minutes:
+        return this._getMinute(date);
+      case TimeScale.Hours:
+        return this._getHour(date);
+      case TimeScale.Days:
+        return this._getDay(date);
+    }
+  }
+
   private _getMinute(date: number): number {
     return new Date(1000 * date).getMinutes();
   }
 
-  private getColor_(): Array<{name: string; value: string}> {
+  private _getHour(date: number): number {
+    return new Date(1000 * date).getHours();
+  }
+
+  private _getDay(date: number): number {
+    return new Date(1000 * date).getDay();
+  }
+
+  private _findTimeScale(points: DataPoint[]): void {
+    if (points.length < 1) {
+      return;
+    }
+
+    let metricsCount = 1;
+    let lastTimeUnit = this._getTimeScale(points.pop().x);
+
+    points.forEach(point => {
+      const currTimeUnit = this._getTimeScale(point.x);
+      if (lastTimeUnit !== currTimeUnit) {
+        lastTimeUnit = currTimeUnit;
+        metricsCount++;
+      }
+    });
+
+    if (metricsCount <= this.minMetricsCount_ && this.timeScale_ > TimeScale.Minutes) {
+      this.timeScale_--;
+      return;
+    }
+
+    if (metricsCount > this.maxMetricsCount_ && this.timeScale_ < TimeScale.Days) {
+      this.timeScale_++;
+      this._findTimeScale(points);
+    }
+  }
+
+  private _getColor(): Array<{name: string; value: string}> {
     return this.graphType === GraphType.CPU
       ? [
           {

--- a/src/app/frontend/common/components/graph/style.scss
+++ b/src/app/frontend/common/components/graph/style.scss
@@ -1,0 +1,25 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import '../../../variables';
+
+.chart-container {
+  padding: 2 * $baseline-grid;
+}
+
+.empty-chart-text {
+  font-size: $headline-font-size-base;
+  font-weight: $regular-font-weight;
+  margin-bottom: $baseline-grid / 2;
+}

--- a/src/app/frontend/common/components/graph/template.html
+++ b/src/app/frontend/common/components/graph/template.html
@@ -14,23 +14,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<ngx-charts-area-chart fxFlex
-                       inViewport
-                       [inViewportOptions]="{partial: false}"
-                       (inViewportAction)="changeState($event)"
-                       [xAxis]="true"
-                       [yAxis]="true"
-                       [showYAxisLabel]="true"
-                       [yAxisLabel]="yAxisLabel"
-                       [yAxisTickFormatting]="yAxisTickFormatting"
-                       [yScaleMax]="yScaleMax"
-                       [results]="series"
-                       [showGridLines]="true"
-                       [curve]="curve"
-                       [customColors]="customColors"
-                       [gradient]="true">
-  <ng-template #seriesTooltipTemplate
-               let-model="model">
-    <pre>{{model[0].series}}: {{getTooltipValue(model[0].value)}}</pre>
-  </ng-template>
-</ngx-charts-area-chart>
+<ng-template #noData>
+  <div fxLayout="column"
+       class="kd-muted chart-container">
+    <div fxFlexAlign="center"
+         class="empty-chart-text"
+         i18n>
+      Waiting for more data to display chart...
+    </div>
+  </div>
+</ng-template>
+
+<ng-container *ngIf="shouldShowGraph; else noData">
+  <ngx-charts-area-chart fxFlex
+                         inViewport
+                         [inViewportOptions]="{partial: false}"
+                         (inViewportAction)="changeState($event)"
+                         [xAxis]="true"
+                         [yAxis]="true"
+                         [showYAxisLabel]="true"
+                         [yAxisLabel]="yAxisLabel"
+                         [yAxisTickFormatting]="yAxisTickFormatting"
+                         [yScaleMax]="yScaleMax"
+                         [results]="series"
+                         [showGridLines]="true"
+                         [curve]="curve"
+                         [customColors]="customColors"
+                         [gradient]="true">
+    <ng-template #seriesTooltipTemplate
+                 let-model="model">
+      <pre>{{model[0].series}}: {{getTooltipValue(model[0].value)}}</pre>
+    </ng-template>
+  </ngx-charts-area-chart>
+</ng-container>

--- a/src/app/frontend/common/components/graphcard/component.ts
+++ b/src/app/frontend/common/components/graphcard/component.ts
@@ -33,7 +33,8 @@ export class GraphCardComponent implements OnChanges {
   }
 
   private getSelectedMetrics(): Metric {
-    if (!this.selectedMetricName || (this.metrics.length && this.metrics[0].dataPoints.length === 0)) {
+    const minMetricsLength = 5;
+    if (!this.selectedMetricName || (this.metrics.length && this.metrics[0].dataPoints.length < minMetricsLength)) {
       return null;
     }
 

--- a/src/app/frontend/common/components/graphcard/component.ts
+++ b/src/app/frontend/common/components/graphcard/component.ts
@@ -33,8 +33,7 @@ export class GraphCardComponent implements OnChanges {
   }
 
   private getSelectedMetrics(): Metric {
-    const minMetricsLength = 5;
-    if (!this.selectedMetricName || (this.metrics.length && this.metrics[0].dataPoints.length < minMetricsLength)) {
+    if (!this.selectedMetricName || (this.metrics.length && this.metrics[0].dataPoints.length === 0)) {
       return null;
     }
 


### PR DESCRIPTION
Fixes #6109

### Changes
- chart will scale to the specific time unit if at least 5 metrics per time unit will be available (minute, hour, day)
- in case there are more than 15 metrics per time unit, they will be accumulated based on a modified moving average algorithm to always match the limit

Tested the `dashboard-metrics-scraper` with below arguments:
- `metric-duration` set to `48h`
- `metric-resolution` set to `5s`

Result after ~2h (check bigger time differences between data points)
![image](https://user-images.githubusercontent.com/2285385/120513609-bb6a9080-c3cc-11eb-9b5e-e659dd1e5e31.png)

New empty chart message when there are not enough metrics to render them nicely.
![image](https://user-images.githubusercontent.com/2285385/120518080-77c65580-c3d1-11eb-98d6-e80a59a8fb87.png)
