### PR TITLE
fix: add missing newline to common labels

### DIFF
--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "kubernetes-dashboard.name" . }}
 {{- with .Values.app.labels }}
-{{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Addresses https://github.com/kubernetes/dashboard/issues/9503

Fixes newline between built-in and additional labels specified via `app.labels`