### PR TITLE
fix: update Secret with non-latin1 UTF-8 string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "crop-url": "4.0.1",
         "d3": "6.7.0",
         "file-saver": "2.0.5",
+        "js-base64": "3.7.2",
         "js-beautify": "1.14.3",
         "js-yaml": "4.1.0",
         "jwt-decode": "3.1.2",
@@ -16201,6 +16202,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "node_modules/js-beautify": {
       "version": "1.14.3",
@@ -36607,6 +36613,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-beautify": {
       "version": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "crop-url": "4.0.1",
     "d3": "6.7.0",
     "file-saver": "2.0.5",
+    "js-base64": "3.7.2",
     "js-beautify": "1.14.3",
     "js-yaml": "4.1.0",
     "jwt-decode": "3.1.2",

--- a/src/app/frontend/resource/config/secret/detail/edit/component.ts
+++ b/src/app/frontend/resource/config/secret/detail/edit/component.ts
@@ -19,6 +19,7 @@ import {RawResource} from 'common/resources/rawresource';
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {AlertDialogConfig, AlertDialog} from 'common/dialogs/alert/dialog';
 import {MatDialogConfig, MatDialog} from '@angular/material/dialog';
+import {encode} from 'js-base64';
 
 @Component({
   selector: 'kd-secret-detail-edit',
@@ -69,7 +70,7 @@ export class SecretDetailEditComponent implements OnInit {
       .toPromise()
       .then((resource: any) => {
         const dataValue = this.encode_(this.text);
-        resource.data[this.key] = this.encode_(this.text);
+        resource.data[this.key] = dataValue;
         const url = RawResource.getUrl(this.secret.typeMeta, this.secret.objectMeta);
         this.http_.put(url, resource, {headers: this.getHttpHeaders_(), responseType: 'text'}).subscribe(() => {
           // Update current data value for secret, so refresh isn't needed.
@@ -88,7 +89,9 @@ export class SecretDetailEditComponent implements OnInit {
   }
 
   private encode_(s: string): string {
-    return btoa(s);
+    // Use js-base64 library instead of `btoa`, since we need to encode a UTF-8 string,
+    // however `btoa` only supports binary input (latin1 range).
+    return encode(s, false);
   }
 
   private getHttpHeaders_(): HttpHeaders {


### PR DESCRIPTION
This PR will fix #7411.

Currently, I implement the fix using a third-party library: js-base64, and its size seems okay (minified ~8kb without tree-shaking; total build size: original 251388kb -> after 251392kb, +4kb).

Another way is using the `unescape` and `encodeURIComponent` trick:
```
btoa(unescape(encodeURIComponent(s)))
```
However, considered `unescape` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape), maybe we should avoid using it. Am I right?

