### PR TITLE
feat: add OCI registry support for Helm chart

### DIFF
--- a/.github/workflows/cd-helm.yml
+++ b/.github/workflows/cd-helm.yml
@@ -42,9 +42,10 @@ jobs:
   release:
     name: Helm chart release
     runs-on: ubuntu-latest
-    needs: [ 'lint-test' ]
+    needs: ['lint-test']
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4.1.1
@@ -75,3 +76,20 @@ jobs:
           mark_as_latest: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
Issue: https://github.com/kubernetes/dashboard/issues/9537

Before merging this PR, probably an admin needs to permit this repository on Github Packages to have permission to push.