### PR TITLE
Allow helm users to disable kong and use the ingress

### DIFF
--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -106,3 +106,63 @@ private.key: {{ randBytes 256 | b64enc | quote }}
 {{- fail "value of .Values.app.ingress.issuer.scope must be one of [default, cluster, disabled]"}}
 {{- end -}}
 {{- end -}}
+
+{{- define "kubernetes-dashboard.ingress.paths" -}}
+paths:
+{{- if eq .Values.app.mode "dashboard" }}
+  - pathType: Exact
+    path: {{ .Values.app.ingress.path }}api/v1/login
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
+        port:
+        {{- with (index .Values.auth.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+  - pathType: Exact
+    path: {{ .Values.app.ingress.path }}api/v1/csrftoken/login
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
+        port:
+        {{- with (index .Values.auth.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+  - pathType: Exact
+    path: {{ .Values.app.ingress.path }}api/v1/me
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.auth.role }}
+        port:
+        {{- with (index .Values.auth.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+  - pathType: Prefix
+    path: {{ .Values.app.ingress.path }}
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.web.role }}
+        port:
+        {{- with (index .Values.web.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+{{- end }}
+  - pathType: Prefix
+    path: {{ .Values.app.ingress.path }}api
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
+        port:
+        {{- with (index .Values.api.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+  - pathType: Prefix
+    path: {{ .Values.app.ingress.path }}metrics
+    backend:
+      service:
+        name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.api.role }}
+        port:
+        {{- with (index .Values.api.containers.ports 0) }}
+          number: {{ .containerPort }}
+        {{- end }}
+{{- end -}}

--- a/charts/kubernetes-dashboard/templates/config/gateway.yaml
+++ b/charts/kubernetes-dashboard/templates/config/gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if eq .Values.app.mode "dashboard" }}
+{{- if and .Values.kong.enabled (eq .Values.app.mode "dashboard") }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -61,6 +61,7 @@ spec:
     {{- range $host := .Values.app.ingress.hosts }}
     - host: {{ $host }}
       http:
+        {{- if $.Values.kong.enabled }}
         paths:
         {{- if not (eq $.Values.app.ingress.path "/") }}
           - path: {{ $.Values.app.ingress.path }}(/|$)(.*)
@@ -73,9 +74,13 @@ spec:
                 name: {{ template "kong.fullname" (index $.Subcharts "kong") }}-proxy
                 port:
                   number: {{ $.Values.kong.proxy.tls.servicePort }}
+        {{- else }}
+        {{- include  "kubernetes-dashboard.ingress.paths" $ | nindent 9 }}
+        {{- end }}
     {{- end }}
     {{- else }}
     - http:
+        {{- if .Values.kong.enabled }}
         paths:
           - path: {{ .Values.app.ingress.path }}
             pathType: {{ .Values.app.ingress.pathType }}
@@ -84,5 +89,8 @@ spec:
                 name: {{ template "kong.fullname" (index $.Subcharts "kong") }}-proxy
                 port:
                   number: {{ $.Values.kong.proxy.tls.servicePort }}
+        {{- else }}
+        {{- include  "kubernetes-dashboard.ingress.paths" $ | nindent 9 }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -31,8 +31,10 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.app.ingress.issuer.name }}
     {{- end }}
     {{- if .Values.app.ingress.useDefaultAnnotations }}
+    {{- if .Values.kong.enabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{- end }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     {{- end }}
     {{- if not (eq .Values.app.ingress.path "/") }}


### PR DESCRIPTION
This change allows helm users to disable kong and enable the app.ingress without getting an error. 

Fixes: https://github.com/kubernetes/dashboard/issues/8972

https://kubernetes.io/docs/concepts/services-networking/ingress/#examples

Example values:
```yaml
app:
  ingress:
    enabled: true
    hosts:
    - example.tld
kong:
  enabled: false
```

