### PR TITLE
fix(dashboard): adjust api web order in ingress to prevent 404

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -52,13 +52,6 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ $.Values.app.ingress.paths.web }}
-            pathType: {{ $.Values.app.ingress.pathType }}
-            backend:
-              service:
-                name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ $.Values.web.role }}
-                port:
-                  name: {{ $.Values.web.role }}
           - path: {{ $.Values.app.ingress.paths.api }}
             pathType: {{ $.Values.app.ingress.pathType }}
             backend:
@@ -66,17 +59,17 @@ spec:
                 name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ $.Values.api.role }}
                 port:
                   name: {{ $.Values.api.role }}
+          - path: {{ $.Values.app.ingress.paths.web }}
+            pathType: {{ $.Values.app.ingress.pathType }}
+            backend:
+              service:
+                name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ $.Values.web.role }}
+                port:
+                  name: {{ $.Values.web.role }}
     {{- end }}
     {{- else }}
     - http:
         paths:
-          - path: {{ .Values.app.ingress.paths.web }}
-            pathType: {{ .Values.app.ingress.pathType }}
-            backend:
-              service:
-                name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ .Values.web.role }}
-                port:
-                  name: {{ .Values.web.role }}
           - path: {{ .Values.app.ingress.paths.api }}
             pathType: {{ .Values.app.ingress.pathType }}
             backend:
@@ -84,4 +77,11 @@ spec:
                 name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ .Values.api.role }}
                 port:
                   name: {{ .Values.api.role }}
+          - path: {{ .Values.app.ingress.paths.web }}
+            pathType: {{ .Values.app.ingress.pathType }}
+            backend:
+              service:
+                name: {{ template "kubernetes-dashboard.fullname" $ }}-{{ .Values.web.role }}
+                port:
+                  name: {{ .Values.web.role }}
     {{- end }}

--- a/charts/kubernetes-dashboard.yaml
+++ b/charts/kubernetes-dashboard.yaml
@@ -258,13 +258,6 @@ spec:
     - host: localhost
       http:
         paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kubernetes-dashboard-web
-                port:
-                  name: web
           - path: /api
             pathType: Prefix
             backend:
@@ -272,6 +265,13 @@ spec:
                 name: kubernetes-dashboard-api
                 port:
                   name: api
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kubernetes-dashboard-web
+                port:
+                  name: web
 
 ---
 


### PR DESCRIPTION
This commit adjusts the order of api web in ingress configuration to avoid path matching overlapping which causes 404 errors.