### PR TITLE
To prevent Kong startup failures on systems where IPv6 is disabled by…

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -387,6 +387,10 @@ kong:
     dns_order: LAST,A,CNAME,AAAA,SRV
     plugins: 'off'
     nginx_worker_processes: 1
+    # Ports: 8000 (HTTP), 8443 (HTTPS) when IPv6 is disabled
+    proxy_listen: "0.0.0.0:8000, 0.0.0.0:8443 ssl"
+    # Ports: 8001 (admin HTTP), 8444 (admin HTTPS) when IPv6 is disabled
+    admin_listen: "0.0.0.0:8001, 0.0.0.0:8444 ssl"
   ingressController:
     enabled: false
   manager:


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
To prevent Kong startup failures on systems where IPv6 is disabled by using proxy_listen and admin_listen. 
Two port for each listeners one for HTTP and HTTPS
  8000/8001 = HTTP (unencrypted)
  8443/8444 = HTTPS with SSL/TLS (encrypted)

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/dashboard/issues/10330

Special notes for your reviewer:
None

Does this PR introduce a user-facing change?
None

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None