### PR TITLE
fix(client): GVR core resources caching

### DIFF
--- a/modules/common/client/verber.go
+++ b/modules/common/client/verber.go
@@ -111,8 +111,6 @@ func (v *resourceVerber) buildGroupVersionResourceCache(resourceList []*metav1.A
 		}
 	}
 
-	fmt.Printf("%+v\n", kindToGroupVersionResource)
-
 	return nil
 }
 

--- a/modules/common/client/verber.go
+++ b/modules/common/client/verber.go
@@ -102,12 +102,16 @@ func (v *resourceVerber) buildGroupVersionResourceCache(resourceList []*metav1.A
 			}
 
 			// Mapping for core resources
-			kindToGroupVersionResource[strings.ToLower(apiResource.Kind)] = gvr
+			if len(apiResource.Group) == 0 {
+				kindToGroupVersionResource[strings.ToLower(apiResource.Kind)] = gvr
+			}
 
 			// Mapping for CRD resources with custom kind
 			kindToGroupVersionResource[crdKind] = gvr
 		}
 	}
+
+	fmt.Printf("%+v\n", kindToGroupVersionResource)
 
 	return nil
 }


### PR DESCRIPTION
GVR caching logic did not consider that there can be CRDs with the same names as the core resources in different groups. Since discovery client returns unsorted list with a randomly ordered elements, it resulted in raw client request to a different resource than expected.

Fixes #9994 