### PR TITLE
Update Job status display to actually use job status

### DIFF
--- a/modules/web/src/common/components/resourcelist/job/component.ts
+++ b/modules/web/src/common/components/resourcelist/job/component.ts
@@ -46,9 +46,9 @@ export class JobListComponent extends ResourceListWithStatuses<JobList, Job> {
     this.groupId = ListGroupIdentifier.workloads;
 
     // Register status icon handlers
-    this.registerBinding('kd-success', r => r.podInfo.warnings.length === 0 && r.podInfo.pending === 0, Status.Running);
-    this.registerBinding('kd-warning', r => r.podInfo.warnings.length === 0 && r.podInfo.pending > 0, Status.Pending);
-    this.registerBinding('kd-error', r => r.podInfo.warnings.length > 0, Status.Error);
+    this.registerBinding('kd-success', r => r.jobStatus.status === Status.Complete, Status.Complete);
+    this.registerBinding('kd-warning', r => r.jobStatus.status === Status.Running, Status.Running);
+    this.registerBinding('kd-error', r => r.jobStatus.status === Status.Failed, Status.Failed);
 
     // Register action columns.
     this.registerActionColumn<MenuComponent>('menu', MenuComponent);

--- a/modules/web/src/common/components/resourcelist/statuses.ts
+++ b/modules/web/src/common/components/resourcelist/statuses.ts
@@ -16,6 +16,7 @@ export enum Status {
   Active = 'Active',
   Available = 'Available',
   Bound = 'Bound',
+  Complete = 'Complete',
   Completed = 'Completed',
   ContainerCreating = 'ContainerCreating',
   Error = 'Error',

--- a/modules/web/src/typings/root.api.ts
+++ b/modules/web/src/typings/root.api.ts
@@ -338,6 +338,7 @@ export interface Job extends Resource {
   containerImages: string[];
   initContainerImages: string[];
   parallelism: number;
+  jobStatus: JobStatus;
 }
 
 export interface Namespace extends Resource {


### PR DESCRIPTION
Fixes #6443 (or at least partially).

Currently the state indicator of jobs in the resource list (`/#/job`) always seems to be green on my end, with tooltip `Running`, even when the actual jobs have either failed or succeeded. This is somewhat confusing in terms of UX/UI.

This PR aims to update the job status to actually reflect the state of the job, matching with the available types I traced in the api module (https://github.com/kubernetes/dashboard/blob/010e944dd3b68fd895abea9e588f09663dbf16a9/modules/api/pkg/resource/job/list.go#L46).

Note: I have not yet been able to actually test this, hence this is still a draft. If there's already feedback on how to approach this, please let me know! Also feel free to take over/follow up on this.