### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/src/app/backend/cert/ecdsa/creator.go
+++ b/src/app/backend/cert/ecdsa/creator.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net"
@@ -90,10 +89,10 @@ func (self *ecdsaCreator) StoreCertificates(path string, key interface{}, certBy
 	if err != nil {
 		log.Fatalf("[ECDSAManager] Failed to marshal cert/key pair: %v", err)
 	}
-	if err := ioutil.WriteFile(path+string(os.PathSeparator)+self.GetCertFileName(), certPEM, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(path+string(os.PathSeparator)+self.GetCertFileName(), certPEM, os.FileMode(0644)); err != nil {
 		log.Fatalf("[ECDSAManager] Failed to open %s for writing: %s", self.GetCertFileName(), err)
 	}
-	if err := ioutil.WriteFile(path+string(os.PathSeparator)+self.GetKeyFileName(), keyPEM, os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(path+string(os.PathSeparator)+self.GetKeyFileName(), keyPEM, os.FileMode(0600)); err != nil {
 		log.Fatalf("[ECDSAManager] Failed to open %s for writing: %s", self.GetKeyFileName(), err)
 	}
 }

--- a/src/app/backend/handler/filter.go
+++ b/src/app/backend/handler/filter.go
@@ -17,7 +17,7 @@ package handler
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -81,13 +81,13 @@ func formatRequestLog(request *restful.Request) string {
 		uri = request.Request.URL.RequestURI()
 	}
 
-	byteArr, err := ioutil.ReadAll(request.Request.Body)
+	byteArr, err := io.ReadAll(request.Request.Body)
 	if err == nil {
 		content = string(byteArr)
 	}
 
 	// Restore request body so we can read it again in regular request handlers
-	request.Request.Body = ioutil.NopCloser(bytes.NewReader(byteArr))
+	request.Request.Body = io.NopCloser(bytes.NewReader(byteArr))
 
 	// Is DEBUG level logging enabled? Yes?
 	// Great now let's filter out any content from sensitive URLs

--- a/src/app/backend/handler/localehandler.go
+++ b/src/app/backend/handler/localehandler.go
@@ -16,7 +16,6 @@ package handler
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,7 +53,7 @@ func CreateLocaleHandler() *LocaleHandler {
 
 func getSupportedLocales(configFile string) ([]language.Tag, error) {
 	// read config file
-	localesFile, err := ioutil.ReadFile(configFile)
+	localesFile, err := os.ReadFile(configFile)
 	if err != nil {
 		return []language.Tag{}, err
 	}

--- a/src/app/backend/handler/localehandler_test.go
+++ b/src/app/backend/handler/localehandler_test.go
@@ -16,7 +16,6 @@ package handler
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -51,7 +50,7 @@ func TestGetSupportedLocales(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		configFile, err := ioutil.TempFile("", "test-locale-config")
+		configFile, err := os.CreateTemp("", "test-locale-config")
 		if err != nil {
 			t.Fatalf("%s", err)
 		}

--- a/src/app/backend/resource/container/logs.go
+++ b/src/app/backend/resource/container/logs.go
@@ -17,7 +17,6 @@ package container
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"github.com/kubernetes/dashboard/src/app/backend/resource/logs"
 	v1 "k8s.io/api/core/v1"
@@ -104,7 +103,7 @@ func readRawLogs(client kubernetes.Interface, namespace, podID string, logOption
 
 	defer readCloser.Close()
 
-	result, err := ioutil.ReadAll(readCloser)
+	result, err := io.ReadAll(readCloser)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Special notes for reviewers
No breaking changes.