### PR TITLE
Support npm v7 and nodejs v14 for backward compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,8 +157,8 @@
     "webpack-dev-server": "4.4.0"
   },
   "engines": {
-    "node": ">=16.13.0 <17",
-    "npm": ">=8.1.0 <9"
+    "node": ">=14.18.3 <17",
+    "npm": ">=7.21.0 <9"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
This backward compatibility is for dependabot.
Dashboard may not work in nodejs v14.