### PR TITLE
Fix Scale Resource UI

### DIFF
--- a/modules/web/src/common/dialogs/scaleresource/dialog.ts
+++ b/modules/web/src/common/dialogs/scaleresource/dialog.ts
@@ -37,7 +37,7 @@ export class ScaleResourceDialog implements OnInit {
     const url =
       `api/v1/scale/${this.data.typeMeta.kind}` +
       (this.data.objectMeta.namespace ? `/${this.data.objectMeta.namespace}` : '') +
-      `/${this.data.objectMeta.name}/`;
+      `/${this.data.objectMeta.name}`;
 
     this.http_
       .get<ReplicaCounts>(url)


### PR DESCRIPTION
The callback UI for the `Scale a Resource` panel was wrong, therefore it was not showing the correct number of `actual replicas`.

This PR fixed that. And since I am only deleting code, I am technically increasing our test coverage :)

![image](https://user-images.githubusercontent.com/297498/211692051-951da64f-438d-4a6d-9eb9-390f59a2e065.png)
