### PR TITLE
Add additional controls for pod admission restricted

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 6.0.7
+version: 6.0.8
 appVersion: "v2.7.0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -84,6 +84,7 @@ extraManifests: []
 ## To disable set the following configuration to null:
 # securityContext: null
 securityContext:
+  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
@@ -95,6 +96,8 @@ containerSecurityContext:
   readOnlyRootFilesystem: true
   runAsUser: 1001
   runAsGroup: 2001
+  capabilities:
+    drop: ["ALL"]
 
 ## @param podLabels Extra labels for OAuth2 Proxy pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
This adds some additional default settings to the dashboard helm chart for pod-security restricted.

End users of the chart shouldn't notice anything different as the disabled features are not used by the application.