### PR TITLE
fix(ingress): use web as backend when kong is disabled

### DIFF
--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -69,10 +69,19 @@ spec:
         {{- end }}
             pathType: {{ $.Values.app.ingress.pathType }}
             backend:
+              {{- if $.Values.kong.enabled }}
               service:
                 name: {{ template "kong.fullname" (index $.Subcharts "kong") }}-proxy
                 port:
                   number: {{ $.Values.kong.proxy.tls.servicePort }}
+              {{- else }}
+              service:
+                name: {{ template "kubernetes-dashboard.fullname" . }}-{{ .Values.web.role }}
+                port:
+                  {{- with (index .Values.web.containers.ports 0) }}
+                  number:  {{ .containerPort }}
+                  {{- end }}
+              {{- end }}
     {{- end }}
     {{- else }}
     - http:


### PR DESCRIPTION
Replaces https://github.com/kubernetes/dashboard/pull/8770