### PR TITLE
Update docs for 1.24+

### DIFF
--- a/aio/develop/npm-command.sh
+++ b/aio/develop/npm-command.sh
@@ -55,7 +55,7 @@ else
     echo "1. Run terminal for dashboard container."
     echo "  docker exec -it k8s-dashboard-dev gosu user bash"
     echo "2. Run following to get token for logging into dashboard."
-    echo "  kubectl -n kubernetes-dashboard get secrets \$(kubectl -n kubernetes-dashboard get sa kubernetes-dashboard -ojsonpath=\"{.secrets[0].name}\") -ojsonpath=\"{.data.token}\" | echo \"\$(base64 -d)\""
+    echo "  kubectl -n kubernetes-dashboard create token kubernetes-dashboard"
   fi
   # Start dashboard.
   echo "Start dashboard in production mode"

--- a/docs/user/access-control/creating-sample-user.md
+++ b/docs/user/access-control/creating-sample-user.md
@@ -43,7 +43,7 @@ subjects:
 Now we need to find the token we can use to log in. Execute the following command:
 
 ```shell
-kubectl -n kubernetes-dashboard get secret $(kubectl -n kubernetes-dashboard get sa/admin-user -o jsonpath="{.secrets[0].name}") -o go-template="{{.data.token | base64decode}}"
+kubectl -n kubernetes-dashboard create token admin-user
 ```
 
 It should print something like:


### PR DESCRIPTION
In 1.24+, secret-based tokens are no longer auto-created.

This updates to use the `kubectl create token` command provided instead.