### PR TITLE
Fix cypress config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Helm deps
 charts/helm-chart/kubernetes-dashboard/charts
+
+# Cypress
+screenshots

--- a/modules/web/.gitignore
+++ b/modules/web/.gitignore
@@ -34,7 +34,3 @@ dist/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-
-# Cypress
-
-cypress/screenshots

--- a/modules/web/cypress.config.ts
+++ b/modules/web/cypress.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     video: false,
     chromeWebSecurity: false,
     screenshotOnRunFailure: true,
+    screenshotsFolder: '../../screenshots',
     videoCompression: false,
     pageLoadTimeout: 10000,
     requestTimeout: 10000,


### PR DESCRIPTION
I investigated to exclude `cypress/screenshots` directory from auto reload of dev-server. But `exclude` option for tsconfig did not work as expected, so changed `screenshots` folder from under `cypress` to `modules/web/screenshots`.
