### PR TITLE
Fix air config

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -15,7 +15,6 @@ tmp_dir = ".tmp"
   include_ext = ["go"]
   kill_delay = "1s"
   log = "build-errors.log"
-  send_interrupt = true
   stop_on_error = true
 
 [color]


### PR DESCRIPTION
Since backend process does not treat SIGINT, removed `send_interrupt` config from `./.air.toml`.
Otherwise backend process remains as zombie.

It results the backend process does not stop by `Ctrl+C`.