### PR TITLE
Revert "Bump @angular-devkit/build-angular from 12.0.2 to 12.0.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,15 @@
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-12.0.3.tgz",
-      "integrity": "sha512-zSQaWT64Nr+vMNNJ6JRFMA8ryNUhx9/kBUR5/s5HP43Y68nLw6EjdUryE5c8tIem+Pc+TcnHpZb9/q4d5VumCQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-12.0.2.tgz",
+      "integrity": "sha512-s7tAnqT3L+4uMnDHOwx4nncxDjHrmfPGiQFdi2hI2VTbuB7ZUU7LE9M/2O5MWnRcwNKOlE/Ls6tWZRYD2HoBsA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1200.3",
-        "@angular-devkit/build-optimizer": "0.1200.3",
-        "@angular-devkit/build-webpack": "0.1200.3",
-        "@angular-devkit/core": "12.0.3",
+        "@angular-devkit/architect": "0.1200.2",
+        "@angular-devkit/build-optimizer": "0.1200.2",
+        "@angular-devkit/build-webpack": "0.1200.2",
+        "@angular-devkit/core": "12.0.2",
         "@babel/core": "7.14.3",
         "@babel/generator": "7.14.3",
         "@babel/plugin-transform-async-to-generator": "7.13.0",
@@ -33,7 +33,7 @@
         "@babel/template": "7.12.13",
         "@discoveryjs/json-ext": "0.5.2",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "12.0.3",
+        "@ngtools/webpack": "12.0.2",
         "ansi-colors": "4.1.1",
         "babel-loader": "8.2.2",
         "browserslist": "^4.9.1",
@@ -53,7 +53,7 @@
         "karma-source-map-support": "1.4.0",
         "less": "4.1.1",
         "less-loader": "8.1.1",
-        "license-webpack-plugin": "2.3.19",
+        "license-webpack-plugin": "2.3.17",
         "loader-utils": "2.0.0",
         "mini-css-extract-plugin": "1.5.1",
         "minimatch": "3.0.4",
@@ -82,57 +82,17 @@
         "terser-webpack-plugin": "5.1.2",
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
-        "webpack": "5.38.1",
+        "webpack": "5.36.2",
         "webpack-dev-middleware": "4.1.0",
         "webpack-dev-server": "3.11.2",
         "webpack-merge": "5.7.3",
         "webpack-subresource-integrity": "1.5.2"
       },
       "dependencies": {
-        "@angular-devkit/architect": {
-          "version": "0.1200.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1200.3.tgz",
-          "integrity": "sha512-CaqushsPYQ3Us7eBIuZM9/u5H6Rjvm5tUCYS7D5lr5w4QbiwC+6L4dheWEu1PuS2TyyBt6lVwgUNguOmixDb0Q==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "12.0.3",
-            "rxjs": "6.6.7"
-          }
-        },
-        "@angular-devkit/core": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.0.3.tgz",
-          "integrity": "sha512-d6E4ldHzIerzFpXXZkynluIbZZeYD+VteFLBZ77lOXAuUYuuLEiW8h4bpJOqribeJli5c1cJ/yyELYHrbiiLcw==",
-          "dev": true,
-          "requires": {
-            "ajv": "8.2.0",
-            "ajv-formats": "2.0.2",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.7",
-            "source-map": "0.7.3"
-          }
-        },
         "core-js": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.0.tgz",
           "integrity": "sha512-SaMnchL//WwU2Ot1hhkPflE8gzo7uq1FGvUJ8GKmi3TOU7rGTHIU+eir1WGf6qOtTyxdfdcp10yPdGZ59sQ3hw==",
-          "dev": true
-        },
-        "enhanced-resolve": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-          "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "sass": {
@@ -154,92 +114,18 @@
             "neo-async": "^2.6.2"
           }
         },
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "6.12.6",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-              "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-              "dev": true,
-              "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            }
-          }
-        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
-        },
-        "webpack": {
-          "version": "5.38.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.38.1.tgz",
-          "integrity": "sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.0",
-            "@types/estree": "^0.0.47",
-            "@webassemblyjs/ast": "1.11.0",
-            "@webassemblyjs/wasm-edit": "1.11.0",
-            "@webassemblyjs/wasm-parser": "1.11.0",
-            "acorn": "^8.2.1",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.8.0",
-            "es-module-lexer": "^0.4.0",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.4",
-            "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.0.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.1.1",
-            "watchpack": "^2.2.0",
-            "webpack-sources": "^2.3.0"
-          }
-        },
-        "webpack-sources": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
-          "integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
-          "dev": true,
-          "requires": {
-            "source-list-map": "^2.0.1",
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
-          }
         }
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1200.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1200.3.tgz",
-      "integrity": "sha512-GELr5FTkwLJrTuARfTnBn+NkJjGbmbqrm/+znU6QlhyOTSE/PNZed0kiiTP68BQtL4FO5SeTcJ3tdjOW8i3hiw==",
+      "version": "0.1200.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1200.2.tgz",
+      "integrity": "sha512-46z35d4oOHiF7Peiez7DRcsB5dwjnYP3fm6KwVNm/8Zq6nnykxvipywgJB6inkGdcI0j2m8v3+shVAaWvdS93w==",
       "dev": true,
       "requires": {
         "source-map": "0.7.3",
@@ -256,45 +142,13 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1200.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1200.3.tgz",
-      "integrity": "sha512-RVQ9+mBRnxn1si/q2aMzpnXOXMv1a64nNrhNqP4n43jczZW1Cu85TnwYxeTjXnR3I5u+7wtpifqi9H3pLxV7lQ==",
+      "version": "0.1200.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1200.2.tgz",
+      "integrity": "sha512-tqHq2Ld91CQfIJpdsA8b5q6wq4tS3eX5Z1rwzy2j0gJ5s0I/cpklfTXHBh6StSoS9Df4uHl5V2oLRBagky1pDA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1200.3",
+        "@angular-devkit/architect": "0.1200.2",
         "rxjs": "6.6.7"
-      },
-      "dependencies": {
-        "@angular-devkit/architect": {
-          "version": "0.1200.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1200.3.tgz",
-          "integrity": "sha512-CaqushsPYQ3Us7eBIuZM9/u5H6Rjvm5tUCYS7D5lr5w4QbiwC+6L4dheWEu1PuS2TyyBt6lVwgUNguOmixDb0Q==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "12.0.3",
-            "rxjs": "6.6.7"
-          }
-        },
-        "@angular-devkit/core": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.0.3.tgz",
-          "integrity": "sha512-d6E4ldHzIerzFpXXZkynluIbZZeYD+VteFLBZ77lOXAuUYuuLEiW8h4bpJOqribeJli5c1cJ/yyELYHrbiiLcw==",
-          "dev": true,
-          "requires": {
-            "ajv": "8.2.0",
-            "ajv-formats": "2.0.2",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.7",
-            "source-map": "0.7.3"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
       }
     },
     "@angular-devkit/core": {
@@ -2989,9 +2843,9 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.0.3.tgz",
-      "integrity": "sha512-ql2CMgFdOxWLq9uK18ql4JkrO7jJZOYWJzsjE1BY2XBino8UI7T0bVvIIuBu/2U9KMPiWbH+7OwIhnIc+xDJ4A==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.0.2.tgz",
+      "integrity": "sha512-q+AzIMxWb/8jEDhNrKM2THlJrhUCkX18sKBWY+r221uXtt1sz58MdJyE0UTALvOvjHxEF5OvbWpeAbKUOKgVFA==",
       "dev": true,
       "requires": {
         "enhanced-resolve": "5.7.0"
@@ -15745,9 +15599,9 @@
       }
     },
     "license-webpack-plugin": {
-      "version": "2.3.19",
-      "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-2.3.19.tgz",
-      "integrity": "sha512-z/izhwFRYHs1sCrDgrTUsNJpd+Xsd06OcFWSwHz/TiZygm5ucweVZi1Hu14Rf6tOj/XAl1Ebyc7GW6ZyyINyWA==",
+      "version": "2.3.17",
+      "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-2.3.17.tgz",
+      "integrity": "sha512-4jJ5/oIkhylMw2EjXh9sxPP8KC3FYBjTcxOCoTIaC2J/zVbJhfw992UEpSsov8VTt97XtU+xJyE4cJn4gHB2PA==",
       "dev": true,
       "requires": {
         "@types/webpack-sources": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "zone.js": "0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "12.0.3",
+    "@angular-devkit/build-angular": "12.0.2",
     "@angular/cli": "12.0.2",
     "@angular/compiler-cli": "12.0.2",
     "@angular/language-service": "12.0.3",


### PR DESCRIPTION
Reverts kubernetes/dashboard#6130

To restore the CI, revert this.
There seems to be a problem with WebPack 5 support. However, it's unclear which module is the problem.
Updating other angular related modules to 12.0.3 didn't work.

Not only CI, `run start` is failed.

Also, I tried updating webpack related modules like follow, but they also did not work.
@cypress/webpack-preprocessor@5.9.0