### PR TITLE
Update ingress.yaml to accomodate kong service ports

### DIFF
--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -17,9 +17,14 @@
 
 
 # Determine the service port to use for the ingress configuration
-# If TLS is enabled in the ingress configuration, use the TLS service port.
+# If TLS is enabled in the kong proxy configuration, use the TLS service port.
 # Otherwise, fall back to the HTTP service port.
-{{- $servicePort := (ternary $.Values.kong.proxy.tls.servicePort $.Values.kong.proxy.http.servicePort $.Values.app.ingress.tls.enabled) }}
+{{- $servicePort := (ternary $.Values.kong.proxy.tls.servicePort $.Values.kong.proxy.http.servicePort $.Values.kong.proxy.tls.enabled) }}
+
+# Determine the backend protocol to use for the ingress configuration
+# If TLS is enabled in the kong proxy configuration, use HTTPS
+# Otherwise, fall back to the HTTP
+{{- $backendProtocol := (ternary "HTTPS" "HTTP" $.Values.kong.proxy.tls.enabled) }}
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1
@@ -38,9 +43,13 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.app.ingress.issuer.name }}
     {{- end }}
     {{- if .Values.app.ingress.useDefaultAnnotations }}
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/backend-protocol: "{{ $backendProtocol }}"
+    {{- if .Values.kong.proxy.tls.enabled }}
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{- end }}
+    {{- if .Values.app.ingress.tls.enabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
     {{- end }}
     {{- if not (eq .Values.app.ingress.path "/") }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2


### PR DESCRIPTION
This template built an ingress that incorrectly set `$servicePort` based on `app.ingress.tls.enabled`.

This fixes that by using the `kong.proxy.tls.enabled` for the check instead, thereby selecting the correct service port.

It also adjusts the default annotations to check for `app.ingress.tls.enabled` so unnecessary annotations are avoided.

Finally, it properly sets the backend protocol based on `kong.proxy.tls.enabled`.

I see a few different scenarios:

* SSL Passthrough
  * `app.ingress.tls.enabled` == `false`
  * `kong.proxy.tls.enabled` == `true`

* Ingress terminated TLS
  * `app.ingress.tls.enabled` == `true`
  * `kong.proxy.tls.enabled` == `false`

* Ingress TLS to Kong TLS, though not sure this works because the default ingress annotation `nginx.ingress.kubernetes.io/ssl-redirect: "true"`
  * `app.ingress.tls.enabled` == `true`
  * `kong.proxy.tls.enabled` == `true`

I don't think HTTP to HTTPS proxying is a good idea, so I won't talk more about it.

To fix TLS to TLS, there might be a need to add an additional parameter enabling `ssl-passthrough` behavior.  In this implementation, if `kong.proxy.tls.enabled=true` then it assumes you want to perform SSL-passthrough.  I haven't verified as I'm using Ingress terminated TLS and can't test the needful.

I suspect this has been the culprit of many threads regarding `Error 400 HTTP request to HTTPS`, though I think that might also have something to do with http2 requirements on the proxy -- at least on my deployment.