### PR TITLE
Remove generic types from 'ResourceBase' to resolve failed test cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "sockjs-client": "1.6.0",
         "strip-ansi": "6.0.1",
         "systemjs": "6.12.1",
-        "truncate-url": "2.1.0",
+        "truncate-url": "1.0.0",
         "tslib": "2.3.1",
         "web-animations-js": "2.3.2",
         "xterm": "4.18.0",
@@ -22025,14 +22025,11 @@
       }
     },
     "node_modules/truncate-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/truncate-url/-/truncate-url-2.1.0.tgz",
-      "integrity": "sha512-PACKaRVLSovjqI30LOIqEoSA/KD3wQuhCGe0rY2dcKqeteOeqlNJ8PHmeEqg5AsGSyVEOHjUSG1pVzzDHe9paA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/truncate-url/-/truncate-url-1.0.0.tgz",
+      "integrity": "sha1-hiGabDV12bch04aRvwjISqWtqkI=",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/ts-jest": {
@@ -39972,9 +39969,9 @@
       "dev": true
     },
     "truncate-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/truncate-url/-/truncate-url-2.1.0.tgz",
-      "integrity": "sha512-PACKaRVLSovjqI30LOIqEoSA/KD3wQuhCGe0rY2dcKqeteOeqlNJ8PHmeEqg5AsGSyVEOHjUSG1pVzzDHe9paA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/truncate-url/-/truncate-url-1.0.0.tgz",
+      "integrity": "sha1-hiGabDV12bch04aRvwjISqWtqkI="
     },
     "ts-jest": {
       "version": "27.1.4",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sockjs-client": "1.6.0",
     "strip-ansi": "6.0.1",
     "systemjs": "6.12.1",
-    "truncate-url": "2.1.0",
+    "truncate-url": "1.0.0",
     "tslib": "2.3.1",
     "web-animations-js": "2.3.2",
     "xterm": "4.18.0",

--- a/src/app/frontend/common/components/chips/component.ts
+++ b/src/app/frontend/common/components/chips/component.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {StringMap} from '@api/root.shared';
+// @ts-ignore
 import truncateUrl from 'truncate-url';
 
 import {GlobalSettingsService} from '../../services/global/globalsettings';

--- a/src/app/frontend/common/services/resource/resource.ts
+++ b/src/app/frontend/common/services/resource/resource.ts
@@ -23,7 +23,7 @@ import {GlobalSettingsService} from '../global/globalsettings';
 import {NamespaceService} from '../global/namespace';
 
 @Injectable()
-export class ResourceService<T> extends ResourceBase<T> {
+export class ResourceService<T> extends ResourceBase {
   /**
    * We need to provide HttpClient here since the base is not annotated with
    * @Injectable
@@ -52,7 +52,7 @@ export class ResourceService<T> extends ResourceBase<T> {
 }
 
 @Injectable()
-export class NamespacedResourceService<T> extends ResourceBase<T> {
+export class NamespacedResourceService<T> extends ResourceBase {
   constructor(
     readonly http: HttpClient,
     private readonly namespace_: NamespaceService,

--- a/src/app/frontend/common/services/resource/utility.ts
+++ b/src/app/frontend/common/services/resource/utility.ts
@@ -20,7 +20,7 @@ import {ResourceBase} from '../../resources/resource';
 import {NamespaceService} from '../global/namespace';
 
 @Injectable()
-export class UtilityService<T> extends ResourceBase<T> {
+export class UtilityService<T> extends ResourceBase {
   constructor(readonly http: HttpClient, private readonly namespace_: NamespaceService) {
     super(http);
   }


### PR DESCRIPTION
- Remove generic types from `ResourceBase` to resolve failed test cases
- Downgrade `truncate-url` to `1.0.0` to handle build error raised by Webpack
