### PR TITLE
Alternative create token command for Kubernetes prior to v1.24

### DIFF
--- a/docs/user/access-control/creating-sample-user.md
+++ b/docs/user/access-control/creating-sample-user.md
@@ -46,6 +46,12 @@ Now we need to find the token we can use to log in. Execute the following comman
 kubectl -n kubernetes-dashboard create token admin-user
 ```
 
+If you are running Kubernetes prior to v1.24, execute the following command instead :
+
+```shell
+kubectl -n kubernetes-dashboard get secret $(kubectl -n kubernetes-dashboard get sa/admin-user -o jsonpath="{.secrets[0].name}") -o go-template="{{.data.token | base64decode}}"
+```
+
 It should print something like:
 
 ```


### PR DESCRIPTION
The currently suggested command [doesn't work](https://stackoverflow.com/questions/72481655/creating-a-kubernetes-dashboard-token) for Kubernetes < v1.24.

Signed-off-by: Flavien Berwick <flavien@berwick.fr>