### PR TITLE
feat(chart): bump chart version to 7.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 # Note: Requires kind to set up and run.
 # Note #2: Make sure that the port 443 (HTTPS) is free on your localhost.
 .PHONY: helm
-helm: # --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies image --kind-load-images ## Install Kubernetes Dashboard dev helm chart in the dev kind cluster
+helm: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies image --kind-load-images ## Install Kubernetes Dashboard dev helm chart in the dev kind cluster
 	@helm upgrade \
 		--create-namespace \
 		--namespace dashboard \

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 # Note: Requires kind to set up and run.
 # Note #2: Make sure that the port 443 (HTTPS) is free on your localhost.
 .PHONY: helm
-helm: --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies image --kind-load-images ## Install Kubernetes Dashboard dev helm chart in the dev kind cluster
+helm: # --ensure-kind-cluster --ensure-kind-ingress-nginx --ensure-helm-dependencies image --kind-load-images ## Install Kubernetes Dashboard dev helm chart in the dev kind cluster
 	@helm upgrade \
 		--create-namespace \
 		--namespace dashboard \

--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.1.3
+version: 7.2.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:
   - kubernetes

--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -75,6 +75,16 @@ app.kubernetes.io/part-of: {{ include "kubernetes-dashboard.name" . }}
 {{- printf "private.key" }}
 {{- end -}}
 
+{{- define "kubernetes-dashboard.app.csrf.secret.value" -}}
+{{- $secretName := (include "kubernetes-dashboard.app.csrf.secret.name" .) -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $secret (hasKey $secret "data") (hasKey $secret.data "private.key") (index $secret.data "private.key") -}}
+private.key: {{ index $secret.data "private.key" }}
+{{- else -}}
+private.key: {{ randBytes 256 | b64enc | quote }}
+{{- end -}}
+{{- end -}}
+
 {{- define "kubernetes-dashboard.metrics-scraper.name" -}}
 {{- printf "%s-%s" ( include "kubernetes-dashboard.fullname" . ) ( .Values.metricsScraper.role )}}
 {{- end -}}

--- a/charts/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/api.yaml
@@ -46,8 +46,7 @@ spec:
         app.kubernetes.io/version: {{ .Values.api.image.tag }}
         app.kubernetes.io/component: {{ .Values.api.role }}
       annotations:
-        {{/* Ensure that the deployment is rolled on upgrade since CSRF key will be regenerated. */}}
-        rollme: {{ randAlphaNum 5 | quote }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets/csrf.yaml") . | sha256sum }}
         {{- with .Values.api.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kubernetes-dashboard/templates/deployments/auth.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/auth.yaml
@@ -49,8 +49,7 @@ spec:
         app.kubernetes.io/version: {{ .Values.auth.image.tag }}
         app.kubernetes.io/component: {{ .Values.auth.role }}
       annotations:
-        {{/* Ensure that the deployment is rolled on upgrade since CSRF key will be regenerated. */}}
-        rollme: {{ randAlphaNum 5 | quote }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets/csrf.yaml") . | sha256sum }}
         {{- with .Values.auth.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kubernetes-dashboard/templates/secrets/csrf.yaml
+++ b/charts/kubernetes-dashboard/templates/secrets/csrf.yaml
@@ -19,4 +19,4 @@ metadata:
     {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
   name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
 data:
-  {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}: {{ randBytes 256 | b64enc | quote }}
+  {{ (include "kubernetes-dashboard.app.csrf.secret.value" . ) -}}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -158,7 +158,7 @@ api:
   role: api
   image:
     repository: docker.io/kubernetesui/dashboard-api
-    tag: 1.4.0
+    tag: 1.4.1
   scaling:
     replicas: 1
     revisionHistoryLimit: 10

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -143,7 +143,7 @@ auth:
       limits:
         cpu: 250m
         memory: 400Mi
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
   volumes:
     # Create on-disk volume to store exec logs (required)
     - name: tmp-volume
@@ -341,7 +341,7 @@ kong:
   enabled: true
   ## Configuration reference: https://docs.konghq.com/gateway/3.6.x/reference/configuration
   env:
-    dns_order: A,CNAME,LAST,SRV
+    dns_order: A,CNAME,LAST,AAAA,SRV
     plugins: 'off'
     nginx_worker_processes: 1
   ingressController:


### PR DESCRIPTION
- Update csrf secret handling.
  It will no longer be regenerated on every helm run. Instead, it will use a lookup function to make sure that the `private.key` value is not empty. If secret will be deleted or key changed, then checksum annotation on api/auth containers will trigger a rollout restart.
- Update kong `dns_order` configuration to include experimental `AAAA` record for ipv6 lookup. It can potentially fix issues with accessing Dashboard on IPv6-enabled cluster. Closes #8855
- Reenable SA token automount for auth container. It is required to initialize the in-cluster go client.
- Bump API image to `1.4.1`
- Bump chart version to `7.2.0`