### PR TITLE
Add Gateway API HTTPRoute support to Helm chart

### DIFF
--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: kubernetes-dashboard
-version: 7.13.0
+version: 7.14.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:
   - kubernetes

--- a/charts/kubernetes-dashboard/templates/networking/httproute.yaml
+++ b/charts/kubernetes-dashboard/templates/networking/httproute.yaml
@@ -1,0 +1,60 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.app.httproute.enabled (eq .Values.app.mode "dashboard")}}
+
+# Determine the service port to use for the HTTPRoute configuration
+# If TLS is enabled in the HTTPRoute configuration, use the TLS service port.
+# Otherwise, fall back to the HTTP service port.
+{{- $servicePort := (ternary 443 80 .Values.app.httproute.tls.enabled) }}
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "kubernetes-dashboard.name" . }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- with .Values.app.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "kubernetes-dashboard.annotations" . | nindent 4 }}
+    {{- with .Values.app.httproute.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.app.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.app.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.app.httproute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ template "kong.fullname" (index $.Subcharts "kong") }}-proxy
+          port: {{ $servicePort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -135,6 +135,43 @@ app:
       secretName: ""
     labels: {}
     annotations: {}
+
+  # Gateway API HTTPRoute configuration
+  # NOTE: Requires Gateway API CRDs (v1) installed in cluster
+  # https://gateway-api.sigs.k8s.io/guides/getting-started/
+  httproute:
+    # Enable HTTPRoute resource (alternative to Ingress)
+    enabled: false
+    # Additional HTTPRoute labels
+    labels: {}
+    # Additional HTTPRoute annotations
+    annotations: {}
+    # Gateway references
+    # Must reference an existing Gateway resource
+    parentRefs: []
+      # - name: example-gateway
+      #   namespace: gateway-system
+      #   sectionName: https
+    # List of hostnames
+    hostnames: []
+      # - dashboard.example.com
+    # HTTPRoute rules
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        # Optional filters:
+        # filters:
+        #   - type: RequestHeaderModifier
+        #     requestHeaderModifier:
+        #       add:
+        #         - name: X-Custom-Header
+        #           value: value
+    # TLS configuration (determines Kong proxy port: 443 for TLS, 80 for HTTP)
+    tls:
+      enabled: true
+
   # Use the following toleration if Dashboard can be deployed on a tainted control-plane nodes
   # - key: node-role.kubernetes.io/control-plane
   #   effect: NoSchedule


### PR DESCRIPTION
## Summary
Adds Gateway API HTTPRoute support to Kubernetes Dashboard Helm chart as a modern alternative to traditional Ingress.

## Motivation
- Gateway API reached GA status (v1.0+, October 2023)
- Provides vendor-neutral, portable ingress configuration
- More flexible routing capabilities compared to Ingress
- Supported by major Gateway controllers (Cilium, Istio, Traefik, Kong, Envoy Gateway)

## Changes
- Added `templates/networking/httproute.yaml` template
- Added `app.httproute` configuration section in values.yaml
- Updated Chart version to 7.14.0
- HTTPRoute uses existing Kong proxy backend

## Testing
- [x] helm template renders correctly
- [x] helm lint passes with no errors
- [x] Tested in local cluster with Cilium Gateway API
- [x] HTTPRoute successfully created and accepted by gateway controller
- [x] Kong proxy service correctly referenced as backend

## Configuration Example
```yaml
app:
  httproute:
    enabled: true
    parentRefs:
      - name: my-gateway
        namespace: gateway-system
        sectionName: https
    hostnames:
      - dashboard.example.com
    tls:
      enabled: true
```

Closes #10384