### PR TITLE
fix: update cosmtrek/air project link to air-verse/air

### DIFF
--- a/modules/api/dev.Dockerfile
+++ b/modules/api/dev.Dockerfile
@@ -16,7 +16,7 @@
 
 FROM golang:1.22-alpine3.19 as AIR
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 FROM golang:1.22-alpine3.19
 

--- a/modules/auth/dev.Dockerfile
+++ b/modules/auth/dev.Dockerfile
@@ -16,7 +16,7 @@
 
 FROM golang:1.22-alpine3.19 as AIR
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 FROM golang:1.22-alpine3.19
 

--- a/modules/common/tools/Makefile
+++ b/modules/common/tools/Makefile
@@ -78,7 +78,7 @@ endif
 install-air:
 ifndef AIR_BINARY
 	@echo "[tools] downloading air..."
-	@go install github.com/cosmtrek/air
+	@go install github.com/air-verse/air
 else
 	@echo "[tools] air already exists"
 endif

--- a/modules/common/tools/go.mod
+++ b/modules/common/tools/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.2
 
 require (
 	github.com/apache/skywalking-eyes v0.6.0
-	github.com/cosmtrek/air v1.52.0
+	github.com/air-verse/air v1.52.2
 	github.com/golangci/golangci-lint v1.59.0
 	k8s.io/code-generator v0.30.0
 	sigs.k8s.io/kind v0.23.0

--- a/modules/common/tools/go.sum
+++ b/modules/common/tools/go.sum
@@ -133,8 +133,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cosmtrek/air v1.52.0 h1:fCMADJfEdcBE84oyhChPXv2XS5A1jUN/uLo49ivCnlI=
-github.com/cosmtrek/air v1.52.0/go.mod h1:xILtq8JGIYwe++r/ib4PdhubiuKBmE1vutC49E+5A78=
+github.com/air-verse/air v1.52.0 h1:fCMADJfEdcBE84oyhChPXv2XS5A1jUN/uLo49ivCnlI=
+github.com/air-verse/air v1.52.0/go.mod h1:xILtq8JGIYwe++r/ib4PdhubiuKBmE1vutC49E+5A78=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=

--- a/modules/common/tools/main.go
+++ b/modules/common/tools/main.go
@@ -18,7 +18,7 @@ package tools
 
 import (
 	_ "github.com/apache/skywalking-eyes/cmd/license-eye"
-	_ "github.com/cosmtrek/air"
+	_ "github.com/air-verse/air"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "k8s.io/code-generator"
 	_ "sigs.k8s.io/kind"

--- a/modules/metrics-scraper/dev.Dockerfile
+++ b/modules/metrics-scraper/dev.Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.22-alpine3.19 as AIR
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 FROM golang:1.22-alpine3.19
 

--- a/modules/web/dev.go.Dockerfile
+++ b/modules/web/dev.go.Dockerfile
@@ -16,7 +16,7 @@
 
 FROM golang:1.22-alpine3.19 as AIR
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 FROM golang:1.22-alpine3.19
 


### PR DESCRIPTION
Update Air's project link and version to reflect their changes in [#602](https://github.com/air-verse/air/pull/602)

The change broke the Air dependency for dashboard's local environment scripts via make:
```
 > [scraper air 2/2] RUN go install github.com/cosmtrek/air@latest:
1.217 go: downloading github.com/cosmtrek/air v1.52.2
1.335 go: github.com/cosmtrek/air@latest: version constraints conflict:
1.335   github.com/cosmtrek/air@v1.52.2: parsing go.mod:
1.335   module declares its path as: github.com/air-verse/air
1.335           but was required as: github.com/cosmtrek/air
------
```

Ran ```make test``` and manually tested dev and prod versions:

```
ubuntu@ip:~/dashboard$ make test
[tools] node version requirements met
[tools] yarn already exists
[tools] golang version requirements met
[tools] license-eye already exists
[tools] air already exists
[tools] golangci-lint already exists
[tools] client-gen already exists
[tools] kind already exists
[root] Cleaning up
[dashboard-api] Cleaning up
[dashboard-auth] Cleaning up
[dashboard-metrics-scraper] Cleaning up
[dashboard-web] Cleaning up
[dashboard-api] Running tests
go: downloading github.com/emicklei/go-restful-openapi/v2 v2.10.2
go: downloading github.com/emicklei/go-restful/v3 v3.12.1
go: downloading github.com/go-openapi/spec v0.21.0
go: downloading gopkg.in/igm/sockjs-go.v2 v2.1.0
go: downloading k8s.io/api v0.30.0
go: downloading k8s.io/apimachinery v0.30.0
go: downloading k8s.io/client-go v0.30.0
go: downloading k8s.io/apiextensions-apiserver v0.30.0
go: downloading github.com/docker/distribution v2.8.3+incompatible
go: downloading github.com/gobuffalo/flect v1.0.2
go: downloading github.com/gin-gonic/gin v1.10.0
go: downloading github.com/go-openapi/jsonpointer v0.21.0
go: downloading github.com/go-openapi/jsonreference v0.21.0
go: downloading github.com/go-openapi/swag v0.23.0
go: downloading github.com/gorilla/websocket v1.5.1
go: downloading k8s.io/utils v0.0.0-20230726121419-3b25d923346b
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/google/gofuzz v1.2.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.4.1
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading github.com/golang/protobuf v1.5.4
go: downloading github.com/google/gnostic-models v0.6.8
go: downloading github.com/distribution/reference v0.5.0
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading golang.org/x/term v0.20.0
go: downloading github.com/gin-contrib/sse v0.1.0
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
go: downloading golang.org/x/time v0.5.0
go: downloading github.com/json-iterator/go v1.1.12
go: downloading k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
go: downloading github.com/go-playground/validator/v10 v10.20.0
go: downloading github.com/ugorji/go/codec v1.2.12
go: downloading github.com/josharian/intern v1.0.0
go: downloading github.com/moby/spdystream v0.2.0
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
go: downloading github.com/gabriel-vasile/mimetype v1.4.3
go: downloading github.com/go-playground/universal-translator v0.18.1
go: downloading github.com/leodido/go-urn v1.4.0
go: downloading github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
go: downloading github.com/go-playground/locales v0.14.1
?       k8s.io/dashboard/api    [no test files]
?       k8s.io/dashboard/api/pkg/environment    [no test files]
?       k8s.io/dashboard/api/pkg/args   [no test files]
?       k8s.io/dashboard/api/pkg/handler/parser [no test files]
ok      k8s.io/dashboard/api/pkg/handler        0.079s
?       k8s.io/dashboard/api/pkg/integration/api        [no test files]
ok      k8s.io/dashboard/api/pkg/integration    0.048s
?       k8s.io/dashboard/api/pkg/integration/metric/api [no test files]
ok      k8s.io/dashboard/api/pkg/integration/metric     0.081s
ok      k8s.io/dashboard/api/pkg/integration/metric/common      0.011s
ok      k8s.io/dashboard/api/pkg/integration/metric/sidecar     0.701s
ok      k8s.io/dashboard/api/pkg/resource/clusterrole   0.013s
ok      k8s.io/dashboard/api/pkg/resource/clusterrolebinding    0.017s
ok      k8s.io/dashboard/api/pkg/resource/common        0.018s
ok      k8s.io/dashboard/api/pkg/resource/configmap     0.019s
ok      k8s.io/dashboard/api/pkg/resource/container     0.018s
ok      k8s.io/dashboard/api/pkg/resource/controller    0.034s
ok      k8s.io/dashboard/api/pkg/resource/cronjob       0.018s
?       k8s.io/dashboard/api/pkg/resource/customresourcedefinition/types        [no test files]
ok      k8s.io/dashboard/api/pkg/resource/customresourcedefinition      0.036s
ok      k8s.io/dashboard/api/pkg/resource/customresourcedefinition/v1   0.017s
ok      k8s.io/dashboard/api/pkg/resource/daemonset     0.029s
ok      k8s.io/dashboard/api/pkg/resource/dataselect    0.007s
?       k8s.io/dashboard/api/pkg/resource/endpoint      [no test files]
ok      k8s.io/dashboard/api/pkg/resource/deployment    0.030s
ok      k8s.io/dashboard/api/pkg/resource/event 0.029s
?       k8s.io/dashboard/api/pkg/resource/ingress       [no test files]
ok      k8s.io/dashboard/api/pkg/resource/horizontalpodautoscaler       0.025s
ok      k8s.io/dashboard/api/pkg/resource/ingressclass  0.023s
ok      k8s.io/dashboard/api/pkg/resource/job   0.026s
?       k8s.io/dashboard/api/pkg/resource/logs  [no test files]
ok      k8s.io/dashboard/api/pkg/resource/limitrange    0.005s
?       k8s.io/dashboard/api/pkg/resource/networkpolicy [no test files]
ok      k8s.io/dashboard/api/pkg/resource/namespace     0.019s
ok      k8s.io/dashboard/api/pkg/resource/node  0.024s
ok      k8s.io/dashboard/api/pkg/resource/persistentvolume      0.106s
ok      k8s.io/dashboard/api/pkg/resource/persistentvolumeclaim 0.024s
ok      k8s.io/dashboard/api/pkg/resource/pod   0.028s
ok      k8s.io/dashboard/api/pkg/resource/replicaset    0.024s
ok      k8s.io/dashboard/api/pkg/resource/replicationcontroller 0.026s
ok      k8s.io/dashboard/api/pkg/resource/resourcequota 0.006s
ok      k8s.io/dashboard/api/pkg/resource/role  0.017s
ok      k8s.io/dashboard/api/pkg/resource/rolebinding   0.032s
ok      k8s.io/dashboard/api/pkg/resource/secret        0.018s
?       k8s.io/dashboard/api/pkg/resource/serviceaccount        [no test files]
ok      k8s.io/dashboard/api/pkg/resource/service       0.027s
ok      k8s.io/dashboard/api/pkg/resource/statefulset   0.018s
?       k8s.io/dashboard/api/pkg/scaling        [no test files]
ok      k8s.io/dashboard/api/pkg/resource/storageclass  0.030s
ok      k8s.io/dashboard/api/pkg/validation     0.018s
[dashboard-auth] Running tests
go: downloading github.com/golang-jwt/jwt/v4 v4.5.0
?       k8s.io/dashboard/auth   [no test files]
?       k8s.io/dashboard/auth/pkg/args  [no test files]
?       k8s.io/dashboard/auth/pkg/environment   [no test files]
?       k8s.io/dashboard/auth/pkg/router        [no test files]
?       k8s.io/dashboard/auth/pkg/routes/csrftoken      [no test files]
?       k8s.io/dashboard/auth/pkg/routes/login  [no test files]
?       k8s.io/dashboard/auth/pkg/routes/me     [no test files]
?       k8s.io/dashboard/auth/api/v1    [no test files]
[dashboard-metrics-scraper] Running tests
go: downloading github.com/gorilla/mux v1.8.0
go: downloading modernc.org/sqlite v1.29.1
go: downloading github.com/gorilla/handlers v1.5.1
go: downloading k8s.io/metrics v0.30.0
go: downloading github.com/onsi/ginkgo v1.16.4
go: downloading github.com/onsi/gomega v1.33.1
go: downloading github.com/felixge/httpsnoop v1.0.3
go: downloading github.com/nxadm/tail v1.4.8
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading modernc.org/libc v1.41.0
go: downloading github.com/ncruces/go-strftime v0.1.9
go: downloading github.com/dustin/go-humanize v1.0.1
go: downloading modernc.org/mathutil v1.6.0
go: downloading modernc.org/memory v1.7.2
go: downloading github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
?       k8s.io/dashboard/metrics-scraper        [no test files]
?       k8s.io/dashboard/metrics-scraper/pkg/api        [no test files]
?       k8s.io/dashboard/metrics-scraper/pkg/api/dashboard      [no test files]
?       k8s.io/dashboard/metrics-scraper/pkg/args       [no test files]
?       k8s.io/dashboard/metrics-scraper/pkg/environment        [no test files]
ok      k8s.io/dashboard/metrics-scraper/pkg/database   0.011s
[dashboard-web] Running tests
go: downloading github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
go: downloading github.com/samber/lo v1.39.0
?       k8s.io/dashboard/web    [no test files]
?       k8s.io/dashboard/web/pkg/args   [no test files]
?       k8s.io/dashboard/web/pkg/config [no test files]
?       k8s.io/dashboard/web/pkg/environment    [no test files]
?       k8s.io/dashboard/web/pkg/locale [no test files]
?       k8s.io/dashboard/web/pkg/router [no test files]
?       k8s.io/dashboard/web/pkg/settings       [no test files]
?       k8s.io/dashboard/web/pkg/systembanner   [no test files]
[common.certificates] Running tests
?       k8s.io/dashboard/certificates   [no test files]
?       k8s.io/dashboard/certificates/api       [no test files]
ok      k8s.io/dashboard/certificates/ecdsa     0.004s
[common.client] Running tests
?       k8s.io/dashboard/client [no test files]
[common.csrf] Running tests
?       k8s.io/dashboard/csrf   [no test files]
[common.errors] Running tests
ok      k8s.io/dashboard/errors 0.003s
[common.helpers] Running tests
ok      k8s.io/dashboard/helpers        0.005s
[common.types] Running tests
?       k8s.io/dashboard/types  [no test files]
```