### PR TITLE
cleanup: links to authentication were broken (linking to 404). Issue #7970

### DIFF
--- a/modules/web/src/login/template.html
+++ b/modules/web/src/login/template.html
@@ -51,14 +51,14 @@ limitations under the License.
                             i18n>
                 Make sure that support for basic authentication is enabled in the cluster. To find out more about how to
                 configure basic authentication, please refer to the
-                <a href="https://kubernetes.io/docs/admin/authentication/">Authenticating</a> and
-                <a href="https://kubernetes.io/docs/admin/authorization/abac/">ABAC Mode</a> sections.
+                <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/">Authenticating</a> and
+                <a href="https://kubernetes.io/docs/reference/access-authn-authz/abac/">ABAC Mode</a> sections.
               </ng-container>
               <ng-container *ngSwitchCase="loginModes.Token"
                             i18n>
                 Every Service Account has a Secret with valid Bearer Token that can be used to log in to Dashboard. To
                 find out more about how to configure and use Bearer Tokens, please refer to the
-                <a href="https://kubernetes.io/docs/admin/authentication/">Authentication</a> section.
+                <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/">Authentication</a> section.
               </ng-container>
             </div>
           </div>


### PR DESCRIPTION
Links detailing the setup of authentication in the cluster were broken. I updated them with the correct ones pointing to the latest [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/).

See Issue [#7970](https://github.com/kubernetes/dashboard/issues/7970)