### PR TITLE
ingress paths are now clickable

### DIFF
--- a/modules/web/src/common/components/ingressrulelist/template.html
+++ b/modules/web/src/common/components/ingressrulelist/template.html
@@ -37,7 +37,8 @@ limitations under the License.
         <mat-cell *matCellDef="let ingressRuleFlat">
           <ng-container *ngIf="ingressRuleFlat.host">
             <a href="https://{{ ingressRuleFlat.host }}"
-               target="_blank"> {{ ingressRuleFlat.host }} </a>
+               target="_blank"
+               rel="noopener noreferrer"> {{ ingressRuleFlat.host }} </a>
           </ng-container>
           <ng-container *ngIf="!ingressRuleFlat.host">-</ng-container>
         </mat-cell>
@@ -46,7 +47,15 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Path </mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          {{ !!ingressRuleFlat?.path?.path ? ingressRuleFlat?.path?.path : '-' }}
+          <ng-container *ngIf="ingressRuleFlat.path.path">
+            <ng-container *ngIf="ingressRuleFlat.host">
+              <a rel="noopener noreferrer"
+                 href="https://{{ ingressRuleFlat.host }}{{ ingressRuleFlat.path.path }}"
+                 target="_blank">{{ ingressRuleFlat.path.path }}</a>
+            </ng-container>
+            <ng-container *ngIf="!ingressRuleFlat.host">{{ ingressRuleFlat.path.path }}</ng-container>
+          </ng-container>
+          <ng-container *ngIf="!ingressRuleFlat.path.path">-</ng-container>
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[2]">

--- a/modules/web/src/common/components/ingressrulelist/template.html
+++ b/modules/web/src/common/components/ingressrulelist/template.html
@@ -47,7 +47,7 @@ limitations under the License.
         <mat-header-cell *matHeaderCellDef
                          i18n>Path </mat-header-cell>
         <mat-cell *matCellDef="let ingressRuleFlat">
-          <ng-container *ngIf="ingressRuleFlat.path.path">
+          <ng-container *ngIf="ingressRuleFlat?.path?.path">
             <ng-container *ngIf="ingressRuleFlat.host">
               <a rel="noopener noreferrer"
                  href="https://{{ ingressRuleFlat.host }}{{ ingressRuleFlat.path.path }}"
@@ -55,7 +55,7 @@ limitations under the License.
             </ng-container>
             <ng-container *ngIf="!ingressRuleFlat.host">{{ ingressRuleFlat.path.path }}</ng-container>
           </ng-container>
-          <ng-container *ngIf="!ingressRuleFlat.path.path">-</ng-container>
+          <ng-container *ngIf="!ingressRuleFlat?.path?.path">-</ng-container>
         </mat-cell>
       </ng-container>
       <ng-container [matColumnDef]="getIngressRulesFlatColumns()[2]">


### PR DESCRIPTION
This is a copy of #7017
![163737717-08e42793-e9e9-4ba5-b349-4a9390c59af4](https://user-images.githubusercontent.com/297498/193049433-cb8b5d06-6350-401e-a28c-88fbe9e92cfb.png)


-----------

sample YAML to test

```
kind: Ingress
apiVersion: networking.k8s.io/v1
metadata:
  name: kubernetes-dashboard-lb2
  namespace: kubernetes-dashboard
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
spec:
  defaultBackend:
    service:
      name: test
      port:
        number: 80
  rules:
    - host: dashboard.mydomain.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: kubernetes-dashboard
                port:
                  number: 443
    - host: dashboard2.mydomain.com
      http:
        paths:
          - path: /mypath
            pathType: Prefix
            backend:
              service:
                name: kubernetes-dashboard
                port:
                  number: 443
    - host: dashboard2.mydomain.com
      http:
        paths:
          - path: /mypath/morepath
            pathType: Prefix
            backend:
              service:
                name: kubernetes-dashboard
                port:
                  number: 443
    - http:
        paths:
        - path: /testpath
          pathType: Prefix
          backend:
            service:
              name: test
              port:
                number: 80
    - http:
        paths:
          - path: /icons
            pathType: ImplementationSpecific
            backend:
              resource:
                apiGroup: k8s.example.com
                kind: StorageBucket
                name: icon-assets
    - host: "foo.bar.com"
      http:
        paths:
          - pathType: Prefix
            path: "/bar"
            backend:
              service:
                name: service1
                port:
                  number: 80
    - host: "*.foo.com"
      http:
        paths:
          - pathType: Prefix
            path: "/foo"
            backend:
              service:
                name: service2
                port:
                  number: 80
    - host: foo.bar.com
      http:
        paths:
          - path: /foo
            pathType: Prefix
            backend:
              service:
                name: service1
                port:
                  number: 4200
          - path: /bar
            pathType: Prefix
            backend:
              service:
                name: service2
                port:
                  number: 8080
```