### PR TITLE
feat: add read-only proxy

### DIFF
--- a/charts/kubernetes-dashboard/templates/config/ro-proxy.yaml
+++ b/charts/kubernetes-dashboard/templates/config/ro-proxy.yaml
@@ -1,0 +1,63 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubernetes-dashboard.annotations" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-nginx-conf
+data:
+  nginx.conf: |
+    pid /tmp/nginx.pid;
+    error_log /dev/stderr info;
+    events {
+      worker_connections 1024;
+    }
+    include /etc/nginx/conf.d/*.conf;
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubernetes-dashboard.annotations" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-nginx-templates
+data:
+  proxy.conf.template: |
+    http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+        server {
+            listen 8080;
+            access_log /dev/stdout;
+            location / {
+                proxy_pass https://{{ template "kong.fullname" (index $.Subcharts "kong") }}-proxy.{{ .Release.Namespace }}.svc;
+                proxy_ssl_verify off;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_ssl_session_reuse on;
+                proxy_set_header Authorization "Bearer ${DASHBOARD_SERVICE_TOKEN}";
+            }
+        }
+    }
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/deployments/ro-proxy.yaml
+++ b/charts/kubernetes-dashboard/templates/deployments/ro-proxy.yaml
@@ -1,0 +1,137 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+    app.kubernetes.io/version: {{ .Values.api.image.tag }}
+    app.kubernetes.io/component: {{ .Values.roProxy.role }}
+  annotations:
+    {{- include "kubernetes-dashboard.annotations" . | nindent 4 }}
+    {{- with .Values.roProxy.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+spec:
+  replicas: {{ .Values.roProxy.scaling.replicas }}
+  selector:
+    matchLabels:
+      {{- include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+  template:
+    metadata:
+      labels:
+        {{- include "kubernetes-dashboard.labels" . | nindent 8 }}
+        {{- with .Values.roProxy.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+        app.kubernetes.io/version: {{ .Values.roProxy.image.tag }}
+        app.kubernetes.io/component: {{ .Values.roProxy.role }}
+      annotations:
+        {{- with .Values.roProxy.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+      containers:
+        - name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+          image: "{{ .Values.roProxy.image.repository }}:{{ .Values.roProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          {{- with .Values.roProxy.containers.ports }}
+          ports:
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+          - name: DASHBOARD_SERVICE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-token
+                key: token
+          volumeMounts:
+            - name: nginx-rendered-templates
+              mountPath: /etc/nginx/conf.d
+            - name: nginx-templates
+              mountPath: /etc/nginx/templates
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp-volume
+            {{- with .Values.roProxy.containers.volumeMounts }}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.app.security.containerSecurityContext }}
+          securityContext:
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.roProxy.containers.resources }}
+          resources:
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
+     {{- with .Values.app.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.roProxy.automountServiceAccountToken }}
+
+      {{- with .Values.app.security.securityContext }}
+      securityContext:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-nginx-conf
+        - name: nginx-templates
+          configMap:
+            name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-nginx-templates
+        - name: nginx-rendered-templates
+          emptyDir:
+            sizeLimit: 5Mi
+        - name: tmp-volume
+          emptyDir:
+            sizeLimit: 5Mi
+        {{- with .Values.roProxy.volumes }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+
+      {{- with .Values.app.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+
+      {{- if or .Values.roProxy.nodeSelector .Values.app.scheduling.nodeSelector }}
+      nodeSelector:
+      {{- with .Values.roProxy.nodeSelector }}
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.scheduling.nodeSelector }}
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+
+      {{- with .Values.app.tolerations }}
+      tolerations:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/rbac/ro-user/clusterrole.yaml
+++ b/charts/kubernetes-dashboard/templates/rbac/ro-user/clusterrole.yaml
@@ -1,0 +1,55 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-cluster-view: "true"
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-resources
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-cluster-view: "true"
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/rbac/ro-user/clusterrolebinding.yaml
+++ b/charts/kubernetes-dashboard/templates/rbac/ro-user/clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/rbac/ro-user/secret.yaml
+++ b/charts/kubernetes-dashboard/templates/rbac/ro-user/secret.yaml
@@ -1,0 +1,26 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}-token
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/service-account-token
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/rbac/ro-user/serviceaccount.yaml
+++ b/charts/kubernetes-dashboard/templates/rbac/ro-user/serviceaccount.yaml
@@ -1,0 +1,24 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+{{ end }}

--- a/charts/kubernetes-dashboard/templates/services/ro-proxy.yaml
+++ b/charts/kubernetes-dashboard/templates/services/ro-proxy.yaml
@@ -1,0 +1,35 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.roProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels: 
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: kubernetes-dashboard-read-only-proxy
+spec:
+  selector:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- with .Values.roProxy.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "kubernetes-dashboard.name" . }}-{{ .Values.roProxy.role }}
+    app.kubernetes.io/version: {{ .Values.roProxy.image.tag }}
+    app.kubernetes.io/component: {{ .Values.roProxy.role }}
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: http
+{{ end }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -34,6 +34,7 @@ app:
     # To disable set the following configuration to null:
     # securityContext: null
     securityContext:
+      fsGroup: 2001
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
@@ -416,6 +417,35 @@ nginx:
       controllerValue: k8s.io/internal-ingress-nginx
     service:
       type: ClusterIP
+
+## Optional Nginx pre-configured read-only instance
+## This will create a proxy using a pre-defined read-only user
+## This is similar to the "skip-login" functionality of older versions
+## It is unprotected by TLS and should never be run in production
+## It purposefully does not include any ingress or gateway resources
+roProxy:
+  enabled: false
+  role: read-only-proxy
+  image:
+    repository: docker.io/nginx
+    tag: stable-alpine-slim
+  scaling:
+    replicas: 1
+  containers:
+    ports:
+      - name: http
+        containerPort: 8080
+        protocol: TCP
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 250m
+        memory: 400Mi
+    volumeMounts: {}
+  automountServiceAccountToken: false
+  volumes: {}
 
 ## Extra configurations:
 ## - manifests


### PR DESCRIPTION
A number of folks (myself included) are fond of the `skip-login` button from the previous versions.

I'm glad for the move to the new, better auth.  However, a number of my users have asked after the simple read-only view they once had.

This PR adds a fairly naive proxy container which sets the `Authorization` header to a specially created read-only user.

There are probably more things to template, maybe network policies to enforce, and tls to attach.  But for a quick and simple "Give me a read-only view" this works for my site.