### PR TITLE
fix: Correct path in serviceMonitor

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/templates/extras/servicemonitor.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/extras/servicemonitor.yaml
@@ -35,7 +35,7 @@ spec:
       scheme: https
       tlsConfig:
         insecureSkipVerify: true
-  path: /metrics
+      path: /metrics
   selector:
     matchLabels:
     {{ include "kubernetes-dashboard.labels" . | nindent 6 }}


### PR DESCRIPTION
According to

https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint

the path is part of the endpoint list
