### PR TITLE
[helm] fix PDB templating and add support for HPA, pod affinity etc

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.0.0-alpha1
+version: 7.0.0-alpha2
 appVersion: "v3.0.0-alpha0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
@@ -62,3 +62,16 @@ Common label selectors
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: {{ include "kubernetes-dashboard.name" . }}
 {{- end -}}
+
+{{/*
+Define apiVersion of HorizontalPodAutoscaler
+*/}}
+{{- define "kubernetes-dashboard.hpa.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+{{- print "autoscaling/v2" -}}
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/api.yaml
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/component: {{ .Values.api.role }}
   name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.api.role }}
 spec:
-  replicas: {{ .Values.app.scaling.replicas }}
+  replicas: {{ .Values.api.replicas }}
   revisionHistoryLimit: {{ .Values.app.scaling.revisionHistoryLimit }}
   selector:
     matchLabels:
@@ -91,13 +91,19 @@ spec:
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.app.scheduling.nodeSelector }}
-      {{ toYaml . | nindent 8 }}
-      {{- end }}
 
-      {{- with .Values.app.tolerations }}
+      {{- with .Values.api.tolerations }}
       tolerations:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-
+  
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kubernetes-dashboard.fullname" . }}
+
+      {{- with .Values.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -97,14 +97,20 @@ spec:
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.app.scheduling.nodeSelector }}
-      {{ toYaml . | nindent 8 }}
-      {{- end }}
 
-      {{- with .Values.app.tolerations }}
+      {{- with .Values.metricsScraper.tolerations }}
       tolerations:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-
+  
+      {{- with .Values.metricsScraper.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kubernetes-dashboard.fullname" . }}
+
+      {{- with .Values.metricsScraper.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/deployments/web.yaml
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/component: {{ .Values.web.role }}
   name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
 spec:
-  replicas: {{ .Values.app.scaling.replicas }}
+  replicas: {{ .Values.web.replicas }}
   revisionHistoryLimit: {{ .Values.app.scaling.revisionHistoryLimit }}
   selector:
     matchLabels:
@@ -89,13 +89,19 @@ spec:
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.app.scheduling.nodeSelector }}
-      {{ toYaml . | nindent 8 }}
-      {{- end }}
 
-      {{- with .Values.app.tolerations }}
+      {{- with .Values.web.tolerations }}
       tolerations:
       {{ toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kubernetes-dashboard.fullname" . }}
+
+      {{- with .Values.web.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/hpa/api.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/hpa/api.yaml
@@ -1,0 +1,67 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.autoscaling.enabled }}
+apiVersion: {{ include "kubernetes-dashboard.hpa.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- with .Values.api.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
+    app.kubernetes.io/version: {{ .Values.api.image.tag }}
+    app.kubernetes.io/component: {{ .Values.api.role }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.api.role }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.api.role }}
+  minReplicas: {{ .Values.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+  metrics:
+    {{- if eq (include "kubernetes-dashboard.hpa.apiVersion" .) "autoscaling/v2" -}}
+    {{- if .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- else -}}
+    {{- if .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end -}}
+    {{- end }}
+{{- end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/hpa/web.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/hpa/web.yaml
@@ -1,0 +1,67 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.web.autoscaling.enabled }}
+apiVersion: {{ include "kubernetes-dashboard.hpa.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- with .Values.web.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
+    app.kubernetes.io/version: {{ .Values.web.image.tag }}
+    app.kubernetes.io/component: {{ .Values.web.role }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
+  minReplicas: {{ .Values.web.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.web.autoscaling.maxReplicas }}
+  metrics:
+    {{- if eq (include "kubernetes-dashboard.hpa.apiVersion" .) "autoscaling/v2" -}}
+    {{- if .Values.web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.web.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- else -}}
+    {{- if .Values.web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.web.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.web.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.web.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end -}}
+    {{- end }}
+{{- end }}

--- a/charts/helm-chart/kubernetes-dashboard/templates/security/pdb-api.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/security/pdb-api.yaml
@@ -1,0 +1,40 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.api.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+  {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  {{- if .Values.app.labels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.app.labels "context" $ ) | nindent 4 }}
+  {{- end }}
+  annotations:
+  {{- if .Values.app.annotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.app.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.api.role }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+      {{- with .Values.api.labels }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
+      app.kubernetes.io/version: {{ .Values.api.image.tag }}
+      app.kubernetes.io/component: {{ .Values.api.role }}
+  {{- toYaml .Values.api.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/helm-chart/kubernetes-dashboard/templates/security/pdb-web.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/security/pdb-web.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.app.security.podDisruptionBudget.enabled -}}
+{{- if .Values.web.podDisruptionBudget }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -25,17 +25,16 @@ metadata:
   {{- if .Values.app.annotations }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.app.annotations "context" $ ) | nindent 4 }}
   {{- end }}
-  name: {{ template "kubernetes-dashboard.fullname" . }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
 spec:
   selector:
     matchLabels:
-    {{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
-
-  {{- if .Values.app.security.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.app.security.podDisruptionBudget.minAvailable }}
-  {{- end }}
-
-  {{- if .Values.app.security.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.app.security.podDisruptionBudget.maxUnavailable }}
-  {{- end }}
+      {{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+      {{- with .Values.web.labels }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
+      app.kubernetes.io/version: {{ .Values.web.image.tag }}
+      app.kubernetes.io/component: {{ .Values.web.role }}
+  {{- toYaml .Values.web.podDisruptionBudget | nindent 2 }}
 {{- end -}}

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -18,13 +18,7 @@ app:
     pullPolicy: IfNotPresent
     pullSecrets: []
   scaling:
-    # Default number of replicas
-    replicas: 1
     revisionHistoryLimit: 10
-  scheduling:
-    # Node labels for pod assignment
-    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
-    nodeSelector: {}
   security:
     # SecurityContext to be added to pods
     # To disable set the following configuration to null:
@@ -43,12 +37,6 @@ app:
       runAsGroup: 2001
       capabilities:
         drop: ["ALL"]
-    # Pod Disruption Budget configuration
-    # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
-    podDisruptionBudget:
-      enabled: false
-      minAvailable: 0
-      maxUnavailable: 0
     networkPolicy:
       enabled: false
       ingressDenyAll: false
@@ -100,10 +88,6 @@ app:
     paths:
       web: /
       api: /api
-  # Use the following toleration if Dashboard can be deployed on a tainted control-plane nodes
-  # - key: node-role.kubernetes.io/control-plane
-  #   effect: NoSchedule
-  tolerations: []
 
 # API deployment configuration
 api:
@@ -111,6 +95,19 @@ api:
   image:
     repository: docker.io/kubernetesui/dashboard-api
     tag: v1.0.0
+  # Default number of replicas
+  replicas: 1
+  #Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  autoscaling:
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 10
+    # targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 2
   containers:
     ports:
       - name: api
@@ -152,6 +149,17 @@ api:
     - name: tmp-volume
       emptyDir: {}
   nodeSelector: {}
+  # Use the following toleration if API Deployment can be deployed on a tainted control-plane nodes
+  # - key: node-role.kubernetes.io/control-plane
+  #   effect: NoSchedule
+  tolerations: []
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
   # Labels & annotations shared between API related resources
   labels: {}
   annotations: {}
@@ -162,6 +170,19 @@ web:
   image:
     repository: docker.io/kubernetesui/dashboard-web
     tag: v1.0.0
+  # Default number of replicas
+  replicas: 1
+  #Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  autoscaling:
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 10
+    # targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 1
   containers:
     ports:
       - name: web
@@ -205,6 +226,15 @@ web:
   nodeSelector:
     # TODO: check if it's really needed since we offer cross platform images for darwin/windows/linux
     kubernetes.io/os: linux
+  # Use the following toleration if WEB Deployment can be deployed on a tainted control-plane nodes
+  # - key: node-role.kubernetes.io/control-plane
+  #   effect: NoSchedule
+  tolerations: []
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
   # Labels & annotations shared between WEB UI related resources
   labels: {}
   annotations: {}
@@ -263,7 +293,16 @@ metricsScraper:
   nodeSelector:
     # TODO: check if it's really needed since we offer cross platform images for darwin/windows/linux
     kubernetes.io/os: linux
-  # Labels & annotations shared between WEB UI related resources
+  # Use the following toleration if Metric Scraper can be deployed on a tainted control-plane nodes
+  # - key: node-role.kubernetes.io/control-plane
+  #   effect: NoSchedule
+  tolerations: []
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+  # Labels & annotations shared between Metric Scraper related resources
   labels: {}
   annotations: {}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dashboard/issues/8340
Fixes https://github.com/kubernetes/dashboard/issues/8137

- Updated `podDisruptionBudget` template file and splitted it in two files, so we can create a PDB per deployment instead of one for the whole app.
-  Removed `app.scheduling.nodeSelector` as it was breaking tempalting when it was defined but not `api.nodeSelector`
- Added variables to set `affinity`, `tolerations`, `replicas`, `topologySpreadConstraints` and `HorizontalPodAutoscaler` for WEB and API deployments
- moved `replicas` from `app.scaling` to each component so we can set different replica for WEB and API deployments