### PR TITLE
Remove unused import and useless conditional expression

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,10 +12,12 @@ extends:
 plugins:
   - rxjs
 rules:
+  "@typescript-eslint/no-unused-vars":
+    - error
+    - argsIgnorePattern: "^_"
   "@typescript-eslint/ban-ts-comment": off
   "@typescript-eslint/interface-name-prefix": off
   "@typescript-eslint/no-namespace": off
-  "@typescript-eslint/no-unused-vars": off
   "@typescript-eslint/no-this-alias": off
   "@typescript-eslint/no-explicit-any": off
   node/no-unpublished-import: off

--- a/src/app/frontend/chrome/userpanel/component.ts
+++ b/src/app/frontend/chrome/userpanel/component.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Component, Inject, OnInit, ViewChild} from '@angular/core';
-import {MatMenu, MatMenuTrigger} from '@angular/material/menu';
+import {MatMenuTrigger} from '@angular/material/menu';
 import {LoginStatus} from '@api/root.api';
 import {IConfig} from '@api/root.ui';
 import {AuthService} from '@common/services/global/authentication';

--- a/src/app/frontend/common/components/breadcrumbs/component.ts
+++ b/src/app/frontend/common/components/breadcrumbs/component.ts
@@ -101,7 +101,7 @@ export class BreadcrumbsComponent implements OnInit {
 
         // Explore the route tree to the root route (parent references have to be defined by us on
         // each route).
-        if (route && route.data && route.data.parent) {
+        if (route.data && route.data.parent) {
           route = route.data.parent;
         } else {
           break;

--- a/src/app/frontend/common/components/breadcrumbs/component.ts
+++ b/src/app/frontend/common/components/breadcrumbs/component.ts
@@ -101,11 +101,7 @@ export class BreadcrumbsComponent implements OnInit {
 
         // Explore the route tree to the root route (parent references have to be defined by us on
         // each route).
-        if (route.data && route.data.parent) {
-          route = route.data.parent;
-        } else {
-          break;
-        }
+        route = route?.data?.parent;
       }
     }
 

--- a/src/app/frontend/common/dialogs/config/dialog.ts
+++ b/src/app/frontend/common/dialogs/config/dialog.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Component, Inject} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 export interface ConfirmDialogConfig {
   title: string;

--- a/src/app/frontend/common/pipes/stripansi.ts
+++ b/src/app/frontend/common/pipes/stripansi.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Pipe, SecurityContext} from '@angular/core';
-import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
+import {Pipe} from '@angular/core';
+import {SafeHtml} from '@angular/platform-browser';
 import stripAnsi from 'strip-ansi';
 
 /**

--- a/src/app/frontend/common/resources/resource.ts
+++ b/src/app/frontend/common/resources/resource.ts
@@ -14,7 +14,6 @@
 
 import {HttpClient} from '@angular/common/http';
 
-// @ts-ignore
-export abstract class ResourceBase<T> {
+export abstract class ResourceBase {
   protected constructor(protected readonly http_: HttpClient) {}
 }

--- a/src/app/frontend/resource/cluster/persistentvolume/detail/component.ts
+++ b/src/app/frontend/resource/cluster/persistentvolume/detail/component.ts
@@ -16,7 +16,6 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {MatTableDataSource} from '@angular/material/table';
 import {ActivatedRoute} from '@angular/router';
 import {CapacityItem, PersistentVolumeDetail} from '@api/root.api';
-import {StringMap} from '@api/root.shared';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 


### PR DESCRIPTION
Remove unused import:
- `MatMenu` in `src/app/frontend/chrome/userpanel/component.ts`
- `MatDialogRef` in `src/app/frontend/common/dialogs/config/dialog.ts`
- `SecurityContext` and `DomSanitizer` in `src/app/frontend/common/pipes/stripansi.ts`
- `StringMap` in `src/app/frontend/resource/cluster/persistentvolume/detail/component.ts`

Remove useless conditional expression:
- `route` in `src/app/frontend/common/components/breadcrumbs/component.ts`
