### PR TITLE
Bump kindest/node image to 1.26.3

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ct lint --config=charts/helm-chart/.helm-chart-testing.yaml
       - uses: helm/kind-action@v1.5.0
         with:
-          node_image: kindest/node:v1.26.2
+          node_image: kindest/node:v1.26.3
       - run: kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
       - name: Run chart-testing (install)
         run: ct install --config=charts/helm-chart/.helm-chart-testing.yaml

--- a/hack/scripts/conf.sh
+++ b/hack/scripts/conf.sh
@@ -29,7 +29,7 @@ ARCH=$(uname | awk '{print tolower($0)}')
 HEAPSTER_VERSION="v1.5.4"
 HEAPSTER_PORT=8082
 KIND_VERSION="v0.17.0"
-K8S_VERSION="v1.26.2"
+K8S_VERSION="v1.26.3"
 KIND_BIN=${CACHE_DIR}/kind-${KIND_VERSION}
 
 function ensure-cache {


### PR DESCRIPTION
Use following image
https://hub.docker.com/layers/kindest/node/v1.26.3/images/sha256-94eb63275ad6305210041cdb5aca87c8562cc50fa152dbec3fef8c58479db4ff?context=explore