### PR TITLE
check the existence of the http member of a ingress rule before iterating through it

### DIFF
--- a/modules/api/pkg/resource/ingress/filter.go
+++ b/modules/api/pkg/resource/ingress/filter.go
@@ -36,6 +36,9 @@ func ingressMatchesServiceName(ingress networkingv1.Ingress, serviceName string)
 	}
 
 	for _, rule := range spec.Rules {
+		if rule.IngressRuleValue.HTTP == nil {
+			continue
+		}
 		for _, path := range rule.IngressRuleValue.HTTP.Paths {
 			if ingressBackendMatchesServiceName(&path.Backend, serviceName) {
 				return true


### PR DESCRIPTION
Fixes: #7480
