### PR TITLE
docs: Fixing redirects from docs/user-guide which were removed in website repo

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -23,7 +23,7 @@ app:
     pullSecrets: []
   scheduling:
     # Node labels for pod assignment
-    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
     nodeSelector: {}
   security:
     # Allow overriding csrfKey used by API/Auth containers.

--- a/modules/web/src/create/from/form/createsecret/template.html
+++ b/modules/web/src/create/from/form/createsecret/template.html
@@ -59,7 +59,7 @@ limitations under the License.
           <kd-user-help>
             <span i18n>A secret with the specified name will be added to the cluster in the namespace.</span>
             <a
-              href="https://kubernetes.io/docs/user-guide/secrets/"
+              href="https://kubernetes.io/docs/concepts/configuration/secret/"
               target="_blank"
               tabindex="-1"
               i18n
@@ -99,7 +99,7 @@ limitations under the License.
               file.</ng-container
             >
             <a
-              href="https://kubernetes.io/docs/user-guide/images/#specifying-imagepullsecrets-on-a-pod"
+              href="https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod"
               target="_blank"
               tabindex="-1"
               i18n

--- a/modules/web/src/create/from/form/template.html
+++ b/modules/web/src/create/from/form/template.html
@@ -63,7 +63,7 @@ limitations under the License.
         >An 'app' label with this value will be added to the Deployment and Service that get deployed.</ng-container
       >
       <a
-        href="https://kubernetes.io/docs/user-guide/labels/"
+        href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
         target="_blank"
         tabindex="-1"
         i18n
@@ -104,7 +104,7 @@ limitations under the License.
         Registry.</ng-container
       >
       <a
-        href="https://kubernetes.io/docs/user-guide/images/"
+        href="https://kubernetes.io/docs/concepts/containers/images/
         target="_blank"
         tabindex="-1"
         i18n
@@ -179,7 +179,7 @@ limitations under the License.
         container.</ng-container
       >
       <a
-        href="https://kubernetes.io/docs/user-guide/services/"
+        href="https://kubernetes.io/docs/concepts/services-networking/service/"
         target="_blank"
         tabindex="-1"
         i18n
@@ -262,7 +262,7 @@ limitations under the License.
           include release, environment, tier, partition and track.</ng-container
         >
         <a
-          href="https://kubernetes.io/docs/user-guide/labels/"
+          href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
           target="_blank"
           tabindex="-1"
           i18n
@@ -301,7 +301,7 @@ limitations under the License.
           secret or create a new one.</ng-container
         >
         <a
-          href="https://kubernetes.io/docs/user-guide/secrets/"
+          href="https://kubernetes.io/docs/concepts/configuration/secret/"
           target="_blank"
           tabindex="-1"
           i18n
@@ -401,7 +401,7 @@ limitations under the License.
           options to override the default.</ng-container
         >
         <a
-          href="https://kubernetes.io/docs/user-guide/containers/"
+          href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/"
           target="_blank"
           tabindex="-1"
           i18n

--- a/modules/web/src/create/from/form/template.html
+++ b/modules/web/src/create/from/form/template.html
@@ -104,7 +104,7 @@ limitations under the License.
         Registry.</ng-container
       >
       <a
-        href="https://kubernetes.io/docs/concepts/containers/images/
+        href="https://kubernetes.io/docs/concepts/containers/images/"
         target="_blank"
         tabindex="-1"
         i18n


### PR DESCRIPTION
Fixes #20233

`docs/user-guide` redirects were removed in https://github.com/kubernetes/website/commit/b832ead744d3e8fc5be229cc1f6b83ea1815e017

Cleaning up these redirects from dashboard as well.