### PR TITLE
Deploy dashboard using docker out of K8s cluster.

### DIFF
--- a/aio/deploy/docker/README.md
+++ b/aio/deploy/docker/README.md
@@ -1,0 +1,48 @@
+# Docker for Dashboard
+
+This document describes how to run Dashboard out of your kubernetes cluster by useing Docker.  It is simple and  intuitively clear for beginer.
+
+## Docker images
+
+Visit [Docker Hub](https://hub.docker.com/r/kubernetesui/dashboard) to see all available images and tags.
+
+## Usage
+
+Firstly, You can get the *kubeconfig* file in $HOME/.kube directory of your node.
+
+### `docker run`
+
+Then run the following command to start a container:
+```sh
+sh aio/deploy/docker/deploy_container.sh
+```
+
+Now you can visit the dashboard by url: https://<your_ip>:8443 .
+
+###  `docker-compose`
+
+And you can also deploy it using Docker Compose. 
+
+```sh
+version: "3"
+services:
+  dashboard:
+    restart: always
+    image: kubernetesui/dashboard:latest
+    volumes:
+      - ~/.kube/config:/home/user/.kube/config
+    ports:
+      - 8080:9090
+      - 8443:8443
+    environment:
+      - K8S_DASHBOARD_KUBECONFIG=/home/user/.kube/config
+      - K8S_OWN_CLUSTER=false
+    entrypoint:
+      - /dashboard
+      - --insecure-bind-address=0.0.0.0
+      - --bind-address=0.0.0.0
+      - --kubeconfig=/home/user/.kube/config
+      - --enable-insecure-login=false
+      - --auto-generate-certificates
+      - --enable-skip-login=false
+```

--- a/aio/deploy/docker/deploy_container.sh
+++ b/aio/deploy/docker/deploy_container.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker run \
+    -d --restart=always \
+    -v "${HOME}/.kube/config":"/home/user/.kube/config" \
+    -p 8080:9090 \
+    -p 8443:8443 \
+    -e K8S_DASHBOARD_KUBECONFIG=/home/user/.kube/config \
+    -e K8S_OWN_CLUSTER=false  \
+    --name dashboard kubernetesui/dashboard:latest /dashboard --insecure-bind-address=0.0.0.0 --bind-address=0.0.0.0 --kubeconfig=/home/user/.kube/config --enable-insecure-login=false --auto-generate-certificates --enable-skip-login=false


### PR DESCRIPTION
As title, let people deploy dashboard using docker out of K8s cluster. Everyone can execute it very fast in this way even they are not familiar with K8s.