### PR TITLE
[helm chart] make sure the ServiceMonitor API is available before installing one

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 6.0.6
+version: 6.1.0
 appVersion: "v2.7.0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.serviceMonitor.enabled if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1"  }}
+{{- if and .Values.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1"  }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
I think this is a good practice to have since it avoid errors when the same chart with the same values file is installed into multiple clusters, some of them might not have the relevant CRDs.
I have seen other chart use this pattern: https://github.com/fluent/helm-charts/blob/d808425a73580891a77e115561fe3ea2d2e24347/charts/fluent-bit/templates/servicemonitor.yaml#LL1-L1C106
and I think it is a good one to follow.
