### PR TITLE
Fix bug in multiple removal from crd versions list

### DIFF
--- a/src/app/backend/resource/customresourcedefinition/v1/common.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/common.go
@@ -122,18 +122,14 @@ func isServed(crd apiextensions.CustomResourceDefinition) bool {
 }
 
 func removeNonServedVersions(crd apiextensions.CustomResourceDefinition) apiextensions.CustomResourceDefinition {
-	versions := append(crd.Spec.Versions)
-	if len(versions) == 1 && !versions[0].Served {
-		versions = make([]apiextensions.CustomResourceDefinitionVersion, 0)
-	} else {
-		for i := 0; i < len(versions); i++ {
-			if !versions[i].Served {
-				versions = append(versions[:i], versions[i+1:]...)
-				i--
-			}
+	versions := make([]apiextensions.CustomResourceDefinitionVersion, 0)
+
+	for _, version := range crd.Spec.Versions {
+		if version.Served {
+			versions = append(versions, version)
 		}
 	}
-	
+
 	crd.Spec.Versions = versions
 	return crd
 }

--- a/src/app/backend/resource/customresourcedefinition/v1/common.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/common.go
@@ -123,17 +123,17 @@ func isServed(crd apiextensions.CustomResourceDefinition) bool {
 
 func removeNonServedVersions(crd apiextensions.CustomResourceDefinition) apiextensions.CustomResourceDefinition {
 	versions := append(crd.Spec.Versions)
-	for i, version := range crd.Spec.Versions {
-		if len(versions) == 1 && !version.Served {
-			versions = make([]apiextensions.CustomResourceDefinitionVersion, 0)
-			break
-		}
-
-		if !version.Served {
-			versions = append(versions[:i], versions[i+1:]...)
+	if len(versions) == 1 && !versions[0].Served {
+		versions = make([]apiextensions.CustomResourceDefinitionVersion, 0)
+	} else {
+		for i := 0; i < len(versions); i++ {
+			if !version.Served {
+				versions = append(versions[:i], versions[i+1:]...)
+				i--
+			}
 		}
 	}
-
+	
 	crd.Spec.Versions = versions
 	return crd
 }

--- a/src/app/backend/resource/customresourcedefinition/v1/common.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/common.go
@@ -127,7 +127,7 @@ func removeNonServedVersions(crd apiextensions.CustomResourceDefinition) apiexte
 		versions = make([]apiextensions.CustomResourceDefinitionVersion, 0)
 	} else {
 		for i := 0; i < len(versions); i++ {
-			if !version.Served {
+			if !versions[i].Served {
 				versions = append(versions[:i], versions[i+1:]...)
 				i--
 			}

--- a/src/app/backend/resource/customresourcedefinition/v1/list_test.go
+++ b/src/app/backend/resource/customresourcedefinition/v1/list_test.go
@@ -67,6 +67,51 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 				},
 				Errors: []error{},
 			},
+		}, {
+			[]string{"list"},
+			&apiextensionsv1.CustomResourceDefinitionList{
+				Items: []apiextensionsv1.CustomResourceDefinition{
+					{
+						ObjectMeta: metaV1.ObjectMeta{Name: "foos.samplecontroller.k8s.io"},
+						Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+							Names: apiextensionsv1.CustomResourceDefinitionNames{
+								Kind:   "Foo",
+								Plural: "foos",
+							},
+							Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+								{
+									Served: true,
+									Name:   "v1alpha1",
+								},
+								{
+									Served: false,
+									Name:   "v1beta1",
+								},
+								{
+									Served: true,
+									Name:   "v1gamma1",
+								},
+								{
+									Served: false,
+									Name:   "v1zeta1",
+								},
+							},
+						},
+					},
+				},
+			},
+			&types.CustomResourceDefinitionList{
+				ListMeta: api.ListMeta{TotalItems: 1},
+				Items: []types.CustomResourceDefinition{
+					{
+						ObjectMeta:  api.ObjectMeta{Name: "foos.samplecontroller.k8s.io"},
+						TypeMeta:    api.TypeMeta{Kind: api.ResourceKindCustomResourceDefinition},
+						Version:     "v1alpha1",
+						Established: apiextensions.ConditionUnknown,
+					},
+				},
+				Errors: []error{},
+			},
 		},
 	}
 


### PR DESCRIPTION
If there are multiple served = false in the crd versions list, the original logic will break since the it will result in out of bond error.

Using the basic for loop to check if the Served field is false, if so, remove it from the version list, and shrink the size of list by 1 to avoid out of bond error.