### PR TITLE
Set a timeout prevent memory leak when socket connection exception 

### DIFF
--- a/src/app/backend/handler/terminal.go
+++ b/src/app/backend/handler/terminal.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 
 	restful "github.com/emicklei/go-restful/v3"
 	"gopkg.in/igm/sockjs-go.v2/sockjs"
@@ -306,5 +307,11 @@ func WaitForTerminal(k8sClient kubernetes.Interface, cfg *rest.Config, request *
 		}
 
 		terminalSessions.Close(sessionId, 1, "Process exited")
+
+	case <- time.After(10 * time.Second):
+		// Close chan and delete session when sockjs connection was timeout
+		close(terminalSessions.Get(sessionId).bound)
+		delete(terminalSessions.Sessions, sessionId)
+		return
 	}
 }


### PR DESCRIPTION
Set a timeout for func `WaitForTerminal` to prevent memory leak when socket connection exception 