### PR TITLE
feat(chart): update web, auth images and bump chart

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -34,16 +34,8 @@ jobs:
         with:
           version: v3.12.1
       - uses: helm/chart-testing-action@v2.6.1
-      - id: list-changed
-        run: |
-          changed=$(ct list-changed --config=.ct.yml --target-branch ${{ github.event.repository.default_branch }})
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --config=.ct.yml --target-branch ${{ github.event.repository.default_branch }}
-      - if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.9.0
+      - run: ct lint --config=.ct.yml --target-branch ${{ github.event.repository.default_branch }}
+      - uses: helm/kind-action@v1.9.0
         with:
           node_image: kindest/node:v1.29.0
       - if: steps.list-changed.outputs.changed == 'true'

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.1.0
+version: 7.1.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:
   - kubernetes

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -121,7 +121,7 @@ auth:
   role: auth
   image:
     repository: docker.io/kubernetesui/dashboard-auth
-    tag: 1.1.0
+    tag: 1.1.1
   scaling:
     replicas: 1
     revisionHistoryLimit: 10
@@ -211,7 +211,7 @@ web:
   role: web
   image:
     repository: docker.io/kubernetesui/dashboard-web
-    tag: 1.2.1
+    tag: 1.2.2
   scaling:
     replicas: 1
     revisionHistoryLimit: 10

--- a/modules/web/src/chrome/userpanel/style.scss
+++ b/modules/web/src/chrome/userpanel/style.scss
@@ -43,7 +43,7 @@
 
 .username {
   font-size: $caption-font-size-base;
-  margin-top: .5 * $baseline-grid;
+  margin-top: 0.5 * $baseline-grid;
 }
 
 .method {


### PR DESCRIPTION
- Bump chart to `7.1.1`
- Bump auth image to `1.1.1`
- Bump web image to `1.2.2`
- Remove list changed step from CD chart lint GH action as on master it could never find any change

Waiting for https://github.com/kubernetes/dashboard/actions/runs/8194278887 and https://github.com/kubernetes/dashboard/actions/runs/8194273587 to finish.