### PR TITLE
Ignore updates for angular staffs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,4 +29,7 @@ updates:
     directory: "modules/web/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 30
+    open-pull-requests-limit: 10
+    ignore:
+      # Angular staffs should be manually updated at once.
+      - dependency-name: "@angular*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,4 +29,4 @@ updates:
     directory: "modules/web/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 30


### PR DESCRIPTION
Angular staffs should be manually updated at once.
So, add a setting to ignore updating angular staffs by dependabot.