### PR TITLE
Added seccompProfile to dashboard spec

### DIFF
--- a/aio/deploy/alternative.yaml
+++ b/aio/deploy/alternative.yaml
@@ -174,6 +174,9 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard
           image: kubernetesui/dashboard:v2.4.0

--- a/aio/deploy/head.yaml
+++ b/aio/deploy/head.yaml
@@ -174,6 +174,9 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard-head
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard-head
           image: kubernetesdashboarddev/dashboard:head

--- a/aio/deploy/recommended.yaml
+++ b/aio/deploy/recommended.yaml
@@ -185,6 +185,9 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubernetes-dashboard
           image: kubernetesui/dashboard:v2.4.0


### PR DESCRIPTION
- This PR adds the `securityContext` block to kubernetes-dashboard spec in recommended.yaml
- Fixes issue [https://github.com/kubernetes/website/issues/29917](https://github.com/kubernetes/website/issues/29917)
- currently we get an error : `error: error validating "https://raw.githubusercontent.com/kubernetes/dashboard/v2.4.0/aio/deploy/recommended.yaml": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "seccompProfile" in io.k8s.api.core.v1.PodSecurityContext; if you choose to ignore these errors, turn validation off with --validate=false` 

when running commands from website: `kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.4.0/aio/deploy/recommended.yaml`
