### PR TITLE
Fix seccomp error on helmchart deployment

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -56,10 +56,6 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-{{- with .Values.securityContext }}
-      securityContext:
-{{ toYaml . | nindent 8 }}
-{{- end }}
       serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}


### PR DESCRIPTION
This PR faces the following issue:
- #6685 

It removes the securityContext templating implementation in the `deployment.yaml` at a place where it shouldn't belong.
Please checkout the issue and let me know if this PR works for you. I tested it locally and it works now and the replicaset can be created.

Signed-off-by: Jan Lauber <jan.lauber@protonmail.ch>