### PR TITLE
Add configurable backend service port for Ingress

### DIFF
--- a/charts/kubernetes-dashboard/templates/networking/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/ingress.yaml
@@ -17,9 +17,10 @@
 
 
 # Determine the service port to use for the ingress configuration
-# If TLS is enabled in the ingress configuration, use the TLS service port.
+# If a specific backend port is configured, use that regardless of TLS settings
+# Otherwise, if TLS is enabled in the ingress configuration, use the TLS service port.
 # Otherwise, fall back to the HTTP service port.
-{{- $servicePort := (ternary $.Values.kong.proxy.tls.servicePort $.Values.kong.proxy.http.servicePort $.Values.app.ingress.tls.enabled) }}
+{{- $servicePort := .Values.app.ingress.backendServicePort | default (ternary $.Values.kong.proxy.tls.servicePort $.Values.kong.proxy.http.servicePort $.Values.app.ingress.tls.enabled) }}
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -122,6 +122,11 @@ app:
     # It allows serving Kubernetes Dashboard on a sub-path. Make sure that the configured path
     # does not conflict with gateway route configuration.
     path: /
+    # Explicitly set the backend service port for Kong to use when routing traffic.
+    # This is useful when TLS termination happens outside the cluster (e.g., at a load balancer)
+    # but backend services still listen on HTTPS ports.
+    # If not set, the port is determined based on TLS settings (443 for HTTPS, 80 for HTTP).
+    backendServicePort:
     issuer:
       name: selfsigned
       # Scope determines what kind of issuer annotation will be used on ingress resource


### PR DESCRIPTION
I’m using NGINX Ingress with an AWS Network Load Balancer (NLB), where SSL termination is handled by AWS Certificate Manager (ACM). The NLB terminates HTTPS traffic and forwards plain HTTP to the NGINX Ingress controller. From there, NGINX routes traffic to Kong Gateway, which acts as a reverse proxy to backend services — in this case, the Kubernetes Dashboard.

Problem:
The Kubernetes Dashboard service listens on port 443 (HTTPS) when TLS is enabled. However, in my setup, I want to disable TLS on the dashboard itself while still having Kong connect to it over port 443. The issue arises because the default Kong Helm chart determines the upstream port using the following logic:

$servicePort := (ternary $.Values.kong.proxy.tls.servicePort $.Values.kong.proxy.http.servicePort $.Values.app.ingress.tls.enabled)

Since app.ingress.tls.enabled is false (TLS is terminated at the NLB, not within the cluster), the chart defaults to port 80. But the backend service (Kubernetes Dashboard) does not expose port 80, leading to HTTP 503 errors when Kong tries to route requests.

Fix:
To resolve the issue, I manually modified the Helm chart template to hardcode the default backend port to 443, ensuring Kong would correctly route traffic to the dashboard even with TLS disabled.

Suggestion:
It would be useful if the Helm chart provided an option to explicitly set the backend service port (e.g., defaultBackendPort), decoupled from the TLS configuration, to avoid relying on template hacks or misusing the TLS flag.