### PR TITLE
Change containerSecurityContext rendering and add docs

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 5.1.0
+version: 5.1.1
 appVersion: 2.4.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -143,9 +143,13 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume
-{{- with .Values.metricsScraper.containerSecurityContext }}
+
+{{- if .Values.metricsScraper.containerSecurityContext }}
         securityContext:
-{{ toYaml . | nindent 10 }}
+{{ toYaml .Values.metricsScraper.containerSecurityContext | nindent 10 }}
+{{- else if .Values.containerSecurityContext}}
+        securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 10 }}
 {{- end }}
 {{- with .Values.metricsScraper.resources }}
         resources:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -71,6 +71,7 @@ extraVolumeMounts: []
 # podAnnotations:
 
 # SecurityContext to be added to kubernetes dashboard pods
+# To disable set `securityContext: null`
 securityContext:
   seccompProfile:
     type: RuntimeDefault

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -70,11 +70,21 @@ extraVolumeMounts: []
 ## Annotations to be added to kubernetes dashboard pods
 # podAnnotations:
 
-# SecurityContext to be added to kubernetes dashboard pods
-# To disable set `securityContext: null`
+## SecurityContext to be added to kubernetes dashboard pods
+## To disable set the following configuration to null:
+# securityContext: null
 securityContext:
   seccompProfile:
     type: RuntimeDefault
+
+## SecurityContext defaults for the kubernetes dashboard container and metrics scraper container
+## To disable set the following configuration to null:
+# containerSecurityContext: null
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1001
+  runAsGroup: 2001
 
 ## @param podLabels Extra labels for OAuth2 Proxy pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -237,12 +247,13 @@ metricsScraper:
     repository: kubernetesui/metrics-scraper
     tag: v1.0.7
   resources: {}
-  ## SecurityContext for the kubernetes dashboard metrics scraper container
-  containerSecurityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsUser: 1001
-    runAsGroup: 2001
+  ## SecurityContext especially for the kubernetes dashboard metrics scraper container
+  ## If not set, the global containterSecurityContext values will define these values
+  # containerSecurityContext:
+  #   allowPrivilegeEscalation: false
+  #   readOnlyRootFilesystem: true
+  #   runAsUser: 1001
+  #   runAsGroup: 2001
 #  args:
 #    - --log-level=info
 #    - --logtostderr=true
@@ -309,13 +320,6 @@ podDisruptionBudget:
 # securityContext:
 #   runAsUser: 1001
 #   runAsGroup: 2001
-
-## SecurityContext for the kubernetes dashboard container
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  runAsUser: 1001
-  runAsGroup: 2001
 
 networkPolicy:
   # Whether to create a network policy that allows/restricts access to the service


### PR DESCRIPTION
Facing the discussion of: 
- #6686 
- #6685 

It adds the functionality of adding `securityContext: null` to your custom values.yaml in case of deploying the dashboard deployment without the securityContext inside your cluster. 
When this line is not added to your custom values.yaml file it will render the securityContext values as defined in the default values.yaml file.

Signed-off-by: Jan Lauber <jan.lauber@protonmail.ch>