### PR TITLE
ingress ui shows service names and ports again (because of networking.k8s.io/v1)

### DIFF
--- a/src/app/frontend/common/components/ingressrulelist/template.html
+++ b/src/app/frontend/common/components/ingressrulelist/template.html
@@ -62,10 +62,10 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Service Name</mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.path.backend.serviceName">
-            <a [routerLink]="getDetailsHref(ingressRuleFlat.path.backend.serviceName, 'service')"
+          <ng-container *ngIf="ingressRuleFlat.path.backend.service">
+            <a [routerLink]="getDetailsHref(ingressRuleFlat.path.backend.service.name, 'service')"
                queryParamsHandling="preserve">
-              {{ingressRuleFlat.path.backend.serviceName}}
+              {{ingressRuleFlat.path.backend.service.name}}
             </a>
           </ng-container>
           <ng-container *ngIf="ingressRuleFlat.path.backend.resource">
@@ -80,7 +80,8 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Service Port</mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.path.backend.servicePort">{{ingressRuleFlat.path.backend.servicePort}}</ng-container>
+          <ng-container *ngIf="ingressRuleFlat.path.backend.service.port.name">{{ingressRuleFlat.path.backend.service.port.name}}</ng-container>
+          <ng-container *ngIf="ingressRuleFlat.path.backend.service.port.number">{{ingressRuleFlat.path.backend.service.port.number}}</ng-container>
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[5]">

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -61,7 +61,7 @@ class MiniTestComponent {
                   service: {
                     name: 'test',
                     port: {
-                      number: 80
+                      number: 80,
                     }
                   }
                 },
@@ -124,7 +124,7 @@ class MaxiTestComponent {
                   service: {
                     name: 'service1',
                     port: {
-                      number: 80
+                      number: 80,
                     }
                   },
                 },
@@ -143,7 +143,7 @@ class MaxiTestComponent {
                   service: {
                     name: 'service2',
                     port: {
-                      number: 80
+                      number: 80,
                     }
                   },
                 },

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -62,8 +62,8 @@ class MiniTestComponent {
                     name: 'test',
                     port: {
                       number: 80,
-                    }
-                  }
+                    },
+                  },
                 },
               },
             ],
@@ -81,8 +81,8 @@ class MiniTestComponent {
                     name: 'test',
                     port: {
                       name: 'a_port_name',
-                    }
-                  }
+                    },
+                  },
                 },
               },
             ],
@@ -125,7 +125,7 @@ class MaxiTestComponent {
                     name: 'service1',
                     port: {
                       number: 80,
-                    }
+                    },
                   },
                 },
               },
@@ -144,7 +144,7 @@ class MaxiTestComponent {
                     name: 'service2',
                     port: {
                       number: 80,
-                    }
+                    },
                   },
                 },
               },

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -58,8 +58,12 @@ class MiniTestComponent {
                 path: '/testpath',
                 pathType: 'Prefix',
                 backend: {
-                  serviceName: 'test',
-                  servicePort: 80,
+                  service: {
+                    name: 'test',
+                    port: {
+                      number: 80
+                    }
+                  }
                 },
               },
             ],
@@ -73,8 +77,12 @@ class MiniTestComponent {
                 path: '/bar',
                 pathType: 'Prefix',
                 backend: {
-                  serviceName: 'service1',
-                  servicePort: 'a_port_name',
+                  service: {
+                    name: 'test',
+                    port: {
+                      name: 'a_port_name',
+                    }
+                  }
                 },
               },
             ],
@@ -113,8 +121,11 @@ class MaxiTestComponent {
                 path: '/',
                 pathType: 'Prefix',
                 backend: {
-                  serviceName: 'service1',
-                  servicePort: 80,
+                  service: {
+                    name: 'service1',
+                    port: {
+                      number: 80
+                    }
                 },
               },
             ],
@@ -128,8 +139,11 @@ class MaxiTestComponent {
                 path: '/',
                 pathType: 'Prefix',
                 backend: {
-                  serviceName: 'service2',
-                  servicePort: 80,
+                  service: {
+                    name: 'service2',
+                    port: {
+                      number: 80
+                    }
                 },
               },
             ],

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -147,7 +147,7 @@ class MaxiTestComponent {
                     }
                   },
                 },
-            } ,
+              },
             ],
           },
         },

--- a/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
+++ b/src/app/frontend/resource/discovery/ingress/detail/component.spec.ts
@@ -126,6 +126,7 @@ class MaxiTestComponent {
                     port: {
                       number: 80
                     }
+                  },
                 },
               },
             ],
@@ -144,8 +145,9 @@ class MaxiTestComponent {
                     port: {
                       number: 80
                     }
+                  },
                 },
-              },
+            } ,
             ],
           },
         },

--- a/src/app/frontend/resource/discovery/ingress/detail/template.html
+++ b/src/app/frontend/resource/discovery/ingress/detail/template.html
@@ -24,16 +24,17 @@ limitations under the License.
   <div content
        *ngIf="isInitialized"
        fxLayout="row wrap">
-    <kd-property *ngIf="ingress?.spec?.backend?.serviceName">
+    <kd-property *ngIf="ingress?.spec?.backend?.service?.Name">
       <div key
            i18n>Service Name</div>
-      <div value>{{ingress.spec.backend.serviceName}}</div>
+      <div value>{{ingress.spec.backend.service.Name}}</div>
     </kd-property>
 
-    <kd-property *ngIf="ingress?.spec?.backend?.servicePort">
+    <kd-property *ngIf="ingress?.spec?.backend?.service?.port">
       <div key
            i18n>Service Port</div>
-      <div value>{{ingress.spec.backend.servicePort}}</div>
+      <div *ngIf="ingress?.spec?.backend?.service?.port?.name" value>{{ingress.spec.backend.service.port.name}}</div>
+      <div *ngIf="ingress?.spec?.backend?.service?.port?.number" value>{{ingress.spec.backend.service.port.number}}</div>
     </kd-property>
 
     <kd-property *ngIf="ingress?.spec?.backend?.resource?.name">

--- a/src/app/frontend/resource/discovery/ingress/detail/template.html
+++ b/src/app/frontend/resource/discovery/ingress/detail/template.html
@@ -33,8 +33,10 @@ limitations under the License.
     <kd-property *ngIf="ingress?.spec?.backend?.service?.port">
       <div key
            i18n>Service Port</div>
-      <div *ngIf="ingress?.spec?.backend?.service?.port?.name" value>{{ingress.spec.backend.service.port.name}}</div>
-      <div *ngIf="ingress?.spec?.backend?.service?.port?.number" value>{{ingress.spec.backend.service.port.number}}</div>
+      <div *ngIf="ingress?.spec?.backend?.service?.port?.name"
+           value>{{ingress.spec.backend.service.port.name}}</div>
+      <div *ngIf="ingress?.spec?.backend?.service?.port?.number"
+           value>{{ingress.spec.backend.service.port.number}}</div>
     </kd-property>
 
     <kd-property *ngIf="ingress?.spec?.backend?.resource?.name">

--- a/src/app/frontend/typings/root.api.ts
+++ b/src/app/frontend/typings/root.api.ts
@@ -527,9 +527,18 @@ export interface IngressSpecTLS {
 }
 
 export interface IngressBackend {
-  serviceName?: string;
-  servicePort?: string | number;
+  service?: IngressBackendService;
   resource?: ResourceRef;
+}
+
+export interface IngressBackendService {
+  name: string;
+  port: IngressBackendServicePort;
+}
+
+export interface IngressBackendServicePort {
+  name?: string;
+  number?: number;
 }
 
 export interface IngressSpecRule {


### PR DESCRIPTION
This works again on the ingress detail pane:

![image](https://user-images.githubusercontent.com/297498/120704333-d8ff2f00-c48c-11eb-8641-f87f01d54177.png)
