### PR TITLE
Use `DEPENDABOT` instead of `DEPENDABOT_HOME`

### DIFF
--- a/modules/web/hack/postinstall.sh
+++ b/modules/web/hack/postinstall.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "${DEPENDABOT_HOME}" ]; then
+if [ -z "${DEPENDABOT}" ]; then
   # TODO: if dependabot will support yarn postinstall properly,
   #       move following line into .yarnrc.yml.
   npx ngcc && node ./hack/version.mjs && cd ../../ && npx husky install modules/web/.husky


### PR DESCRIPTION
`DEPENDABOT` env was introduced for presenting that dependabot is running. So switch to this from `DEPENDABOT_HOME` that we use now.

Fixes: https://github.com/kubernetes/dashboard/issues/7817