### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/hack/develop/Dockerfile
+++ b/hack/develop/Dockerfile
@@ -80,7 +80,7 @@ RUN curl -SL https://github.com/docker/compose/releases/download/v2.14.0/docker-
 RUN chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN curl -LO https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396
