### PR TITLE
feat(chart): Disable Kong Manager by default

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -352,6 +352,8 @@ kong:
     nginx_worker_processes: 1
   ingressController:
     enabled: false
+  manager:
+    enabled: false
   dblessConfig:
     configMap: kong-dbless-config
   proxy:


### PR DESCRIPTION
With the current defaults, a type `NodePort` service with name `kubernetes-dashboard-kong-manager` is created. Given that Kong Manager is a GUI for managing Kong resources that is as far as I'm aware not in any way required for functionality of this chart, I think disabling it is a more reasonable default.