### PR TITLE
Show Capacity in the node list and node detail

### DIFF
--- a/src/app/frontend/common/components/resourcelist/node/component.ts
+++ b/src/app/frontend/common/components/resourcelist/node/component.ts
@@ -62,6 +62,19 @@ export class NodeListComponent extends ResourceListWithStatuses<NodeList, Node> 
   }
 
   getDisplayColumns(): string[] {
-    return ['statusicon', 'name', 'labels', 'ready', 'cpureq', 'cpulim', 'memreq', 'memlim', 'pods', 'created'];
+    return [
+      'statusicon',
+      'name',
+      'labels',
+      'ready',
+      'cpureq',
+      'cpulim',
+      'cpucap',
+      'memreq',
+      'memlim',
+      'memcap',
+      'pods',
+      'created',
+    ];
   }
 }

--- a/src/app/frontend/common/components/resourcelist/node/template.html
+++ b/src/app/frontend/common/components/resourcelist/node/template.html
@@ -36,7 +36,7 @@ limitations under the License.
     <mat-table [dataSource]="getData()"
                [trackBy]="trackByResource"
                matSort
-               [matSortActive]="getColumns()[9]"
+               [matSortActive]="getColumns()[11]"
                matSortDisableClear
                matSortDirection="asc">
       <ng-container [matColumnDef]="getColumns()[0]">
@@ -107,6 +107,16 @@ limitations under the License.
       <ng-container [matColumnDef]="getColumns()[6]">
         <mat-header-cell *matHeaderCellDef
                          class="col-stretch-m"
+                         i18n>CPU capacity (cores)</mat-header-cell>
+        <mat-cell *matCellDef="let node"
+                  class="col-stretch-m">
+          {{ node.allocatedResources.cpuCapacity | kdCores }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container [matColumnDef]="getColumns()[7]">
+        <mat-header-cell *matHeaderCellDef
+                         class="col-stretch-m"
                          i18n>Memory requests (bytes)</mat-header-cell>
         <mat-cell *matCellDef="let node"
                   class="col-stretch-m">
@@ -115,7 +125,7 @@ limitations under the License.
         </mat-cell>
       </ng-container>
 
-      <ng-container [matColumnDef]="getColumns()[7]">
+      <ng-container [matColumnDef]="getColumns()[8]">
         <mat-header-cell *matHeaderCellDef
                          class="col-stretch-m"
                          i18n>Memory limits (bytes)</mat-header-cell>
@@ -126,7 +136,17 @@ limitations under the License.
         </mat-cell>
       </ng-container>
 
-      <ng-container [matColumnDef]="getColumns()[8]">
+      <ng-container [matColumnDef]="getColumns()[9]">
+        <mat-header-cell *matHeaderCellDef
+                         class="col-stretch-m"
+                         i18n>Memory capacity (bytes)</mat-header-cell>
+        <mat-cell *matCellDef="let node"
+                  class="col-stretch-m">
+          {{ node.allocatedResources.memoryCapacity | kdMemory }}
+        </mat-cell>
+      </ng-container>
+
+      <ng-container [matColumnDef]="getColumns()[10]">
         <mat-header-cell *matHeaderCellDef
                          class="col-stretch-m"
                          i18n>Pods</mat-header-cell>
@@ -136,7 +156,7 @@ limitations under the License.
         </mat-cell>
       </ng-container>
 
-      <ng-container [matColumnDef]="getColumns()[9]">
+      <ng-container [matColumnDef]="getColumns()[11]">
         <mat-header-cell *matHeaderCellDef
                          mat-sort-header
                          disableClear="true"

--- a/src/app/frontend/resource/cluster/node/detail/template.html
+++ b/src/app/frontend/resource/cluster/node/detail/template.html
@@ -122,6 +122,21 @@ limitations under the License.
            i18n>Architecture</div>
       <div value>{{ node?.nodeInfo.architecture }}</div>
     </kd-property>
+    <kd-property *ngIf="node?.allocatedResources.cpuCapacity">
+      <div key
+           i18n>CPU capacity</div>
+      <div value>{{ node?.allocatedResources.cpuCapacity | kdCores }}</div>
+    </kd-property>
+    <kd-property *ngIf="node?.allocatedResources.memoryCapacity">
+      <div key
+           i18n>Memory capacity</div>
+      <div value>{{ node?.allocatedResources.memoryCapacity | kdMemory }}</div>
+    </kd-property>
+    <kd-property *ngIf="node?.allocatedResources.podCapacity">
+      <div key
+           i18n>Pods capacity</div>
+      <div value>{{ node?.allocatedResources.podCapacity }}</div>
+    </kd-property>
   </div>
 </kd-card>
 


### PR DESCRIPTION
Currently only showing the requests and limits and the fraction,
but not the absolute value (you have to do the percentage math).

Show the capacity values directly instead, formatted as usual.
Looks like it was shown before, but got lost in refactoring ?

Mentioned in: Issue #7109 