### PR TITLE
feat(chart): Set `GOMAXPROCS` and `GOMEMLIMIT` environment variables

### DIFF
--- a/charts/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/api.yaml
@@ -68,6 +68,20 @@ spec:
                 secretKeyRef:
                   name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
                   key: {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}
+
+            {{- if .Values.api.containers.resources.limits.cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- end }}
+            {{- if .Values.api.containers.resources.limits.memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- end }}
+
           {{- with .Values.api.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/templates/deployments/auth.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/auth.yaml
@@ -69,6 +69,20 @@ spec:
                 secretKeyRef:
                   name: {{ template "kubernetes-dashboard.app.csrf.secret.name" . }}
                   key: {{ template "kubernetes-dashboard.app.csrf.secret.key" . }}
+
+            {{- if .Values.auth.containers.resources.limits.cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- end }}
+            {{- if .Values.auth.containers.resources.limits.memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- end }}
+
           {{- with .Values.auth.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -61,8 +61,21 @@ spec:
           {{ toYaml . | nindent 12 }}
           {{- end }}
 
-          {{- with .Values.web.containers.env }}
           env:
+            {{- if .Values.metricsScraper.containers.resources.limits.cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- end }}
+            {{- if .Values.metricsScraper.containers.resources.limits.memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- end }}
+
+          {{- with .Values.metricsScraper.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}
 

--- a/charts/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/web.yaml
@@ -63,8 +63,21 @@ spec:
           {{ toYaml . | nindent 12 }}
           {{- end }}
 
-          {{- with .Values.web.containers.env }}
           env:
+            {{- if .Values.web.containers.resources.limits.cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- end }}
+            {{- if .Values.web.containers.resources.limits.memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- end }}
+
+          {{- with .Values.web.containers.env }}
           {{ toYaml . | nindent 12 }}
           {{- end }}
 


### PR DESCRIPTION
Set `GOMAXPROCS` and `GOMEMLIMIT` environment variables based on container resources.

The [`resourceFieldRef`](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef) is a very specific Kubernetes directive that is created specifically for passing resource-related values, which rounds up the CPU value to the nearest whole number (e.g. 250m to 1) and passes the memory as a numeric value; so `64Mi` would result in the environment variable being set to `67108864`. This by design makes it completely compatible with Go's API.

An example is documented within Kubernetes documentation itself: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables.

Inspired by https://github.com/traefik/traefik-helm-chart/pull/1029, this should reduce potential CPU throttling and OOMKills on containers.

This also replaces a reference to `.Values.web.containers.env` in the `metrics-scraper` deployment, which I assumed to be an unintented faulty value.