### PR TITLE
style: Various improvements to Dockerfiles

### DIFF
--- a/modules/api/Dockerfile
+++ b/modules/api/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.21 as user
+FROM alpine:3.21 AS user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.21 as builder
+FROM golang:1.23-alpine3.21 AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -58,7 +58,7 @@ RUN echo ${VERSION}
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X k8s.io/dashboard/api/pkg/environment.Version=${VERSION}" -o dashboard-api .
 
 # Scratch can be used as the base image because the binary is compiled to include all dependencies.
-FROM scratch as final
+FROM scratch AS final
 
 COPY --from=builder /workspace/api/dashboard-api /dashboard-api
 

--- a/modules/api/Dockerfile
+++ b/modules/api/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.19 as user
+FROM alpine:3.21 as user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.19 as builder
+FROM golang:1.23-alpine3.21 as builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/modules/api/dev.Dockerfile
+++ b/modules/api/dev.Dockerfile
@@ -14,11 +14,11 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.19 as AIR
+FROM golang:1.23-alpine3.21 as AIR
 
 RUN go install github.com/air-verse/air@latest
 
-FROM golang:1.23-alpine3.19
+FROM golang:1.23-alpine3.21
 
 # Copy air binary
 COPY --from=AIR $GOPATH/bin/air $GOPATH/bin/air

--- a/modules/api/dev.Dockerfile
+++ b/modules/api/dev.Dockerfile
@@ -14,7 +14,7 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.21 as AIR
+FROM golang:1.23-alpine3.21 AS AIR
 
 RUN go install github.com/air-verse/air@latest
 

--- a/modules/auth/Dockerfile
+++ b/modules/auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.21 as user
+FROM alpine:3.21 AS user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.21 as builder
+FROM golang:1.23-alpine3.21 AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -58,7 +58,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldfl
 
 # Scratch can be used as the base image because the backend is compiled to include all
 # its dependencies.
-FROM scratch as final
+FROM scratch AS final
 ARG TARGETARCH
 ARG TARGETOS
 

--- a/modules/auth/Dockerfile
+++ b/modules/auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.19 as user
+FROM alpine:3.21 as user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.19 as builder
+FROM golang:1.23-alpine3.21 as builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/modules/auth/dev.Dockerfile
+++ b/modules/auth/dev.Dockerfile
@@ -14,11 +14,11 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.19 as AIR
+FROM golang:1.23-alpine3.21 as AIR
 
 RUN go install github.com/air-verse/air@latest
 
-FROM golang:1.23-alpine3.19
+FROM golang:1.23-alpine3.21
 
 # Copy air binary
 COPY --from=AIR $GOPATH/bin/air $GOPATH/bin/air

--- a/modules/auth/dev.Dockerfile
+++ b/modules/auth/dev.Dockerfile
@@ -14,7 +14,7 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.21 as AIR
+FROM golang:1.23-alpine3.21 AS AIR
 
 RUN go install github.com/air-verse/air@latest
 

--- a/modules/metrics-scraper/Dockerfile
+++ b/modules/metrics-scraper/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.21 as user
+FROM alpine:3.21 AS user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.21 as builder
+FROM golang:1.23-alpine3.21 AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -52,7 +52,7 @@ COPY metrics-scraper/main.go ./
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X k8s.io/dashboard/metrics-scraper/pkg/environment.Version=${VERSION}" -o dashboard-metrics-scraper .
 
 # Scratch can be used as the base image because the binary is compiled to include all dependencies.
-FROM scratch as final
+FROM scratch AS final
 
 COPY --from=builder /workspace/metrics-scraper/dashboard-metrics-scraper /dashboard-metrics-scraper
 

--- a/modules/metrics-scraper/Dockerfile
+++ b/modules/metrics-scraper/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.19 as user
+FROM alpine:3.21 as user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -27,7 +27,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM golang:1.23-alpine3.19 as builder
+FROM golang:1.23-alpine3.21 as builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/modules/metrics-scraper/dev.Dockerfile
+++ b/modules/metrics-scraper/dev.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-alpine3.21 as AIR
+FROM golang:1.23-alpine3.21 AS AIR
 
 RUN go install github.com/air-verse/air@latest
 

--- a/modules/metrics-scraper/dev.Dockerfile
+++ b/modules/metrics-scraper/dev.Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-alpine3.19 as AIR
+FROM golang:1.23-alpine3.21 as AIR
 
 RUN go install github.com/air-verse/air@latest
 
-FROM golang:1.23-alpine3.19
+FROM golang:1.23-alpine3.21
 
 # Copy air binary
 COPY --from=AIR $GOPATH/bin/air $GOPATH/bin/air

--- a/modules/web/Dockerfile
+++ b/modules/web/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG WEB_BUILDER_ARCH=amd64
 
-FROM alpine:3.19 as user
+FROM alpine:3.21 as user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -29,7 +29,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM --platform=linux/${WEB_BUILDER_ARCH} node:20.11.1-alpine3.19  as web-builder
+FROM --platform=linux/${WEB_BUILDER_ARCH} node:20.11.1-alpine3.21  as web-builder
 
 RUN apk add --no-cache \
     make \
@@ -53,7 +53,7 @@ RUN SKIP_POSTINSTALL=true yarn workspaces focus
 # Build prod version of web app
 RUN make build-frontend
 
-FROM golang:1.23-alpine3.19 as go-builder
+FROM golang:1.23-alpine3.21 as go-builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/modules/web/Dockerfile
+++ b/modules/web/Dockerfile
@@ -29,7 +29,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM --platform=linux/${WEB_BUILDER_ARCH} node:20.11.1-alpine3.21 AS web-builder
+FROM --platform=linux/${WEB_BUILDER_ARCH} node:20-alpine3.21 AS web-builder
 
 RUN apk add --no-cache \
     make \

--- a/modules/web/Dockerfile
+++ b/modules/web/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG WEB_BUILDER_ARCH=amd64
 
-FROM alpine:3.21 as user
+FROM alpine:3.21 AS user
 
 ENV USER=nonroot
 ENV UID=10001
@@ -29,7 +29,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-FROM --platform=linux/${WEB_BUILDER_ARCH} node:20.11.1-alpine3.21  as web-builder
+FROM --platform=linux/${WEB_BUILDER_ARCH} node:20.11.1-alpine3.21 AS web-builder
 
 RUN apk add --no-cache \
     make \
@@ -53,7 +53,7 @@ RUN SKIP_POSTINSTALL=true yarn workspaces focus
 # Build prod version of web app
 RUN make build-frontend
 
-FROM golang:1.23-alpine3.21 as go-builder
+FROM golang:1.23-alpine3.21 AS go-builder
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -82,7 +82,7 @@ COPY /modules/web/main.go ./
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w -X k8s.io/dashboard/web/pkg/environment.Version=${VERSION}" -o dashboard-web .
 
 # Scratch can be used as the base image because the binary is compiled to include all dependencies.
-FROM scratch as final
+FROM scratch AS final
 
 WORKDIR /web
 

--- a/modules/web/dev.go.Dockerfile
+++ b/modules/web/dev.go.Dockerfile
@@ -14,11 +14,11 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.19 as AIR
+FROM golang:1.23-alpine3.21 as AIR
 
 RUN go install github.com/air-verse/air@latest
 
-FROM golang:1.23-alpine3.19
+FROM golang:1.23-alpine3.21
 
 # Copy air binary
 COPY --from=AIR $GOPATH/bin/air $GOPATH/bin/air

--- a/modules/web/dev.go.Dockerfile
+++ b/modules/web/dev.go.Dockerfile
@@ -14,7 +14,7 @@
 
 # ! Context expected to be set to "modules" dir !
 
-FROM golang:1.23-alpine3.21 as AIR
+FROM golang:1.23-alpine3.21 AS AIR
 
 RUN go install github.com/air-verse/air@latest
 

--- a/modules/web/dev.web.Dockerfile
+++ b/modules/web/dev.web.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:20-alpine3.19
+FROM node:20-alpine3.21
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This PR introduces the following three improvements to all Dockerfiles:
- Update from Alpine 3.19 to 3.21; given that the Docker official images only support the last two Alpine versions, this ensures up-to-date images are used
- Use consistent `FROM` + `AS` keyword casing to solve Docker style warning (see e.g. https://github.com/kubernetes/dashboard/actions/runs/13896030290/job/38876759635#step:8:10851 and https://docs.docker.com/reference/build-checks/from-as-casing/)
- Update a specific Node image tag with a major-only tag, to ensure the latest minor+patch version is used

Note these are practically unrelated changes, but given they all alter the same lines of code, I've opted to combine them into a single PR regardless. If any of these changes should be removed our submitted individually, let me know!