### PR TITLE
Cronjob status.lastSuccessfulTime not populated by a manually triggered job

### DIFF
--- a/modules/api/pkg/resource/cronjob/jobs.go
+++ b/modules/api/pkg/resource/cronjob/jobs.go
@@ -114,16 +114,11 @@ func TriggerCronJob(client client.Interface,
 
 	jobToCreate := &batch.Job{
 		ObjectMeta: meta.ObjectMeta{
-			Name:        newJobName,
-			Namespace:   namespace,
-			Annotations: annotations,
-			Labels:      labels,
-			OwnerReferences: []meta.OwnerReference{{
-				APIVersion: CronJobAPIVersion,
-				Kind:       CronJobKindName,
-				Name:       cronJob.Name,
-				UID:        cronJob.UID,
-			}},
+			Name:            newJobName,
+			Namespace:       namespace,
+			Annotations:     annotations,
+			Labels:          labels,
+			OwnerReferences: []meta.OwnerReference{*meta.NewControllerRef(cronJob, batch.SchemeGroupVersion.WithKind("CronJob"))},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,
 	}


### PR DESCRIPTION
I trigger the cronjob manually via the Kubernetes dashboard and this job ends successfully. However, status.lastSuccessfulTime is not updated, thus making it difficult to monitor failed cronjobs.

The same issue was fixed for kubectl command via https://github.com/kubernetes/kubernetes/issues/118276 but it's still open for dashboards

Closes #9805 