### PR TITLE
feat: Update helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters.
 
 ![Dashboard UI workloads page](docs/images/overview.png)
 
-## Getting Started
-
-**IMPORTANT:** Read the [Access Control](docs/user/access-control/README.md) guide before performing any further steps. The default Dashboard deployment contains a minimal set of RBAC privileges needed to run.
-
 ## Installation
 
 Kubernetes Dashboard supports only Helm-based installation currently as it is faster and gives us better control
@@ -21,7 +17,7 @@ over all dependencies required by Dashboard to run. We now use a single-containe
 as a gateway that connects all our containers and exposes the UI. Users can then use any ingress controller or proxy
 in front of kong gateway. To find out more about ways to customize your installation check out [helm chart values](charts/kubernetes-dashboard/values.yaml).
 
-In order install Kubernetes Dashboard simply run:
+In order to install Kubernetes Dashboard simply run:
 ```console
 # Add kubernetes-dashboard repository
 helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
@@ -31,19 +27,14 @@ helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dash
 
 For more information about our Helm chart visit [ArtifactHub](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard).
 
-## Access
-
-You can access the Dashboard as described in the instructions that can be found in the [access guide](docs/user/accessing-dashboard/README.md).
-
-## Create An Authentication Token (RBAC)
-To find out how to create sample user and log in follow [Creating sample user](docs/user/access-control/creating-sample-user.md) guide.
-
 ## Documentation
 
-Dashboard documentation can be found on [docs](docs/README.md) directory which contains:
+Dashboard documentation can be found in the [docs](docs/README.md) directory which contains:
 
 * [Common](docs/common/README.md): Entry-level overview.
-* [User Guide](docs/user/README.md): [Accessing Dashboard](docs/user/accessing-dashboard/README.md) and more for users.
+* [User Guide](docs/user/README.md): Helpful information for users.
+* [How to access Dashboard](docs/user/accessing-dashboard/README.md) - Everything you need to know to get access to you Kubernetes Dashboard instance after installation.
+* [Access Control](docs/user/access-control/README.md): Find out how to control access to your Kubernetes Dashboard and [create sample user](docs/user/access-control/creating-sample-user.md) that can be used to log in.
 * [Developer Guide](DEVELOPMENT.md): Important information for contributors that would like to test, run and work on Dashboard locally.
 
 ## Community, discussion, contribution, and support

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.0.0-alpha2
-appVersion: "v3.0.0-alpha0"
+version: 7.0.0
+appVersion: "v3.0.0"
 description: General-purpose web UI for Kubernetes clusters
 keywords:
   - kubernetes

--- a/charts/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/web.yaml
@@ -50,6 +50,8 @@ spec:
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}
           args:
             - --settings-config-map-name={{ .Values.web.settings.configMap }}
+          {{/* TODO: Can be removed after updating default locale-config path in web container */}}
+            - --locale-config=/locale_conf.json
           {{- with .Values.web.containers.args }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -122,7 +122,7 @@ auth:
   role: auth
   image:
     repository: docker.io/kubernetesui/dashboard-auth
-    tag: v1.0.0
+    tag: 1.1.0
   scaling:
     replicas: 1
     revisionHistoryLimit: 10
@@ -158,7 +158,7 @@ api:
   role: api
   image:
     repository: docker.io/kubernetesui/dashboard-api
-    tag: v1.0.0
+    tag: 1.2.0
   scaling:
     replicas: 3
     revisionHistoryLimit: 10
@@ -212,7 +212,7 @@ web:
   role: web
   image:
     repository: docker.io/kubernetesui/dashboard-web
-    tag: v1.0.0
+    tag: 1.2.0
   scaling:
     replicas: 1
     revisionHistoryLimit: 10
@@ -271,7 +271,7 @@ metricsScraper:
   role: metrics-scraper
   image:
     repository: docker.io/kubernetesui/metrics-scraper
-    tag: v1.0.9
+    tag: 1.1.1
   scaling:
     replicas: 1
     revisionHistoryLimit: 10
@@ -338,6 +338,8 @@ metrics-server:
 ## for our all containers.
 kong:
   enabled: true
+  env:
+    dns_order: LAST,A,SRV,CNAME
   ingressController:
     enabled: false
   dblessConfig:

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -270,7 +270,7 @@ metricsScraper:
   enabled: true
   role: metrics-scraper
   image:
-    repository: docker.io/kubernetesui/metrics-scraper
+    repository: docker.io/kubernetesui/dashboard-metrics-scraper
     tag: 1.1.1
   scaling:
     replicas: 1

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -83,9 +83,9 @@ app:
   ingress:
     enabled: false
     hosts:
-    # Keep 'localhost' host only if you want to access Dashboard using 'kubectl port-forward ...' on:
-    # https://localhost:8443
-    - localhost
+      # Keep 'localhost' host only if you want to access Dashboard using 'kubectl port-forward ...' on:
+      # https://localhost:8443
+      - localhost
     # - kubernetes.dashboard.domain.com
     ingressClassName: internal-nginx
     # Use only if your ingress controllers support default ingress classes.
@@ -147,11 +147,11 @@ auth:
   volumes:
     # Create on-disk volume to store exec logs (required)
     - name: tmp-volume
-      emptyDir: { }
-  nodeSelector: { }
+      emptyDir: {}
+  nodeSelector: {}
   # Labels & annotations shared between API related resources
-  labels: { }
-  annotations: { }
+  labels: {}
+  annotations: {}
 
 # API deployment configuration
 api:

--- a/docs/user/access-control/README.md
+++ b/docs/user/access-control/README.md
@@ -33,7 +33,8 @@ Kubernetes Dashboard supports two different ways of authenticating users:
 
 ### Login view
 
-In case you are using the latest recommended installation then login functionality will be enabled by default. In any other case and if you prefer to configure certificates manually you need to pass `--tls-cert-file` and `--tls-cert-key` flags to Dashboard. HTTPS endpoint will be exposed on port `8443` of Dashboard container. You can change it by providing `--port` flag.
+In case you are using the latest installation then login functionality will be enabled by default and exposed via our
+gateway.
 
 ![Sing in](../../images/signin.png)
 
@@ -45,7 +46,7 @@ To make Dashboard use authorization header you simply need to pass `Authorizatio
 
 To quickly test it check out [Requestly](https://chrome.google.com/webstore/detail/requestly-redirect-url-mo/mdnleldcmiljblolnjhpnblkcekpdkpa) Chrome browser plugin that allows to manually modify request headers.
 
-**IMPORTANT:** Authorization header will not work if Dashboard is accessed through API server proxy. Both `kubectl proxy` and `API Server` way of accessing Dashboard described in [Accessing Dashboard](../accessing-dashboard/README.md) guide will not work. It is due to the fact that once request reaches API server all additional headers are dropped.
+**IMPORTANT:** Authorization header will not work if Dashboard is accessed through API server proxy. `kubectl port-forward` described in [Accessing Dashboard](../accessing-dashboard/README.md) guide will not work. It is due to the fact that once request reaches API server all additional headers are dropped.
 
 ### Bearer Token
 

--- a/hack/docker/dev.compose.yml
+++ b/hack/docker/dev.compose.yml
@@ -25,7 +25,7 @@ services:
       - "KONG_ADMIN_ACCESS_LOG=/dev/stdout"
       - "KONG_PROXY_ERROR_LOG=/dev/stderr"
       - "KONG_ADMIN_ERROR_LOG=/dev/stderr"
-      - "KONG_DNS_ORDER=LAST,A,CNAME"
+      - "KONG_DNS_ORDER=LAST,A,SRV,CNAME"
     volumes:
       - ${PWD}/hack/gateway/dev.kong.yml:/kong/declarative/kong.yml
     ports:


### PR DESCRIPTION
- Update documentation
- Fix `make run` target
- Add `make helm-release` target (uses default chart images)
- Update helm chart with latest images
- Bump helm chart version/appVersion
- Small update for `KONG_DNS_ORDER` configuration that should improve DNS resolve performance when accessing K8S services
- Add `locale-config` fix to helm chart. Can be removed after releasing patch for the web container