### PR TITLE
Update nodejs install method

### DIFF
--- a/hack/develop/Dockerfile
+++ b/hack/develop/Dockerfile
@@ -23,9 +23,16 @@ FROM golang:1.20-bullseye
 # Install Node.js. Go is already installed.
 # A small tweak, apt-get update is already run by the nodejs setup script,
 # so there's no need to run it again.
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
-	&& apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+  gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | \
+  tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get install -y --no-install-recommends \
 	nodejs \
+	npm \
 	patch \
 	chromium \
 	bc \
@@ -76,7 +83,8 @@ RUN curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-23.0
 
 # Install docker compose plugin
 RUN mkdir -p /usr/local/lib/docker/cli-plugins
-RUN curl -SL https://github.com/docker/compose/releases/download/v2.14.0/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+RUN curl -SL https://github.com/docker/compose/releases/download/v2.14.0/docker-compose-linux-x86_64 \
+  -o /usr/local/lib/docker/cli-plugins/docker-compose
 RUN chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 # Install kubectl
@@ -88,7 +96,8 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 # `npm ci` installs golangci, but this installation is needed
 # for running `npm run check` singlely, like
 # `hack/develop/run-dev-container.sh run check`.
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+  sh -s -- -b $(go env GOPATH)/bin v1.52.2
 
 # Enable go mod.
 ENV GO111MODULE=on


### PR DESCRIPTION
GPG key is needed for installation now.
`npm` does not seems to be installed with `nodejs` packages, so it is specified.