### PR TITLE
Helm: Update CI, upgrade metrics-server

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -20,8 +20,8 @@ on:
     - '.github/workflows/ci-helm.yml'
 permissions:
   contents: read
-jobs:
 
+jobs:
   helm-lint-test:
     name: Lint and test
     runs-on: ubuntu-latest
@@ -30,23 +30,28 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Validate schema
-        uses: wiremind/helm-kubeval-action@v1.2.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
         with:
-          path: charts/helm-chart
-          config: charts/helm-chart/config_repos
-          version: 1.23.0
-      - uses: actions/setup-python@v4.5.0
+          version: v3.11.0
+
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Install kubecomform
+        run: |
+          helm plugin install https://github.com/jtyr/kubeconform-helm
+
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
-      - name: Cleanup charts directory
-        id: cleanup
-        run: sudo rm -rf charts/helm-chart/kubernetes-dashboard/charts
+        uses: helm/chart-testing-action@v2
+
       - name: Run chart-testing (lint)
         id: lint
         run: ct lint --config=charts/helm-chart/.helm-chart-testing.yaml
+
       - name: Start kind cluster
         uses: helm/kind-action@v1.5.0
         with:
@@ -54,5 +59,6 @@ jobs:
       - name: Install Prometheus Operator CRDs
         id: prom
         run: kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+
       - name: Run chart-testing (install)
         run: ct install --config=charts/helm-chart/.helm-chart-testing.yaml

--- a/charts/helm-chart/.helm-chart-testing.yaml
+++ b/charts/helm-chart/.helm-chart-testing.yaml
@@ -16,4 +16,6 @@ chart-dirs:
   - charts/helm-chart
 chart-repos:
   - metrics-server=https://kubernetes-sigs.github.io/metrics-server/
-debug: true
+debug: false
+additional-commands:
+  - helm kubeconform {{ .Path }} --config charts/helm-chart/.kubeconform

--- a/charts/helm-chart/.kubeconform
+++ b/charts/helm-chart/.kubeconform
@@ -1,0 +1,3 @@
+schema-location:
+  - default
+  - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json

--- a/charts/helm-chart/.kubeconform
+++ b/charts/helm-chart/.kubeconform
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 schema-location:
   - default
   - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json

--- a/charts/helm-chart/config_repos
+++ b/charts/helm-chart/config_repos
@@ -1,2 +1,0 @@
-# Repository_name=Repository_URL
-metrics-server=https://kubernetes-sigs.github.io/metrics-server

--- a/charts/helm-chart/kubernetes-dashboard/Chart.lock
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
-  version: 3.5.0
-digest: sha256:5e472fb28387489d7ff5946178ecfa44d5fd414364906f3b5a0312ddfaabb8fd
-generated: "2021-10-05T12:13:00.705224804+02:00"
+  version: 3.8.3
+digest: sha256:1a0d2dc060982d837eee877a65ff5fceb205b1006ffe91aaefd3447b5fac4216
+generated: "2023-01-20T17:24:45.791966+01:00"

--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 6.0.3
+version: 6.0.4
 appVersion: "v2.7.0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:
@@ -30,6 +30,6 @@ icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.s
 kubeVersion: ">=1.19.0-0"
 dependencies:
   - name: metrics-server
-    version: 3.5.0
+    version: 3.8.3
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled


### PR DESCRIPTION
- Update CI, move from kubeval to kubeconform in order to have up-to-date support for newer Kubernetes versions.
- Helm: upgrade metrics-server subchart from 3.5.0 to 3.8.3.