### PR TITLE
fix(common): when init container restartPolicy is always, think as sidecar

### DIFF
--- a/modules/api/pkg/resource/pod/common.go
+++ b/modules/api/pkg/resource/pod/common.go
@@ -49,7 +49,10 @@ func getPodStatus(pod v1.Pod) string {
 	for i := range pod.Status.InitContainerStatuses {
 		container := pod.Status.InitContainerStatuses[i]
 		restarts += int(container.RestartCount)
+		containerSpec := pod.Spec.InitContainers[i]
 		switch {
+		case container.State.Terminated == nil && *containerSpec.RestartPolicy == v1.ContainerRestartPolicyAlways:
+			continue;
 		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
 			continue
 		case container.State.Terminated != nil:


### PR DESCRIPTION
fix https://github.com/kubernetes/dashboard/issues/9299

# Context
According to the [documentation](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/), when the `restartPolicy` of an `initContainer` is set to `Always`, it is considered a sidecar container. Therefore, these containers should be considered as running normally (i.e., not in the initialization state) as long as they are not in the `Terminated` state.

# Solution Proposed
Add a check for the `restartPolicy` in the `initContainer` spec and whether the current `initContainer` is in the `State.Terminated`.
