### PR TITLE
Change Command Argument to multiple arguments

### DIFF
--- a/src/app/backend/resource/deployment/deploy.go
+++ b/src/app/backend/resource/deployment/deploy.go
@@ -189,7 +189,7 @@ func DeployApp(spec *AppDeploymentSpec, client client.Interface) error {
 		containerSpec.Command = []string{*spec.ContainerCommand}
 	}
 	if spec.ContainerCommandArgs != nil {
-		containerSpec.Args = []string{*spec.ContainerCommandArgs}
+		containerSpec.Args = strings.Fields(*spec.ContainerCommandArgs)
 	}
 
 	if spec.CpuRequirement != nil {

--- a/src/app/backend/resource/deployment/deploy_test.go
+++ b/src/app/backend/resource/deployment/deploy_test.go
@@ -17,6 +17,7 @@ package deployment
 import (
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	apps "k8s.io/api/apps/v1"
@@ -90,7 +91,7 @@ func TestDeployApp(t *testing.T) {
 
 func TestDeployAppContainerCommands(t *testing.T) {
 	command := "foo-command"
-	commandArgs := "foo-command-args"
+	commandArgs := "foo-command-args1 foo-command-args2"
 	spec := &AppDeploymentSpec{
 		Namespace:            "foo-namespace",
 		Name:                 "foo-name",
@@ -109,9 +110,13 @@ func TestDeployAppContainerCommands(t *testing.T) {
 			command, container.Command)
 	}
 
-	if container.Args[0] != commandArgs {
-		t.Errorf("Expected command args to be %#v but got %#v",
-			commandArgs, container.Args)
+	if container.Args[0] != strings.Fields(commandArgs)[0] {
+		t.Errorf("Expected command args 1st argument to be %#v but got %#v",
+			strings.Fields(commandArgs)[0], container.Args[0])
+	}
+	if container.Args[1] != strings.Fields(commandArgs)[1] {
+		t.Errorf("Expected command args 2nd argument to be %#v but got %#v",
+			strings.Fields(commandArgs)[1], container.Args[1])
 	}
 }
 


### PR DESCRIPTION
Fixes #2569 

file.sh(see next lines) shows how arguments are passed to the pod
#!/bin/bash
while :
do
  echo arg1 = $1 arg2 = $2
  sleep 10
done

In UI create form the following entries are made
Run command: ./file.sh
Run command arguments: argument1 argument2 argument3

### Before change:
POD log shows
arg1 = argument1 argument2 argument3 arg2 =

so all 3 arguments are passed as one argument

Deployment yaml shows(only container part)
    spec:
      containers:
        - name: demo-arg-old
          image: tcnthomas/arguments
          command:
            - ./file.sh
          args:
            - argument1 argument2 argument3

### After change
POD log shows
arg1 = argument1 arg2 = argument2
First 2 arguments are shown as expected.
3rd argument is not shown as it is not part of the script

Deployment yaml shows(only container part)
    spec:
      containers:
        - name: demo-arg-new
          image: tcnthomas/arguments
          command:
            - ./file.sh
          args:
            - argument1
            - argument2
            - argument3