### PR TITLE
Fix build in development container

### DIFF
--- a/hack/develop/run-command.sh
+++ b/hack/develop/run-command.sh
@@ -63,8 +63,9 @@ if [[ "${K8S_OWN_CLUSTER}" != true ]] ; then
   echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
 fi
 
-# Install dependencies
+# Clean install dependencies
 cd modules/web
+rm -fr node_modules
 yarn
 cd ${ROOT_DIR}
 


### PR DESCRIPTION
Remove `modules/web/node_modules` directory before `yarn`, to do clean install as a default behavior.