### PR TITLE
fix how we display nfs mounts

### DIFF
--- a/src/app/frontend/typings/volume.api.ts
+++ b/src/app/frontend/typings/volume.api.ts
@@ -164,7 +164,7 @@ export class NFSVolumeSource implements IVolumeSource {
   }
 
   get displayName(): string {
-    return `${this.server}/${this.path}`;
+    return `${this.server}:${this.path}`;
   }
 }
 


### PR DESCRIPTION
NFS mounts should be displayed as SERVER:PATH

something like `my.nfs.server.com:/share` We are currently displaying it as `my.nfs.server.com//share` which is awful :)

![image](https://user-images.githubusercontent.com/297498/121260819-37128480-c888-11eb-9208-0bfb56819ed2.png)

