### PR TITLE
fix: typo error in args for api module

### DIFF
--- a/modules/api/pkg/args/args.go
+++ b/modules/api/pkg/args/args.go
@@ -62,7 +62,7 @@ var (
 	argPort                    = pflag.Int("port", defaultPort, "secure port to listen to for incoming HTTPS requests")
 	argMetricClientCheckPeriod = pflag.Int("metric-client-check-period", 30, "time interval between separate metric client health checks in seconds")
 
-	argInsecureBindAddress = pflag.IP("insecure-bind-address", net.IPv4(127, 0, 0, 1), "IP address on which to serve the --insecure-port, set to 127.0.0.1 for all interfaces")
+	argInsecureBindAddress = pflag.IP("insecure-bind-address", net.IPv4(127, 0, 0, 1), "IP address on which to serve the --insecure-port, set to 0.0.0.0 for all interfaces")
 	argBindAddress         = pflag.IP("bind-address", net.IPv4(0, 0, 0, 0), "IP address on which to serve the --port, set to 0.0.0.0 for all interfaces")
 
 	argDefaultCertDir            = pflag.String("default-cert-dir", "/certs", "directory path containing files from --tls-cert-file and --tls-key-file, used also when auto-generating certificates flag is set")


### PR DESCRIPTION
for all eth interface, the `insecure-bind-address` should be set as `0.0.0.0`