### PR TITLE
Resource owner now shown in every pane

### DIFF
--- a/modules/api/pkg/api/types.go
+++ b/modules/api/pkg/api/types.go
@@ -65,6 +65,39 @@ type ObjectMeta struct {
 	// don't ONLY use UUIDs, this is an alias to string.  Being a type captures
 	// intent and helps make sure that UIDs and names do not get conflated.
 	UID types.UID `json:"uid,omitempty"`
+
+	// List of objects depended by this object. If ALL objects in the list have
+	// been deleted, this object will be garbage collected. If this object is managed by a controller,
+	// then an entry in this list will point to this controller, with the controller field set to true.
+	// There cannot be more than one managing controller.
+	// +optional
+	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+}
+
+type OwnerReference struct {
+	// Kind of the referent.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	Kind string `json:"kind"`
+	// Name of the referent.
+	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	Name string `json:"name"`
+}
+
+func getOwnerRerefereces(k8SOwnerReferences []metaV1.OwnerReference) []OwnerReference {
+	size := len(k8SOwnerReferences)
+	if size == 0 {
+		return nil
+	}
+
+	ownerReferences := make([]OwnerReference, 0, size)
+	for _, k8sOwnerReference := range k8SOwnerReferences {
+		myOwnerReferences := OwnerReference{
+			Kind: k8sOwnerReference.Kind,
+			Name: k8sOwnerReference.Name,
+		}
+		ownerReferences = append(ownerReferences, myOwnerReferences)
+	}
+	return ownerReferences
 }
 
 // TypeMeta describes an individual object in an API response or request with strings representing
@@ -99,6 +132,7 @@ func NewObjectMeta(k8SObjectMeta metaV1.ObjectMeta) ObjectMeta {
 		CreationTimestamp: k8SObjectMeta.CreationTimestamp,
 		Annotations:       k8SObjectMeta.Annotations,
 		UID:               k8SObjectMeta.UID,
+		OwnerReferences:   getOwnerRerefereces(k8SObjectMeta.OwnerReferences),
 	}
 }
 

--- a/modules/web/i18n/de/messages.de.xlf
+++ b/modules/web/i18n/de/messages.de.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>nicht festgelegt</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>Ressourcenlimits</target>

--- a/modules/web/i18n/es/messages.es.xlf
+++ b/modules/web/i18n/es/messages.es.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>no definido</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>Límites de Recursos</target>

--- a/modules/web/i18n/fr/messages.fr.xlf
+++ b/modules/web/i18n/fr/messages.fr.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>non défini</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>Limites de ressources</target>

--- a/modules/web/i18n/ja/messages.ja.xlf
+++ b/modules/web/i18n/ja/messages.ja.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>なし</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>リソース上限</target>

--- a/modules/web/i18n/ko/messages.ko.xlf
+++ b/modules/web/i18n/ko/messages.ko.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>설정 취소</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>리소스 제한</target>

--- a/modules/web/i18n/messages.xlf
+++ b/modules/web/i18n/messages.xlf
@@ -678,6 +678,9 @@
       <trans-unit id="3663367271392398931" datatype="html">
         <source>unset</source>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
       </trans-unit>

--- a/modules/web/i18n/zh-Hans/messages.zh-Hans.xlf
+++ b/modules/web/i18n/zh-Hans/messages.zh-Hans.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>未设置</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target>资源限制</target>

--- a/modules/web/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
+++ b/modules/web/i18n/zh-Hant-HK/messages.zh-Hant-HK.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>未設置</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target state="new">Resource Limits</target>

--- a/modules/web/i18n/zh-Hant/messages.zh-Hant.xlf
+++ b/modules/web/i18n/zh-Hant/messages.zh-Hant.xlf
@@ -930,6 +930,10 @@
         <source>unset</source>
         <target>未設置</target>
       </trans-unit>
+      <trans-unit id="3715596725146409911" datatype="html">
+        <source>Owner</source>
+        <target state="new">Owner</target>
+      </trans-unit>
       <trans-unit id="374277779600579508" datatype="html">
         <source>Resource Limits</source>
         <target state="new">Resource Limits</target>

--- a/modules/web/src/common/components/objectmeta/component.ts
+++ b/modules/web/src/common/components/objectmeta/component.ts
@@ -14,6 +14,9 @@
 
 import {Component, Input} from '@angular/core';
 import {ObjectMeta} from '@api/root.api';
+import {GlobalServicesModule} from '../../services/global/module';
+import {KdStateService} from '../../services/global/state';
+import {Resource} from '@common/services/resource/endpoint';
 
 @Component({
   selector: 'kd-object-meta',
@@ -23,6 +26,8 @@ export class ObjectMetaComponent {
   @Input() initialized = false;
 
   private objectMeta_: ObjectMeta;
+  private readonly kdState_: KdStateService = GlobalServicesModule.injector.get(KdStateService);
+
   get objectMeta(): ObjectMeta {
     return this.objectMeta_;
   }
@@ -34,5 +39,13 @@ export class ObjectMetaComponent {
     } else {
       this.objectMeta_ = val;
     }
+  }
+
+  getObjectHref(kind: string, name: string): string {
+    if (!Object.values(Resource).includes(kind.toLowerCase() as Resource)) {
+      return '';
+    }
+
+    return this.kdState_.href(kind.toLowerCase(), name, this.objectMeta_.namespace);
   }
 }

--- a/modules/web/src/common/components/objectmeta/template.html
+++ b/modules/web/src/common/components/objectmeta/template.html
@@ -71,6 +71,22 @@ limitations under the License.
              i18n>UID</div>
         <div value>{{ objectMeta?.uid }}</div>
       </kd-property>
+      <kd-property *ngIf="objectMeta?.ownerReferences"
+                   [ngClass]="'object-meta-ownerReferences'">
+        <div key
+             i18n>Owner</div>
+        <div value
+             *ngFor="let ownerReference of objectMeta?.ownerReferences">
+
+          <a *ngIf="getObjectHref(ownerReference.kind, ownerReference.name); else unsupportedObject"
+             [routerLink]="getObjectHref(ownerReference.kind, ownerReference.name)"
+             queryParamsHandling="preserve">
+            {{ownerReference.kind}}/{{ownerReference.name}}
+          </a>
+          <ng-template #unsupportedObject>{{ownerReference.kind}}/{{ownerReference.name}}</ng-template>
+
+        </div>
+      </kd-property>
       <kd-property *ngIf="objectMeta?.labels"
                    fxFlex="100"
                    [ngClass]="'object-meta-labels'">

--- a/modules/web/src/typings/root.api.ts
+++ b/modules/web/src/typings/root.api.ts
@@ -32,6 +32,12 @@ export interface ObjectMeta {
   annotations?: StringMap;
   creationTimestamp?: string;
   uid?: string;
+  ownerReferences?: OwnerReference[];
+}
+
+export interface OwnerReference {
+  kind: string;
+  name: string;
 }
 
 export interface JobStatus {


### PR DESCRIPTION
This is a duplicate of #6237

![image](https://user-images.githubusercontent.com/297498/124763966-de77eb00-df0a-11eb-981d-c360c12cea40.png)

I am not sure if this is useful anywhere but in a `ReplicaSet` and in a `Job` started by a `CronJob` Also, we have the "problem" of having the info shown twice in Pods.

@floreks , my team and I use this every day. It's quite useful. Consider merging, please!

This PR can be tested using the following containers:

* marcosdiez/dashboard-api:v2.7.0.b
* marcosdiez/dashboard-web:v2.7.0.b