### PR TITLE
feat(chart): add automountServiceAccountToken to deployment specs in Helm chart

### DIFF
--- a/charts/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/api.yaml
@@ -100,6 +100,8 @@ spec:
       {{- end }}
       {{- end }}
 
+      automountServiceAccountToken: {{ .Values.api.automountServiceAccountToken }}
+
       {{- with .Values.app.security.securityContext }}
       securityContext:
       {{ toYaml . | nindent 8 }}

--- a/charts/kubernetes-dashboard/templates/deployments/auth.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/auth.yaml
@@ -101,6 +101,8 @@ spec:
       {{- end }}
       {{- end }}
 
+      automountServiceAccountToken: {{ .Values.auth.automountServiceAccountToken }}
+
       {{- with .Values.app.security.securityContext }}
       securityContext:
       {{ toYaml . | nindent 8 }}

--- a/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -98,6 +98,8 @@ spec:
       {{- end }}
       {{- end }}
 
+      automountServiceAccountToken: {{ .Values.metricsScraper.automountServiceAccountToken }}
+
       {{- with .Values.app.security.securityContext }}
       securityContext:
       {{ toYaml . | nindent 8 }}

--- a/charts/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/web.yaml
@@ -95,6 +95,8 @@ spec:
       {{- end }}
       {{- end }}
 
+      automountServiceAccountToken: {{ .Values.web.automountServiceAccountToken }}
+
       {{- with .Values.app.security.securityContext }}
       securityContext:
       {{ toYaml . | nindent 8 }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -143,6 +143,7 @@ auth:
       limits:
         cpu: 250m
         memory: 400Mi
+  automountServiceAccountToken: false
   volumes:
     # Create on-disk volume to store exec logs (required)
     - name: tmp-volume
@@ -192,6 +193,7 @@ api:
       limits:
         cpu: 250m
         memory: 400Mi
+  automountServiceAccountToken: true
   # Additional volumes
   # - name: dashboard-kubeconfig
   #   secret:
@@ -246,6 +248,7 @@ web:
       limits:
         cpu: 250m
         memory: 400Mi
+  automountServiceAccountToken: true
   # Additional volumes
   # - name: dashboard-kubeconfig
   #   secret:
@@ -305,6 +308,7 @@ metricsScraper:
         port: 8000
       initialDelaySeconds: 30
       timeoutSeconds: 30
+  automountServiceAccountToken: true
   # Additional volumes
   # - name: dashboard-kubeconfig
   #   secret:


### PR DESCRIPTION
This MR adds the option to set the value of `automountServiceAccountToken` for deployments.

Moreover, it uses `false` as default value for the `auth` deployment, given that it has no service account and not automounting the token of the `default` account is considered best practice by some people, including me.