### PR TITLE
Update Dashboard Tour href to point to Dashboard Docs instead of nothing

### DIFF
--- a/modules/web/src/common/components/zerostate/template.html
+++ b/modules/web/src/common/components/zerostate/template.html
@@ -27,8 +27,8 @@ limitations under the License.
       You can
       <a routerLink="deploy"
          queryParamsHandling="preserve">deploy a containerized app</a>, select other namespace or
-      <a href="https://kubernetes.io/docs/user-guide/ui/"
-         target="_blank">take the Dashboard Tour
+      <a href="https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/#using-dashboard"
+         target="_blank">check the Dashboard Docs
         <mat-icon class="kd-zerostate-icon">open_in_new</mat-icon>
       </a>
       to learn more.


### PR DESCRIPTION
https://kubernetes.io/docs/user-guide/ui/ is a dead link, this changes the link to https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/#using-dashboard in the Dashboard landing page