### PR TITLE
Show Cluster status with cumulative node resources

### DIFF
--- a/src/app/backend/resource/node/detail.go
+++ b/src/app/backend/resource/node/detail.go
@@ -197,39 +197,58 @@ func getNodeAllocatedResources(node v1.Node, podList *v1.PodList) (NodeAllocated
 	cpuRequests, cpuLimits, memoryRequests, memoryLimits := reqs[v1.ResourceCPU],
 		limits[v1.ResourceCPU], reqs[v1.ResourceMemory], limits[v1.ResourceMemory]
 
-	var cpuRequestsFraction, cpuLimitsFraction float64 = 0, 0
-	if capacity := float64(node.Status.Allocatable.Cpu().MilliValue()); capacity > 0 {
-		cpuRequestsFraction = float64(cpuRequests.MilliValue()) / capacity * 100
-		cpuLimitsFraction = float64(cpuLimits.MilliValue()) / capacity * 100
+	res := NodeAllocatedResources{
+		CPURequests:    cpuRequests.MilliValue(),
+		CPULimits:      cpuLimits.MilliValue(),
+		CPUCapacity:    node.Status.Allocatable.Cpu().MilliValue(),
+		MemoryRequests: memoryRequests.Value(),
+		MemoryLimits:   memoryLimits.Value(),
+		MemoryCapacity: node.Status.Allocatable.Memory().Value(),
+		AllocatedPods:  len(podList.Items),
+		PodCapacity:    node.Status.Capacity.Pods().Value(),
 	}
+	res = setNodeAllocatedFractions(res)
+
+	return res, nil
+}
+
+func setNodeAllocatedFractions(res NodeAllocatedResources) NodeAllocatedResources {
+	var cpuRequestsFraction, cpuLimitsFraction float64 = 0, 0
+	if capacity := float64(res.CPUCapacity); capacity > 0 {
+		cpuRequestsFraction = float64(res.CPURequests) / capacity * 100
+		cpuLimitsFraction = float64(res.CPULimits) / capacity * 100
+	}
+	res.CPURequestsFraction = cpuRequestsFraction
+	res.CPULimitsFraction = cpuLimitsFraction
 
 	var memoryRequestsFraction, memoryLimitsFraction float64 = 0, 0
-	if capacity := float64(node.Status.Allocatable.Memory().MilliValue()); capacity > 0 {
-		memoryRequestsFraction = float64(memoryRequests.MilliValue()) / capacity * 100
-		memoryLimitsFraction = float64(memoryLimits.MilliValue()) / capacity * 100
+	if capacity := float64(res.MemoryCapacity); capacity > 0 {
+		memoryRequestsFraction = float64(res.MemoryRequests) / capacity * 100
+		memoryLimitsFraction = float64(res.MemoryLimits) / capacity * 100
 	}
+	res.MemoryRequestsFraction = memoryRequestsFraction
+	res.MemoryLimitsFraction = memoryLimitsFraction
 
 	var podFraction float64 = 0
-	var podCapacity int64 = node.Status.Capacity.Pods().Value()
-	if podCapacity > 0 {
-		podFraction = float64(len(podList.Items)) / float64(podCapacity) * 100
+	if podCapacity := int64(res.PodCapacity); podCapacity > 0 {
+		podFraction = float64(res.AllocatedPods) / float64(podCapacity) * 100
 	}
+	res.PodFraction = podFraction
 
+	return res
+}
+
+func addNodeAllocatedResources(res NodeAllocatedResources, node Node) NodeAllocatedResources {
 	return NodeAllocatedResources{
-		CPURequests:            cpuRequests.MilliValue(),
-		CPURequestsFraction:    cpuRequestsFraction,
-		CPULimits:              cpuLimits.MilliValue(),
-		CPULimitsFraction:      cpuLimitsFraction,
-		CPUCapacity:            node.Status.Allocatable.Cpu().MilliValue(),
-		MemoryRequests:         memoryRequests.Value(),
-		MemoryRequestsFraction: memoryRequestsFraction,
-		MemoryLimits:           memoryLimits.Value(),
-		MemoryLimitsFraction:   memoryLimitsFraction,
-		MemoryCapacity:         node.Status.Allocatable.Memory().Value(),
-		AllocatedPods:          len(podList.Items),
-		PodCapacity:            podCapacity,
-		PodFraction:            podFraction,
-	}, nil
+		CPURequests:    res.CPURequests + node.AllocatedResources.CPURequests,
+		CPULimits:      res.CPULimits + node.AllocatedResources.CPULimits,
+		CPUCapacity:    res.CPUCapacity + node.AllocatedResources.CPUCapacity,
+		MemoryRequests: res.MemoryRequests + node.AllocatedResources.MemoryRequests,
+		MemoryLimits:   res.MemoryLimits + node.AllocatedResources.MemoryLimits,
+		MemoryCapacity: res.MemoryCapacity + node.AllocatedResources.MemoryCapacity,
+		AllocatedPods:  res.AllocatedPods + node.AllocatedResources.AllocatedPods,
+		PodCapacity:    res.PodCapacity + node.AllocatedResources.PodCapacity,
+	}
 }
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all

--- a/src/app/backend/resource/node/list_test.go
+++ b/src/app/backend/resource/node/list_test.go
@@ -42,8 +42,10 @@ func TestGetNodeList(t *testing.T) {
 				ListMeta: api.ListMeta{
 					TotalItems: 1,
 				},
-				Errors:            []error{},
-				CumulativeMetrics: make([]metricapi.Metric, 0),
+				Errors:             []error{},
+				Condition:          NodeCondition{Unknown: 1},
+				CumulativeMetrics:  make([]metricapi.Metric, 0),
+				AllocatedResources: NodeAllocatedResources{},
 				Nodes: []Node{{
 					ObjectMeta: api.ObjectMeta{Name: "test-node"},
 					TypeMeta:   api.TypeMeta{Kind: api.ResourceKindNode},

--- a/src/app/frontend/common/components/clusterstatus/component.ts
+++ b/src/app/frontend/common/components/clusterstatus/component.ts
@@ -1,0 +1,61 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, Input} from '@angular/core';
+import {ResourcesAllocation} from '@api/root.ui';
+
+export const emptyResourcesAllocation: ResourcesAllocation = {
+  nodeResources: [],
+  cpuResources: [],
+  memoryResources: [],
+  podResources: [],
+};
+
+@Component({
+  selector: 'kd-cluster-statuses',
+  templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
+})
+export class ClusterStatusComponent {
+  @Input() resourcesAllocation = emptyResourcesAllocation;
+  colors: string[] = [];
+  animations = false;
+  labels = true;
+  trimLabels = false;
+  size = [350, 250];
+
+  getStatusColor(label: string): string {
+    if (label.includes('Ready')) {
+      return '#00c752';
+    } else if (label.includes('NotReady')) {
+      return '#f00';
+    } else if (label.includes('Unknown')) {
+      return '#eeeeee';
+    }
+    return '';
+  }
+
+  getCustomColor(label: string): string {
+    if (label.includes('Requests')) {
+      return '#00c752';
+    } else if (label.includes('Limits')) {
+      return '#ffad20';
+    } else if (label.includes('Allocation')) {
+      return '#00c752';
+    } else if (label.includes('Capacity')) {
+      return '#99e9ba';
+    }
+    return '';
+  }
+}

--- a/src/app/frontend/common/components/clusterstatus/style.scss
+++ b/src/app/frontend/common/components/clusterstatus/style.scss
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component} from '@angular/core';
+@use '../../../variables' as *;
 
-import {GroupedResourceList} from '@common/resources/groupedlist';
+.kd-graph-container {
+  flex: auto;
+  text-align: center;
+}
 
-@Component({
-  selector: 'kd-cluster',
-  templateUrl: './template.html',
-})
-export class ClusterComponent extends GroupedResourceList {
-  showClusterStatuses(): boolean {
-    return true;
-  }
+.kd-graph-title {
+  font-size: $subhead-font-size-base;
+  padding-bottom: 2 * $baseline-grid;
 }

--- a/src/app/frontend/common/components/clusterstatus/template.html
+++ b/src/app/frontend/common/components/clusterstatus/template.html
@@ -1,0 +1,92 @@
+<!--
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<kd-card [graphMode]="true">
+  <div title
+       fxLayout="row"
+       i18n>Cluster Status</div>
+  <div content
+       fxLayout="row wrap">
+
+    <div class="kd-graph-container">
+      <div fxLayout="column"
+           fxLayoutAlign="center center">
+        <ngx-charts-pie-chart [results]="resourcesAllocation.nodeResources"
+                              [view]="size"
+                              [customColors]="getStatusColor"
+                              [animations]="animations"
+                              [labels]="labels"
+                              [trimLabels]="trimLabels">
+          <ng-template #tooltipTemplate
+                       let-model="model"> {{ model.label }} </ng-template>
+        </ngx-charts-pie-chart>
+      </div>
+      <div class="kd-graph-title"
+           i18n>Nodes</div>
+    </div>
+
+    <div class="kd-graph-container">
+      <div fxLayout="column"
+           fxLayoutAlign="center center">
+        <ngx-charts-pie-chart [results]="resourcesAllocation.cpuResources"
+                              [view]="size"
+                              [customColors]="getCustomColor"
+                              [animations]="animations"
+                              [labels]="labels"
+                              [trimLabels]="trimLabels">
+          <ng-template #tooltipTemplate
+                       let-model="model"> {{ model.label }} </ng-template>
+        </ngx-charts-pie-chart>
+      </div>
+      <div class="kd-graph-title"
+           i18n>CPU</div>
+    </div>
+
+    <div class="kd-graph-container">
+      <div fxLayout="column"
+           fxLayoutAlign="center center">
+        <ngx-charts-pie-chart [results]="resourcesAllocation.memoryResources"
+                              [view]="size"
+                              [customColors]="getCustomColor"
+                              [animations]="animations"
+                              [labels]="labels"
+                              [trimLabels]="trimLabels">
+          <ng-template #tooltipTemplate
+                       let-model="model"> {{ model.label }} </ng-template>
+        </ngx-charts-pie-chart>
+      </div>
+      <div class="kd-graph-title"
+           i18n>Memory</div>
+    </div>
+
+    <div class="kd-graph-container">
+      <div fxLayout="column"
+           fxLayoutAlign="center center">
+        <ngx-charts-pie-chart [results]="resourcesAllocation.podResources"
+                              [view]="size"
+                              [customColors]="getCustomColor"
+                              [animations]="animations"
+                              [labels]="labels"
+                              [trimLabels]="trimLabels">
+          <ng-template #tooltipTemplate
+                       let-model="model"> {{ model.label }} </ng-template>
+        </ngx-charts-pie-chart>
+      </div>
+      <div class="kd-graph-title"
+           i18n>Pods</div>
+    </div>
+  </div>
+</kd-card>

--- a/src/app/frontend/common/components/graph/helper.ts
+++ b/src/app/frontend/common/components/graph/helper.ts
@@ -82,4 +82,12 @@ export class FormattedValue {
 
     return new FormattedValue(memoryBase, value, memoryPowerSuffixes);
   }
+
+  static NewFormattedPodValue(value: number): FormattedValue {
+    const intBase = 1;
+
+    const intPowerSuffixes = [''];
+
+    return new FormattedValue(intBase, value, intPowerSuffixes);
+  }
 }

--- a/src/app/frontend/common/components/module.ts
+++ b/src/app/frontend/common/components/module.ts
@@ -69,6 +69,7 @@ import {ProxyComponent} from './proxy/component';
 import {ResourceQuotaListComponent} from './quotas/component';
 import {ClusterRoleListComponent} from './resourcelist/clusterrole/component';
 import {ClusterRoleBindingListComponent} from './resourcelist/clusterrolebinding/component';
+import {ClusterStatusComponent} from './clusterstatus/component';
 import {ConfigMapListComponent} from './resourcelist/configmap/component';
 import {CRDListComponent} from './resourcelist/crd/component';
 import {CRDObjectListComponent} from './resourcelist/crdobject/component';
@@ -129,6 +130,7 @@ const components = [
   PluginListComponent,
   ColumnComponent,
   ChipDialog,
+  ClusterStatusComponent,
   ContainerCardComponent,
   ConditionListComponent,
   CreatorCardComponent,

--- a/src/app/frontend/common/resources/groupedlist.ts
+++ b/src/app/frontend/common/resources/groupedlist.ts
@@ -18,20 +18,24 @@ import {
   DeploymentList,
   JobList,
   Metric,
+  NodeList,
   PodList,
   ReplicaSetList,
   ReplicationControllerList,
   ResourceList,
   StatefulSetList,
 } from '@api/root.api';
-import {OnListChangeEvent, ResourcesRatio} from '@api/root.ui';
+import {OnListChangeEvent, ResourcesRatio, ResourcesAllocation} from '@api/root.ui';
 
 import {Helper, ResourceRatioModes} from '../../overview/helper';
+import {FormattedValue} from '@common/components/graph/helper';
 import {ListGroupIdentifier, ListIdentifier} from '../components/resourcelist/groupids';
 import {emptyResourcesRatio} from '../components/workloadstatus/component';
+import {emptyResourcesAllocation} from '../components/clusterstatus/component';
 
 export class GroupedResourceList {
   resourcesRatio: ResourcesRatio = emptyResourcesRatio;
+  resourcesAllocation: ResourcesAllocation = emptyResourcesAllocation;
   cumulativeMetrics: Metric[] = [];
 
   private readonly items_: {[id: string]: number} = {};
@@ -98,6 +102,49 @@ export class GroupedResourceList {
           jobs.listMeta.totalItems,
           ResourceRatioModes.Completable
         );
+        break;
+      }
+      case ListIdentifier.node: {
+        const nodes = list as NodeList;
+        const ready = nodes.condition.true;
+        const notready = nodes.condition.false;
+        const unknown = nodes.condition.unknown;
+        this.resourcesAllocation.nodeResources = [
+          {name: 'Ready: ' + ready, value: ready},
+          {name: 'NotReady: ' + notready, value: notready},
+          {name: 'Unknown: ' + unknown, value: unknown},
+        ];
+        const cpuLimits = nodes.allocatedResources.cpuLimits;
+        const cpuRequests = nodes.allocatedResources.cpuRequests - cpuLimits;
+        const cpuCapacity = nodes.allocatedResources.cpuCapacity - cpuLimits - cpuRequests;
+        const memoryLimits = nodes.allocatedResources.memoryLimits;
+        const memoryRequests = nodes.allocatedResources.memoryRequests - memoryLimits;
+        const memoryCapacity = nodes.allocatedResources.memoryCapacity - memoryLimits - memoryRequests;
+        const podAllocation = nodes.allocatedResources.allocatedPods;
+        const podCapacity = nodes.allocatedResources.podCapacity - podAllocation;
+        const cpuLimitsValue = FormattedValue.NewFormattedCoreValue(nodes.allocatedResources.cpuLimits);
+        const cpuRequestsValue = FormattedValue.NewFormattedCoreValue(nodes.allocatedResources.cpuRequests);
+        const cpuCapacityValue = FormattedValue.NewFormattedCoreValue(nodes.allocatedResources.cpuCapacity);
+        const memoryLimitsValue = FormattedValue.NewFormattedMemoryValue(nodes.allocatedResources.memoryLimits);
+        const memoryRequestsValue = FormattedValue.NewFormattedMemoryValue(nodes.allocatedResources.memoryRequests);
+        const memoryCapacityValue = FormattedValue.NewFormattedMemoryValue(nodes.allocatedResources.memoryCapacity);
+        const podAllocationValue = FormattedValue.NewFormattedPodValue(nodes.allocatedResources.allocatedPods);
+        const podCapacityValue = FormattedValue.NewFormattedPodValue(nodes.allocatedResources.podCapacity);
+        this.resourcesAllocation.cpuResources = [
+          {name: 'Capacity: ' + cpuCapacityValue.value + cpuCapacityValue.suffix, value: cpuCapacity},
+          {name: 'Requests: ' + cpuRequestsValue.value + cpuRequestsValue.suffix, value: cpuRequests},
+          {name: 'Limits: ' + cpuLimitsValue.value + cpuLimitsValue.suffix, value: cpuLimits},
+        ];
+        this.resourcesAllocation.memoryResources = [
+          {name: 'Capacity: ' + memoryCapacityValue.value + memoryCapacityValue.suffix, value: memoryCapacity},
+          {name: 'Requests: ' + memoryRequestsValue.value + memoryRequestsValue.suffix, value: memoryRequests},
+          {name: 'Limits: ' + memoryLimitsValue.value + memoryLimitsValue.suffix, value: memoryLimits},
+        ];
+        this.resourcesAllocation.podResources = [
+          {name: 'Capacity: ' + podCapacityValue.value + podCapacityValue.suffix, value: podCapacity},
+          {name: 'Allocation: ' + podAllocationValue.value + podAllocationValue.suffix, value: podAllocation},
+        ];
+        this.cumulativeMetrics = nodes.cumulativeMetrics;
         break;
       }
       case ListIdentifier.pod: {

--- a/src/app/frontend/overview/component.ts
+++ b/src/app/frontend/overview/component.ts
@@ -41,4 +41,8 @@ export class OverviewComponent extends GroupedResourceList {
   showWorkloadStatuses(): boolean {
     return Object.values(this.resourcesRatio).reduce((sum, ratioItems) => sum + ratioItems.length, 0) !== 0;
   }
+
+  showClusterStatuses(): boolean {
+    return true;
+  }
 }

--- a/src/app/frontend/overview/template.html
+++ b/src/app/frontend/overview/template.html
@@ -74,6 +74,8 @@ limitations under the License.
        [hidden]="!hasCluster()"
        i18n>Cluster</div>
   <div>
+    <kd-cluster-statuses *ngIf="showClusterStatuses()"
+                         [hideable]="true"></kd-cluster-statuses>
     <kd-cluster-role-binding-list (onchange)="onListUpdate($event)"
                                   [hideable]="true"></kd-cluster-role-binding-list>
     <kd-cluster-role-list (onchange)="onListUpdate($event)"

--- a/src/app/frontend/resource/cluster/template.html
+++ b/src/app/frontend/resource/cluster/template.html
@@ -15,6 +15,8 @@ limitations under the License.
 -->
 
 <div [hidden]="shouldShowZeroState()">
+  <kd-cluster-statuses *ngIf="showClusterStatuses()"
+                       [resourcesAllocation]="resourcesAllocation"></kd-cluster-statuses>
   <kd-cluster-role-binding-list (onchange)="onListUpdate($event)"
                                 [hideable]="true"></kd-cluster-role-binding-list>
   <kd-cluster-role-list (onchange)="onListUpdate($event)"

--- a/src/app/frontend/typings/root.api.ts
+++ b/src/app/frontend/typings/root.api.ts
@@ -157,6 +157,14 @@ export interface NamespaceList extends ResourceList {
 export interface NodeList extends ResourceList {
   cumulativeMetrics: Metric[] | null;
   nodes: Node[];
+  condition: NodeCondition;
+  allocatedResources: NodeAllocatedResources;
+}
+
+export interface NodeCondition {
+  true: number;
+  false: number;
+  unknown: number;
 }
 
 export interface PersistentVolumeClaimList extends ResourceList {

--- a/src/app/frontend/typings/root.ui.ts
+++ b/src/app/frontend/typings/root.ui.ts
@@ -113,6 +113,18 @@ export interface ResourcesRatio {
   statefulSetRatio: RatioItem[];
 }
 
+export interface ResourceItem {
+  name: string;
+  value: number;
+}
+
+export interface ResourcesAllocation {
+  nodeResources: ResourceItem[];
+  cpuResources: ResourceItem[];
+  memoryResources: ResourceItem[];
+  podResources: ResourceItem[];
+}
+
 export interface StateError {
   error: KdError;
 }


### PR DESCRIPTION
Add a summary of nodes and resources at the top of Cluster,
similar to the existing summary of pods at the top of Workload.

Refactor the calculation of fractions, to reduce duplication
and to make it possible to apply after adding up all the nodes.

Closes #7109 