### PR TITLE
feat(chart): remove kong configuration if kong disabled in values

### DIFF
--- a/charts/kubernetes-dashboard/templates/config/gateway.yaml
+++ b/charts/kubernetes-dashboard/templates/config/gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if eq .Values.app.mode "dashboard" }}
+{{- if and (eq .Values.app.mode "dashboard") (.Values.kong.enabled) }}
 
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
This change aims to remove unnecessary configuration if Kong subchart disabled by Helm Chart values.
I have inserted condition to ConfigMap, that requires `.Values.kong.enabled` set to `true`.