### PR TITLE
Allow string values in extra manifests helm variable to allow raw template values.

### DIFF
--- a/charts/kubernetes-dashboard/templates/extras/manifests.yaml
+++ b/charts/kubernetes-dashboard/templates/extras/manifests.yaml
@@ -14,5 +14,9 @@
 
 {{ range .Values.extras.manifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
Template extra manifest directly if the type is string, so that raw untemplated values (invalid yaml) don't cause issues.