### PR TITLE
ci: Fix CodeQL check and ignore codecov token error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
       - uses: codecov/codecov-action@v4.1.0
         with:
           directory: ./.tmp
-          fail_ci_if_error: true
+          #fail_ci_if_error: true
+          # PR from dependabot causes an error, so comment this out until the problem is resolved.
+          # See https://github.com/codecov/codecov-action/issues/1274
           token: ${{ secrets.CODECOV_TOKEN }}
 
 # TODO: needs to be fixed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: modules/api/go.mod
+          check-latest: true
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,6 @@ jobs:
       - uses: codecov/codecov-action@v4.1.0
         with:
           directory: ./.tmp
-          #fail_ci_if_error: true
-          # PR from dependabot causes an error, so comment this out until the problem is resolved.
-          # See https://github.com/codecov/codecov-action/issues/1274
           token: ${{ secrets.CODECOV_TOKEN }}
 
 # TODO: needs to be fixed


### PR DESCRIPTION
As of now, we need to manually setup golang for 1.22.
https://github.com/github/codeql/issues/15647#issuecomment-2003768106

Also, ignore Codecov token not found error.
PR from dependabot causes an error, so comment this out until the problem is resolved.
See https://github.com/codecov/codecov-action/issues/1274