### PR TITLE
Fix: Plugin API reverted to the correct version

### DIFF
--- a/hack/test-resources/plugin-crd.yml
+++ b/hack/test-resources/plugin-crd.yml
@@ -24,7 +24,7 @@ spec:
   group: dashboard.k8s.io
   scope: Namespaced
   versions:
-    - name: v1
+    - name: v1alpha1
       served: true
       storage: true
       schema:

--- a/hack/test-resources/plugin-test.yml
+++ b/hack/test-resources/plugin-test.yml
@@ -14,7 +14,7 @@
 
 # A manifest that creates test plugin resources.
 
-apiVersion: dashboard.k8s.io/v1
+apiVersion: dashboard.k8s.io/v1alpha1
 kind: Plugin
 metadata:
   name: k8s-plugin
@@ -26,7 +26,7 @@ spec:
 
 ---
 
-apiVersion: dashboard.k8s.io/v1
+apiVersion: dashboard.k8s.io/v1alpha1
 kind: Plugin
 metadata:
   name: plugin1


### PR DESCRIPTION
@maciaszczykm  back in #7732, I forgot to revert the API version from my local environment to what we currently offer in the repo. This will fix the problem and let the plugin tab appear in the UI.
https://github.com/kubernetes/dashboard/blob/78a2b5f8527d4d082c9d2114e94b7f0758f7f39c/modules/api/pkg/plugin/apis/v1alpha1/register.go#L15
![image](https://github.com/kubernetes/dashboard/assets/54559947/57c849ac-352e-4448-907f-a10b9eb6f741)
