### PR TITLE
Update method ToEvent to compatible with new event api

### DIFF
--- a/src/app/backend/resource/event/common.go
+++ b/src/app/backend/resource/event/common.go
@@ -16,11 +16,8 @@ package event
 
 import (
 	"context"
+	"time"
 
-	"github.com/kubernetes/dashboard/src/app/backend/api"
-	"github.com/kubernetes/dashboard/src/app/backend/errors"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
-	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -28,6 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubernetes/dashboard/src/app/backend/api"
+	"github.com/kubernetes/dashboard/src/app/backend/errors"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/common"
+	"github.com/kubernetes/dashboard/src/app/backend/resource/dataselect"
 )
 
 // EmptyEventList is a empty list of events.
@@ -169,6 +171,18 @@ func FillEventsType(events []v1.Event) []v1.Event {
 
 // ToEvent converts event api Event to Event model object.
 func ToEvent(event v1.Event) common.Event {
+	firstTimestamp, lastTimestamp := event.FirstTimestamp, event.LastTimestamp
+
+	if !event.EventTime.IsZero() {
+		eventTime := metaV1.NewTime(time.Unix(event.EventTime.Unix(), 0))
+		if event.FirstTimestamp.IsZero() {
+			firstTimestamp = eventTime
+		}
+		if event.LastTimestamp.IsZero() {
+			lastTimestamp = firstTimestamp
+		}
+	}
+
 	result := common.Event{
 		ObjectMeta:         api.NewObjectMeta(event.ObjectMeta),
 		TypeMeta:           api.NewTypeMeta(api.ResourceKindEvent),
@@ -180,8 +194,8 @@ func ToEvent(event v1.Event) common.Event {
 		SubObjectName:      event.InvolvedObject.Name,
 		SubObjectNamespace: event.InvolvedObject.Namespace,
 		Count:              event.Count,
-		FirstSeen:          event.FirstTimestamp,
-		LastSeen:           event.LastTimestamp,
+		FirstSeen:          firstTimestamp,
+		LastSeen:           lastTimestamp,
 		Reason:             event.Reason,
 		Type:               event.Type,
 	}

--- a/src/app/backend/resource/event/common.go
+++ b/src/app/backend/resource/event/common.go
@@ -16,7 +16,6 @@ package event
 
 import (
 	"context"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,15 +171,14 @@ func FillEventsType(events []v1.Event) []v1.Event {
 // ToEvent converts event api Event to Event model object.
 func ToEvent(event v1.Event) common.Event {
 	firstTimestamp, lastTimestamp := event.FirstTimestamp, event.LastTimestamp
+	eventTime := metaV1.NewTime(event.EventTime.Time)
 
-	if !event.EventTime.IsZero() {
-		eventTime := metaV1.NewTime(time.Unix(event.EventTime.Unix(), 0))
-		if event.FirstTimestamp.IsZero() {
-			firstTimestamp = eventTime
-		}
-		if event.LastTimestamp.IsZero() {
-			lastTimestamp = firstTimestamp
-		}
+	if firstTimestamp.IsZero() {
+		firstTimestamp = eventTime
+	}
+
+	if lastTimestamp.IsZero() {
+		lastTimestamp = firstTimestamp
 	}
 
 	result := common.Event{


### PR DESCRIPTION
Fix similar bug like   kubernetes/kubernetes#94019 in 'kubectl printer'.

Because the fields FirstTimestamp&LastTimestamp aren't used in new events api.

Like: 
Fixes for the internal printer are already merged in master:
- lastTimestamp: https://github.com/kubernetes/kubernetes/pull/86557
- firstTimestamp: https://github.com/kubernetes/kubernetes/pull/89999

`firstTimestamp` is present in 1.19 but not to 1.18
`lastTimestamp` is present in both 1.19 and 1.18

`firstTimestamp` 1.18 backport: https://github.com/kubernetes/kubernetes/pull/94252

_Originally posted by @ingvagabund in https://github.com/kubernetes/kubernetes/issues/94019#issuecomment-680838311_
![image](https://user-images.githubusercontent.com/879096/139365455-a663b0f8-81e4-4981-9888-89083b29ce92.png)
![image](https://user-images.githubusercontent.com/879096/139365676-c39f2b42-22b5-46e6-bcab-3ba7df358388.png)
