### PR TITLE
Correct misplaced quoting in sample user documentation.

### DIFF
--- a/docs/user/access-control/creating-sample-user.md
+++ b/docs/user/access-control/creating-sample-user.md
@@ -70,7 +70,7 @@ type: kubernetes.io/service-account-token
 After Secret is created, we can execute the following command to get the token which is saved in the Secret:
 
 ```shell
-kubectl get secret admin-user -n kubernetes-dashboard -o jsonpath={".data.token"} | base64 -d
+kubectl get secret admin-user -n kubernetes-dashboard -o jsonpath="{.data.token}" | base64 -d
 ```
 
 Check [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount) for more information about long-lived API tokens for a ServiceAccount.


### PR DESCRIPTION
Documentation describing how to retrieve a bearer token is incorrect due to misplaced double quotes.