### PR TITLE
Bump helm chart version from 5.1.1 to 5.1.2

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 5.1.1
+version: 5.1.2
 appVersion: 2.4.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:


### PR DESCRIPTION
Because the helm GitHub action is failing, the helm chart version needs a bump:
```
 ✖︎ kubernetes-dashboard => (version: "5.1.1", path: "aio/deploy/helm-chart/kubernetes-dashboard") > Chart version not ok. Needs a version bump!
```

Failing Github action: https://github.com/kubernetes/dashboard/runs/4814593019?check_suite_focus=true

Signed-off-by: Jan Lauber <jan.lauber@protonmail.ch>