### PR TITLE
Fix for situation when ingress has no http rules

### DIFF
--- a/modules/api/pkg/resource/ingress/filter.go
+++ b/modules/api/pkg/resource/ingress/filter.go
@@ -36,6 +36,9 @@ func ingressMatchesServiceName(ingress networkingv1.Ingress, serviceName string)
 	}
 
 	for _, rule := range spec.Rules {
+		if rule.IngressRuleValue == nil {
+			continue
+		}
 		if rule.IngressRuleValue.HTTP == nil {
 			continue
 		}


### PR DESCRIPTION
If there is ingress without http rules exists in namespace:

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    nginx.ingress.kubernetes.io/server-snippet: |
      return 301 https://my.another.pretty.domain$request_uri;
  name: my-pretty-ingress
  namespace: my-pretty-namespace
spec:
  ingressClassName: nginx
  rules:
  - host: my.pretty.domain
  tls:
  - hosts:
    - my.pretty.domain
```

There is panic in https://github.com/kubernetes/dashboard/blob/master/modules/api/pkg/resource/ingress/filter.go#L39, because rule.IngressRuleValue is nil.

This PR fix it.