### PR TITLE
Fix Scale Resource (part 2)

### DIFF
--- a/modules/api/pkg/handler/apihandler.go
+++ b/modules/api/pkg/handler/apihandler.go
@@ -288,11 +288,11 @@ func CreateHTTPAPIHandler(iManager integration.IntegrationManager, cManager clie
 			Writes(deployment.DeploymentDetail{}))
 
 	apiV1Ws.Route(
-		apiV1Ws.PUT("/scale/{kind}/{namespace}/{name}/").
+		apiV1Ws.PUT("/scale/{kind}/{namespace}/{name}").
 			To(apiHandler.handleScaleResource).
 			Writes(scaling.ReplicaCounts{}))
 	apiV1Ws.Route(
-		apiV1Ws.PUT("/scale/{kind}/{name}/").
+		apiV1Ws.PUT("/scale/{kind}/{name}").
 			To(apiHandler.handleScaleResource).
 			Writes(scaling.ReplicaCounts{}))
 	apiV1Ws.Route(

--- a/modules/web/src/common/services/global/verber.ts
+++ b/modules/web/src/common/services/global/verber.ts
@@ -93,7 +93,7 @@ export class VerberService {
         switchMap(result => {
           const url = `api/v1/scale/${typeMeta.kind}${objectMeta.namespace ? `/${objectMeta.namespace}` : ''}/${
             objectMeta.name
-          }/`;
+          }`;
 
           return this.http_.put(url, {scaleBy: result}, {params: {scaleBy: result}});
         })


### PR DESCRIPTION
This PR complements https://github.com/kubernetes/dashboard/pull/7584

After splitting the dashboard into two, scale a resource got broken.

The previous PR fixes the GET so the UI can see how many resources we have now. 
This PR fixes the PUT so we can actually modify the value.
