### PR TITLE
[helm] add if for ingressClassName

### DIFF
--- a/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -40,7 +40,9 @@ metadata:
     {{- end }}
   name: {{ template "kubernetes-dashboard.name" . }}
 spec:
+  {{- if .Values.app.ingress.ingressClassName }}
   ingressClassName: {{ .Values.app.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.app.ingress.hosts }}
   tls:
     - hosts:

--- a/charts/helm-chart/kubernetes-dashboard/values.yaml
+++ b/charts/helm-chart/kubernetes-dashboard/values.yaml
@@ -85,7 +85,7 @@ app:
     # https://localhost:8443
     - localhost
     # - kubernetes.dashboard.domain.com
-    ingressClassName: internal-nginx
+    ingressClassName: ""
     pathType: ImplementationSpecific
     secretName: kubernetes-dashboard-certs
     issuer:


### PR DESCRIPTION
- fixes #8593

using default ingressClass by default.

AS-IS
```
$ helm template . --set app.ingress.ingressClassName=hello | grep ingressClassName:
  ingressClassName: hello
$ helm template . --set app.ingress.ingressClassName="" | grep ingressClassName:
  ingressClassName: 
$ helm template . | grep ingressClassName:
  ingressClassName: internal-nginx
$
```

TO-BE
```
$ helm template . --set app.ingress.ingressClassName=hello | grep ingressClassName:
  ingressClassName: hello
$ helm template . --set app.ingress.ingressClassName="" | grep ingressClassName:
$ helm template . | grep ingressClassName:
$
```

If ingressClassName is not specified, the ingressClassName block is omitted. This allows us to use the cluster's default IngressClass.

similar case(helm chart):
https://github.com/prometheus-community/helm-charts/blob/alertmanager-1.7.0/charts/alertmanager/templates/ingress.yaml#L16-L18

k8s docs:
https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class




