### PR TITLE
Replace deprecated k8s registry references.

### DIFF
--- a/.github/workflows/ci-global.yml
+++ b/.github/workflows/ci-global.yml
@@ -90,7 +90,7 @@ jobs:
           kubectl_version: v1.25.1
           cluster_name: k8s-cluster-ci
       - run: |
-          docker run --net=host -d k8s.gcr.io/heapster-amd64:v1.5.4 \
+          docker run --net=host -d registry.k8s.io/heapster-amd64:v1.5.4 \
              --heapster-port=8082 \
              --source=kubernetes:http://127.0.0.1:8080?inClusterConfig=false&auth=""
       - run: kind get kubeconfig --name="k8s-cluster-ci" > ${HOME}/.kube/config

--- a/hack/scripts/start-cluster.sh
+++ b/hack/scripts/start-cluster.sh
@@ -19,7 +19,7 @@ ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
 
 function start-ci-heapster {
   echo "\nRunning heapster in standalone mode"
-  docker run --net=host -d k8s.gcr.io/heapster-amd64:${HEAPSTER_VERSION} \
+  docker run --net=host -d registry.k8s.io/heapster-amd64:${HEAPSTER_VERSION} \
              --heapster-port ${HEAPSTER_PORT} \
              --source=kubernetes:http://127.0.0.1:8080?inClusterConfig=false&auth=""
 

--- a/hack/test-resources/env-variables-pod.yaml
+++ b/hack/test-resources/env-variables-pod.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: k8s.gcr.io/busybox
+      image: registry.k8s.io/busybox
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/modules/api/pkg/resource/pod/detail_test.go
+++ b/modules/api/pkg/resource/pod/detail_test.go
@@ -161,7 +161,7 @@ func TestEvalEnvFrom(t *testing.T) {
 		{
 			container: v1.Container{
 				Name:  "echoserver",
-				Image: "k8s.gcr.io/echoserver",
+				Image: "registry.k8s.io/echoserver",
 				EnvFrom: []v1.EnvFromSource{
 					{
 						SecretRef: &v1.SecretEnvSource{


### PR DESCRIPTION
Problem:
Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp.  Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution:
As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This commit migrates all remaining references for kubernetes/dashboard to registry.k8s.io.