### PR TITLE
Bump metrics-server dependency in helm chart to 3.8.4

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.lock
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
-  version: 3.8.3
-digest: sha256:1a0d2dc060982d837eee877a65ff5fceb205b1006ffe91aaefd3447b5fac4216
-generated: "2023-01-20T17:24:45.791966+01:00"
+  version: 3.8.4
+digest: sha256:a1d1c43676057ed97dd3b88d3ecac8440e7fdfc57b0befdac7a069dd450bec8e
+generated: "2023-04-13T15:38:14.174214045+01:00"

--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -30,6 +30,6 @@ icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.s
 kubeVersion: ">=1.19.0-0"
 dependencies:
   - name: metrics-server
-    version: 3.8.3
+    version: 3.8.4
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled


### PR DESCRIPTION
Bump metrics-server dependency in helm chart from 3.8.3 to 3.8.4 to account for migration of k8s.gcr.io to registry.k8s.io.

Migration of image registry is the only listed change in the changelog for metric server's 3.8.4 chart.

https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/