### PR TITLE
Normalize graph values after determining the highest suffix in the whole dataset

### DIFF
--- a/src/app/frontend/common/components/graph/component.ts
+++ b/src/app/frontend/common/components/graph/component.ts
@@ -95,16 +95,16 @@ export class GraphComponent implements OnInit, OnChanges {
         throw new Error(`Unsupported graph type ${this.graphType}.`);
     }
 
-    // Find out the highest suffix and normalize all values to a single suffix
-    series.map(value => {
+    // Find out the highest suffix and normalize all values to a single suffix.
+    // We have to loop twice to get the highest suffix (which could be later on)
+    // and then normalise *all* values to that one suffix.
+    series.forEach(value => {
       if (highestSuffixPower < value.suffixPower) {
         highestSuffixPower = value.suffixPower;
         highestSuffix = value.suffix;
       }
-
-      value.normalize(highestSuffix);
-      return value;
     });
+    series.forEach(value => value.normalize(highestSuffix));
 
     this.yAxisSuffix_ = highestSuffix;
 
@@ -144,7 +144,7 @@ export class GraphComponent implements OnInit, OnChanges {
         this.yScaleMax = maxValue + 0.01;
         break;
       case GraphType.Memory:
-        this.yScaleMax = maxValue + 10;
+        this.yScaleMax = maxValue + 1;
         break;
       default:
     }


### PR DESCRIPTION
I noticed the graphs have subtly incorrect normalizing behaviour if latter data points have a higher suffix. For example, crossing the Mi to Gi boundary results in the strange behaviour of the graph being in Gi but some values being unnormalized Mi:
![Pre](https://user-images.githubusercontent.com/7294642/161404058-6a5a1da6-7abe-4d26-a1c2-ee48ed8a4bdb.PNG)

This patch tweaks normalization to happen on all values after finding the suffix. It also tweaks the 'ballast' added to memory graphs so that the change between Mi and Gi is less jarring:
![Post](https://user-images.githubusercontent.com/7294642/161404194-84d75351-88ef-4196-be28-ce3f6b19f3bd.PNG)
