### PR TITLE
Specify bit size to int32

### DIFF
--- a/modules/api/pkg/scaling/scale.go
+++ b/modules/api/pkg/scaling/scale.go
@@ -70,7 +70,7 @@ func ScaleResource(cfg *rest.Config, kind, namespace, name, count string) (*Repl
 		return nil, err
 	}
 
-	c, err := strconv.Atoi(count)
+	c, err := strconv.ParseInt(count, 10, 32)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Default bit size for `atoi` is int64, but using `int32(c)` for the result can cause a violation.
To parse string to int32, switch from `atoi` to `ParseInt` with specifying bit size.

Fixing security alert from CodeQL.
