### PR TITLE
Document helm chart PodSecurityPolicy deprecation and PodSecurityAdmission alternative

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 6.0.4
+version: 6.0.5
 appVersion: "v2.7.0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/helm-chart/kubernetes-dashboard/README.md
+++ b/charts/helm-chart/kubernetes-dashboard/README.md
@@ -65,6 +65,16 @@ helm install kubernetes-dashboard/kubernetes-dashboard --name kubernetes-dashboa
 
 > **Tip**: You can use the default [values.yaml](values.yaml), which is used by default, as reference
 
+### Pod security policy and admission
+
+The chart supports enabling ``PodSecurityPolicy`` for kubernetes 1.24 and prior via a flag in `values.yaml`.
+
+Please be aware `PodSecurityPolicy` is now deprecated and removed from kubernetes 1.25+ onwards. An alternative is to enable ``PodSecurityAdmission`` for the namespace that kubernetes dashboard will be deployed in. To do this add [labels to the namespace](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels). Example below:
+
+```console
+kubectl label --overwrite ns kubernetes-dashboard pod-security.kubernetes.io/enforce=baseline
+```
+
 ## Upgrading an existing Release to a new major version
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -344,6 +344,8 @@ networkPolicy:
   enabled: false
 
 ## podSecurityPolicy for fine-grained authorization of pod creation and updates
+## Note that PSP is deprecated and has been removed from kubernetes 1.25 onwards.
+## For 1.25+ consider enabling PodSecurityAdmission, refer to chart README.md.
 podSecurityPolicy:
   # Specifies whether a pod security policy should be created
   enabled: false


### PR DESCRIPTION
Pod security policy has been removed from kubernetes 1.25 onwards. The successor pod security admission is not fully supported in helm as it involved labeling the release namespace which helm does not support. Refer https://github.com/helm/helm/issues/3503.

Additionally since pod security admission is managed at the namespace level we probably shouldn't touch it unless we can be certain we are the sole namespace tenant.

Perhaps we should just be updating documentation to outline how users of the chart can label their namespace post chart deployment to add a pod security policy label?

Starting this pull request as a draft to generate some discussion on next steps and hopefully get a consensus.

Fixes: #7608