### PR TITLE
Add secure domains args

### DIFF
--- a/src/app/backend/args/builder.go
+++ b/src/app/backend/args/builder.go
@@ -162,6 +162,12 @@ func (self *holderBuilder) SetNamespace(namespace string) *holderBuilder {
 	return self
 }
 
+// SetSecureDomains 'secure-domains' argument of Dashboard binary.
+func (self *holderBuilder) SetSecureDomains(secureDomains []string) *holderBuilder {
+	self.holder.secureDomains = secureDomains
+	return self
+}
+
 // SetLocaleConfig 'locale-config' argument of Dashboard binary.
 func (self *holderBuilder) SetLocaleConfig(localeConfig string) *holderBuilder {
 	self.holder.localeConfig = localeConfig

--- a/src/app/backend/args/holder.go
+++ b/src/app/backend/args/holder.go
@@ -47,6 +47,7 @@ type holder struct {
 	namespace            string
 
 	authenticationMode []string
+	secureDomains      []string
 
 	autoGenerateCertificates  bool
 	enableInsecureLogin       bool
@@ -153,6 +154,11 @@ func (self *holder) GetAPILogLevel() string {
 // GetAuthenticationMode 'authentication-mode' argument of Dashboard binary.
 func (self *holder) GetAuthenticationMode() []string {
 	return self.authenticationMode
+}
+
+// GetSecureDomains 'secure-domains' argument of Dashboard binary.
+func (self *holder) GetSecureDomains() []string {
+	return self.secureDomains
 }
 
 // GetAutoGenerateCertificates 'auto-generate-certificates' argument of Dashboard binary.

--- a/src/app/backend/auth/api/types.go
+++ b/src/app/backend/auth/api/types.go
@@ -89,6 +89,8 @@ type AuthManager interface {
 	AuthenticationModes() []AuthenticationMode
 	// AuthenticationSkippable tells if the Skip button should be enabled or not
 	AuthenticationSkippable() bool
+	// SecureDomains returns array of domain that allowed to login.
+	SecureDomains() []string
 }
 
 // TokenManager is responsible for generating and decrypting tokens used for authorization. Authorization is handled
@@ -155,4 +157,9 @@ type LoginModesResponse struct {
 // Note that this only hides the button, it doesn't disable unauthenticated access.
 type LoginSkippableResponse struct {
 	Skippable bool `json:"skippable"`
+}
+
+// SecureDomainsResponse contains list of domain that allowed to login with insecure HTTP
+type SecureDomainsResponse struct {
+	SecureDomains []string `json:"secureDomains"`
 }

--- a/src/app/backend/auth/handler.go
+++ b/src/app/backend/auth/handler.go
@@ -54,6 +54,10 @@ func (self AuthHandler) Install(ws *restful.WebService) {
 		ws.GET("/login/skippable").
 			To(self.handleLoginSkippable).
 			Writes(authApi.LoginSkippableResponse{}))
+	ws.Route(
+		ws.GET("/securedomains").
+			To(self.handleSecureDomains).
+			Writes([]string{}))
 }
 
 func (self AuthHandler) handleLogin(request *restful.Request, response *restful.Response) {
@@ -105,6 +109,10 @@ func (self *AuthHandler) handleLoginModes(request *restful.Request, response *re
 
 func (self *AuthHandler) handleLoginSkippable(request *restful.Request, response *restful.Response) {
 	response.WriteHeaderAndEntity(http.StatusOK, authApi.LoginSkippableResponse{Skippable: self.manager.AuthenticationSkippable()})
+}
+
+func (self *AuthHandler) handleSecureDomains(request *restful.Request, response *restful.Response) {
+	response.WriteHeaderAndEntity(http.StatusOK, authApi.SecureDomainsResponse{SecureDomains: self.manager.SecureDomains()})
 }
 
 // NewAuthHandler created AuthHandler instance.

--- a/src/app/backend/auth/manager.go
+++ b/src/app/backend/auth/manager.go
@@ -28,6 +28,7 @@ type authManager struct {
 	clientManager           clientapi.ClientManager
 	authenticationModes     authApi.AuthenticationModes
 	authenticationSkippable bool
+	secureDomains           []string
 }
 
 // Login implements auth manager. See AuthManager interface for more information.
@@ -65,6 +66,10 @@ func (self authManager) AuthenticationModes() []authApi.AuthenticationMode {
 	return self.authenticationModes.Array()
 }
 
+func (self authManager) SecureDomains() []string {
+	return self.secureDomains
+}
+
 func (self authManager) AuthenticationSkippable() bool {
 	return self.authenticationSkippable
 }
@@ -95,11 +100,12 @@ func (self authManager) healthCheck(authInfo api.AuthInfo) (string, error) {
 
 // NewAuthManager creates auth manager.
 func NewAuthManager(clientManager clientapi.ClientManager, tokenManager authApi.TokenManager,
-	authenticationModes authApi.AuthenticationModes, authenticationSkippable bool) authApi.AuthManager {
+	authenticationModes authApi.AuthenticationModes, authenticationSkippable bool, secureDomains []string) authApi.AuthManager {
 	return &authManager{
 		tokenManager:            tokenManager,
 		clientManager:           clientManager,
 		authenticationModes:     authenticationModes,
 		authenticationSkippable: authenticationSkippable,
+		secureDomains:           secureDomains,
 	}
 }

--- a/src/app/backend/auth/manager_test.go
+++ b/src/app/backend/auth/manager_test.go
@@ -156,7 +156,7 @@ func TestAuthManager_Login(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		authManager := NewAuthManager(c.cManager, c.tManager, authApi.AuthenticationModes{authApi.Token: true}, true)
+		authManager := NewAuthManager(c.cManager, c.tManager, authApi.AuthenticationModes{authApi.Token: true}, true, []string{"localhost", "127.0.0.1"})
 		response, err := authManager.Login(c.spec)
 
 		if !areErrorsEqual(err, c.expectedErr) {
@@ -183,7 +183,7 @@ func TestAuthManager_AuthenticationModes(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		authManager := NewAuthManager(cManager, tManager, c.modes, true)
+		authManager := NewAuthManager(cManager, tManager, c.modes, true, []string{"localhost", "127.0.0.1"})
 		got := authManager.AuthenticationModes()
 
 		if !reflect.DeepEqual(got, c.expected) {
@@ -198,7 +198,7 @@ func TestAuthManager_AuthenticationSkippable(t *testing.T) {
 	cModes := authApi.AuthenticationModes{}
 
 	for _, flag := range []bool{true, false} {
-		authManager := NewAuthManager(cManager, tManager, cModes, flag)
+		authManager := NewAuthManager(cManager, tManager, cModes, flag, []string{"localhost", "127.0.0.1"})
 		got := authManager.AuthenticationSkippable()
 		if got != flag {
 			t.Errorf("Expected %v, but got %v.", flag, got)

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -68,7 +68,7 @@ var (
 	argAPILogLevel               = pflag.String("api-log-level", "INFO", "level of API request logging, should be one of 'NONE', 'INFO' or 'DEBUG'")
 	argDisableSettingsAuthorizer = pflag.Bool("disable-settings-authorizer", false, "disables settings page user authorizer so anyone can access settings page")
 	argNamespace                 = pflag.String("namespace", getEnv("POD_NAMESPACE", "kube-system"), "if non-default namespace is used encryption key will be created in the specified namespace")
-	argSecureDomains             = pflag.StringSlice("secure-domains", []string{"localhost", "127.0.0.1"}, "Set domains that allowed to login within insecure HTTP, usefull for local development server")
+	argSecureDomains             = pflag.StringSlice("secure-domains", []string{"localhost", "127.0.0.1"}, "Set domains that allowed to login within insecure HTTP, useful for local development server")
 	localeConfig                 = pflag.String("locale-config", "./locale_conf.json", "path to file containing the locale configuration")
 )
 

--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -68,6 +68,7 @@ var (
 	argAPILogLevel               = pflag.String("api-log-level", "INFO", "level of API request logging, should be one of 'NONE', 'INFO' or 'DEBUG'")
 	argDisableSettingsAuthorizer = pflag.Bool("disable-settings-authorizer", false, "disables settings page user authorizer so anyone can access settings page")
 	argNamespace                 = pflag.String("namespace", getEnv("POD_NAMESPACE", "kube-system"), "if non-default namespace is used encryption key will be created in the specified namespace")
+	argSecureDomains             = pflag.StringSlice("secure-domains", []string{"localhost", "127.0.0.1"}, "Set domains that allowed to login within insecure HTTP, usefull for local development server")
 	localeConfig                 = pflag.String("locale-config", "./locale_conf.json", "path to file containing the locale configuration")
 )
 
@@ -215,7 +216,10 @@ func initAuthManager(clientManager clientapi.ClientManager) authApi.AuthManager 
 	// UI logic dictates this should be the inverse of the cli option
 	authenticationSkippable := args.Holder.GetEnableSkipLogin()
 
-	return auth.NewAuthManager(clientManager, tokenManager, authModes, authenticationSkippable)
+	// List of domain that allowed to login with HTPP
+	secureDomains := args.Holder.GetSecureDomains()
+
+	return auth.NewAuthManager(clientManager, tokenManager, authModes, authenticationSkippable, secureDomains)
 }
 
 func initArgHolder() {
@@ -243,6 +247,7 @@ func initArgHolder() {
 	builder.SetDisableSettingsAuthorizer(*argDisableSettingsAuthorizer)
 	builder.SetEnableSkipLogin(*argEnableSkip)
 	builder.SetNamespace(*argNamespace)
+	builder.SetSecureDomains(*argSecureDomains)
 	builder.SetLocaleConfig(*localeConfig)
 }
 

--- a/src/app/backend/handler/apihandler_test.go
+++ b/src/app/backend/handler/apihandler_test.go
@@ -44,7 +44,7 @@ func getTokenManager() authApi.TokenManager {
 
 func TestCreateHTTPAPIHandler(t *testing.T) {
 	cManager := client.NewClientManager("", "http://localhost:8080")
-	authManager := auth.NewAuthManager(cManager, getTokenManager(), authApi.AuthenticationModes{}, true)
+	authManager := auth.NewAuthManager(cManager, getTokenManager(), authApi.AuthenticationModes{}, true, []string{"localhost", "127.0.0.1"})
 	sManager := settings.NewSettingsManager()
 	sbManager := systembanner.NewSystemBannerManager("Hello world!", "INFO")
 	_, err := CreateHTTPAPIHandler(nil, cManager, authManager, sManager, sbManager)

--- a/src/app/frontend/typings/root.api.ts
+++ b/src/app/frontend/typings/root.api.ts
@@ -1244,6 +1244,10 @@ export interface LoginSkippableResponse {
   skippable: boolean;
 }
 
+export interface SecureDomainsResponse {
+  secureDomains: string[];
+}
+
 export interface SystemBanner {
   message: string;
   severity: string;


### PR DESCRIPTION
Add argumens on dashboard binary to enable login button on frontend that includ in the domains

default domains is: `localhost` `127.0.0.1`

with `--secure-domains`, developer can customize that list to fit their needed. So frontend will enable login on custom domain like `dashboard.svc.cluster.local`