### PR TITLE
Fix ingress nginx dependency condition

### DIFF
--- a/charts/helm-chart/.helm-chart-testing.yaml
+++ b/charts/helm-chart/.helm-chart-testing.yaml
@@ -17,7 +17,7 @@ chart-dirs:
 chart-repos:
   - metrics-server=https://kubernetes-sigs.github.io/metrics-server/
   - cert-manager=https://charts.jetstack.io
-  - nginx-ingress=https://helm.nginx.com/stable
+  - ingress-nginx=https://kubernetes.github.io/ingress-nginx
 debug: false
 # additional-commands:
 #  - helm kubeconform {{ .Path }} --config charts/helm-chart/.kubeconforma

--- a/charts/helm-chart/kubernetes-dashboard/Chart.lock
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.8.4
-digest: sha256:805f6405d0cb3ceb4c6068e5235c4c18845bc30bafa900b69bc4c66bfeefc4fd
-generated: "2023-07-07T11:44:54.033948186+02:00"
+digest: sha256:a55a0d3f36aa4d4a38218c7f79224b273ce6388743574de2d679400c93d2b2d6
+generated: "2023-07-08T19:07:40.182171996+02:00"

--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
     alias: nginx
     version: 4.7.1
     repository: https://kubernetes.github.io/ingress-nginx
-    condition: nginx-ingress.enabled
+    condition: nginx.enabled
   - name: cert-manager
     version: v1.11.2
     repository: https://charts.jetstack.io

--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.0.0
+version: 7.0.1
 appVersion: "v3.0.0-alpha0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:


### PR DESCRIPTION
This fixes ingress-nginx's dependency condition such that when `nginx.enabled` is set to `false` in values, the subchart is actually disabled.

On a separate note, I installed the new version of kubernetes-dashboard without ingress-nginx at all. I'm using traefik for my ingress and the dashboard is working normally. Is the dependency therefore really mandatory, and perhaps a note could be added if not?