### PR TITLE
Enable npm update check with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
     directory: "modules/web/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 0 # FIXME: https://github.com/kubernetes/dashboard/issues/7470
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Now dependabot seems to support yarn v2, so re-enable npm update check. https://github.com/dependabot/dependabot-core/issues/1297#issuecomment-1285998196