### PR TITLE
fail to scrape metrics when use https

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 5.3.0
+version: 5.3.1
 appVersion: 2.5.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
@@ -33,6 +33,9 @@ spec:
     - port: http
     {{- else }}
     - port: https
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
     {{- end }}
       path: /metrics
   selector:


### PR DESCRIPTION
If `https` is used, the service monitor is not properly configured to scrape metrics.