### PR TITLE
Add flag to prevent ingress

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/README.md
+++ b/charts/helm-chart/kubernetes-dashboard/README.md
@@ -45,6 +45,12 @@ See this [guide](https://github.com/kubernetes/dashboard/blob/master/docs/user/a
 
 It is highly recommended to use RBAC with minimal privileges needed for Dashboard to run.
 
+### NetworkPolicy
+
+You can enable a networkPolicy for this application via the `networkPolicy.enabled` boolean. By default it permits ingress only to the HTTP or HTTPS port (see `protocolHttp` from values.yaml).
+
+If you wish to disable all ingress to this application you may set the `networkPolicy.ingressDenyAll` boolean to `true`. If ingress is disabled you must use direct port-forwarding to access this application.
+
 ## Configuration
 
 Please refer to [values.yaml](https://github.com/kubernetes/dashboard/blob/master/charts/helm-chart/kubernetes-dashboard/values.yaml)

--- a/charts/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
@@ -33,6 +33,9 @@ spec:
   podSelector:
     matchLabels:
 {{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+{{- if .Values.networkPolicy.ingressDenyAll }}
+  ingress: []
+{{- else }}
   ingress:
   - ports:
 {{- if .Values.protocolHttp }}
@@ -41,5 +44,6 @@ spec:
 {{- else }}
     - port: https
       protocol: TCP
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -343,6 +343,9 @@ networkPolicy:
   # Whether to create a network policy that allows/restricts access to the service
   enabled: false
 
+  # Whether to set network policy to deny all ingress traffic for the kubernetes-dashboard
+  ingressDenyAll: false
+
 ## podSecurityPolicy for fine-grained authorization of pod creation and updates
 ## Note that PSP is deprecated and has been removed from kubernetes 1.25 onwards.
 ## For 1.25+ consider enabling PodSecurityAdmission, refer to chart README.md.


### PR DESCRIPTION
To help ensure someone doesn't expose the dashboard, I'd like to set a network policy to block ingress.  I figured while I was at it, I'd make it more generic so this could be used more broadly.

Folks who want to be sure no one comes along and adds an ingress to the dashboard now have an easy toggle to lock it down.