### PR TITLE
Fix install-codegen.sh

### DIFF
--- a/aio/scripts/install-codegen.sh
+++ b/aio/scripts/install-codegen.sh
@@ -31,3 +31,4 @@ function install_codegen() {
 }
 
 install_codegen
+go mod tidy


### PR DESCRIPTION
Added `go mod tidy` because `install-codegen.sh` is modifying `go.mod` and `go.sum` and they are needed to clean up.