### PR TITLE
fix:change toleration from master to control-plane

### DIFF
--- a/charts/alternative.yaml
+++ b/charts/alternative.yaml
@@ -213,7 +213,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
 
 ---
@@ -281,7 +281,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/charts/alternative/06_dashboard-deployment.yaml
+++ b/charts/alternative/06_dashboard-deployment.yaml
@@ -69,5 +69,5 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/charts/alternative/08_scraper-deployment.yaml
+++ b/charts/alternative/08_scraper-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/charts/head.yaml
+++ b/charts/head.yaml
@@ -225,7 +225,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
 
 ---
@@ -293,7 +293,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/charts/head/06_dashboard-deployment.yaml
+++ b/charts/head/06_dashboard-deployment.yaml
@@ -89,5 +89,5 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/charts/head/08_scraper-deployment.yaml
+++ b/charts/head/08_scraper-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/charts/recommended.yaml
+++ b/charts/recommended.yaml
@@ -231,7 +231,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
 
 ---
@@ -299,7 +299,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/charts/recommended/06_dashboard-deployment.yaml
+++ b/charts/recommended/06_dashboard-deployment.yaml
@@ -76,5 +76,5 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule

--- a/charts/recommended/08_scraper-deployment.yaml
+++ b/charts/recommended/08_scraper-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       volumes:
         - name: tmp-volume

--- a/hack/test-resources/kubernetes-dashboard-local.yaml
+++ b/hack/test-resources/kubernetes-dashboard-local.yaml
@@ -180,7 +180,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
 
 ---
@@ -243,7 +243,7 @@ spec:
         "kubernetes.io/os": linux
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       volumes:
       - emptyDir: {}


### PR DESCRIPTION
## Background

`node-role.kubernetes.io/master` is deprecated
It is recommended to use `node-role.kubernetes.io/control-plane`

ref:
- https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint#kep-2067-rename-the-kubeadm-master-label-and-taint

## Changes

Change tolerations from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`

