### PR TITLE
Fix the unexpected confirmation dialog in 'Create from *'

### DIFF
--- a/src/app/frontend/common/services/create/service.ts
+++ b/src/app/frontend/common/services/create/service.ts
@@ -90,6 +90,9 @@ export class CreateService {
     } else {
       this.router_.navigate(['overview'], {
         queryParams: {[NAMESPACE_STATE_PARAM]: this.namespace_.current()},
+        state: {
+          bypassGuard: true,
+        },
       });
     }
 

--- a/src/app/frontend/common/services/guard/candeactivate.ts
+++ b/src/app/frontend/common/services/guard/candeactivate.ts
@@ -14,18 +14,18 @@
 
 import {Injectable} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
-import {CanDeactivate} from '@angular/router';
+import {CanDeactivate, Router} from '@angular/router';
 import {ConfirmDialog, ConfirmDialogConfig} from '@common/dialogs/config/dialog';
 import {ICanDeactivate} from '@common/interfaces/candeactivate';
-import {Observable, of} from 'rxjs';
+import {Observable} from 'rxjs';
 
 @Injectable()
 export class CanDeactivateGuard implements CanDeactivate<ICanDeactivate> {
-  constructor(private readonly dialog_: MatDialog) {}
+  constructor(private readonly dialog_: MatDialog, private router: Router) {}
 
-  canDeactivate(component: ICanDeactivate): Observable<boolean> {
-    if (component.canDeactivate()) {
-      return of(true);
+  canDeactivate(component: ICanDeactivate): boolean | Observable<boolean> {
+    if (component.canDeactivate() || this.router.getCurrentNavigation()?.extras?.state?.bypassGuard) {
+      return true;
     }
 
     const config = {

--- a/src/app/frontend/common/services/guard/candeactivate.ts
+++ b/src/app/frontend/common/services/guard/candeactivate.ts
@@ -30,7 +30,7 @@ export class CanDeactivateGuard implements CanDeactivate<ICanDeactivate> {
 
     const config = {
       title: 'Unsaved changes',
-      message: 'The form has not been submitted yet, do you really want to leave?',
+      message: 'The form has not been submitted yet. Do you really want to leave?',
     } as ConfirmDialogConfig;
 
     return this.dialog_.open(ConfirmDialog, {data: config}).afterClosed();

--- a/src/app/frontend/create/from/file/component.ts
+++ b/src/app/frontend/create/from/file/component.ts
@@ -43,17 +43,17 @@ export class CreateFromFileComponent extends ICanDeactivate {
     return !this.file || this.file.content.length === 0 || this.create_.isDeployDisabled();
   }
 
-  async create(): Promise<void> {
+  create(): void {
     this.creating_ = true;
-    try {
-      await this.create_.createContent(this.file.content, true, this.file.name);
-      this.file = {
-        name: '',
-        content: '',
-      };
-    } finally {
-      this.creating_ = false;
-    }
+    this.create_
+      .createContent(this.file.content, true, this.file.name)
+      .then(() => {
+        this.file = {
+          name: '',
+          content: '',
+        };
+      })
+      .finally(() => (this.creating_ = false));
   }
 
   onFileLoad(file: KdFile): void {

--- a/src/app/frontend/create/from/file/component.ts
+++ b/src/app/frontend/create/from/file/component.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, ViewChild} from '@angular/core';
-import {NgForm} from '@angular/forms';
+import {Component} from '@angular/core';
 import {KdFile} from '@api/root.ui';
 import {ICanDeactivate} from '@common/interfaces/candeactivate';
 
@@ -28,8 +27,6 @@ import {NamespaceService} from '@common/services/global/namespace';
 })
 export class CreateFromFileComponent extends ICanDeactivate {
   file: KdFile;
-  @ViewChild(NgForm, {static: true}) private readonly ngForm: NgForm;
-  private creating_ = false;
 
   constructor(
     private readonly namespace_: NamespaceService,
@@ -44,16 +41,7 @@ export class CreateFromFileComponent extends ICanDeactivate {
   }
 
   create(): void {
-    this.creating_ = true;
-    this.create_
-      .createContent(this.file.content, true, this.file.name)
-      .then(() => {
-        this.file = {
-          name: '',
-          content: '',
-        };
-      })
-      .finally(() => (this.creating_ = false));
+    this.create_.createContent(this.file.content, true, this.file.name);
   }
 
   onFileLoad(file: KdFile): void {
@@ -69,6 +57,6 @@ export class CreateFromFileComponent extends ICanDeactivate {
   }
 
   canDeactivate(): boolean {
-    return this.isCreateDisabled() && !this.creating_;
+    return this.isCreateDisabled();
   }
 }

--- a/src/app/frontend/create/from/file/component.ts
+++ b/src/app/frontend/create/from/file/component.ts
@@ -43,12 +43,17 @@ export class CreateFromFileComponent extends ICanDeactivate {
     return !this.file || this.file.content.length === 0 || this.create_.isDeployDisabled();
   }
 
-  create(): void {
+  async create(): Promise<void> {
     this.creating_ = true;
-    this.create_
-      .createContent(this.file.content, true, this.file.name)
-      .then(() => (this.creating_ = false))
-      .finally(() => (this.creating_ = false));
+    try {
+      await this.create_.createContent(this.file.content, true, this.file.name);
+      this.file = {
+        name: '',
+        content: '',
+      };
+    } finally {
+      this.creating_ = false;
+    }
   }
 
   onFileLoad(file: KdFile): void {

--- a/src/app/frontend/create/from/file/template.html
+++ b/src/app/frontend/create/from/file/template.html
@@ -36,7 +36,7 @@ limitations under the License.
                   label="Choose YAML or JSON file"
                   i18n-label> </kd-upload-file>
 
-  <button type="button"
+  <button type="submit"
           [disabled]="isCreateDisabled()"
           color="primary"
           mat-raised-button

--- a/src/app/frontend/create/from/form/component.ts
+++ b/src/app/frontend/create/from/form/component.ts
@@ -59,8 +59,6 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
   labelArr: DeployLabel[] = [];
   form: FormGroup;
 
-  private creating_ = false;
-
   constructor(
     private readonly namespace_: NamespaceService,
     private readonly create_: CreateService,
@@ -178,10 +176,6 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
     this.imagePullSecret.patchValue('');
   }
 
-  hasUnsavedChanges(): boolean {
-    return this.form.dirty;
-  }
-
   isCreateDisabled(): boolean {
     return !this.form.valid || this.create_.isDeployDisabled();
   }
@@ -292,13 +286,9 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
   }
 
   deploy(): void {
-    this.creating_ = true;
+    this.form.markAsPristine();
     const spec = this.getSpec();
-
-    this.create_
-      .deploy(spec)
-      .then(() => this.form.markAsPristine())
-      .finally(() => (this.creating_ = false));
+    this.create_.deploy(spec);
   }
 
   private getSpec(): AppDeploymentSpec {
@@ -325,6 +315,6 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
   }
 
   canDeactivate(): boolean {
-    return !this.hasUnsavedChanges() && !this.creating_;
+    return this.form.pristine;
   }
 }

--- a/src/app/frontend/create/from/form/component.ts
+++ b/src/app/frontend/create/from/form/component.ts
@@ -297,7 +297,9 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
 
     this.create_
       .deploy(spec)
-      .then(() => (this.creating_ = false))
+      .then(() => {
+        this.form.markAsPristine();
+      })
       .finally(() => (this.creating_ = false));
   }
 

--- a/src/app/frontend/create/from/form/component.ts
+++ b/src/app/frontend/create/from/form/component.ts
@@ -297,9 +297,7 @@ export class CreateFromFormComponent extends ICanDeactivate implements OnInit {
 
     this.create_
       .deploy(spec)
-      .then(() => {
-        this.form.markAsPristine();
-      })
+      .then(() => this.form.markAsPristine())
       .finally(() => (this.creating_ = false));
   }
 

--- a/src/app/frontend/create/from/input/component.ts
+++ b/src/app/frontend/create/from/input/component.ts
@@ -26,7 +26,6 @@ import {NamespaceService} from '@common/services/global/namespace';
 })
 export class CreateFromInputComponent extends ICanDeactivate {
   inputData = '';
-  private creating_ = false;
 
   constructor(
     private readonly namespace_: NamespaceService,
@@ -41,11 +40,7 @@ export class CreateFromInputComponent extends ICanDeactivate {
   }
 
   create(): void {
-    this.creating_ = true;
-    this.create_
-      .createContent(this.inputData)
-      .then(() => (this.inputData = ''))
-      .finally(() => (this.creating_ = false));
+    this.create_.createContent(this.inputData);
   }
 
   cancel(): void {
@@ -57,6 +52,6 @@ export class CreateFromInputComponent extends ICanDeactivate {
   }
 
   canDeactivate(): boolean {
-    return this.isCreateDisabled() && !this.creating_;
+    return this.isCreateDisabled();
   }
 }

--- a/src/app/frontend/create/from/input/component.ts
+++ b/src/app/frontend/create/from/input/component.ts
@@ -40,14 +40,12 @@ export class CreateFromInputComponent extends ICanDeactivate {
     return !this.inputData || this.inputData.length === 0 || this.create_.isDeployDisabled();
   }
 
-  async create(): Promise<void> {
+  create(): void {
     this.creating_ = true;
-    try {
-      await this.create_.createContent(this.inputData);
-      this.inputData = '';
-    } finally {
-      this.creating_ = false;
-    }
+    this.create_
+      .createContent(this.inputData)
+      .then(() => (this.inputData = ''))
+      .finally(() => (this.creating_ = false));
   }
 
   cancel(): void {

--- a/src/app/frontend/create/from/input/component.ts
+++ b/src/app/frontend/create/from/input/component.ts
@@ -40,12 +40,14 @@ export class CreateFromInputComponent extends ICanDeactivate {
     return !this.inputData || this.inputData.length === 0 || this.create_.isDeployDisabled();
   }
 
-  create(): void {
+  async create(): Promise<void> {
     this.creating_ = true;
-    this.create_
-      .createContent(this.inputData)
-      .then(() => (this.creating_ = false))
-      .finally(() => (this.creating_ = false));
+    try {
+      await this.create_.createContent(this.inputData);
+      this.inputData = '';
+    } finally {
+      this.creating_ = false;
+    }
   }
 
   cancel(): void {


### PR DESCRIPTION
The dialog that alerts 'The form has not been submitted yet, do you really want to leave?' (introduced in #6566) will appear even if the user clicked the 'Upload' or 'Deploy' button and the request is successful. This pull request fixes the unexpected confirmation dialog in the 'Create from file', 'Create from form', and 'Create from input' components.

The `this.create_.createContent()` function navigates to the `/overview` page before it returns, but the `this.creating_` variable will be changed to `false` after the function returns. Therefore, the`CanDeactivateGuard` guard will prevent the navigation.

```ts
  create(): void {
    this.creating_ = true;
    this.create_
      .createContent(this.file.content, true, this.file.name)
      .then(() => (this.creating_ = false))
      .finally(() => (this.creating_ = false));
  }
```

The solution is to include a `bypassGuard` state in the navigation of `this.create_.createContent()` function to let it bypass the `CanDeactivate` guard.