### PR TITLE
fix: Fix Static check job failure

### DIFF
--- a/modules/auth/pkg/args/args.go
+++ b/modules/auth/pkg/args/args.go
@@ -31,7 +31,7 @@ var (
 	argKubeconfig             = pflag.String("kubeconfig", "", "path to kubeconfig file")
 	argApiServerHost          = pflag.String("apiserver-host", "", "address of the Kubernetes API server to connect to in the format of protocol://address:port, leave it empty if the binary runs inside cluster for local discovery attempt")
 	argApiServerSkipTLSVerify = pflag.Bool("apiserver-skip-tls-verify", false, "enable if connection with remote Kubernetes API server should skip TLS verify")
-	argApiServerCaBundle				 = pflag.String("apiserver-ca-bundle", "", "file containing the x509 certificates used for HTTPS connection to the API Server")
+	argApiServerCaBundle      = pflag.String("apiserver-ca-bundle", "", "file containing the x509 certificates used for HTTPS connection to the API Server")
 )
 
 func init() {

--- a/modules/common/client/init.go
+++ b/modules/common/client/init.go
@@ -63,7 +63,7 @@ func (in *configBuilder) buildBaseConfig() (config *rest.Config, err error) {
 
 	if len(in.caBundlePath) > 0 {
 		klog.InfoS("Using custom CA Bundle", "caBundle", in.caBundlePath)
-		config.TLSClientConfig.CAFile = in.caBundlePath
+		config.CAFile = in.caBundlePath
 	}
 
 	if err != nil {


### PR DESCRIPTION
Static check jobs are failing since one of the file was not formatted properly.
Applied gofmt across all the files.

Also while fixing above, found below issue
```
Error: modules/common/client/init.go:66:10: QF1008: could remove embedded field "TLSClientConfig" from selector (staticcheck)
```

This occured as we can directly access `CAFile` without using having to use `TLSClientConfig ` object since it is embeded.