### PR TITLE
Update Spanish translations

### DIFF
--- a/modules/web/i18n/es/messages.es.xlf
+++ b/modules/web/i18n/es/messages.es.xlf
@@ -380,7 +380,7 @@
       </trans-unit>
       <trans-unit id="2127150478980536520" datatype="html">
         <source>Max Replicas</source>
-        <target>Máx. de réplicas</target>
+        <target>Máx. número de réplicas</target>
       </trans-unit>
       <trans-unit id="21275452006765587" datatype="html">
         <source>Commands</source>
@@ -672,7 +672,7 @@
       </trans-unit>
       <trans-unit id="3012870639723698090" datatype="html">
         <source> Port must be greater than 0. </source>
-        <target state="new"> El puerto debe ser superior a 0. </target>
+        <target state="new"> El puerto debe ser mayor a 0. </target>
       </trans-unit>
       <trans-unit id="3012906865384504293" datatype="html">
         <source>Image</source>
@@ -728,7 +728,7 @@
       </trans-unit>
       <trans-unit id="3175667526023915046" datatype="html">
         <source> Label Value must not exceed 253 characters. </source>
-        <target state="new"> El valor de la etiqueta no dee exceder 253 caracteres. </target>
+        <target state="new"> El valor de la etiqueta no debe exceder 253 caracteres. </target>
       </trans-unit>
       <trans-unit id="3193976279273491157" datatype="html">
         <source>Actions</source>
@@ -836,7 +836,7 @@
       </trans-unit>
       <trans-unit id="3413133151717525161" datatype="html">
         <source>Min Replicas</source>
-        <target>Mín. réplicas</target>
+        <target>Mín. número de réplicas</target>
       </trans-unit>
       <trans-unit id="3415340061451880090" datatype="html">
         <source>Remove all notifications</source>
@@ -920,7 +920,7 @@
       </trans-unit>
       <trans-unit id="3609669829589519658" datatype="html">
         <source> CPU requirement must be given as a valid number. </source>
-        <target state="new"> el requisito de CPU debe ser un número válido. </target>
+        <target state="new"> El requisito de CPU debe ser un número válido. </target>
       </trans-unit>
       <trans-unit id="3611950223744571613" datatype="html">
         <source>Service Port Number</source>
@@ -1578,7 +1578,7 @@
       </trans-unit>
       <trans-unit id="6194056995548896650" datatype="html">
         <source>The new secret will be added to the cluster</source>
-        <target>El nuevo Secret será añadido al clúster</target>
+        <target>El Secret nuevo será añadido al clúster</target>
       </trans-unit>
       <trans-unit id="6239075439253810960" datatype="html">
         <source>Pending: </source>
@@ -1654,7 +1654,7 @@
       </trans-unit>
       <trans-unit id="6588659171333501682" datatype="html">
         <source>By default, your containers run the selected image&apos;s default entrypoint command. You can use the command options to override the default.</source>
-        <target>Por defecto, tus contenedores ejecutan el comando entrypoint defecto de la imagen seleccionada. Puedes usar las opciones de comando para sobreescribirlas.</target>
+        <target>De forma predeterminada, tus contenedores ejecutan el comando entrypoint por defecto de la imagen seleccionada. Puedes usar las opciones de comando para sobreescribirlas.</target>
       </trans-unit>
       <trans-unit id="6595420178679632820" datatype="html">
         <source>Ports (Name, Port, Protocol)</source>
@@ -1854,7 +1854,7 @@
       </trans-unit>
       <trans-unit id="7198836215060144081" datatype="html">
         <source>Host </source>
-        <target state="new">Anfitrión </target>
+        <target state="new">Host </target>
       </trans-unit>
       <trans-unit id="7204408227432067199" datatype="html">
         <source>Restarts</source>
@@ -1950,7 +1950,7 @@
       </trans-unit>
       <trans-unit id="7541092997061001831" datatype="html">
         <source> Setting high number of pods may cause performance issues of the cluster and Dashboard UI. </source>
-        <target state="new"> Establecer un número alto de pods puede causar problemas de desempeño del clúster y la interfaz gráfica del Dashboard. </target>
+        <target state="new"> Establecer un número elevado de Pods puede causar problemas de desempeño del clúster y la interfaz gráfica del Dashboard. </target>
       </trans-unit>
       <trans-unit id="7542300534444838884" datatype="html">
         <source>Kubernetes Dashboard</source>

--- a/modules/web/i18n/es/messages.es.xlf
+++ b/modules/web/i18n/es/messages.es.xlf
@@ -20,7 +20,7 @@
       </trans-unit>
       <trans-unit id="1045499538393271132" datatype="html">
         <source>Auto-refresh (every <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> s.)</source>
-        <target>Refrescar auto (cada <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
+        <target>Refrescar automáticamente (cada <x id="INTERPOLATION" equiv-text="{{refreshInterval}}"/> s.)</target>
       </trans-unit>
       <trans-unit id="1046894941566596460" datatype="html">
         <source>Resource Information</source>
@@ -56,7 +56,7 @@
       </trans-unit>
       <trans-unit id="1134765132854526890" datatype="html">
         <source>Service Name </source>
-        <target state="new">Nombre del Servicio</target>
+        <target state="new">Nombre de Servicio</target>
       </trans-unit>
       <trans-unit id="1138159535667068803" datatype="html">
         <source>Memory requirement (MiB)</source>
@@ -88,7 +88,7 @@
       </trans-unit>
       <trans-unit id="1243984730371237241" datatype="html">
         <source>Cluster Role Bindings </source>
-        <target state="new">Mapeo de Rol de Cluster</target>
+        <target state="new">Mapeo de Rol de Clúster</target>
       </trans-unit>
       <trans-unit id="1244504753529533521" datatype="html">
         <source>Edit Namespace List</source>
@@ -100,7 +100,7 @@
       </trans-unit>
       <trans-unit id="1268395641466243700" datatype="html">
         <source> Every Service Account has a Secret with valid Bearer Token that can be used to log in to Dashboard. To find out more about how to configure and use Bearer Tokens, please refer to the <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>Authentication<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/> section. </source>
-        <target state="new">Cada cuenta de servicio tiene un Secret asociado a un Bearer Token que puede usarse para iniciar sesión en el tablero. Para saber más sobre cómo configurar y utilizar Bearer Tokens, referirse a la sección <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Authentificación<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target state="new">Cada cuenta de servicio tiene un Secret asociado a un Bearer Token que puede usarse para iniciar sesión en el tablero. Para saber más sobre cómo configurar y utilizar Bearer Tokens, referirse a la sección <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Autenticación<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
       </trans-unit>
       <trans-unit id="1292699022746959928" datatype="html">
         <source>Non-resource URL</source>
@@ -108,7 +108,7 @@
       </trans-unit>
       <trans-unit id="1321877744367304738" datatype="html">
         <source>Image: </source>
-        <target state="new">Imagen :</target>
+        <target state="new">Imagen: </target>
       </trans-unit>
       <trans-unit id="1328651869817330586" datatype="html">
         <source>Mount Option(s)</source>
@@ -136,7 +136,7 @@
       </trans-unit>
       <trans-unit id="1429641498515055959" datatype="html">
         <source>Revision history limit</source>
-        <target>Limite de históricos de revisión</target>
+        <target>Límite de históricos de revisión</target>
       </trans-unit>
       <trans-unit id="1431416938026210429" datatype="html">
         <source>Password</source>
@@ -204,7 +204,7 @@
       </trans-unit>
       <trans-unit id="1622528103709985950" datatype="html">
         <source> Local settings are stored in the browser cookies, so they are not synchronized between multiple devices. Changes are applied automatically on every change. </source>
-        <target state="new">Los ajustes locales se guardan en las cookies del navegador, así que no se sincronizan entre multiples dispositivos. Los cambios se aplican en cada cambio.</target>
+        <target state="new">Los ajustes locales se guardan en las cookies del navegador, así que no se sincronizan entre múltiples dispositivos. Los cambios se aplican en cada cambio.</target>
       </trans-unit>
       <trans-unit id="1631799239961659924" datatype="html">
         <source>Volume Attributes</source>
@@ -252,7 +252,7 @@
       </trans-unit>
       <trans-unit id="1761780531172486555" datatype="html">
         <source>Available: </source>
-        <target state="new">Disponibles :</target>
+        <target state="new">Disponibles: </target>
       </trans-unit>
       <trans-unit id="1763461605200938061" datatype="html">
         <source>Desired replicas</source>
@@ -268,11 +268,11 @@
       </trans-unit>
       <trans-unit id="1781490455950079869" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#10\uFFFD&quot;"/>Community<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#10\uFFFD&quot;"/></source>
-        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#10\uFFFD&quot;"/>Community<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#10\uFFFD&quot;"/></target>
+        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#10\uFFFD&quot;"/>Comunidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#10\uFFFD&quot;"/></target>
       </trans-unit>
       <trans-unit id="1791198005341902530" datatype="html">
         <source> Deploy </source>
-        <target state="new">Desplegar</target>
+        <target state="new"> Desplegar </target>
       </trans-unit>
       <trans-unit id="1813894172148248223" datatype="html">
         <source>Ingress Classes </source>
@@ -284,11 +284,11 @@
       </trans-unit>
       <trans-unit id="1832995043073719610" datatype="html">
         <source>A secret with the specified name will be added to the cluster in the namespace.</source>
-        <target>Un secret con el nombre especificado será añadido al clúster en el espacio de nombre.</target>
+        <target>Un Secret con el nombre especificado será añadido al clúster en el espacio de nombre.</target>
       </trans-unit>
       <trans-unit id="1850293262697508820" datatype="html">
         <source>Revision history limit: </source>
-        <target state="new">Limite de históricos de revisión :</target>
+        <target state="new">Límite de históricos de revisión :</target>
       </trans-unit>
       <trans-unit id="1853314835104660335" datatype="html">
         <source>The new namespace will be added to the cluster.</source>
@@ -296,7 +296,7 @@
       </trans-unit>
       <trans-unit id="1861657886309326" datatype="html">
         <source>Events </source>
-        <target state="new">Eventos</target>
+        <target state="new">Eventos </target>
       </trans-unit>
       <trans-unit id="187187500641108332" datatype="html">
         <source>
@@ -364,7 +364,7 @@
       </trans-unit>
       <trans-unit id="2081098100751596052" datatype="html">
         <source>iSCSI target lun number</source>
-        <target state="new">iSCSI target lun number</target>
+        <target state="new">Número de iSCSI target lun</target>
       </trans-unit>
       <trans-unit id="2083766050425503902" datatype="html">
         <source> Application name must start with a lowercase letter and contain only lowercase letters, numbers, and &apos;-&apos; between words. </source>
@@ -376,11 +376,11 @@
       </trans-unit>
       <trans-unit id="2122768143452494504" datatype="html">
         <source>Unsupported graph type <x id="PH" equiv-text="this.graphType"/>.</source>
-        <target state="new">Unsupported graph type <x id="PH" equiv-text="this.graphType"/>.</target>
+        <target state="new">Tipo de grafo <x id="PH" equiv-text="this.graphType"/> no soportado.</target>
       </trans-unit>
       <trans-unit id="2127150478980536520" datatype="html">
         <source>Max Replicas</source>
-        <target>Max réplicas</target>
+        <target>Máx. de réplicas</target>
       </trans-unit>
       <trans-unit id="21275452006765587" datatype="html">
         <source>Commands</source>
@@ -392,7 +392,7 @@
       </trans-unit>
       <trans-unit id="2131524838680811873" datatype="html">
         <source>You can <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#6\uFFFD&quot;"/>deploy a containerized app<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#7\uFFFD]&quot;"/>, select other namespace or <x id="START_LINK_1" equiv-text="&quot;\uFFFD#7\uFFFD&quot;"/>check the Dashboard Docs <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#8\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#8\uFFFD&quot;"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#7\uFFFD]&quot;"/> to learn more.</source>
-        <target state="new">Puedes <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>desplegar una aplicación contenerizada<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, selecciona otra espacio de nombre select o <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>haz el tour guiado del Dashboard <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para aprender más.</target>
+        <target state="new">Puedes <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>desplegar una aplicación contenerizada<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, selecciona otra espacio de nombre o <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>revisa la documentación del Dashboard <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para aprender más.</target>
       </trans-unit>
       <trans-unit id="2132886845235480834" datatype="html">
         <source>Resource type</source>
@@ -400,7 +400,7 @@
       </trans-unit>
       <trans-unit id="2135976822395163664" datatype="html">
         <source> Please select the kubeconfig file that you have created to configure access to the cluster. To find out more about how to configure and use kubeconfig file, please refer to the <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>Configure Access to Multiple Clusters<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/> section. </source>
-        <target state="new">Por favor, selecciona el fichero kubeconfig que has creado para configurar el acceso al cluster. Para encontrar más información sobre cómo configurar y usar el fichero kubeconfig, referirse a la sección <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Configurar el acceso a varios clústeres<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target state="new">Por favor, selecciona el fichero kubeconfig que has creado para configurar el acceso al clúster. Para encontrar más información sobre cómo configurar y usar el fichero kubeconfig, referirse a la sección <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Configurar el acceso a varios clústeres<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
       </trans-unit>
       <trans-unit id="214884265476562782" datatype="html">
         <source>Seccomp Profile Type</source>
@@ -412,7 +412,7 @@
       </trans-unit>
       <trans-unit id="217048540478746172" datatype="html">
         <source> Target port must be an integer. </source>
-        <target state="new">El puerto objetivo debe ser un entero.</target>
+        <target state="new">El puerto objetivo debe ser un número entero.</target>
       </trans-unit>
       <trans-unit id="2176659033176029418" datatype="html">
         <source>Key</source>
@@ -424,7 +424,7 @@
       </trans-unit>
       <trans-unit id="21860712120581731" datatype="html">
         <source>Updated: </source>
-        <target state="new">Actualizado :</target>
+        <target state="new">Actualizado: </target>
       </trans-unit>
       <trans-unit id="2188854519574316630" datatype="html">
         <source>Server</source>
@@ -436,7 +436,7 @@
       </trans-unit>
       <trans-unit id="222595489358095649" datatype="html">
         <source> Kubernetes Dashboard v<x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> © <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> The Kubernetes Authors </source>
-        <target state="new"> Kubernetes Dashboard v<x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> © <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> The Kubernetes Authors </target>
+        <target state="new"> Kubernetes Dashboard v<x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> © <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> Los autores de Kubernetes </target>
       </trans-unit>
       <trans-unit id="2235593604907350097" datatype="html">
         <source>Resource Names</source>
@@ -476,7 +476,7 @@
       </trans-unit>
       <trans-unit id="2317196056953748991" datatype="html">
         <source>Old Replica Sets</source>
-        <target>Antiguo Replica Sets</target>
+        <target>Replica Sets antiguas</target>
       </trans-unit>
       <trans-unit id="2320200316076079587" datatype="html">
         <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;[\uFFFD#5\uFFFD|\uFFFD#8\uFFFD]&quot;"/>Are you sure you want to delete <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD#6\uFFFD|\uFFFD#2:1\uFFFD]&quot;"/><x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#2:1\uFFFD]&quot;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&quot;[\uFFFD/#5\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*7:1\uFFFD|\uFFFD/#8\uFFFD]&quot;"/><x id="START_TAG_SPAN_1" ctype="x-span_1" equiv-text="&quot;\uFFFD*7:1\uFFFD\uFFFD#1:1\uFFFD&quot;"/> in namespace <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD#6\uFFFD|\uFFFD#2:1\uFFFD]&quot;"/><x id="INTERPOLATION_2" equiv-text="&quot;\uFFFD0:1\uFFFD&quot;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#2:1\uFFFD]&quot;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&quot;[\uFFFD/#5\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*7:1\uFFFD|\uFFFD/#8\uFFFD]&quot;"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;[\uFFFD#5\uFFFD|\uFFFD#8\uFFFD]&quot;"/>?<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&quot;[\uFFFD/#5\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*7:1\uFFFD|\uFFFD/#8\uFFFD]&quot;"/></source>
@@ -516,7 +516,7 @@
       </trans-unit>
       <trans-unit id="2411065404041685586" datatype="html">
         <source>Path Type </source>
-        <target state="new">Tipo de ruta</target>
+        <target state="new">Tipo de ruta </target>
       </trans-unit>
       <trans-unit id="2417328504220076358" datatype="html">
         <source>Settings have changed since last reload</source>
@@ -612,7 +612,7 @@
       </trans-unit>
       <trans-unit id="2833767909565048391" datatype="html">
         <source> Do you want to stay on current page and change namespace from <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD#7\uFFFD|\uFFFD#8\uFFFD]&quot;"/><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD/#7\uFFFD|\uFFFD/#8\uFFFD]&quot;"/> to <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD#7\uFFFD|\uFFFD#8\uFFFD]&quot;"/><x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&quot;[\uFFFD/#7\uFFFD|\uFFFD/#8\uFFFD]&quot;"/>? </source>
-        <target state="new">¿Deseas permanecer en la página en curso y modificar el nombre de <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="INTERPOLATION" equiv-text="{{namespace}}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> a <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="INTERPOLATION_1" equiv-text="{{newNamespace}}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> ?</target>
+        <target state="new">¿Deseas permanecer en la página en curso y modificar el nombre de <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="INTERPOLATION" equiv-text="{{namespace}}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> a <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="INTERPOLATION_1" equiv-text="{{newNamespace}}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> ? </target>
       </trans-unit>
       <trans-unit id="284876663522831141" datatype="html">
         <source>Source Type</source>
@@ -636,7 +636,7 @@
       </trans-unit>
       <trans-unit id="2933331719200534418" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#7\uFFFD&quot;"/>Documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#7\uFFFD&quot;"/></source>
-        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#7\uFFFD&quot;"/>Documentation<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#7\uFFFD&quot;"/></target>
+        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#7\uFFFD&quot;"/>Documentación<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#7\uFFFD&quot;"/></target>
       </trans-unit>
       <trans-unit id="2944102521023817891" datatype="html">
         <source>Cluster</source>
@@ -664,7 +664,7 @@
       </trans-unit>
       <trans-unit id="2987268586260348582" datatype="html">
         <source>Total: </source>
-        <target state="new">Total :</target>
+        <target state="new">Total: </target>
       </trans-unit>
       <trans-unit id="3000799346062046358" datatype="html">
         <source>Suffix &apos;<x id="PH" equiv-text="suffix"/>&apos; not recognized.</source>
@@ -672,7 +672,7 @@
       </trans-unit>
       <trans-unit id="3012870639723698090" datatype="html">
         <source> Port must be greater than 0. </source>
-        <target state="new">El puerto debe ser superior a 0.</target>
+        <target state="new"> El puerto debe ser superior a 0. </target>
       </trans-unit>
       <trans-unit id="3012906865384504293" datatype="html">
         <source>Image</source>
@@ -684,7 +684,7 @@
       </trans-unit>
       <trans-unit id="3037001602563649018" datatype="html">
         <source> Name must be alphanumeric and may contain dashes. </source>
-        <target state="new">El nombre debe ser alfanumérico y puede contener guiones.</target>
+        <target state="new"> El nombre debe ser alfanumérico y puede contener guiones. </target>
       </trans-unit>
       <trans-unit id="3039940756451018621" datatype="html">
         <source>Token</source>
@@ -692,11 +692,11 @@
       </trans-unit>
       <trans-unit id="3068261068429094032" datatype="html">
         <source>Max unavailable: </source>
-        <target state="new">Máx no disponible :</target>
+        <target state="new">Máx. no disponible :</target>
       </trans-unit>
       <trans-unit id="3094294427304814088" datatype="html">
         <source>Strategy: </source>
-        <target state="new">Estrategia :</target>
+        <target state="new">Estrategia: </target>
       </trans-unit>
       <trans-unit id="3117139905742018214" datatype="html">
         <source>Close notifications panel</source>
@@ -728,7 +728,7 @@
       </trans-unit>
       <trans-unit id="3175667526023915046" datatype="html">
         <source> Label Value must not exceed 253 characters. </source>
-        <target state="new">El valor de la etiqueta no dee exceder 253 caracteres.</target>
+        <target state="new"> El valor de la etiqueta no dee exceder 253 caracteres. </target>
       </trans-unit>
       <trans-unit id="3193976279273491157" datatype="html">
         <source>Actions</source>
@@ -752,11 +752,11 @@
       </trans-unit>
       <trans-unit id="3252882636701023997" datatype="html">
         <source>Max unavailable</source>
-        <target>Máx no disponible</target>
+        <target>Máx. no disponible</target>
       </trans-unit>
       <trans-unit id="3283019513707383139" datatype="html">
         <source> Hosts <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/></source>
-        <target state="new">Hosts <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;external-link-icon kd-clickable&quot; i18n-matTooltip matTooltip=&quot;Host links are external links that will be open in a new tab.&quot;&gt;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></target>
+        <target state="new"> Hosts <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/></target>
       </trans-unit>
       <trans-unit id="3294686077659093992" datatype="html">
         <source>Namespace</source>
@@ -776,7 +776,7 @@
       </trans-unit>
       <trans-unit id="3323415564519831786" datatype="html">
         <source> Name is required. </source>
-        <target state="new">El nombre es requerido.</target>
+        <target state="new"> El nombre es requerido. </target>
       </trans-unit>
       <trans-unit id="3326877877555410533" datatype="html">
         <source>Started</source>
@@ -816,11 +816,11 @@
       </trans-unit>
       <trans-unit id="3370944056293075657" datatype="html">
         <source>Name must be up to <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> characters long.</source>
-        <target state="new">El nombre debe tener hasta <x id="INTERPOLATION" equiv-text="{{namespaceMaxLength}}"/> carácteres.</target>
+        <target state="new">El nombre debe tener hasta <x id="INTERPOLATION" equiv-text="{{namespaceMaxLength}}"/> caracteres.</target>
       </trans-unit>
       <trans-unit id="3370944056293075657" datatype="html">
         <source> Name must be up to <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> characters long. </source>
-        <target state="new">El nombre debe tener hasta <x id="INTERPOLATION" equiv-text="{{secretNameMaxLength}}"/> carácteres.</target>
+        <target state="new">El nombre debe tener hasta <x id="INTERPOLATION" equiv-text="{{secretNameMaxLength}}"/> caracteres.</target>
       </trans-unit>
       <trans-unit id="3375720161310377589" datatype="html">
         <source>value</source>
@@ -836,7 +836,7 @@
       </trans-unit>
       <trans-unit id="3413133151717525161" datatype="html">
         <source>Min Replicas</source>
-        <target>Min réplicas</target>
+        <target>Mín. réplicas</target>
       </trans-unit>
       <trans-unit id="3415340061451880090" datatype="html">
         <source>Remove all notifications</source>
@@ -844,7 +844,7 @@
       </trans-unit>
       <trans-unit id="3422667190879443306" datatype="html">
         <source>Container runtime version</source>
-        <target>Version de runtime del contenedor</target>
+        <target>Versión de runtime del contenedor</target>
       </trans-unit>
       <trans-unit id="3426643717372750272" datatype="html">
         <source>Service Port </source>
@@ -888,7 +888,7 @@
       </trans-unit>
       <trans-unit id="3534088723520522114" datatype="html">
         <source> Variable name must be a valid C identifier. </source>
-        <target state="new">El nombre de variable debe ser un identificador C válido.</target>
+        <target state="new"> El nombre de variable debe ser un identificador C válido. </target>
       </trans-unit>
       <trans-unit id="3540108566782816830" datatype="html">
         <source>Selector</source>
@@ -904,11 +904,11 @@
       </trans-unit>
       <trans-unit id="3551329346991932579" datatype="html">
         <source> Protocol is required. </source>
-        <target state="new">El protocolo es requerido.</target>
+        <target state="new"> El protocolo es requerido. </target>
       </trans-unit>
       <trans-unit id="3569677708978335155" datatype="html">
         <source>Desired: </source>
-        <target state="new">Deseado:</target>
+        <target state="new">Deseado: </target>
       </trans-unit>
       <trans-unit id="3583123851975839013" datatype="html">
         <source>Session Affinity</source>
@@ -916,11 +916,11 @@
       </trans-unit>
       <trans-unit id="3588315191655475025" datatype="html">
         <source> Container image is required </source>
-        <target state="new">La imagen del contenedor es requerida</target>
+        <target state="new"> La imagen del contenedor es requerida </target>
       </trans-unit>
       <trans-unit id="3609669829589519658" datatype="html">
         <source> CPU requirement must be given as a valid number. </source>
-        <target state="new">el requisito de CPU debe ser un número válido.</target>
+        <target state="new"> el requisito de CPU debe ser un número válido. </target>
       </trans-unit>
       <trans-unit id="3611950223744571613" datatype="html">
         <source>Service Port Number</source>
@@ -972,7 +972,7 @@
       </trans-unit>
       <trans-unit id="3844914972911579334" datatype="html">
         <source> Number of pods must be a positive integer </source>
-        <target state="new">El número de pods debe ser un entero positivo</target>
+        <target state="new"> El número de pods debe ser un entero positivo </target>
       </trans-unit>
       <trans-unit id="3847048283826460449" datatype="html">
         <source>Run command arguments</source>
@@ -988,7 +988,7 @@
       </trans-unit>
       <trans-unit id="3910914001392684259" datatype="html">
         <source> Port must be an integer. </source>
-        <target state="new">El puerto debe ser un entero.</target>
+        <target state="new"> El puerto debe ser un entero. </target>
       </trans-unit>
       <trans-unit id="3911411545389266400" datatype="html">
         <source>Choose YAML or JSON file</source>
@@ -1004,7 +1004,7 @@
       </trans-unit>
       <trans-unit id="400776614514525117" datatype="html">
         <source>Schedule: </source>
-        <target state="new">Planificación:</target>
+        <target state="new">Planificación: </target>
       </trans-unit>
       <trans-unit id="4021752662928002901" datatype="html">
         <source>Update</source>
@@ -1020,7 +1020,7 @@
       </trans-unit>
       <trans-unit id="4052052481087794292" datatype="html">
         <source>Role Bindings </source>
-        <target state="new">Vinculaciones de roles</target>
+        <target state="new">Vinculaciones de roles </target>
       </trans-unit>
       <trans-unit id="4052582653153593975" datatype="html">
         <source>Config and Storage</source>
@@ -1036,7 +1036,7 @@
       </trans-unit>
       <trans-unit id="4105691782196566273" datatype="html">
         <source> Port must be less than 65536. </source>
-        <target state="new">El puerto debe ser inferior a 65536.</target>
+        <target state="new"> El puerto debe ser inferior a 65536. </target>
       </trans-unit>
       <trans-unit id="4111811676793706889" datatype="html">
         <source>Readiness Probe</source>
@@ -1052,7 +1052,7 @@
       </trans-unit>
       <trans-unit id="4170719254013309689" datatype="html">
         <source> Skip </source>
-        <target state="new">Saltar</target>
+        <target state="new"> Saltar </target>
       </trans-unit>
       <trans-unit id="4207916966377787111" datatype="html">
         <source>Created</source>
@@ -1064,7 +1064,7 @@
       </trans-unit>
       <trans-unit id="4216678889012737533" datatype="html">
         <source> Deployment or service with this name already exists within namespace. </source>
-        <target state="new">Un Deployment o un service ya existe con este nombre dentro del espacio de nombre.</target>
+        <target state="new"> Un Deployment o un service ya existe con este nombre dentro del espacio de nombre. </target>
       </trans-unit>
       <trans-unit id="4222409682577085383" datatype="html">
         <source>Storage class</source>
@@ -1076,7 +1076,7 @@
       </trans-unit>
       <trans-unit id="4285755342959217630" datatype="html">
         <source>Pin resource</source>
-        <target state="new">Pin resource</target>
+        <target state="new">Fijar recurso</target>
       </trans-unit>
       <trans-unit id="4287392502726135197" datatype="html">
         <source>Config Maps </source>
@@ -1084,11 +1084,11 @@
       </trans-unit>
       <trans-unit id="4288379540371209568" datatype="html">
         <source> Create a new namespace... </source>
-        <target state="new">Crear un nuevo espacio de nombre...</target>
+        <target state="new"> Crear un nuevo espacio de nombre... </target>
       </trans-unit>
       <trans-unit id="4296726543175330378" datatype="html">
         <source> Enter YAML or JSON content specifying the resources to create to the currently selected namespace. </source>
-        <target state="new">Ingresa un contenido YAML O JSON especificando los recursos para crear en el espacio de nombres seleccionado.</target>
+        <target state="new"> Ingresa un contenido YAML O JSON especificando los recursos para crear en el espacio de nombres seleccionado. </target>
       </trans-unit>
       <trans-unit id="43228639508046926" datatype="html">
         <source>Completions: </source>
@@ -1124,7 +1124,7 @@
       </trans-unit>
       <trans-unit id="4475093671158329161" datatype="html">
         <source>Pin</source>
-        <target>fijar</target>
+        <target>Fijar</target>
       </trans-unit>
       <trans-unit id="4482184335435539588" datatype="html">
         <source>This action is equivalent to:</source>
@@ -1172,7 +1172,7 @@
       </trans-unit>
       <trans-unit id="4613805182430195952" datatype="html">
         <source>Namespaces </source>
-        <target state="new">Espacios de Nombre</target>
+        <target state="new">Espacios de Nombre </target>
       </trans-unit>
       <trans-unit id="4645345687322304891" datatype="html">
         <source>Rules</source>
@@ -1188,7 +1188,7 @@
       </trans-unit>
       <trans-unit id="4686783485484478974" datatype="html">
         <source>Parallelism: </source>
-        <target state="new">Paralelismo:</target>
+        <target state="new">Paralelismo: </target>
       </trans-unit>
       <trans-unit id="4708304467453184793" datatype="html">
         <source>Environment variables</source>
@@ -1212,7 +1212,7 @@
       </trans-unit>
       <trans-unit id="4773463022110715023" datatype="html">
         <source> Enter YAML or JSON content specifying the resources to create to the namespace specified in the file. </source>
-        <target state="new">Ingresa un contenido YAML O JSON especificando los recursos para crear el espacio de nombre especificado en el fichero.</target>
+        <target state="new"> Ingresa un contenido YAML O JSON especificando los recursos para crear el espacio de nombre especificado en el fichero. </target>
       </trans-unit>
       <trans-unit id="4775550080689015987" datatype="html">
         <source>Reason</source>
@@ -1228,7 +1228,7 @@
       </trans-unit>
       <trans-unit id="4930506384627295710" datatype="html">
         <source>Settings</source>
-        <target state="new">Settings</target>
+        <target state="new">Ajustes</target>
       </trans-unit>
       <trans-unit id="4964247147355186491" datatype="html">
         <source>Controlled by</source>
@@ -1260,7 +1260,7 @@
       </trans-unit>
       <trans-unit id="5103064776441485656" datatype="html">
         <source>Running: </source>
-        <target state="new">En ejecución:</target>
+        <target state="new">En ejecución: </target>
       </trans-unit>
       <trans-unit id="5112388980413175570" datatype="html">
         <source>Keyring</source>
@@ -1280,7 +1280,7 @@
       </trans-unit>
       <trans-unit id="5156388212535235462" datatype="html">
         <source> Environment Variables </source>
-        <target state="new">Variables de Entorno</target>
+        <target state="new"> Variables de Entorno </target>
       </trans-unit>
       <trans-unit id="5159814115056353668" datatype="html">
         <source>Addresses</source>
@@ -1304,7 +1304,7 @@
       </trans-unit>
       <trans-unit id="5257636795023365764" datatype="html">
         <source> Upload </source>
-        <target state="new">Cargar</target>
+        <target state="new"> Cargar </target>
       </trans-unit>
       <trans-unit id="5278726417886231851" datatype="html">
         <source>IP: </source>
@@ -1316,7 +1316,7 @@
       </trans-unit>
       <trans-unit id="528589796437229259" datatype="html">
         <source> Memory requirement must be given as a positive number. </source>
-        <target state="new">El requisito de memoria debe ser un número positivo.</target>
+        <target state="new"> El requisito de memoria debe ser un número positivo. </target>
       </trans-unit>
       <trans-unit id="5298392270155336139" datatype="html">
         <source>CPU capacity</source>
@@ -1364,7 +1364,7 @@
       </trans-unit>
       <trans-unit id="5509177505397229412" datatype="html">
         <source> Target port must be less than 65536. </source>
-        <target state="new">El puerto objetivo debe ser inferior a 65536.</target>
+        <target state="new"> El puerto objetivo debe ser inferior a 65536. </target>
       </trans-unit>
       <trans-unit id="5519023941949331063" datatype="html">
         <source>Invert colors</source>
@@ -1380,7 +1380,7 @@
       </trans-unit>
       <trans-unit id="5596215605725734238" datatype="html">
         <source> Data is required. </source>
-        <target state="new">Los datos son requeridos.</target>
+        <target state="new"> Los datos son requeridos. </target>
       </trans-unit>
       <trans-unit id="5603542439272909460" datatype="html">
         <source>Processes in privileged containers are equivalent to processes running as root on the host.</source>
@@ -1416,11 +1416,11 @@
       </trans-unit>
       <trans-unit id="2131524838680811873" datatype="html">
         <source> You can <x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#6\uFFFD&quot;"/>deploy a containerized app<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#7\uFFFD]&quot;"/>, select other namespace or <x id="START_LINK_1" equiv-text="&quot;\uFFFD#7\uFFFD&quot;"/>check the Dashboard Docs <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#8\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#8\uFFFD&quot;"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;[\uFFFD/#6\uFFFD|\uFFFD/#7\uFFFD]&quot;"/> to learn more. </source>
-        <target state="new">Puedes <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>desplegar una aplicación contenerizada<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, selecciona otra espacio de nombre select o <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>haz el tour guiado del Dashboard <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para aprender más.</target>
+        <target state="new"> Puedes <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>desplegar una aplicación contenerizada<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, selecciona otra espacio de nombre o <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/>revisa la documentación del Dashboard <x id="START_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;mat-icon&gt;"/>open_in_new<x id="CLOSE_TAG_MAT-ICON" ctype="x-mat-icon" equiv-text="&lt;/mat-icon&gt;"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para aprender más. </target>
       </trans-unit>
       <trans-unit id="5693993471751761333" datatype="html">
         <source> Create a new secret... </source>
-        <target state="new">Crear un nuevo secret...</target>
+        <target state="new"> Crear un nuevo Secret... </target>
       </trans-unit>
       <trans-unit id="5729418620241283277" datatype="html">
         <source>Events</source>
@@ -1436,7 +1436,7 @@
       </trans-unit>
       <trans-unit id="577038887888857351" datatype="html">
         <source> Add </source>
-        <target state="new">Añadir</target>
+        <target state="new"> Añadir </target>
       </trans-unit>
       <trans-unit id="5793766132158032827" datatype="html">
         <source>No namespaces selected</source>
@@ -1526,7 +1526,7 @@
       </trans-unit>
       <trans-unit id="6031271337180125854" datatype="html">
         <source>Windows Run as User</source>
-        <target state="new">Windows Run as User</target>
+        <target state="new">Windows Ejecutar como Usuario</target>
       </trans-unit>
       <trans-unit id="6046016632304545069" datatype="html">
         <source>Show timestamps</source>
@@ -1570,7 +1570,7 @@
       </trans-unit>
       <trans-unit id="6163370502260387661" datatype="html">
         <source> Invalid protocol. </source>
-        <target state="new">Protocolo inválido.</target>
+        <target state="new"> Protocolo inválido. </target>
       </trans-unit>
       <trans-unit id="6185721657347844438" datatype="html">
         <source>Can&apos;t find dependency &quot;<x id="PH" equiv-text="dep"/>&quot; for plugin &quot;<x id="PH_1" equiv-text="pluginName"/>&quot;</source>
@@ -1578,19 +1578,19 @@
       </trans-unit>
       <trans-unit id="6194056995548896650" datatype="html">
         <source>The new secret will be added to the cluster</source>
-        <target>El nuevo secret será añadido al clúster</target>
+        <target>El nuevo Secret será añadido al clúster</target>
       </trans-unit>
       <trans-unit id="6239075439253810960" datatype="html">
         <source>Pending: </source>
-        <target state="new">Pendiente:</target>
+        <target state="new">Pendiente: </target>
       </trans-unit>
       <trans-unit id="6283035888557195281" datatype="html">
         <source>Cluster </source>
-        <target state="new">Cluster </target>
+        <target state="new">Clúster </target>
       </trans-unit>
       <trans-unit id="6284431271548714587" datatype="html">
         <source>Suspend: </source>
-        <target state="new">Suspendido:</target>
+        <target state="new">Suspendido: </target>
       </trans-unit>
       <trans-unit id="6350980688187906033" datatype="html">
         <source>Security Context</source>
@@ -1598,7 +1598,7 @@
       </trans-unit>
       <trans-unit id="6393773098525856112" datatype="html">
         <source>TCP Socket</source>
-        <target>Socket TCP</target>
+        <target>Conector TCP</target>
       </trans-unit>
       <trans-unit id="6407858727320871864" datatype="html">
         <source>Persistent Volumes</source>
@@ -1610,7 +1610,7 @@
       </trans-unit>
       <trans-unit id="642253290448532904" datatype="html">
         <source>Min ready seconds: </source>
-        <target state="new">Segundos mínimos para estar listo :</target>
+        <target state="new">Segundos mínimos para estar listo: </target>
       </trans-unit>
       <trans-unit id="6423210280939340786" datatype="html">
         <source>Ready</source>
@@ -1626,7 +1626,7 @@
       </trans-unit>
       <trans-unit id="6462224380417375328" datatype="html">
         <source>Service Accounts </source>
-        <target state="new">Cuentas de Servicio</target>
+        <target state="new">Cuentas de Servicio </target>
       </trans-unit>
       <trans-unit id="6478267560860767436" datatype="html">
         <source>Memory capacity (bytes)</source>
@@ -1638,7 +1638,7 @@
       </trans-unit>
       <trans-unit id="6494596911805287915" datatype="html">
         <source>Items: </source>
-        <target state="new">Elementos:</target>
+        <target state="new">Elementos: </target>
       </trans-unit>
       <trans-unit id="6501135579599829770" datatype="html">
         <source>Network Policies</source>
@@ -1654,7 +1654,7 @@
       </trans-unit>
       <trans-unit id="6588659171333501682" datatype="html">
         <source>By default, your containers run the selected image&apos;s default entrypoint command. You can use the command options to override the default.</source>
-        <target>Por defecto, tus contenedores ejecutan el comando entrypoint por defecto de la imagen seleccionada. Puedes usar las opciones command para sobreescribirlas .</target>
+        <target>Por defecto, tus contenedores ejecutan el comando entrypoint defecto de la imagen seleccionada. Puedes usar las opciones de comando para sobreescribirlas.</target>
       </trans-unit>
       <trans-unit id="6595420178679632820" datatype="html">
         <source>Ports (Name, Port, Protocol)</source>
@@ -1662,7 +1662,7 @@
       </trans-unit>
       <trans-unit id="6596586911518775971" datatype="html">
         <source> Target port cannot be empty. </source>
-        <target state="new">El puerto objetivo no puede estar vacío.</target>
+        <target state="new"> El puerto objetivo no puede estar vacío. </target>
       </trans-unit>
       <trans-unit id="6599752784987327249" datatype="html">
         <source>Kind</source>
@@ -1682,7 +1682,7 @@
       </trans-unit>
       <trans-unit id="6663783128602596673" datatype="html">
         <source> Sign in </source>
-        <target state="new">Iniciar sesión</target>
+        <target state="new"> Iniciar sesión </target>
       </trans-unit>
       <trans-unit id="6677684716540733511" datatype="html">
         <source>List Kind</source>
@@ -1694,7 +1694,7 @@
       </trans-unit>
       <trans-unit id="6753642863059953692" datatype="html">
         <source> Port cannot be empty. </source>
-        <target state="new">El puerto no puede estar vacío.</target>
+        <target state="new"> El puerto no puede estar vacío. </target>
       </trans-unit>
       <trans-unit id="6762504134540024018" datatype="html">
         <source>Quantity</source>
@@ -1718,7 +1718,7 @@
       </trans-unit>
       <trans-unit id="6817133402332255232" datatype="html">
         <source>Pod CIDR</source>
-        <target>CIDR del pod</target>
+        <target>CIDR del Pod</target>
       </trans-unit>
       <trans-unit id="6843740457605413855" datatype="html">
         <source>Kernel version</source>
@@ -1726,7 +1726,7 @@
       </trans-unit>
       <trans-unit id="6852503341223458730" datatype="html">
         <source>Persistent Volumes </source>
-        <target state="new">Volúmenes Persistentes</target>
+        <target state="new">Volúmenes Persistentes </target>
       </trans-unit>
       <trans-unit id="6869304038391725752" datatype="html">
         <source>Containers</source>
@@ -1734,7 +1734,7 @@
       </trans-unit>
       <trans-unit id="686980668228952182" datatype="html">
         <source>Workloads </source>
-        <target state="new">Cargas de trabajo</target>
+        <target state="new">Cargas de trabajo </target>
       </trans-unit>
       <trans-unit id="6870709634537724397" datatype="html">
         <source>Container image</source>
@@ -1754,7 +1754,7 @@
       </trans-unit>
       <trans-unit id="6915193719482636823" datatype="html">
         <source>Name: </source>
-        <target state="new">Nombre:</target>
+        <target state="new">Nombre: </target>
       </trans-unit>
       <trans-unit id="6929072613146586031" datatype="html">
         <source>Scale a resource</source>
@@ -1766,7 +1766,7 @@
       </trans-unit>
       <trans-unit id="695074596983358387" datatype="html">
         <source> Application name is required. </source>
-        <target state="new">El nombre de la aplicación es requerido.</target>
+        <target state="new"> El nombre de la aplicación es requerido. </target>
       </trans-unit>
       <trans-unit id="6959497441009812685" datatype="html">
         <source>Full Name</source>
@@ -1778,7 +1778,7 @@
       </trans-unit>
       <trans-unit id="6984509752476604600" datatype="html">
         <source>Cluster IP</source>
-        <target>IP del cluster</target>
+        <target>IP del clúster</target>
       </trans-unit>
       <trans-unit id="6991803345598959405" datatype="html">
         <source>There is nothing to display here</source>
@@ -1806,7 +1806,7 @@
       </trans-unit>
       <trans-unit id="7076883018082745028" datatype="html">
         <source> Label key name must be alphanumeric separated by &apos;-&apos;, &apos;_&apos; or &apos;.&apos;, optionally prefixed by a DNS subdomain and &apos;/&apos;. </source>
-        <target state="new">El nombre de la clave de la etiqueta debe ser alfanumérico separado por &apos;-&apos;, &apos;_&apos; o &apos;.&apos;, opcionalmente prefijado por un subdominio DNS y &apos;/&apos;.</target>
+        <target state="new"> El nombre de la clave de la etiqueta debe ser alfanumérico separado por &apos;-&apos;, &apos;_&apos; o &apos;.&apos;, opcionalmente prefijado por un subdominio DNS y &apos;/&apos;. </target>
       </trans-unit>
       <trans-unit id="7101197021456818771" datatype="html">
         <source>Pool</source>
@@ -1818,7 +1818,7 @@
       </trans-unit>
       <trans-unit id="7109976949603290892" datatype="html">
         <source> Logs from <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&quot;[\uFFFD/#2\uFFFD|\uFFFD/#3\uFFFD]&quot;"/> to <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&quot;\uFFFD#3\uFFFD&quot;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&quot;[\uFFFD/#2\uFFFD|\uFFFD/#3\uFFFD]&quot;"/> UTC </source>
-        <target state="new">Logs desde <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot; format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> a <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot; format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> UTC</target>
+        <target state="new"> Logs desde <x id="START_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.fromDate&quot; format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> a <x id="START_TAG_KD_DATE_1" ctype="x-kd_date_1" equiv-text="&lt;kd-date [date]=&quot;podLogs?.info.toDate&quot; format=&quot;short&quot;&gt;"/><x id="CLOSE_TAG_KD_DATE" ctype="x-kd_date" equiv-text="&lt;/kd-date&gt;"/> UTC </target>
       </trans-unit>
       <trans-unit id="7136018875175606726" datatype="html">
         <source>in</source>
@@ -1842,11 +1842,11 @@
       </trans-unit>
       <trans-unit id="7194375808015467595" datatype="html">
         <source>Max surge: </source>
-        <target state="new">Oleada máxima :</target>
+        <target state="new">Oleada máxima: </target>
       </trans-unit>
       <trans-unit id="7194477224906924674" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#13\uFFFD&quot;"/>Feedback<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#13\uFFFD&quot;"/></source>
-        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#13\uFFFD&quot;"/>Feedback<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#13\uFFFD&quot;"/></target>
+        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&quot;\uFFFD#13\uFFFD&quot;"/>Comentarios<x id="CLOSE_LINK" ctype="x-a" equiv-text="&quot;\uFFFD/#13\uFFFD&quot;"/></target>
       </trans-unit>
       <trans-unit id="7198245360163776718" datatype="html">
         <source>Success Threshold</source>
@@ -1854,7 +1854,7 @@
       </trans-unit>
       <trans-unit id="7198836215060144081" datatype="html">
         <source>Host </source>
-        <target state="new">Anfitrión</target>
+        <target state="new">Anfitrión </target>
       </trans-unit>
       <trans-unit id="7204408227432067199" datatype="html">
         <source>Restarts</source>
@@ -1862,11 +1862,11 @@
       </trans-unit>
       <trans-unit id="7206849842963127297" datatype="html">
         <source>Custom Resource Definitions </source>
-        <target state="new">Definiciones de recursos personalizadas</target>
+        <target state="new">Definiciones de recursos personalizadas </target>
       </trans-unit>
       <trans-unit id="7207867066492367466" datatype="html">
         <source>Settings </source>
-        <target state="new">Ajustes</target>
+        <target state="new">Ajustes </target>
       </trans-unit>
       <trans-unit id="7239750919884229270" datatype="html">
         <source>Updated</source>
@@ -1886,7 +1886,7 @@
       </trans-unit>
       <trans-unit id="7293190222859783293" datatype="html">
         <source>Plugins </source>
-        <target state="new">Complementos</target>
+        <target state="new">Complementos </target>
       </trans-unit>
       <trans-unit id="7298863100332850221" datatype="html">
         <source>There is no data to display.</source>
@@ -1894,11 +1894,11 @@
       </trans-unit>
       <trans-unit id="7327432642990246284" datatype="html">
         <source>Default service account </source>
-        <target state="new">Cuenta de servicio por defecto</target>
+        <target state="new">Cuenta de servicio por defecto </target>
       </trans-unit>
       <trans-unit id="7330483736355831593" datatype="html">
         <source>Config and Storage </source>
-        <target state="new">Configuración y Almacenamiento</target>
+        <target state="new">Configuración y Almacenamiento </target>
       </trans-unit>
       <trans-unit id="7335089825053673252" datatype="html">
         <source>Privileged</source>
@@ -1910,7 +1910,7 @@
       </trans-unit>
       <trans-unit id="7409958205893937925" datatype="html">
         <source>Active Jobs: </source>
-        <target state="new">Jobs activos :</target>
+        <target state="new">Jobs activos: </target>
       </trans-unit>
       <trans-unit id="741892530496074339" datatype="html">
         <source>Signal</source>
@@ -1918,7 +1918,7 @@
       </trans-unit>
       <trans-unit id="7425524211157837406" datatype="html">
         <source>Unpin</source>
-        <target>Despegar</target>
+        <target>Desfijar</target>
       </trans-unit>
       <trans-unit id="7446822750532518350" datatype="html">
         <source>Network Policies </source>
@@ -1930,7 +1930,7 @@
       </trans-unit>
       <trans-unit id="7494553487547465000" datatype="html">
         <source>Logs auto-refresh time interval</source>
-        <target>Intérvalo de actualización automática de logs</target>
+        <target>Intervalo de actualización automática de logs</target>
       </trans-unit>
       <trans-unit id="750562982544545067" datatype="html">
         <source>kube-proxy version</source>
@@ -1950,7 +1950,7 @@
       </trans-unit>
       <trans-unit id="7541092997061001831" datatype="html">
         <source> Setting high number of pods may cause performance issues of the cluster and Dashboard UI. </source>
-        <target state="new">Establecer un número alto de pods puede causar problemas de desempeño del clúster y la UI del Dashboard.</target>
+        <target state="new"> Establecer un número alto de pods puede causar problemas de desempeño del clúster y la interfaz gráfica del Dashboard. </target>
       </trans-unit>
       <trans-unit id="7542300534444838884" datatype="html">
         <source>Kubernetes Dashboard</source>
@@ -1958,7 +1958,7 @@
       </trans-unit>
       <trans-unit id="7546647490531252189" datatype="html">
         <source>Namespace: </source>
-        <target state="new">Espacio de nombre:</target>
+        <target state="new">Espacio de nombre: </target>
       </trans-unit>
       <trans-unit id="7571663901157580742" datatype="html">
         <source>NAMESPACES</source>
@@ -1974,15 +1974,15 @@
       </trans-unit>
       <trans-unit id="7613204568422973266" datatype="html">
         <source>Default Backend</source>
-        <target state="new">Backend por Default</target>
+        <target state="new">Backend por defecto</target>
       </trans-unit>
       <trans-unit id="7624297849860603812" datatype="html">
         <source>Specify the data for your secret to hold. The value is the Base64 encoded content of a .dockercfg file.</source>
-        <target>Especifica la data para contener en tu secret. El valor es el contenido codificado en Base64 de un fichero .dockercfg.</target>
+        <target>Especifica los datos para contener en tu Secret. El valor es el contenido codificado en Base64 de un fichero .dockercfg.</target>
       </trans-unit>
       <trans-unit id="765635835361713756" datatype="html">
         <source> Preview </source>
-        <target state="new">Vista previa</target>
+        <target state="new"> Vista previa </target>
       </trans-unit>
       <trans-unit id="7678167194170686460" datatype="html">
         <source>Cancel </source>
@@ -2006,7 +2006,7 @@
       </trans-unit>
       <trans-unit id="7709318275445309520" datatype="html">
         <source>Last probe time</source>
-        <target>último sondeo</target>
+        <target>Último sondeo</target>
       </trans-unit>
       <trans-unit id="7737323664003098638" datatype="html">
         <source>Secret reference name</source>
@@ -2018,7 +2018,7 @@
       </trans-unit>
       <trans-unit id="7747200628816231618" datatype="html">
         <source> Label Key name should not exceed 63 characters. </source>
-        <target state="new">El nombre de la clave no debe exceder 63 caracteres.</target>
+        <target state="new"> El nombre de la clave de la etiqueta no debe exceder 63 caracteres. </target>
       </trans-unit>
       <trans-unit id="7769329651019167020" datatype="html">
         <source>Run as Group</source>
@@ -2046,7 +2046,7 @@
       </trans-unit>
       <trans-unit id="7846239389723666576" datatype="html">
         <source> Data must be Base64 encoded. </source>
-        <target state="new">Los datos deben estar codificados en Base64.</target>
+        <target state="new"> Los datos deben estar codificados en Base64. </target>
       </trans-unit>
       <trans-unit id="7873445996550708978" datatype="html">
         <source>Running: <x id="PH" equiv-text="status.running"/></source>
@@ -2070,7 +2070,7 @@
       </trans-unit>
       <trans-unit id="7941428823403788384" datatype="html">
         <source> Create </source>
-        <target state="new">Crear</target>
+        <target state="new"> Crear </target>
       </trans-unit>
       <trans-unit id="795890916060309463" datatype="html">
         <source>Roles</source>
@@ -2110,7 +2110,7 @@
       </trans-unit>
       <trans-unit id="8107673552387655091" datatype="html">
         <source>Max number of labels that are displayed by default on most views.</source>
-        <target>Número máximo de etiquetas que son mostradas por defecto en la mayoría de las vistas☺.</target>
+        <target>Número máximo de etiquetas que son mostradas por defecto en la mayoría de las vistas.</target>
       </trans-unit>
       <trans-unit id="8108958927167803950" datatype="html">
         <source>Cluster name</source>
@@ -2142,7 +2142,7 @@
       </trans-unit>
       <trans-unit id="8175189185819474284" datatype="html">
         <source> Container image is invalid: <x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> </source>
-        <target state="new">La imagen del contenedor es inválida : <x id="INTERPOLATION" equiv-text="{{containerImage.errors?.validImageReference}}"/></target>
+        <target state="new"> La imagen del contenedor es inválida : <x id="INTERPOLATION" equiv-text="{{containerImage.errors?.validImageReference}}"/> </target>
       </trans-unit>
       <trans-unit id="8177873832400820695" datatype="html">
         <source>Count</source>
@@ -2150,7 +2150,7 @@
       </trans-unit>
       <trans-unit id="8193431940379462508" datatype="html">
         <source>Replication Controllers </source>
-        <target state="new">Controladores de Replicación</target>
+        <target state="new">Controladores de Replicación </target>
       </trans-unit>
       <trans-unit id="8204176479746810612" datatype="html">
         <source>Active</source>
@@ -2198,7 +2198,7 @@
       </trans-unit>
       <trans-unit id="8360417359291444150" datatype="html">
         <source>Upload </source>
-        <target state="new">Cargar</target>
+        <target state="new">Cargar </target>
       </trans-unit>
       <trans-unit id="8384742917026482252" datatype="html">
         <source>Phase</source>
@@ -2214,7 +2214,7 @@
       </trans-unit>
       <trans-unit id="8433565378732329468" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> will be updated to reflect the desired replicas count.</source>
-        <target state="new"><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> will be updated to reflect the desired replicas count.</target>
+        <target state="new"><x id="INTERPOLATION" equiv-text="&quot;\uFFFD0\uFFFD&quot;"/> <x id="INTERPOLATION_1" equiv-text="&quot;\uFFFD1\uFFFD&quot;"/> será actualizado para reflejar la cantidad deseada de replicas.</target>
       </trans-unit>
       <trans-unit id="843549869562029376" datatype="html">
         <source>OS Image</source>
@@ -2226,7 +2226,7 @@
       </trans-unit>
       <trans-unit id="8444287437490086299" datatype="html">
         <source> Endpoints <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/></source>
-        <target state="new">Endpoints <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;external-link-icon kd-clickable&quot; i18n-matTooltip matTooltip=&quot;Endpoint links are external links that will be open in a new tab.&quot;&gt;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></target>
+        <target state="new"> Endpoints <x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD#2\uFFFD&quot;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&quot;\uFFFD/#2\uFFFD&quot;"/></target>
       </trans-unit>
       <trans-unit id="8451232601628619325" datatype="html">
         <source>Create from form</source>
@@ -2246,15 +2246,15 @@
       </trans-unit>
       <trans-unit id="8542934565724912440" datatype="html">
         <source> Prefix is not a valid DNS subdomain prefix (eg. my-domain.com). </source>
-        <target state="new">El prefijo no es un prefijo de subdominio DNS válido (ej. my-domain.com).</target>
+        <target state="new"> El prefijo no es un prefijo de subdominio DNS válido (ej. my-domain.com). </target>
       </trans-unit>
       <trans-unit id="8548218669860642537" datatype="html">
         <source>File is ready to download!</source>
-        <target state="new">El fichero está listo para descargarse!</target>
+        <target state="new">¡El fichero está listo para descargarse!</target>
       </trans-unit>
       <trans-unit id="858785118348238543" datatype="html">
         <source>Succeeded: </source>
-        <target state="new">Exitosos:</target>
+        <target state="new">Exitosos: </target>
       </trans-unit>
       <trans-unit id="8601511221316154701" datatype="html">
         <source>Download logs</source>
@@ -2286,7 +2286,7 @@
       </trans-unit>
       <trans-unit id="864882670483831190" datatype="html">
         <source> There are no notifications </source>
-        <target state="new">No hay notificaciones</target>
+        <target state="new"> No hay notificaciones </target>
       </trans-unit>
       <trans-unit id="8650499415827640724" datatype="html">
         <source>Type</source>
@@ -2310,19 +2310,19 @@
       </trans-unit>
       <trans-unit id="8712863007933324556" datatype="html">
         <source>The specified labels will be applied to the created Deployment, Service (if any) and Pods. Common labels include release, environment, tier, partition and track.</source>
-        <target>Las etiquetas especificadas serán aplicadas al Deployment creado, Service (si hay alguno) y pods. Las etiquetas comunes incluyen release, environment, tier, partition y track.</target>
+        <target>Las etiquetas especificadas serán aplicadas al Deployment creado, Service (si hay alguno) y Pods. Las etiquetas comunes incluyen release, environment, tier, partition y track.</target>
       </trans-unit>
       <trans-unit id="8713955401469120119" datatype="html">
         <source> Select YAML or JSON file specifying the resources to deploy to the currently selected namespace. </source>
-        <target state="new">Selecciona un fichero YAML o JSON especificando los recursos a desplegar en el espacio de nombre seleccionado.</target>
+        <target state="new"> Selecciona un fichero YAML o JSON especificando los recursos a desplegar en el espacio de nombre seleccionado. </target>
       </trans-unit>
       <trans-unit id="8716879065476971568" datatype="html">
         <source>Status: </source>
-        <target state="new">Estado:</target>
+        <target state="new">Estado: </target>
       </trans-unit>
       <trans-unit id="8764790219135296178" datatype="html">
         <source> Target port must be greater than 0. </source>
-        <target state="new">El puerto objetivo debe ser mayor que 0.</target>
+        <target state="new"> El puerto objetivo debe ser mayor que 0. </target>
       </trans-unit>
       <trans-unit id="8773342478342887379" datatype="html">
         <source>Nodes</source>
@@ -2382,7 +2382,7 @@
       </trans-unit>
       <trans-unit id="8971403803665717398" datatype="html">
         <source> Number of pods is required </source>
-        <target state="new">El número de pods es requerido</target>
+        <target state="new"> El número de Pods es requerido </target>
       </trans-unit>
       <trans-unit id="9014417675256704625" datatype="html">
         <source>Added Capabilities</source>
@@ -2394,7 +2394,7 @@
       </trans-unit>
       <trans-unit id="9044448882574381355" datatype="html">
         <source> CPU requirement must be given as a positive number. </source>
-        <target state="new">El requisito de CPU debe ser un número positivo.</target>
+        <target state="new"> El requisito de CPU debe ser un número positivo. </target>
       </trans-unit>
       <trans-unit id="9045596623183360040" datatype="html">
         <source>Enter the URL of a public image on any registry, or a private image hosted on Docker Hub or Google Container Registry.</source>
@@ -2418,7 +2418,7 @@
       </trans-unit>
       <trans-unit id="9114998185638265090" datatype="html">
         <source>Timeout (Seconds)</source>
-        <target state="new">Timeout (Seconds)</target>
+        <target state="new">Tiempo límite (Seconds)</target>
       </trans-unit>
       <trans-unit id="9137392283924504534" datatype="html">
         <source>Sysctls</source>
@@ -2430,7 +2430,7 @@
       </trans-unit>
       <trans-unit id="9169828761871989299" datatype="html">
         <source> Prefix should not exceed 253 characters. </source>
-        <target state="new">El prefijo no debe exceder 253 caracteres.</target>
+        <target state="new"> El prefijo no debe exceder 253 caracteres. </target>
       </trans-unit>
       <trans-unit id="9182918211699394982" datatype="html">
         <source>Failed: <x id="PH" equiv-text="status.failed"/></source>
@@ -2450,7 +2450,7 @@
       </trans-unit>
       <trans-unit id="97066167691656299" datatype="html">
         <source>Provisioner</source>
-        <target>Aprovisionar</target>
+        <target>Aprovisionador</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Hi team,

I've started contributing with the kubernetes-docs-es (Kubernetes Slack's channel handle) team this year, and they shared with me that the dashboard's Spanish strings have not been updated since #7496. So I worked on it by following [docs/development/internationalization.md](https://github.com/kubernetes/dashboard/blob/master/docs/developer/internationalization.md) guidelines.

This changeset focuses on the following:

- Updating web's i18n terms from the source
- Updating phrasing, punctuation and spacing on Spanish terms

I have requested kubernetes-docs-es team support to pre-review this change separately, and due to that, they co-author part of the git history. cc @electrocucaracha @ramrodo
