### PR TITLE
Add barebones support for generic ephemeral volume

### DIFF
--- a/src/app/frontend/typings/volume.api.ts
+++ b/src/app/frontend/typings/volume.api.ts
@@ -45,6 +45,7 @@ export class PersistentVolumeSource {
   scaleIO: ScaleIOVolumeSource;
   storageOS: StorageOSVolumeSource;
   csi?: CSIVolumeSource;
+  ephemeral?: EphemeralVolumeSource;
 
   constructor(volume: PersistentVolumeSource) {
     Object.assign(this, volume);
@@ -75,6 +76,17 @@ export class PersistentVolumeSource {
 export class IVolumeSource {
   mountType: string;
   displayName: string;
+}
+
+export class EphemeralVolumeSource implements IVolumeSource {
+  get mountType(): string {
+    return 'Ephemeral';
+  }
+
+  // TODO: Populate this with the ephemeral volume's PVC details
+  displayName = '-';
+  name: string;
+  volumeClaimTemplate?: {};
 }
 
 export class HostPathVolumeSource implements IVolumeSource {
@@ -584,4 +596,5 @@ const VolumeSourceRegistry: Map<keyof PersistentVolumeSourceRaw, IVolumeSource> 
   ['scaleIO', new ScaleIOVolumeSource()],
   ['storageOS', new StorageOSVolumeSource()],
   ['csi', new CSIVolumeSource()],
+  ['ephemeral', new EphemeralVolumeSource()],
 ]);

--- a/src/app/frontend/typings/volume.api.ts
+++ b/src/app/frontend/typings/volume.api.ts
@@ -63,6 +63,10 @@ export class PersistentVolumeSource {
     }
 
     const volumeSource = VolumeSourceRegistry.get(sourceKey);
+    if (!volumeSource) {
+      return undefined;
+    }
+
     return Object.assign(volumeSource, (this as any)[sourceKey]);
   }
 }


### PR DESCRIPTION
Adds an "Ephemeral" volume source with blank ("-") values so that the page loads atleast

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/3601491/167696811-116de839-cf1f-4577-a216-602cf7cbcd02.png">




See #7080 