### PR TITLE
remove duplicate metadata.annotation key from psp template in helm chart

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 5.0.5
+version: 5.0.6
 appVersion: 2.4.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/psp.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/psp.yaml
@@ -23,11 +23,10 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   privileged: false
   fsGroup:


### PR DESCRIPTION
In v5.0.5 of the helm chart included in this repository, the template for the podsecuritypolicy yaml template contains the `metadata.annotation` key two times, which leads to errors when trying to parse the yaml with some tools, e.g. flux2's helm-controller.

This commit will deduplicate the yaml key which should make it parseable again.