### PR TITLE
fix: the divisor field in resourceFieldRefs should be a string

### DIFF
--- a/charts/kubernetes-dashboard/templates/deployments/api.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/api.yaml
@@ -75,14 +75,14 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
             {{- if .Values.api.containers.resources.limits.memory }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
 
           {{- with .Values.api.containers.env }}

--- a/charts/kubernetes-dashboard/templates/deployments/auth.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/auth.yaml
@@ -76,14 +76,14 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
             {{- if .Values.auth.containers.resources.limits.memory }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
 
           {{- with .Values.auth.containers.env }}

--- a/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/metrics-scraper.yaml
@@ -68,14 +68,14 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
             {{- if .Values.metricsScraper.containers.resources.limits.memory }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
 
           {{- with .Values.metricsScraper.containers.env }}

--- a/charts/kubernetes-dashboard/templates/deployments/web.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/web.yaml
@@ -70,14 +70,14 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
             {{- if .Values.web.containers.resources.limits.memory }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-                  divisor: 1
+                  divisor: "1"
             {{- end }}
 
           {{- with .Values.web.containers.env }}


### PR DESCRIPTION
This fixes the type in the yaml, introduced in #9486.

See also: https://github.com/kubernetes/dashboard/blob/1b58a29c161150bf0c151c69cdff9f6e48344ffe/modules/web/schema/schema.graphql#L3843-L3852
