### PR TITLE
[Helm Chart] Change Kong Pod annotations to work out-of-the-box with Kuma and Istio

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -397,6 +397,11 @@ kong:
     type: ClusterIP
     http:
       enabled: false
+  # Enable inbound mesh proxying for Kuma and Istio, which is disabled by default in Kong chart
+  # ref: https://github.com/Kong/charts/tree/main/charts/kong#general-parameters
+  podAnnotations:
+    kuma.io/gateway: disabled
+    traffic.sidecar.istio.io/includeInboundPorts: "*"
 
 ## Optional Cert Manager sub-chart configuration
 ## Enable this if you don't already have cert-manager enabled on your cluster.


### PR DESCRIPTION
The default Kong Chart we rely on sets these two annotations, by default, on its Pods.

Source: https://github.com/Kong/charts/blob/5c2eb33076061e90f49ac05c9b26e2b961a8bc4a/charts/kong/values.yaml#L986-L988
```yaml
podAnnotations:
  kuma.io/gateway: enabled
  traffic.sidecar.istio.io/includeInboundPorts: ""
```

This prevents service meshes from correctly intercepting incoming traffic to the Kong Pod, for example when we want to expose the Dashboard using an Ingress or Gateway.
For more details, see #10376 .

This PR modifies the Kubernetes Dashboard's Chart default values to set these values as [suggested](https://github.com/Kong/charts/blob/5c2eb33076061e90f49ac05c9b26e2b961a8bc4a/charts/kong/README.md?plain=1#L951-L963) in the Kong Proxy's Chart README, in the case we want to use it as an internal proxy rather than an external gateway (which is the default configuration).

```yaml
kong:
  # Enable inbound mesh proxying for Kuma and Istio
  podAnnotations:
    kuma.io/gateway: disabled
    traffic.sidecar.istio.io/includeInboundPorts: "*"
```