### PR TITLE
Fixed indent of selector.matchLabels in serviceMonitor

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 5.1.1
+version: 5.1.2
 appVersion: 2.4.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
@@ -37,5 +37,5 @@ spec:
       path: /metrics
   selector:
     matchLabels:
-      {{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+      {{ include "kubernetes-dashboard.labels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
An error occurs when activating serviceMonitor as shown below.

```yaml
serviceMonitor:
  enabled: true
```

```bash
$ helm -n rdbox-systems install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard -f values_for_k8s-dashboard.yaml
Error: INSTALLATION FAILED: YAML parse error on kubernetes-dashboard/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 25: did not find expected key
```
The reason why this error occurs is that the number of indentations in selector.matchLabels is not specified correctly.
I have corrected this number in my PR. Please take care of it.
