### PR TITLE
fix(signin button): signin button is clickable when token is autofilled by browser

### DIFF
--- a/modules/web/src/login/component.spec.ts
+++ b/modules/web/src/login/component.spec.ts
@@ -153,7 +153,7 @@ describe('LoginComponent', () => {
       // set inputs and fire change events to trigger onChange()
       const token = fixture.debugElement.query(By.css(queries.token)).nativeElement;
       token.value = loginToken;
-      token.dispatchEvent(new Event('keyup'));
+      token.dispatchEvent(new Event('input'));
 
       submit();
 

--- a/modules/web/src/login/template.html
+++ b/modules/web/src/login/template.html
@@ -47,7 +47,7 @@ limitations under the License.
             placeholder="Bearer token"
             type="password"
             required
-            (keyup)="onChange($event)"
+            (change)="onChange($event)"
           />
         </mat-form-field>
         <mat-error

--- a/modules/web/src/login/template.html
+++ b/modules/web/src/login/template.html
@@ -47,7 +47,7 @@ limitations under the License.
             placeholder="Bearer token"
             type="password"
             required
-            (change)="onChange($event)"
+            (input)="onChange($event)"
           />
         </mat-form-field>
         <mat-error


### PR DESCRIPTION
close #8755

Keep sign in button clickable when token is autofilled by browser

## Screenshot

### Firefox

https://github.com/user-attachments/assets/ed2a21df-ec4e-4fb5-be1b-370d8a68e2f2

### Chrome

When Chrome, must have an interaction with the browser.

https://github.com/user-attachments/assets/776a86c0-20d5-44c9-a2fa-773c4ae3140a

