### PR TITLE
fix(helm): use fully qualified image name for kong sub-chart

### DIFF
--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -382,6 +382,9 @@ metrics-server:
 ## for our all containers.
 kong:
   enabled: true
+  image:
+    repository: docker.io/library/kong
+    tag: "3.9"
   ## Configuration reference: https://docs.konghq.com/gateway/3.6.x/reference/configuration
   env:
     dns_order: LAST,A,CNAME,AAAA,SRV


### PR DESCRIPTION
#10423 

Modified charts/kubernetes-dashboard/values.yaml to explicitly set the Kong image repository to docker.io/library/kong.

<img width="699" height="152" alt="image" src="https://github.com/user-attachments/assets/e0b42e8d-283b-4f52-af1c-4ec272702862" />
