### PR TITLE
Fix an issue with CRD retrieval

### DIFF
--- a/src/app/backend/resource/customresourcedefinition/v1/list.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/list.go
@@ -47,11 +47,21 @@ func toCustomResourceDefinitionList(crds []apiextensionsv1.CustomResourceDefinit
 		Errors:   nonCriticalErrors,
 	}
 
+	for i, crd := range crds {
+		crds[i] = removeNonServedVersions(crd)
+	}
+
 	crdCells, filteredTotal := dataselect.GenericDataSelectWithFilter(toCells(crds), dsQuery)
 	crds = fromCells(crdCells)
 	crdList.ListMeta = api.ListMeta{TotalItems: filteredTotal}
 
 	for _, crd := range crds {
+		if !isServed(crd) {
+			filteredTotal--
+			crdList.ListMeta = api.ListMeta{TotalItems: filteredTotal}
+			continue
+		}
+
 		crdList.Items = append(crdList.Items, toCustomResourceDefinition(&crd))
 	}
 

--- a/src/app/backend/resource/customresourcedefinition/v1/list_test.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/list_test.go
@@ -47,7 +47,8 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 							},
 							Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 								{
-									Name: "v1alpha1",
+									Served: true,
+									Name:   "v1alpha1",
 								},
 							},
 						},

--- a/src/app/backend/resource/customresourcedefinition/v1/objects.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/objects.go
@@ -38,7 +38,7 @@ func GetCustomResourceObjectList(client apiextensionsclientset.Interface, config
 
 	customResourceDefinition, err := client.ApiextensionsV1().
 		CustomResourceDefinitions().
-		Get(context.TODO(), crdName, metav1.GetOptions{ResourceVersion: "0"})
+		Get(context.TODO(), crdName, metav1.GetOptions{})
 	nonCriticalErrors, criticalError := errors.HandleError(err)
 	if criticalError != nil {
 		return nil, criticalError

--- a/src/app/frontend/common/errors/errors.ts
+++ b/src/app/frontend/common/errors/errors.ts
@@ -27,6 +27,7 @@ export enum ErrorStatus {
   internal = 'Internal error',
   unknown = 'Unknown error',
   badRequest = 'Bad Request',
+  notFound = 'Not Found',
 }
 
 export enum ErrorCode {
@@ -34,6 +35,7 @@ export enum ErrorCode {
   forbidden = 403,
   internal = 500,
   badRequest = 400,
+  notFound = 404,
 }
 
 const localizedErrors: {[key: string]: string} = {
@@ -114,6 +116,9 @@ export function AsKdError(error: HttpErrorResponse): KdError {
       break;
     case ErrorCode.internal:
       status = ErrorStatus.internal;
+      break;
+    case ErrorCode.notFound:
+      status = ErrorStatus.notFound;
       break;
     default:
       status = ErrorStatus.unknown;


### PR DESCRIPTION
### Issue
Fixes #6632

### Explanation
Apparently, the k8s API regardless of what is being written in the code documentation doesn't really sort the returned versions.
![image](https://user-images.githubusercontent.com/2285385/151355905-0da44973-abf0-4fa1-9b75-73a295e50c80.png)

Let's consider this simple YAML
```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  # name must match the spec fields below, and be in the form: <plural>.<group>
  name: crontabs.stable.example.com
spec:
  # group name to use for REST API: /apis/<group>/<version>
  group: stable.example.com
  # list of versions supported by this CustomResourceDefinition
  versions:
    - name: v1alpha1
      served: false
      storage: false
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                cronSpec:
                  type: string
                image:
                  type: string
                replicas:
                  type: integer
    - name: v1
      # Each version can be enabled/disabled by Served flag.
      served: true
      # One and only one version must be marked as the storage version.
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                cronSpec:
                  type: string
                image:
                  type: string
                replicas:
                  type: integer
  # either Namespaced or Cluster
  scope: Namespaced
  names:
    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
    plural: crontabs
    # singular name to be used as an alias on the CLI and for display
    singular: crontab
    # kind is normally the CamelCased singular type. Your resource manifests use this.
    kind: CronTab
    # shortNames allow shorter string to match your resource on the CLI
    shortNames:
    - ct
```

`v1alpha1` is being listed first and it has `served: false`. `v1` version is listed second and has `served: true`. Even though the `spec.versions` should list versions as `[v1, v1alpha1]` it does not. I have added some checks to not fall into this trap :slightly_smiling_face: 

Right now if all versions will be disabled from being served below error will be shown.
![no-served-versions](https://user-images.githubusercontent.com/2285385/151356804-866ced2b-9b99-4732-a873-09ff0e60853c.png)

A list of pinned resources will not be modified and it still might result in a leftover CRD that is not accessible. We might think about a feature that would periodically scan and check if those resources are still accessible.
