### PR TITLE
fix: update Secret with non-latin1 UTF-8 string

### DIFF
--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -64,6 +64,7 @@
     "d3-shape": "3.1.0",
     "d3-time-format": "4.1.0",
     "file-saver": "2.0.5",
+    "js-base64": "3.7.2",
     "js-yaml": "4.1.0",
     "jwt-decode": "3.1.2",
     "material-design-icons": "3.0.1",

--- a/modules/web/src/resource/config/secret/detail/edit/component.ts
+++ b/modules/web/src/resource/config/secret/detail/edit/component.ts
@@ -19,6 +19,7 @@ import {RawResource} from 'common/resources/rawresource';
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {AlertDialogConfig, AlertDialog} from 'common/dialogs/alert/dialog';
 import {MatDialogConfig, MatDialog} from '@angular/material/dialog';
+import {encode} from 'js-base64';
 
 @Component({
   selector: 'kd-secret-detail-edit',
@@ -69,7 +70,7 @@ export class SecretDetailEditComponent implements OnInit {
       .toPromise()
       .then((resource: any) => {
         const dataValue = this.encode_(this.text);
-        resource.data[this.key] = this.encode_(this.text);
+        resource.data[this.key] = dataValue;
         const url = RawResource.getUrl(this.secret.typeMeta, this.secret.objectMeta);
         this.http_.put(url, resource, {headers: this.getHttpHeaders_(), responseType: 'text'}).subscribe(() => {
           // Update current data value for secret, so refresh isn't needed.
@@ -88,7 +89,9 @@ export class SecretDetailEditComponent implements OnInit {
   }
 
   private encode_(s: string): string {
-    return btoa(s);
+    // Use js-base64 library instead of `btoa`, since we need to encode a UTF-8 string,
+    // however `btoa` only supports binary input (latin1 range).
+    return encode(s, false);
   }
 
   private getHttpHeaders_(): HttpHeaders {

--- a/modules/web/yarn.lock
+++ b/modules/web/yarn.lock
@@ -10138,6 +10138,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-base64@npm:3.7.2":
+  version: 3.7.2
+  resolution: "js-base64@npm:3.7.2"
+  checksum: 573f28e9a27c3df60096d4d3f551bcb4fcb6d49161cf83396e9bad9b76f94736a70bb70b8808fe834dff2a388f76604ba09d6e153bbf181646e407720139fa5b
+  languageName: node
+  linkType: hard
+
 "js-beautify@npm:1.14.3":
   version: 1.14.3
   resolution: "js-beautify@npm:1.14.3"
@@ -10483,6 +10490,7 @@ __metadata:
     jasmine-spec-reporter: 7.0.0
     jest: 28.1.0
     jest-preset-angular: 12.0.1
+    js-base64: 3.7.2
     js-beautify: 1.14.3
     js-yaml: 4.1.0
     jwt-decode: 3.1.2


### PR DESCRIPTION
(This is a new PR against the current refactored master)

This PR will fix #7411.

Currently, I implement the fix using a third-party library: js-base64, and its size seems okay (minified ~8kb without tree-shaking; total build size: original 251388kb -> after 251392kb, +4kb).

Another way is using the `unescape` and `encodeURIComponent` trick:
```
btoa(unescape(encodeURIComponent(s)))
```
However, considered `unescape` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape), maybe we should avoid using it. Am I right?

