### PR TITLE
feat: implement filter action when getting events

### DIFF
--- a/modules/api/pkg/resource/event/common.go
+++ b/modules/api/pkg/resource/event/common.go
@@ -231,7 +231,10 @@ func CreateEventList(events []v1.Event, dsQuery *dataselect.DataSelectQuery) com
 		ListMeta: types.ListMeta{TotalItems: len(events)},
 	}
 
-	events = fromCells(dataselect.GenericDataSelect(toCells(events), dsQuery))
+	eventCells, filteredTotal := dataselect.GenericDataSelectWithFilter(toCells(events), dsQuery)
+	events = fromCells(eventCells)
+	eventList.ListMeta = types.ListMeta{TotalItems: filteredTotal}
+
 	for _, event := range events {
 		eventDetail := ToEvent(event)
 		eventList.Events = append(eventList.Events, eventDetail)


### PR DESCRIPTION
This PR is trying to fix the issue [#10083](https://github.com/kubernetes/dashboard/issues/10083).

## Before change 

We cannot get the events filtered by name, namepsace, etc.

![image](https://github.com/user-attachments/assets/0e8e3349-f016-46b2-a2cd-3ba549609662)

![image](https://github.com/user-attachments/assets/e11d7ac3-c91d-4ab9-8197-c6fe209dc3d9)


## After change 

We can get the events filtered by name, namespace, etc....

![image](https://github.com/user-attachments/assets/45303b0b-a3ea-48d1-a4eb-8d53c7de58cd)

![image](https://github.com/user-attachments/assets/612fee99-2ad0-4766-8ef8-eb4538757798)






