### PR TITLE
fix: remove unsecure ciphers

### DIFF
--- a/src/app/backend/dashboard.go
+++ b/src/app/backend/dashboard.go
@@ -176,6 +176,26 @@ func main() {
 			TLSConfig: &tls.Config{
 				Certificates: servingCerts,
 				MinVersion:   tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				},
+				PreferServerCipherSuites: true,
 			},
 		}
 		go func() { log.Fatal(server.ListenAndServeTLS("", "")) }()


### PR DESCRIPTION
Hello, 
first contribution here, many thx for that great project.
we got security warnings about insecure ciphers, and to mitigate that, here is  a PR only enabling, secure (as of today) ciphers.

```
nmap --script ssl-enum-ciphers -p 30001 192.168.x.x
```


![image](https://user-images.githubusercontent.com/2891702/167125266-9486d13c-8d30-49e2-a0f5-c9871b33d82d.png)

