### PR TITLE
Fix: Support GCE in ingress path

### DIFF
--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -62,11 +62,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-        {{- if not (eq $.Values.app.ingress.path "/") }}
-          - path: {{ $.Values.app.ingress.path }}(/|$)(.*)
-        {{- else }}
           - path: {{ $.Values.app.ingress.path }}
-        {{- end }}
             pathType: {{ $.Values.app.ingress.pathType }}
             backend:
               service:


### PR DESCRIPTION
Compatbility with GKE / GCE, where GCE requires a path that contains /* to function properly.
With the current path setup we can't use the /* and it messes up the ingress.

NB: let the user choose his own path, if he wants more complicated paths then he will do it on his own after consulting the documentation. DO NOT FORCE PATHS ON USERS