### PR TITLE
fix: add missing pullsecrets reference

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/api.yaml
@@ -87,6 +87,14 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
 
+
+      {{- with .Values.app.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -93,6 +93,14 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
 
+
+      {{- with .Values.app.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+
       {{- with .Values.metricsScraper.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/web.yaml
@@ -85,6 +85,14 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
 
+
+      {{- with .Values.app.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+
       {{- with .Values.web.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
The reference to the pullSecrets variable was removed in this commit https://github.com/kubernetes/dashboard/commit/abb9f0defbfa4962056538b69332ab29e6405d21 