### PR TITLE
Prevent to run postinstall for yarn during dependabot check

### DIFF
--- a/modules/web/.yarnrc.yml
+++ b/modules/web/.yarnrc.yml
@@ -6,4 +6,4 @@ plugins:
 
 yarnPath: .yarn/releases/yarn-3.2.2.cjs
 
-postinstall: env && test -n "${DEPENDABOT_HOME}" || npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky
+postinstall: ./hack/postinstall.sh

--- a/modules/web/.yarnrc.yml
+++ b/modules/web/.yarnrc.yml
@@ -6,4 +6,4 @@ plugins:
 
 yarnPath: .yarn/releases/yarn-3.2.2.cjs
 
-postinstall: npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky
+postinstall: env && test -n "${DEPENDABOT_HOME}" || npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky

--- a/modules/web/hack/postinstall.sh
+++ b/modules/web/hack/postinstall.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "$(env | grep DEPENDABOT_HOME)" ]; then
+  # TODO: if dependabot will support yarn postinstall properly,
+  #       move following line into .yarnrc.yml.
+  npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky
+  exit $?
+fi
+
+exit 0

--- a/modules/web/hack/postinstall.sh
+++ b/modules/web/hack/postinstall.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "$(env | grep DEPENDABOT_HOME)" ]; then
+if [ -z "${DEPENDABOT_HOME}" ]; then
   # TODO: if dependabot will support yarn postinstall properly,
   #       move following line into .yarnrc.yml.
   npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky


### PR DESCRIPTION
Investigate workaround to run dependabot for js/ts.
dependabot fails to execute postinstall when checking js/ts dependencies. I don't think dependabot needs postinstall, so I'll try not to run postinstall on dependabot.