### PR TITLE
feat(chart): update helm chart and bump to 7.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ helm: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependenci
 helm-release: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies ## Install Kubernetes Dashboard helm chart in the dev kind cluster
 	@helm upgrade \
 		--create-namespace \
-		--namespace kubernetes-dashboard \
+		--namespace dashboard \
 		--install kubernetes-dashboard \
 		--set metrics-server.enabled=true \
 		--set app.ingress.enabled=true \
@@ -179,7 +179,7 @@ helm-release: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-de
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm dev installation of Kubernetes Dashboard
-	@helm uninstall -n kubernetes-dashboard kubernetes-dashboard
+	@helm uninstall -n dashboard kubernetes-dashboard
 
 # ============================ Private ============================ #
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ endif
 helm: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies image --kind-load-images ## Install Kubernetes Dashboard dev helm chart in the dev kind cluster
 	@helm upgrade \
 		--create-namespace \
-		--namespace kubernetes-dashboard \
+		--namespace dashboard \
 		--install kubernetes-dashboard \
 		--set auth.image.repository=dashboard-auth \
 		--set auth.image.tag=latest \
@@ -141,6 +141,7 @@ helm: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependenci
 		--set metricsScraper.image.repository=dashboard-scraper \
 		--set metricsScraper.image.tag=latest \
 		--set metrics-server.enabled=true \
+		--set cert-manager.enabled=true \
 		--set app.ingress.enabled=true \
 		--set app.ingress.ingressClassName=nginx \
 		--set api.scaling.replicas=3 \

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.0.0
+version: 7.0.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:
   - kubernetes

--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -63,8 +63,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: {{ include "kubernetes-dashboard.name" . }}
 {{- end -}}
 
+{{- define "kubernetes-dashboard.app.csrf.secret.name" -}}
+{{- printf "%s-%s" ( include "kubernetes-dashboard.fullname" . ) "csrf"}}
+{{- end -}}
+
+{{- define "kubernetes-dashboard.app.ingress.secret.name" -}}
+{{- printf "%s-%s" ( include "kubernetes-dashboard.fullname" . ) "certs"}}
+{{- end -}}
+
+{{- define "kubernetes-dashboard.app.csrf.secret.key" -}}
+{{- printf "private.key" }}
+{{- end -}}
+
 {{- define "kubernetes-dashboard.metrics-scraper.name" -}}
 {{- printf "%s-%s" ( include "kubernetes-dashboard.fullname" . ) ( .Values.metricsScraper.role )}}
+{{- end -}}
+
+{{- define "kubernetes-dashboard.web.configMap.settings.name" -}}
+{{- printf "%s-%s-%s" ( include "kubernetes-dashboard.fullname" . ) ( .Values.web.role ) "settings" }}
 {{- end -}}
 
 {{- define "kubernetes-dashboard.validate.mode" -}}

--- a/charts/kubernetes-dashboard/templates/config/settings.yaml
+++ b/charts/kubernetes-dashboard/templates/config/settings.yaml
@@ -19,7 +19,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
-  name: {{ .Values.web.settings.configMap }}
+  name: {{ template "kubernetes-dashboard.web.configMap.settings.name" . }}
 data:
 {{- with .Values.app.settings.global }}
   settings: {{ toJson . | quote }}

--- a/charts/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/api.yaml
@@ -23,6 +23,10 @@ metadata:
     app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
     app.kubernetes.io/version: {{ .Values.api.image.tag }}
     app.kubernetes.io/component: {{ .Values.api.role }}
+  annotations:
+    {{- with .Values.api.annotations }}
+    {{ toYaml . | nindent 8 }}
+    {{- end }}
   name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.api.role }}
 spec:
   replicas: {{ .Values.api.scaling.replicas }}
@@ -41,6 +45,12 @@ spec:
         app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
         app.kubernetes.io/version: {{ .Values.api.image.tag }}
         app.kubernetes.io/component: {{ .Values.api.role }}
+      annotations:
+        {{/* Ensure that the deployment is rolled on upgrade since CSRF key will be regenerated. */}}
+        rollme: {{ randAlphaNum 5 | quote }}
+        {{- with .Values.api.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
@@ -57,8 +67,8 @@ spec:
             - name: CSRF_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.app.csrf.secretName }}
-                  key: {{ .Values.app.csrf.secretKey }}
+                  name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
+                  key: {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}
           {{- with .Values.api.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/templates/deployments/auth.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/auth.yaml
@@ -26,6 +26,10 @@ metadata:
     app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
     app.kubernetes.io/version: {{ .Values.api.image.tag }}
     app.kubernetes.io/component: {{ .Values.auth.role }}
+  annotations:
+    {{- with .Values.auth.annotations }}
+    {{ toYaml . | nindent 8 }}
+    {{- end }}
   name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.auth.role }}
 spec:
   replicas: {{ .Values.auth.scaling.replicas }}
@@ -44,6 +48,12 @@ spec:
         app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
         app.kubernetes.io/version: {{ .Values.auth.image.tag }}
         app.kubernetes.io/component: {{ .Values.auth.role }}
+      annotations:
+        {{/* Ensure that the deployment is rolled on upgrade since CSRF key will be regenerated. */}}
+        rollme: {{ randAlphaNum 5 | quote }}
+        {{- with .Values.auth.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
@@ -58,8 +68,8 @@ spec:
             - name: CSRF_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.app.csrf.secretName }}
-                  key: {{ .Values.app.csrf.secretKey }}
+                  name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
+                  key: {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}
           {{- with .Values.auth.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -25,6 +25,10 @@ metadata:
     app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.metricsScraper.role }}
     app.kubernetes.io/version: {{ .Values.metricsScraper.image.tag }}
     app.kubernetes.io/component: {{ .Values.metricsScraper.role }}
+  annotations:
+    {{- with .Values.metricsScraper.annotations }}
+    {{ toYaml . | nindent 8 }}
+    {{- end }}
   name: {{ template "kubernetes-dashboard.metrics-scraper.name" . }}
 spec:
   replicas: {{ .Values.metricsScraper.scaling.replicas }}
@@ -43,6 +47,10 @@ spec:
         app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.metricsScraper.role }}
         app.kubernetes.io/version: {{ .Values.metricsScraper.image.tag }}
         app.kubernetes.io/component: {{ .Values.metricsScraper.role }}
+      annotations:
+        {{- with .Values.metricsScraper.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.metricsScraper.role }}

--- a/charts/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/web.yaml
@@ -25,6 +25,10 @@ metadata:
     app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
     app.kubernetes.io/version: {{ .Values.web.image.tag }}
     app.kubernetes.io/component: {{ .Values.web.role }}
+  annotations:
+    {{- with .Values.web.annotations }}
+    {{ toYaml . | nindent 8 }}
+    {{- end }}
   name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
 spec:
   replicas: {{ .Values.web.scaling.replicas }}
@@ -43,15 +47,18 @@ spec:
         app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
         app.kubernetes.io/version: {{ .Values.web.image.tag }}
         app.kubernetes.io/component: {{ .Values.web.role }}
+      annotations:
+        {{- with .Values.web.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}
           args:
-            - --settings-config-map-name={{ .Values.web.settings.configMap }}
-          {{/* TODO: Can be removed after updating default locale-config path in web container */}}
-            - --locale-config=/locale_conf.json
+            - --namespace={{ .Release.Namespace }}
+            - --settings-config-map-name={{ template "kubernetes-dashboard.web.configMap.settings.name" . }}
           {{- with .Values.web.containers.args }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -50,7 +50,7 @@ spec:
   tls:
     - hosts:
       {{- toYaml .Values.app.ingress.hosts | nindent 6 }}
-      secretName: {{ .Values.app.ingress.secretName }}
+      secretName: {{ template "kubernetes-dashboard.app.ingress.secret.name" . }}
   {{- end }}
   rules:
     {{- if .Values.app.ingress.hosts }}

--- a/charts/kubernetes-dashboard/templates/rbac/web/role.yaml
+++ b/charts/kubernetes-dashboard/templates/rbac/web/role.yaml
@@ -24,7 +24,7 @@ rules:
     # Allow Dashboard Web to get and update 'kubernetes-dashboard-settings' config map.
   - apiGroups: [ "" ]
     resources: [ "configmaps" ]
-    resourceNames: [ "{{ .Values.web.settings.configMap }}" ]
+    resourceNames: [ "{{ template "kubernetes-dashboard.web.configMap.settings.name" . }}" ]
     verbs: [ "get", "update" ]
 
 {{- end -}}

--- a/charts/kubernetes-dashboard/templates/secrets/csrf.yaml
+++ b/charts/kubernetes-dashboard/templates/secrets/csrf.yaml
@@ -17,6 +17,6 @@ kind: Secret
 metadata:
   labels:
     {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
-  name: {{ .Values.app.csrf.secretName }}
+  name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
 data:
-  {{.Values.app.csrf.secretKey}}: {{ randBytes 256 | b64enc | quote }}
+  {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}: {{ randBytes 256 | b64enc | quote }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -95,7 +95,6 @@ app:
     #    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     useDefaultAnnotations: true
     pathType: ImplementationSpecific
-    secretName: kubernetes-dashboard-certs
     # If path is not the default (/), rewrite-target annotation will be added to the Ingress.
     # It allows serving Kubernetes Dashboard on a sub-path. Make sure that the configured path
     # does not conflict with gateway route configuration.

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -55,9 +55,6 @@ app:
   # Common labels & annotations shared across all deployed resources
   labels: {}
   annotations: {}
-  csrf:
-    secretName: kubernetes-dashboard-csrf
-    secretKey: private.key
   settings:
     ## Global dashboard settings
     global:
@@ -212,12 +209,10 @@ web:
   role: web
   image:
     repository: docker.io/kubernetesui/dashboard-web
-    tag: 1.2.0
+    tag: 1.2.1
   scaling:
     replicas: 1
     revisionHistoryLimit: 10
-  settings:
-    configMap: kubernetes-dashboard-settings
   containers:
     ports:
       - name: web


### PR DESCRIPTION
- Bump chart version to 7.0.1
- Generate names for some resources instead of using `values.yaml` with strict names:
  - CSRF secret name/key
  - Ingress certificates secret name
  - Web settings config map
- Allow configuring annotations for all deployment via `values.yaml`
- Add special `rollme` annotation to API/Auth deployments to ensure pod rollout restart on chart upgrade. This is required to ensure that the regenerated CSRF key stored in a secret will be used by all pods at once (fixes #8756).
- Add `namespace` argument based on `Release.Namespace` to web settings (fixes #8749).
- Updated web container to the latest version (1.2.1)