### PR TITLE
Fix development container

### DIFF
--- a/aio/develop/npm-command.sh
+++ b/aio/develop/npm-command.sh
@@ -39,8 +39,8 @@ else
     sudo chown ${LOCAL_UID}:${LOCAL_GID} /tmp/kind.kubeconfig
     # Edit kubeconfig for kind
     KIND_CONTAINER_NAME="k8s-cluster-ci-control-plane"
-    KIND_ADDR=$(sudo docker inspect -f='{{.NetworkSettings.IPAddress}}' ${KIND_CONTAINER_NAME})
-    sed -e "s/localhost:[0-9]\+/${KIND_ADDR}:6443/g" /tmp/kind.kubeconfig > ~/.kube/config
+    KIND_ADDR=$(sudo docker inspect -f='{{.NetworkSettings.Networks.kind.IPAddress}}' ${KIND_CONTAINER_NAME})
+    sed -e "s/127.0.0.1:[0-9]\+/${KIND_ADDR}:6443/g" /tmp/kind.kubeconfig > ~/.kube/config
     # Deploy recommended.yaml to deploy dashboard-metrics-scraper sidecar
     echo "Deploy dashboard-metrics-scraper into kind cluster"
     kubectl apply -f aio/deploy/recommended.yaml
@@ -50,10 +50,16 @@ else
     kill ${KUBECTL_PID}
     nohup kubectl proxy --address 127.0.0.1 --port 8000 >/tmp/kubeproxy.log 2>&1 &
     export K8S_DASHBOARD_SIDECAR_HOST="http://localhost:8000/api/v1/namespaces/kubernetes-dashboard/services/dashboard-metrics-scraper:/proxy/"
+    # Inform how to get token for logging in to dashboard
+    echo "HOW TO GET TOKEN FOR LOGGING INTO DASHBOARD"
+    echo "1. Run terminal for dashboard container."
+    echo "  docker exec -it k8s-dashboard-dev gosu user bash"
+    echo "2. Run following to get token for logging into dashboard."
+    echo "  kubectl -n kubernetes-dashboard get secrets \$(kubectl -n kubernetes-dashboard get sa kubernetes-dashboard -ojsonpath=\"{.secrets[0].name}\") -ojsonpath=\"{.data.token}\" | echo \"\$(base64 -d)\""
   fi
   # Start dashboard.
-  echo "Start dashboard"
-  npm start \
+  echo "Start dashboard in production mode"
+  npm run start:prod \
     --bind_address=${K8S_DASHBOARD_BIND_ADDRESS} \
     --sidecar_host=${K8S_DASHBOARD_SIDECAR_HOST} \
     --port=${K8S_DASHBOARD_PORT}

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -147,9 +147,8 @@ At first, change directory to kubernetes dashboard repository of your fork.
 
 ### Allow accessing dashboard from outside the container
 
-Development container runs Kubernetes Dashboard in insecure mode by default,
-but Kubernetes Dashboard is not exposed to outside the container in insecure
-mode by default.
+Development container builds Kubernetes Dashboard and runs it with self-certificates by default,
+but Kubernetes Dashboard is not exposed to outside the container with insecure certificates by default.
 
 To allow accessing dashboard from outside the development container,
 pass value for `--insecure-bind-address` option to dashboard as follows:
@@ -166,7 +165,7 @@ As default, development container uses `8080` port to expose dashboard. If you n
 1. Run `aio/develop/run-npm-on-container.sh`.
 
 That's all. It will build dashboard container from your local repository, will create also kubernetes cluster container for your dashboard using [`kind`](https://github.com/kubernetes-sigs/kind), and will run dashboard.
-Then you can see dashboard `http://localhost:8080` with your browser.
+Then you can see dashboard `http://localhost:8080` with your browser. Since dashboard uses self-certificates, so you need ignore warning or error about it in your browser.
 
 ### To run with your another Kubernetes cluster
 
@@ -186,7 +185,7 @@ e.g.
 1. To test dashboard, run `aio/develop/run-npm-on-container.sh run test`.
 2. To check your code changes, run `aio/develop/run-npm-on-container.sh run check`.
 
-This container create `user` with `UID` and `GID` same as local user, switch user to `user` with `gosu` and run commands. So created or updated files like results of `npm run fix` or `npm run build` would have same ownership as your host. You can commit them immediately from your host.
+This container create `user` with `UID` and `GID` same as local user, switch user to `user` with `gosu` and run commands. So created or updated files like results of `npm run fix` or `npm run check` would have same ownership as your host. You can commit them immediately from your host.
 
 ### To run container without creating cluster and running dashboard
 


### PR DESCRIPTION
* Use specified docker network, due to latest `kind` uses it.
* Change default running mode to `npm run start:prod`, because almost initial user
  for this development container is assumed to try dashboard or to translate dashboard.