### PR TITLE
Adding auth port in netpol

### DIFF
--- a/charts/kubernetes-dashboard/templates/security/networkpolicy.yaml
+++ b/charts/kubernetes-dashboard/templates/security/networkpolicy.yaml
@@ -39,5 +39,7 @@ spec:
         protocol: TCP
       - port: {{ $.Values.api.role }}
         protocol: TCP
+      - port: {{ $.Values.auth.role }}
+        protocol: TCP
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Without the auth port in netpol, the auth api isn't reachable and it's breaking login.

This is what I see without the auth role:

```
2024/05/04 12:24:42 [error] 1321#0: *744 upstream timed out (110: Connection timed out) while connecting to upstream, client: 10.2.2.46, server: kong, request: "GET /api/v1/me HTTP/1.1", upstream: "http://10.3.60.63:8000/api/v1/me", host: "hello.dvd.dev", referrer: "https://hello.dvd.dev/", request_id: "6f31940c647aaf1e452092720d521833"
```