### PR TITLE
Trim space around the token

### DIFF
--- a/src/app/frontend/login/component.ts
+++ b/src/app/frontend/login/component.ts
@@ -133,7 +133,7 @@ export class LoginComponent implements OnInit {
         this.onFileLoad_(event as KdFile);
         break;
       case LoginModes.Token:
-        this.token_ = (event.target as HTMLInputElement).value;
+        this.token_ = (event.target as HTMLInputElement).value.trim();
         break;
       case LoginModes.Basic:
         if ((event.target as HTMLInputElement).id === 'username') {
@@ -147,7 +147,7 @@ export class LoginComponent implements OnInit {
   }
 
   private hasEmptyToken_(): boolean {
-    return this.selectedAuthenticationMode === LoginModes.Token && (!this.token_ || !this.token_.trim());
+    return this.selectedAuthenticationMode === LoginModes.Token && (!this.token_);
   }
 
   private saveLastLoginMode_(): void {

--- a/src/app/frontend/login/component.ts
+++ b/src/app/frontend/login/component.ts
@@ -147,7 +147,7 @@ export class LoginComponent implements OnInit {
   }
 
   private hasEmptyToken_(): boolean {
-    return this.selectedAuthenticationMode === LoginModes.Token && (!this.token_);
+    return this.selectedAuthenticationMode === LoginModes.Token && !this.token_;
   }
 
   private saveLastLoginMode_(): void {


### PR DESCRIPTION
Fixes #6543 
A token is base 64 encoded and should not contains space at start or end.
By trimming spaces the resulting token will be passed to login process
If a token is invalid then a proper message will be issued
  Unauthorized (401): Invalid credentials provided

The current kubernetes login process seems to accept a token starting with
a space and then logs on as an anonymous user.