### PR TITLE
Use batch/v1 for fetching cronjob jobs

### DIFF
--- a/modules/api/pkg/resource/cronjob/jobs.go
+++ b/modules/api/pkg/resource/cronjob/jobs.go
@@ -48,7 +48,7 @@ var emptyJobList = &job.JobList{
 func GetCronJobJobs(client client.Interface, metricClient metricapi.MetricClient,
 	dsQuery *dataselect.DataSelectQuery, namespace, name string, active bool) (*job.JobList, error) {
 
-	cronJob, err := client.BatchV1beta1().CronJobs(namespace).Get(context.TODO(), name, meta.GetOptions{})
+	cronJob, err := client.BatchV1().CronJobs(namespace).Get(context.TODO(), name, meta.GetOptions{})
 	if err != nil {
 		return emptyJobList, err
 	}


### PR DESCRIPTION
# Summary 

Follow up for #7301 

#7301 has fixed the cronjobs list page, but still produces an issue when opening the details of a cronjob. This is because `GetCronJobJobs()` still uses `batch/v1beta1` (which seems like it was missed in the original PR). The proposed change fixes the issue for me, and the page then opens properly.

A quick grep for `BatchV1beta1()` does not point to usage of this client in other places, so this fix should be sufficient.