### PR TITLE
Fix deprecated Ingress API version in Helm Chart (#6330)

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 4.5.0
+version: 5.0.0
 appVersion: 2.3.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:
@@ -27,7 +27,7 @@ maintainers:
 - name: desaintmartin
   email: cdesaintmartin@wiremind.fr
 icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
-kubeVersion: ">=1.14.0-0"
+kubeVersion: ">=1.19.0-0"
 dependencies:
 - name: metrics-server
   version: 2.11.1

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -70,6 +70,10 @@ helm install kubernetes-dashboard/kubernetes-dashboard --name my-release -f valu
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
 incompatible breaking change needing manual actions.
 
+### Upgrade from 4.x.x to 5.x.x
+
+- Switch Ingress from networking.k8s.io/v1beta1 to networking.k8s.io/v1. Requires kubernetes >= 1.19.0.
+
 ### Upgrade from 2.x.x to 3.x.x
 
 - Switch Ingress from extensions/v1beta1 to networking.k8s.io/v1beta1. Requires kubernetes >= 1.14.0.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -16,7 +16,7 @@
 {{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $paths := .Values.ingress.paths -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
@@ -51,9 +51,12 @@ spec:
   {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number:  {{ $servicePort }}
   {{- end -}}
   {{- end -}}
   {{- end -}}
@@ -65,9 +68,12 @@ spec:
   {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number:  {{ $servicePort }}
   {{- end -}}
   {{- end -}}
   {{- end -}}


### PR DESCRIPTION
Fixes Kubernetes 1.22 compatibility ([Ingress 1.22 deprecation-guide][1]).

```
Fix deprecated Ingress API version in Helm Chart (#6330)

* Switch Ingress from networking.k8s.io/v1beta1 to networking.k8s.io/v1. 
* Update minimal version requirement of Kubernetes >= 1.19.0. 
```

[1]: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122