### PR TITLE
feat: use port name for livenessProbe in helm chart

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -319,7 +319,8 @@ metricsScraper:
     extraSpec: ~
   containers:
     ports:
-      - containerPort: 8000
+      - name: metrics
+        containerPort: 8000
         protocol: TCP
     args: []
     # Additional container environment variables
@@ -347,7 +348,7 @@ metricsScraper:
       httpGet:
         scheme: HTTP
         path: /
-        port: 8000
+        port: metrics
       initialDelaySeconds: 30
       timeoutSeconds: 30
   automountServiceAccountToken: true


### PR DESCRIPTION
My config linter (https://popeyecli.io/) recommends using port names for the `livenessProbe`