### PR TITLE
add ability to disable ingress creation

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.0.2
+version: 7.0.3
 appVersion: "v3.0.0-alpha0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.app.ingress.enabled }}
 {{- if not (or (eq .Values.app.ingress.issuer.scope "default") (eq .Values.app.ingress.issuer.scope "cluster")) }}
 {{- fail "value of .Values.app.ingress.issuer.scope must be one of [default, cluster]"}}
 {{- end }}
@@ -85,3 +86,4 @@ spec:
                 port:
                   name: {{ .Values.api.role }}
     {{- end }}
+{{- end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/networking/post-install-ingress-issuer.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/networking/post-install-ingress-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.app.ingress.issuer.name "selfsigned" -}}
+{{- if and (.Values.app.ingress.enabled) (eq .Values.app.ingress.issuer.name "selfsigned") -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -76,6 +76,7 @@ app:
     #  #  Is this CRD namespaced?
     #  namespaced: true
   ingress:
+    enabled: true
     hosts:
     # Keep 'localhost' host only if you want to access Dashboard using 'kubectl port-forward ...' on:
     # https://localhost:8443


### PR DESCRIPTION
This PR adds the ability to disable ingress creation when deploying the helm chart. We are using ingressRoute CR provided by traefik so the ingress is not needed, neither the issuer.